### PR TITLE
Add support for tsx

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,9 +33,9 @@
       }
     },
     "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -44,9 +44,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
       "dev": true
     },
     "align-text": {
@@ -722,9 +722,9 @@
       "dev": true
     },
     "debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -890,17 +890,17 @@
       }
     },
     "eslint": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.1.tgz",
-      "integrity": "sha1-hJgEE2lT6+NmeC+fhhHiy9G1RoE=",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
+      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.2.3",
         "babel-code-frame": "6.26.0",
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "3.0.1",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
         "espree": "3.5.1",
@@ -930,7 +930,7 @@
         "semver": "5.4.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
+        "table": "4.0.2",
         "text-table": "0.2.0"
       }
     },
@@ -1063,7 +1063,7 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -1084,9 +1084,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -4382,184 +4382,60 @@
       }
     },
     "nsp": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.8.0.tgz",
-      "integrity": "sha512-Xd2O4BpocQZJJF0DCK5rhOPEPyo9L7A/UlVmT9/Hof14cVgizgDF3y6MSDwJQHD+5eNXN46hdlG528Lrao83Sw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.8.1.tgz",
+      "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "cli-table": "0.3.1",
-        "cvss": "1.0.1",
+        "cvss": "1.0.2",
         "https-proxy-agent": "1.0.0",
         "joi": "6.10.1",
         "nodesecurity-npm-utils": "5.0.0",
-        "path-is-absolute": "1.0.0",
-        "rc": "1.1.6",
-        "semver": "5.1.0",
-        "subcommand": "2.0.3",
+        "path-is-absolute": "1.0.1",
+        "rc": "1.2.1",
+        "semver": "5.4.1",
+        "subcommand": "2.1.0",
         "wreck": "6.3.0"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "optional": true
-        },
-        "acorn": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-          "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
           "requires": {
-            "acorn": "3.3.0"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           },
           "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+            "semver": {
+              "version": "5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+              "dev": true
             }
           }
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-        },
-        "align-text": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-        },
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
-        "argparse": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "requires": {
-            "array-uniq": "1.0.3"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-        },
-        "assertion-error": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "bossy": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.3.tgz",
-          "integrity": "sha1-p9JHiuDC33X0cJi5ute9ZB7tX68=",
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "caller-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-          "requires": {
-            "callsites": "0.2.0"
-          }
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
-          }
-        },
-        "chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-          "requires": {
-            "assertion-error": "1.0.2",
-            "deep-eql": "0.1.3",
-            "type-detect": "1.0.0"
           }
         },
         "chalk": {
@@ -4572,572 +4448,68 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "requires": {
-                "ansi-regex": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "requires": {
-                "ansi-regex": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
-          }
-        },
-        "circular-json": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
           }
         },
         "cli-table": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
           "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-          "dev": true,
           "requires": {
             "colors": "1.0.3"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-              "dev": true
-            }
           }
         },
-        "cli-width": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-              "optional": true
-            }
-          }
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-        },
-        "code": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/code/-/code-1.5.0.tgz",
-          "integrity": "sha1-1hWfvQ7p+ERRZ4CdQ7XNm8QFEDo=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "cvss": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.1.tgz",
-          "integrity": "sha1-XAffU2FqxW1m6PR0vtJePBRhk9s=",
+        "cliclopts": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
           "dev": true
         },
-        "d": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "requires": {
-            "es5-ext": "0.10.30"
-          }
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "cvss": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz",
+          "integrity": "sha1-32fpK/EqeW9J6Sh5nI2zunS5/NY=",
+          "dev": true
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "optional": true
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-            }
-          }
-        },
-        "deep-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-        },
-        "del": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "diff": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
-        },
-        "es5-ext": {
-          "version": "0.10.30",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-          "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
-          "requires": {
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "es6-iterator": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "es6-map": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-          "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-set": "0.1.5",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
-          }
-        },
-        "es6-set": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-          "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
-          }
-        },
-        "es6-symbol": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30"
-          }
-        },
-        "es6-weak-map": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-          "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1"
-          }
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
-        "escope": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-          "requires": {
-            "es6-map": "0.1.5",
-            "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.0",
-            "estraverse": "4.2.0"
-          }
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true
         },
