### PR TITLE
recognize bundled dependencies

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -219,6 +219,7 @@ This is a list of dependency types dependency-cruiser currently detects.
  npm-dev         | it's a module in package.json's `devDependencies`      | "chai"
  npm-optional    | it's a module in package.json's `optionalDependencies` | "livescript"
  npm-peer        | it's a module in package.json's `peerDependencies` - note: deprecated in npm 3 | "thing-i-am-a-plugin-for"
+ npm-bundled     | it's a module that occurs in package.json's `bundle(d)Dependencies` array | "iwillgetbundled"
  npm-no-pkg      | it's an npm module - but it's nowhere in your package.json | "forgetmenot"
  npm-unknown     | it's an npm module - but there is no (parseable/ valid) package.json in your package |
  deprecated      | it's an npm module, but the version you're using or the module itself is officially deprecated                                | "some-deprecated-package"

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -62,9 +62,6 @@ const getAST = _.memoize(getASTBare);
  */
 module.exports = (pFileName, pOptions) => {
     try {
-        const lAST = getAST(pFileName);
-        let lDependencies = [];
-
         pOptions = _.defaults(
             pOptions,
             {
@@ -72,6 +69,9 @@ module.exports = (pFileName, pOptions) => {
                 moduleSystems: ["cjs", "es6", "amd"]
             }
         );
+
+        const lAST = getAST(path.join(pOptions.baseDir, pFileName));
+        let lDependencies = [];
 
         if (_.includes(pOptions.moduleSystems, "cjs")){
             extractCommonJSDependencies(lAST, lDependencies);
@@ -93,7 +93,7 @@ module.exports = (pFileName, pOptions) => {
                     const lResolved = resolve(
                         pDependency,
                         pOptions.baseDir,
-                        path.dirname(pFileName)
+                        path.join(pOptions.baseDir, path.dirname(pFileName))
                     );
 
                     return Object.assign(

--- a/src/extract/gatherInitialSources.js
+++ b/src/extract/gatherInitialSources.js
@@ -2,6 +2,7 @@ const fs            = require('fs');
 const path          = require('path');
 const ignore        = require('./ignore');
 const transpileMeta = require('./transpile/meta');
+const _             = require('lodash');
 
 const SUPPORTED_EXTENSIONS = transpileMeta.scannableExtensions;
 
@@ -19,10 +20,17 @@ function gatherScannableFilesFromDir (pDirName, pOptions) {
         }, []);
 }
 
-module.exports = (pFileDirArray, pOptions) =>
-    pFileDirArray.reduce(
+module.exports = (pFileDirArray, pOptions) => {
+    pOptions = _.defaults(
+        pOptions,
+        {
+            baseDir: process.cwd(),
+            moduleSystems: ["cjs", "es6", "amd"]
+        }
+    );
+    return pFileDirArray.reduce(
         (pAll, pThis) => {
-            if (fs.statSync(pThis).isDirectory()) {
+            if (fs.statSync(path.join(pOptions.baseDir, pThis)).isDirectory()) {
                 return pAll.concat(gatherScannableFilesFromDir(pThis, pOptions));
             } else {
                 return pAll.concat(pThis);
@@ -30,3 +38,4 @@ module.exports = (pFileDirArray, pOptions) =>
         },
         []
     );
+};

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -155,6 +155,14 @@ function addCircularityCheckToGraph (pDependencies) {
 module.exports = (pFileDirArray, pOptions, pCallback) => {
     const lCallback = pCallback ? pCallback : (pInput => pInput);
 
+    pOptions = _.defaults(
+        pOptions,
+        {
+            baseDir: process.cwd(),
+            moduleSystems: ["cjs", "es6", "amd"]
+        }
+    );
+
     let lDependencies = _(
         extractFileDirArray(pFileDirArray, pOptions).reduce(complete, [])
     ).uniqBy(pDependency => pDependency.source)

--- a/src/extract/jsonschema.json
+++ b/src/extract/jsonschema.json
@@ -184,6 +184,7 @@
                 "npm-dev",
                 "npm-optional",
                 "npm-peer",
+                "npm-bundled",
                 "npm-no-pkg",
                 "npm-unknown",
                 "core",

--- a/src/extract/resolve/determineDependencyTypes.js
+++ b/src/extract/resolve/determineDependencyTypes.js
@@ -36,6 +36,19 @@ function dependencyIsDeprecated (pModule, pBaseDir) {
     return lRetval;
 }
 
+function dependencyIsBundled(pModule, pPackageDeps) {
+    let lRetval = false;
+
+    if (Boolean(pPackageDeps)){
+        const lBundledDependencies = pPackageDeps.bundledDependencies || pPackageDeps.bundleDependencies;
+
+        if (lBundledDependencies) {
+            lRetval = lBundledDependencies.some(pDep => pDep === pModule);
+        }
+    }
+    return lRetval;
+}
+
 module.exports = (pDependency, pModuleName, pPackageDeps, pBaseDir) => {
     let lRetval = ["undetermined"];
 
@@ -66,7 +79,9 @@ module.exports = (pDependency, pModuleName, pPackageDeps, pBaseDir) => {
         if (dependencyIsDeprecated(pModuleName, pBaseDir)) {
             lRetval.push("deprecated");
         }
-
+        if (dependencyIsBundled(pModuleName, pPackageDeps)) {
+            lRetval.push("npm-bundled");
+        }
     }
 
     return lRetval;

--- a/src/validate/jsonschema.json
+++ b/src/validate/jsonschema.json
@@ -123,6 +123,7 @@
                 "npm-dev",
                 "npm-optional",
                 "npm-peer",
+                "npm-bundled",
                 "npm-no-pkg",
                 "npm-unknown",
                 "core",

--- a/test/extract/extract-composite.spec.js
+++ b/test/extract/extract-composite.spec.js
@@ -5,6 +5,7 @@ const expect                  = chai.expect;
 const extract                 = require('../../src/extract');
 const cjsRecursiveFixtures    = require('./fixtures/cjs-recursive.json');
 const deprecationFixtures     = require('./fixtures/deprecated-node-module.json');
+const bundledFixtures         = require('./fixtures/bundled-dependencies.json');
 const amdRecursiveFixtures    = require('./fixtures/amd-recursive.json');
 const tsRecursiveFixtures     = require('./fixtures/ts-recursive.json');
 const coffeeRecursiveFixtures = require('./fixtures/coffee-recursive.json');
@@ -29,6 +30,7 @@ function runRecursiveFixture(pFixture) {
 
 describe('CommonJS recursive - ', () => cjsRecursiveFixtures.forEach(runRecursiveFixture));
 describe('Deprecation - ', () => deprecationFixtures.forEach(runRecursiveFixture));
+describe('Bundled - ', () => bundledFixtures.forEach(runRecursiveFixture));
 describe('AMD recursive - ', () => amdRecursiveFixtures.forEach(runRecursiveFixture));
 describe('TypeScript recursive - ', () => tsRecursiveFixtures.forEach(runRecursiveFixture));
 describe('CoffeeScript recursive - ', () => coffeeRecursiveFixtures.forEach(runRecursiveFixture));

--- a/test/extract/extract.spec.js
+++ b/test/extract/extract.spec.js
@@ -86,10 +86,11 @@ describe('Error scenarios - ', () => {
         ).to.not.throw("Extracting dependencies ran afoul of... Unexpected token (1:3)");
     });
     it('Raises an exception on non-existing files', () => {
+        // extract("non-existing-file.js")
         expect(
             () => extract("non-existing-file.js")
         ).to.throw(
-            "Extracting dependencies ran afoul of...\n\n  ENOENT: no such file or directory, open 'non-existing-file.js'\n"
+            "Extracting dependencies ran afoul of...\n\n  ENOENT: no such file or directory, open "
         );
     });
 });

--- a/test/extract/fixtures/bundled-dependencies.json
+++ b/test/extract/fixtures/bundled-dependencies.json
@@ -1,0 +1,52 @@
+[
+    {
+        "title": "can detect bundled dependencies",
+        "input": {
+            "fileName": "index.js",
+            "options": {
+                "moduleSystems": ["cjs"],
+                "baseDir": "test/extract/fixtures/bundled-dependencies"
+            }
+        },
+        "expected": [
+            {
+                "source": "index.js",
+                "dependencies": [
+                    {
+                        "resolved": "node_modules/idontgetbundled/index.js",
+                        "coreModule": false,
+                        "followable": true,
+                        "couldNotResolve": false,
+                        "dependencyTypes": [
+                            "npm"
+                        ],
+                        "module": "idontgetbundled",
+                        "moduleSystem": "cjs",
+                        "valid": true
+                    },
+                    {
+                        "resolved": "node_modules/igetbundled/index.js",
+                        "coreModule": false,
+                        "followable": true,
+                        "couldNotResolve": false,
+                        "dependencyTypes": [
+                            "npm",
+                            "npm-bundled"
+                        ],
+                        "module": "igetbundled",
+                        "moduleSystem": "cjs",
+                        "valid": true
+                    }
+                ]
+            },
+            {
+                "source": "node_modules/idontgetbundled/index.js",
+                "dependencies": []
+            },
+            {
+                "source": "node_modules/igetbundled/index.js",
+                "dependencies": []
+            }
+        ]
+    }
+]

--- a/test/extract/fixtures/bundled-dependencies/index.js
+++ b/test/extract/fixtures/bundled-dependencies/index.js
@@ -1,0 +1,4 @@
+const bundled = require('igetbundled');
+const notbundled = require('idontgetbundled');
+
+console.log(`${bundled}}/ ${notbundled}`);

--- a/test/extract/fixtures/bundled-dependencies/node_modules/idontgetbundled/index.js
+++ b/test/extract/fixtures/bundled-dependencies/node_modules/idontgetbundled/index.js
@@ -1,0 +1,1 @@
+module.exports = "I don't get bundled ;-(";

--- a/test/extract/fixtures/bundled-dependencies/node_modules/idontgetbundled/package.json
+++ b/test/extract/fixtures/bundled-dependencies/node_modules/idontgetbundled/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "idontgetbundled",
+  "version": "1.0.0",
+  "description": "Testing bundled dependencies. Yo",
+  "repository": "git://localhost",
+  "main": "index.js",
+  "keywords": [],
+  "author": "Bas Gitaar",
+  "license": "MIT"
+}

--- a/test/extract/fixtures/bundled-dependencies/node_modules/igetbundled/index.js
+++ b/test/extract/fixtures/bundled-dependencies/node_modules/igetbundled/index.js
@@ -1,0 +1,1 @@
+module.exports = "I' get bundled :-P";

--- a/test/extract/fixtures/bundled-dependencies/node_modules/igetbundled/package.json
+++ b/test/extract/fixtures/bundled-dependencies/node_modules/igetbundled/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bundled",
+  "version": "1.0.0",
+  "description": "Testing bundled dependencies. Yo",
+  "repository": "git://localhost",
+  "main": "index.js",
+  "author": "Bas Gitaar",
+  "license": "MIT"
+}

--- a/test/extract/fixtures/bundled-dependencies/package.json
+++ b/test/extract/fixtures/bundled-dependencies/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bundled",
+  "version": "1.0.0",
+  "description": "Testing bundled dependencies. Yo",
+  "repository": "git://localhost",
+  "main": "index.js",
+  "dependencies": {
+    "igetbundled": "1.0.0",
+    "idontgetbundled": "1.0.0"
+  },
+  "bundledDependencies": [
+    "igetbundled"
+  ],
+  "keywords": [],
+  "author": "Bas Gitaar",
+  "license": "MIT"
+}


### PR DESCRIPTION
### 🐣 adds support for recognizing 'bundled dependencies'
  - see https://docs.npmjs.com/files/package.json#bundleddependencies
  - introduces a new 'npm-bundled' dependency type, that can come on top of other dependency types.
  - the dependency type can be present in the output format and can be used in the rule spec

### 🐛  improves handling of relative paths 
  - prerequisite for properly testing bundled dependencies
  - extract has a pOptions.baseDir parameter that allows callers to specify a base dir.
  - this base dir was respected in some places, not in others - resulting in errors
  - we haven't bumped into this in production because
    - the cli doesn't expose it yet
    - no consumer yet uses the feature

  - So why fix it now?
    - It's convenient when testing - testing bundled dependencies would be hard without it (would e.g. require to have dependency-cruiser's own package.json include a bundled dependency)