-        "eslint": {
-          "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
-          "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
-          "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.8",
-            "doctrine": "1.5.0",
-            "es6-map": "0.1.5",
-            "escope": "3.6.0",
-            "espree": "3.5.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.5",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.16.1",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.9.1",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "optionator": "0.8.2",
-            "path-is-absolute": "1.0.0",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.6.1",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
-          }
-        },
-        "eslint-config-hapi": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-3.0.2.tgz",
-          "integrity": "sha1-Wk+tJQeELM0phRtjrwWitbFnw2c="
-        },
-        "eslint-config-nodesecurity": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/eslint-config-nodesecurity/-/eslint-config-nodesecurity-1.3.1.tgz",
-          "integrity": "sha1-8IAQ/DDJZPrdG0Yi5mO8Dx8P7Uk=",
-          "requires": {
-            "eslint-plugin-hapi": "4.0.0"
-          },
-          "dependencies": {
-            "eslint-plugin-hapi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
-              "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
-              "requires": {
-                "hapi-capitalize-modules": "1.1.6",
-                "hapi-for-you": "1.0.0",
-                "hapi-scope-start": "2.1.1",
-                "no-arrowception": "1.0.0"
-              }
-            }
-          }
-        },
-        "eslint-plugin-hapi": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-1.2.2.tgz",
-          "integrity": "sha1-QcwGNDhxibEcAGdWM6cVZGq4lJA=",
-          "requires": {
-            "hapi-capitalize-modules": "1.1.6",
-            "hapi-scope-start": "1.1.4",
-            "no-shadow-relaxed": "1.0.1"
-          },
-          "dependencies": {
-            "hapi-scope-start": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-1.1.4.tgz",
-              "integrity": "sha1-VxC1r7dOdJYdrn6wmdjYvkp1sA4="
-            }
-          }
-        },
-        "espree": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-          "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
-          "requires": {
-            "acorn": "5.1.1",
-            "acorn-jsx": "3.0.1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-        },
-        "esrecurse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-          "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-          "requires": {
-            "estraverse": "4.2.0",
-            "object-assign": "4.1.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-        },
-        "estraverse-fb": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
-          "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q="
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-          "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30"
-          }
-        },
-        "exit": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-          "optional": true
-        },
-        "exit-hook": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "file-entry-cache": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
-          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-          "requires": {
-            "flat-cache": "1.2.2",
-            "object-assign": "4.1.1"
-          }
-        },
-        "flat-cache": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-          "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-          "requires": {
-            "circular-json": "0.3.3",
-            "del": "2.2.2",
-            "graceful-fs": "4.1.11",
-            "write": "0.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "generate-function": {
+        "has-ansi": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
           "requires": {
-            "is-property": "1.0.2"
+            "ansi-regex": "2.1.1"
           }
-        },
-        "get-stdin": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-          "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4="
-        },
-        "git-validate": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/git-validate/-/git-validate-2.2.2.tgz",
-          "integrity": "sha1-nMj/ABF3lXoRcmq1CNQVu4Cxi88="
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "handlebars": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          }
-        },
-        "hapi-capitalize-modules": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
-          "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg="
-        },
-        "hapi-for-you": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
-          "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans="
-        },
-        "hapi-scope-start": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
-          "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI="
         },
         "hoek": {
           "version": "2.16.3",
@@ -5148,1342 +4520,80 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-          "dev": true,
           "requires": {
-            "agent-base": "2.0.1",
-            "debug": "2.2.0",
-            "extend": "3.0.0"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-              "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
-              "dev": true,
-              "requires": {
-                "extend": "3.0.0",
-                "semver": "5.0.3"
-              },
-              "dependencies": {
-                "semver": {
-                  "version": "5.0.3",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                  "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-                  "dev": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                  "dev": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-              "dev": true
-            }
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
-        "ignore": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-          "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true
         },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.4",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-          "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-          "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-          "requires": {
-            "is-path-inside": "1.0.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-          "requires": {
-            "path-is-inside": "1.0.2"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-          "requires": {
-            "tryit": "1.0.3"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "items": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/items/-/items-1.1.1.tgz",
-          "integrity": "sha1-Q1td0hvKKLPP0lu1xrJ4txUBD9k="
+        "isemail": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
+          "dev": true
         },
         "joi": {
           "version": "6.10.1",
           "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
           "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "dev": true,
           "requires": {
             "hoek": "2.16.3",
             "isemail": "1.2.0",
-            "moment": "2.12.0",
+            "moment": "2.18.1",
             "topo": "1.1.0"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            },
-            "isemail": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-              "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-              "dev": true
-            },
-            "moment": {
-              "version": "2.12.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-              "integrity": "sha1-3CVg0Zg41sBzGxpq+gRnUmTTYNY=",
-              "dev": true
-            },
-            "topo": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-              "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-          "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
-        "jslint": {
-          "version": "0.9.8",
-          "resolved": "https://registry.npmjs.org/jslint/-/jslint-0.9.8.tgz",
-          "integrity": "sha1-uSyoXKhtaoKXchCO6RnshJ3EsSk=",
-          "optional": true,
-          "requires": {
-            "exit": "0.1.2",
-            "glob": "4.5.3",
-            "nopt": "3.0.6",
-            "readable-stream": "1.0.34"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-              "optional": true,
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "optional": true
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "optional": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "optional": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "optional": true
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        },
-        "lab": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/lab/-/lab-6.2.0.tgz",
-          "integrity": "sha1-RonomYv3V1YH0nNpgmjRXMWe3Qg=",
-          "requires": {
-            "bossy": "1.0.3",
-            "diff": "2.2.3",
-            "eslint": "1.5.1",
-            "eslint-config-hapi": "3.0.2",
-            "eslint-plugin-hapi": "1.2.2",
-            "espree": "2.2.5",
-            "handlebars": "4.0.10",
-            "hoek": "2.16.3",
-            "items": "1.1.1",
-            "jslint": "0.9.8",
-            "json-stringify-safe": "5.0.1",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.3.3"
-          },
-          "dependencies": {
-            "cli-width": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-              "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
-            },
-            "doctrine": {
-              "version": "0.7.2",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-              "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
-              "requires": {
-                "esutils": "1.1.6",
-                "isarray": "0.0.1"
-              }
-            },
-            "eslint": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
-              "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
-              "requires": {
-                "chalk": "1.1.3",
-                "concat-stream": "1.6.0",
-                "debug": "2.6.8",
-                "doctrine": "0.7.2",
-                "escape-string-regexp": "1.0.5",
-                "escope": "3.6.0",
-                "espree": "2.2.5",
-                "estraverse": "4.2.0",
-                "estraverse-fb": "1.3.2",
-                "file-entry-cache": "1.3.1",
-                "glob": "5.0.15",
-                "globals": "8.18.0",
-                "handlebars": "4.0.10",
-                "inquirer": "0.9.0",
-                "is-my-json-valid": "2.16.1",
-                "is-resolvable": "1.0.0",
-                "js-yaml": "3.9.1",
-                "lodash.clonedeep": "3.0.2",
-                "lodash.merge": "3.3.2",
-                "lodash.omit": "3.1.0",
-                "minimatch": "2.0.10",
-                "mkdirp": "0.5.1",
-                "object-assign": "2.1.1",
-                "optionator": "0.5.0",
-                "path-is-absolute": "1.0.0",
-                "path-is-inside": "1.0.2",
-                "shelljs": "0.3.0",
-                "strip-json-comments": "1.0.4",
-                "text-table": "0.2.0",
-                "to-double-quotes": "1.0.2",
-                "to-single-quotes": "1.0.4",
-                "user-home": "1.1.1",
-                "xml-escape": "1.0.0"
-              }
-            },
-            "espree": {
-              "version": "2.2.5",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-              "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs="
-            },
-            "esutils": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
-            },
-            "fast-levenshtein": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-              "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk="
-            },
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
-              }
-            },
-            "globals": {
-              "version": "8.18.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-              "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ="
-            },
-            "inquirer": {
-              "version": "0.9.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
-              "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
-              "requires": {
-                "ansi-regex": "2.1.1",
-                "chalk": "1.1.3",
-                "cli-width": "1.1.1",
-                "figures": "1.7.0",
-                "lodash": "3.10.1",
-                "readline2": "0.1.1",
-                "run-async": "0.1.0",
-                "rx-lite": "2.5.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            },
-            "levn": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "mute-stream": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-              "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34="
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-            },
-            "optionator": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-              "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "1.0.7",
-                "levn": "0.2.5",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "0.0.3"
-              }
-            },
-            "readline2": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-              "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-              "requires": {
-                "mute-stream": "0.0.4",
-                "strip-ansi": "2.0.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
-                },
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-                  "requires": {
-                    "ansi-regex": "1.1.1"
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "2.5.2",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
-              "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ="
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-              "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-            },
-            "user-home": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-            }
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "optional": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "lodash._arraycopy": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-          "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
-        },
-        "lodash._arrayeach": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-          "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
-        },
-        "lodash._arraymap": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
-          "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY="
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-          "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
-          }
-        },
-        "lodash._baseclone": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-          "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-          "requires": {
-            "lodash._arraycopy": "3.0.0",
-            "lodash._arrayeach": "3.0.0",
-            "lodash._baseassign": "3.2.0",
-            "lodash._basefor": "3.0.3",
-            "lodash.isarray": "3.0.4",
-            "lodash.keys": "3.1.2"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-        },
-        "lodash._basedifference": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-          "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
-          "requires": {
-            "lodash._baseindexof": "3.1.0",
-            "lodash._cacheindexof": "3.0.2",
-            "lodash._createcache": "3.1.2"
-          }
-        },
-        "lodash._baseflatten": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-          "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
-          "requires": {
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "lodash._basefor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-          "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
-        },
-        "lodash._createassigner": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-          "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-          "requires": {
-            "lodash._bindcallback": "3.0.1",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash.restparam": "3.6.1"
-          }
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-          "requires": {
-            "lodash._getnative": "3.9.1"
-          }
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-        },
-        "lodash._pickbyarray": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
-          "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU="
-        },
-        "lodash._pickbycallback": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
-          "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
-          "requires": {
-            "lodash._basefor": "3.0.3",
-            "lodash.keysin": "3.0.8"
-          }
-        },
-        "lodash.clonedeep": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-          "requires": {
-            "lodash._baseclone": "3.3.0",
-            "lodash._bindcallback": "3.0.1"
-          }
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.isplainobject": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-          "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-          "requires": {
-            "lodash._basefor": "3.0.3",
-            "lodash.isarguments": "3.1.0",
-            "lodash.keysin": "3.0.8"
-          }
-        },
-        "lodash.istypedarray": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-          "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "lodash.keysin": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-          "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-          "requires": {
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "lodash.merge": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-          "requires": {
-            "lodash._arraycopy": "3.0.0",
-            "lodash._arrayeach": "3.0.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4",
-            "lodash.isplainobject": "3.2.0",
-            "lodash.istypedarray": "3.0.6",
-            "lodash.keys": "3.1.2",
-            "lodash.keysin": "3.0.8",
-            "lodash.toplainobject": "3.0.0"
-          }
-        },
-        "lodash.omit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
-          "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
-          "requires": {
-            "lodash._arraymap": "3.0.0",
-            "lodash._basedifference": "3.0.3",
-            "lodash._baseflatten": "3.1.4",
-            "lodash._bindcallback": "3.0.1",
-            "lodash._pickbyarray": "3.0.2",
-            "lodash._pickbycallback": "3.0.0",
-            "lodash.keysin": "3.0.8",
-            "lodash.restparam": "3.6.1"
-          }
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.toplainobject": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-          "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keysin": "3.0.8"
-          }
-        },
-        "longest": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
+        "moment": {
+          "version": "2.18.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
-        "mute-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-        },
-        "no-arrowception": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
-          "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno="
-        },
-        "no-shadow-relaxed": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/no-shadow-relaxed/-/no-shadow-relaxed-1.0.1.tgz",
-          "integrity": "sha1-z2zAFAL0IwuE/TvYoVZG3d8i7fI=",
-          "requires": {
-            "eslint": "0.24.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
-            },
-            "cli-width": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-              "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
-            },
-            "doctrine": {
-              "version": "0.6.4",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
-              "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
-              "requires": {
-                "esutils": "1.1.6",
-                "isarray": "0.0.1"
-              }
-            },
-            "eslint": {
-              "version": "0.24.1",
-              "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
-              "integrity": "sha1-VKUICYVbllVyHG8u5Xs1HtzigQE=",
-              "requires": {
-                "chalk": "1.1.3",
-                "concat-stream": "1.6.0",
-                "debug": "2.6.8",
-                "doctrine": "0.6.4",
-                "escape-string-regexp": "1.0.5",
-                "escope": "3.6.0",
-                "espree": "2.2.5",
-                "estraverse": "4.2.0",
-                "estraverse-fb": "1.3.2",
-                "globals": "8.18.0",
-                "inquirer": "0.8.5",
-                "is-my-json-valid": "2.16.1",
-                "js-yaml": "3.9.1",
-                "minimatch": "2.0.10",
-                "mkdirp": "0.5.1",
-                "object-assign": "2.1.1",
-                "optionator": "0.5.0",
-                "path-is-absolute": "1.0.0",
-                "strip-json-comments": "1.0.4",
-                "text-table": "0.2.0",
-                "user-home": "1.1.1",
-                "xml-escape": "1.0.0"
-              }
-            },
-            "espree": {
-              "version": "2.2.5",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-              "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs="
-            },
-            "esutils": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
-            },
-            "fast-levenshtein": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-              "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk="
-            },
-            "globals": {
-              "version": "8.18.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-              "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ="
-            },
-            "inquirer": {
-              "version": "0.8.5",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
-              "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
-              "requires": {
-                "ansi-regex": "1.1.1",
-                "chalk": "1.1.3",
-                "cli-width": "1.1.1",
-                "figures": "1.7.0",
-                "lodash": "3.10.1",
-                "readline2": "0.1.1",
-                "rx": "2.5.3",
-                "through": "2.3.8"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            },
-            "levn": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "mute-stream": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-              "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34="
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-            },
-            "optionator": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-              "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "1.0.7",
-                "levn": "0.2.5",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "0.0.3"
-              }
-            },
-            "readline2": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-              "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-              "requires": {
-                "mute-stream": "0.0.4",
-                "strip-ansi": "2.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-              "requires": {
-                "ansi-regex": "1.1.1"
-              }
-            },
-            "user-home": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-            }
-          }
-        },
-        "nock": {
-          "version": "7.7.3",
-          "resolved": "https://registry.npmjs.org/nock/-/nock-7.7.3.tgz",
-          "integrity": "sha1-0GAJgKREPt9uULXtMxRgLLfMxIk=",
-          "requires": {
-            "chai": "3.5.0",
-            "debug": "2.6.8",
-            "deep-equal": "1.0.1",
-            "json-stringify-safe": "5.0.1",
-            "lodash": "3.10.1",
-            "mkdirp": "0.5.1",
-            "propagate": "0.3.1",
-            "qs": "6.5.0"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-            }
-          }
-        },
         "nodesecurity-npm-utils": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz",
-          "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk=",
-          "dev": true
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-            }
-          }
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+          "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk="
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
-        },
-        "propagate": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
-          "integrity": "sha1-46hEBKfs6CDda76p9tkk4xNa4Jw="
-        },
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
-        },
-        "rc": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-          "dev": true,
-          "requires": {
-            "deep-extend": "0.4.1",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "1.0.4"
-          },
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-              "dev": true
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-              "dev": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "readline2": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-          "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "mute-stream": "0.0.5"
-          }
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-        },
-        "require-uncached": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-          "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
-          }
-        },
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "run-async": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "rx": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-          "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY="
-        },
-        "rx-lite": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
-        "shelljs": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-          "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
-        },
-        "shrinkydink": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/shrinkydink/-/shrinkydink-1.0.1.tgz",
-          "integrity": "sha1-3IbklqHndptP4GIYm89s18TxhIY=",
+        "rc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "dev": true,
           "requires": {
-            "minimist": "1.2.0"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "source-map-support": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
-          "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -6494,260 +4604,51 @@
           }
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         },
         "subcommand": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
-          "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz",
+          "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
           "dev": true,
           "requires": {
             "cliclopts": "1.1.1",
-            "debug": "2.2.0",
+            "debug": "2.6.9",
             "minimist": "1.2.0",
             "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "cliclopts": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-              "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
-              "dev": true
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                  "dev": true
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-              "dev": true
-            }
           }
         },
-        "table": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-          "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.4",
-            "slice-ansi": "0.0.4",
-            "string-width": "2.1.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-        },
-        "to-double-quotes": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
-          "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
-          "requires": {
-            "get-stdin": "3.0.2"
-          }
-        },
-        "to-single-quotes": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
-          "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
-          "requires": {
-            "get-stdin": "3.0.2"
-          }
-        },
-        "tryit": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-          "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "optional": true
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-          "optional": true
-        },
-        "user-home": {
+        "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "topo": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+          "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "hoek": "2.16.3"
           }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "wreck": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
           "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
-          "dev": true,
           "requires": {
             "boom": "2.10.1",
             "hoek": "2.16.3"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            }
           }
-        },
-        "write": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-          "requires": {
-            "mkdirp": "0.5.1"
-          }
-        },
-        "xml-escape": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
-          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI="
         },
         "xtend": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
         }
       }
     },
@@ -7324,10 +5225,13 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -7935,63 +5839,17 @@
       }
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.1.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "tempfile": {
@@ -8097,9 +5955,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
     "chai": "4.1.2",
     "chai-json-schema": "1.5.0",
     "coffee-script": "1.12.7",
-    "eslint": "4.7.1",
+    "eslint": "4.7.2",
     "eslint-plugin-security": "1.4.0",
     "intercept-stdout": "0.1.2",
     "istanbul": "0.4.5",
     "js-makedepend": "2.2.7",
     "mocha": "3.5.3",
     "npm-check-updates": "2.12.1",
-    "nsp": "2.8.0",
-    "typescript": "2.5.2"
+    "nsp": "2.8.1",
+    "typescript": "2.5.3"
   },
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/sverweij/dependency-cruiser",
   "dependencies": {
     "acorn": "5.1.2",
-    "ajv": "5.2.2",
+    "ajv": "5.2.3",
     "chalk": "2.1.0",
     "commander": "2.11.0",
     "figures": "2.0.0",

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -10,6 +10,7 @@ const supportedTranspilers = require("../../../package.json").supportedTranspile
 const extension2wrapper = {
     ".js"        : javaScriptWrap,
     ".ts"        : typeScriptWrap,
+    ".tsx"       : typeScriptWrap,
     ".d.ts"      : typeScriptWrap,
     ".ls"        : liveScriptWrap,
     ".coffee"    : coffeeWrap,

--- a/test/extract/transpile/meta.spec.js
+++ b/test/extract/transpile/meta.spec.js
@@ -9,7 +9,7 @@ describe("transpiler meta", () => {
     it("tells which extensions can be scanned", () => {
         expect(
             meta.scannableExtensions
-        ).to.deep.equal([".js", ".ts", ".d.ts", ".coffee", ".litcoffee", ".coffee.md"]);
+        ).to.deep.equal([".js", ".ts", ".tsx", ".d.ts", ".coffee", ".litcoffee", ".coffee.md"]);
     });
 
     it("returns the 'js' wrapper for unknown extensions", () => {

--- a/test/main/fixtures/tsx.json
+++ b/test/main/fixtures/tsx.json
@@ -1,0 +1,56 @@
+{
+    "dependencies": [
+        {
+            "source": "test/main/fixtures/tsx/index.ts",
+            "dependencies": [
+                {
+                    "resolved": "test/main/fixtures/tsx/sub/render.tsx",
+                    "coreModule": false,
+                    "followable": true,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "module": "./sub/render",
+                    "moduleSystem": "es6",
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "source": "test/main/fixtures/tsx/sub/render.tsx",
+            "dependencies": [
+                {
+                    "resolved": "react-dom",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "react-dom",
+                    "moduleSystem": "es6",
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "source": "react-dom",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        }
+    ],
+    "summary": {
+        "violations": [],
+        "error": 0,
+        "warn": 0,
+        "info": 0,
+        "totalCruised": 3,
+        "optionsUsed": {}
+    }
+}

--- a/test/main/fixtures/tsx/index.ts
+++ b/test/main/fixtures/tsx/index.ts
@@ -1,0 +1,5 @@
+import {render as appRender} from './sub/render';
+
+console.log(
+    appRender()
+);

--- a/test/main/fixtures/tsx/sub/render.tsx
+++ b/test/main/fixtures/tsx/sub/render.tsx
@@ -1,0 +1,10 @@
+import * as ReactDOM from 'react-dom';
+
+export async function render(container: Element | null) {
+    ReactDOM.render(
+        <Provider store={store}>
+            <Index />
+        </Provider>,
+        container,
+    );
+};

--- a/test/main/main.spec.js
+++ b/test/main/main.spec.js
@@ -1,9 +1,10 @@
 "use strict";
-const chai      = require('chai');
-const expect    = chai.expect;
-const main      = require("../../src/main");
-const tsFixture = require('./fixtures/ts.json');
-const depSchema = require('../../src/extract/jsonschema.json');
+const chai       = require('chai');
+const expect     = chai.expect;
+const main       = require("../../src/main");
+const tsFixture  = require('./fixtures/ts.json');
+const tsxFixture = require('./fixtures/tsx.json');
+const depSchema  = require('../../src/extract/jsonschema.json');
 
 chai.use(require('chai-json-schema'));
 
@@ -12,6 +13,12 @@ describe("main", () => {
         const lResult = main.cruise(["test/main/fixtures/ts"]);
 
         expect(lResult).to.deep.equal(tsFixture);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("Also processes tsx correctly", () => {
+        const lResult = main.cruise(["test/main/fixtures/tsx"]);
+
+        expect(lResult).to.deep.equal(tsxFixture);
         expect(lResult).to.be.jsonSchema(depSchema);
     });
 });


### PR DESCRIPTION
## Description
Adds support for .tsx

## Motivation and Context
- dependency-cruiser currently doesn't supports .tsx (as signaled in #10 by @kyo-ago => thanks!)
- it should (high value)
- it's easy to add (low effort)

low effort * high value = high priority

## How Has This Been Tested?
Yep - added unit tests

## Types of changes
- tsc already supports tsx out of the box, so adding the .tsx extension to `meta.js` solves the issue
- the rest of the commits are
  - tests to prove this stuff works as intended
  - version upgrades of some of the dependencies that weren't on _latest_ yet (<= should've been done on develop first and merged on here later but 🤷‍♂️ )

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] ~~~My change requires a change to the documentation.~~~
- [x] ~~~I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.