### PR TITLE
WIP: add support for jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "author": "Sander Verweij",
   "license": "MIT",
   "devDependencies": {
+    "babel-core": "6.26.0",
+    "babel-preset-react": "6.24.1",
     "chai": "4.1.2",
     "chai-json-schema": "1.5.0",
     "coffee-script": "1.12.7",
@@ -75,6 +77,8 @@
   "supportedTranspilers": {
     "coffee-script": ">=1.0.0 <2.0.0",
     "livescript": ">=1.0.0 <2.0.0",
-    "typescript": ">=2.0.0 <3.0.0"
+    "typescript": ">=2.0.0 <3.0.0",
+    "babel-core": ">=6.0.0 <8.0.0",
+    "babel-preset-react": ">=6.0.0 <8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "6.26.0",
-    "babel-preset-react": "6.24.1",
+    "babel-plugin-transform-react-jsx": "6.24.1",
     "chai": "4.1.2",
     "chai-json-schema": "1.5.0",
     "coffee-script": "1.12.7",
@@ -79,6 +79,6 @@
     "livescript": ">=1.0.0 <2.0.0",
     "typescript": ">=2.0.0 <3.0.0",
     "babel-core": ">=6.0.0 <8.0.0",
-    "babel-preset-react": ">=6.0.0 <8.0.0"
+    "babel-plugin-transform-react-jsx": ">=6.0.0 <8.0.0"
   }
 }

--- a/src/extract/transpile/jsxWrap.js
+++ b/src/extract/transpile/jsxWrap.js
@@ -5,8 +5,8 @@ const babel = tryRequire(
     require("../../../package.json").supportedTranspilers['babel-core']
 );
 const presetReact = tryRequire(
-    "babel-preset-react",
-    require("../../../package.json").supportedTranspilers['babel-preset-react']
+    "babel-plugin-transform-react-jsx",
+    require("../../../package.json").supportedTranspilers['babel-plugin-transform-react-jsx']
 );
 
 exports.isAvailable = () => (Boolean(babel) && Boolean(presetReact)) !== false;
@@ -15,8 +15,8 @@ exports.transpile = pFile =>
     babel.transform(
         pFile,
         {
-            presets: [
-                "react"
+            plugins: [
+                "transform-react-jsx"
             ]
         }
     ).code;

--- a/src/extract/transpile/jsxWrap.js
+++ b/src/extract/transpile/jsxWrap.js
@@ -1,0 +1,22 @@
+"use strict";
+const tryRequire = require("./tryRequire");
+const babel = tryRequire(
+    "babel-core",
+    require("../../../package.json").supportedTranspilers['babel-core']
+);
+const presetReact = tryRequire(
+    "babel-preset-react",
+    require("../../../package.json").supportedTranspilers['babel-preset-react']
+);
+
+exports.isAvailable = () => (Boolean(babel) && Boolean(presetReact)) !== false;
+
+exports.transpile = pFile =>
+    babel.transform(
+        pFile,
+        {
+            presets: [
+                "react"
+            ]
+        }
+    ).code;

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -23,7 +23,7 @@ const extension2wrapper = {
 const transpiler2wrapper = {
     "javascript"         : javaScriptWrap,
     "babel-core"         : jsxWrap,
-    "babel-preset-react" : jsxWrap,
+    "babel-plugin-transform-react-jsx" : jsxWrap,
     "coffee-script"      : coffeeWrap,
     "livescript"         : liveScriptWrap,
     "typescript"         : typeScriptWrap

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const javaScriptWrap       = require("./javaScriptWrap");
+const jsxWrap              = require("./jsxWrap");
 const typeScriptWrap       = require("./typeScriptWrap");
 const liveScriptWrap       = require("./liveScriptWrap");
 const coffeeWrap           = require("./coffeeWrap")();
@@ -9,6 +10,7 @@ const supportedTranspilers = require("../../../package.json").supportedTranspile
 
 const extension2wrapper = {
     ".js"        : javaScriptWrap,
+    ".jsx"       : jsxWrap,
     ".ts"        : typeScriptWrap,
     ".tsx"       : typeScriptWrap,
     ".d.ts"      : typeScriptWrap,
@@ -19,10 +21,12 @@ const extension2wrapper = {
 };
 
 const transpiler2wrapper = {
-    "javascript"    : javaScriptWrap,
-    "coffee-script" : coffeeWrap,
-    "livescript"    : liveScriptWrap,
-    "typescript"    : typeScriptWrap
+    "javascript"         : javaScriptWrap,
+    "babel-core"         : jsxWrap,
+    "babel-preset-react" : jsxWrap,
+    "coffee-script"      : coffeeWrap,
+    "livescript"         : liveScriptWrap,
+    "typescript"         : typeScriptWrap
 };
 
 /**

--- a/test/extract/transpile/fixtures/jsx.js
+++ b/test/extract/transpile/fixtures/jsx.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const MyComponents = {
+  DatePicker: function DatePicker(props) {
+    return React.createElement(
+      "div",
+      null,
+      "Imagine a ",
+      props.color,
+      " datepicker here."
+    );
+  }
+};
+
+function BlueDatePicker() {
+  return React.createElement(MyComponents.DatePicker, { color: "blue" });
+}

--- a/test/extract/transpile/fixtures/jsx.jsx
+++ b/test/extract/transpile/fixtures/jsx.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const MyComponents = {
+  DatePicker: function DatePicker(props) {
+    return <div>Imagine a {props.color} datepicker here.</div>;
+  }
+}
+
+function BlueDatePicker() {
+  return <MyComponents.DatePicker color="blue" />;
+}

--- a/test/extract/transpile/jsxWrap.spec.js
+++ b/test/extract/transpile/jsxWrap.spec.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const expect = require("chai").expect;
+const fs     = require('fs');
+const wrap   = require("../../../src/extract/transpile/jsxWrap");
+
+describe("jsx transpiler (babel with babel-preset-react)", () => {
+    it("tells the jsx transpiler is available", () => {
+        expect(
+            wrap.isAvailable()
+        ).to.equal(true);
+    });
+
+    it("transpiles jsx", () => {
+        expect(
+            wrap.transpile(
+                fs.readFileSync("./test/extract/transpile/fixtures/jsx.jsx", 'utf8')
+            )
+        ).to.equal(
+            fs.readFileSync("./test/extract/transpile/fixtures/jsx.js", 'utf8')
+        );
+    });
+});

--- a/test/extract/transpile/meta.spec.js
+++ b/test/extract/transpile/meta.spec.js
@@ -44,7 +44,7 @@ describe("transpiler meta", () => {
             "version": ">=6.0.0 <8.0.0",
             "available": true
         }, {
-            "name": "babel-preset-react",
+            "name": "babel-plugin-transform-react-jsx",
             "version": ">=6.0.0 <8.0.0",
             "available": true
         }]);

--- a/test/extract/transpile/meta.spec.js
+++ b/test/extract/transpile/meta.spec.js
@@ -9,7 +9,7 @@ describe("transpiler meta", () => {
     it("tells which extensions can be scanned", () => {
         expect(
             meta.scannableExtensions
-        ).to.deep.equal([".js", ".ts", ".tsx", ".d.ts", ".coffee", ".litcoffee", ".coffee.md"]);
+        ).to.deep.equal([".js", ".jsx", ".ts", ".tsx", ".d.ts", ".coffee", ".litcoffee", ".coffee.md"]);
     });
 
     it("returns the 'js' wrapper for unknown extensions", () => {
@@ -38,6 +38,14 @@ describe("transpiler meta", () => {
         }, {
             "name": "typescript",
             "version": ">=2.0.0 <3.0.0",
+            "available": true
+        }, {
+            "name": "babel-core",
+            "version": ">=6.0.0 <8.0.0",
+            "available": true
+        }, {
+            "name": "babel-preset-react",
+            "version": ">=6.0.0 <8.0.0",
             "available": true
         }]);
     });

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -1,0 +1,56 @@
+{
+    "dependencies": [
+        {
+            "source": "test/main/fixtures/jsx/index.js",
+            "dependencies": [
+                {
+                    "resolved": "test/main/fixtures/jsx/sub/render.jsx",
+                    "coreModule": false,
+                    "followable": true,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "module": "./sub/render",
+                    "moduleSystem": "es6",
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "source": "test/main/fixtures/jsx/sub/render.jsx",
+            "dependencies": [
+                {
+                    "resolved": "react-dom",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "react-dom",
+                    "moduleSystem": "es6",
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "source": "react-dom",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        }
+    ],
+    "summary": {
+        "violations": [],
+        "error": 0,
+        "warn": 0,
+        "info": 0,
+        "totalCruised": 3,
+        "optionsUsed": {}
+    }
+}

--- a/test/main/fixtures/jsx/index.js
+++ b/test/main/fixtures/jsx/index.js
@@ -1,0 +1,5 @@
+import {render as appRender} from './sub/render';
+
+console.log(
+    appRender()
+);

--- a/test/main/fixtures/jsx/sub/render.jsx
+++ b/test/main/fixtures/jsx/sub/render.jsx
@@ -1,0 +1,10 @@
+import ReactDOM from 'react-dom';
+
+export function render(container) {
+    ReactDOM.render(
+        <Provider store={store}>
+            <Index />
+        </Provider>,
+        container
+    );
+};

--- a/test/main/main.spec.js
+++ b/test/main/main.spec.js
@@ -4,6 +4,7 @@ const expect     = chai.expect;
 const main       = require("../../src/main");
 const tsFixture  = require('./fixtures/ts.json');
 const tsxFixture = require('./fixtures/tsx.json');
+const jsxFixture = require('./fixtures/jsx.json');
 const depSchema  = require('../../src/extract/jsonschema.json');
 
 chai.use(require('chai-json-schema'));
@@ -15,7 +16,13 @@ describe("main", () => {
         expect(lResult).to.deep.equal(tsFixture);
         expect(lResult).to.be.jsonSchema(depSchema);
     });
-    it("Also processes tsx correctly", () => {
+    it("Processes jsx correctly", () => {
+        const lResult = main.cruise(["test/main/fixtures/jsx"]);
+
+        expect(lResult).to.deep.equal(jsxFixture);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("Processes tsx correctly", () => {
         const lResult = main.cruise(["test/main/fixtures/tsx"]);
 
         expect(lResult).to.deep.equal(tsxFixture);


### PR DESCRIPTION
## Description
- adds support for .jsx
- uses acorn_loose for parsing. This might seem a strange choice - see _alternatives_ for reasons

## Implementation rationale
### Alternative: babel (not chosen - possibility for later)
- For this I introduced jsx as a new alt-js language - with babel-core as the transpiler. 
- babel-core needs plugins to be able to do anything. For react there is:
  - `babel-plugin-transform-react-jsx` - this should suffice for purely jsx additions to no-frills javascript (sorta es3). Most react projects uses fancier javascript (es6 or better, with classes, proper module support etc), so without the plugins supporting those the transpilation would fail.
  - `babel-preset-react` - this is a collection of plugins. It contains transform-react-jsx, and some nice stuff for typical react projects (a.o. es6+ support). 
- The philosophy of dependency-cruiser is to use the already available transpiler. While babel-core is likely to be part of the project, neither `babel-preset-react` nor `babel-plugin-transform-react-jsx` are guaranteed to be available _or even used_:
  - react-native projects typically use a different set of plugins
  - projects have complete liberty to use whatever plugins they want and there's no fixed set that's going to work for all projects.
- Alternatively I could _damn the philosophy_ and package a superset of babel plugins with dependency-cruiser. But even that won't cover all cases - and the cost (in download size) is not small- (7.2Mb for the core-js library, 1.1Mb for babel-core and a few bits and bobs for plugins & other deps). 

**=> not a viable option for the short term**

More react research:
- `babel` and `babel-preset-react` seem to be the prevalent way to get from jsx to something digestible, but...
  - is it the only one (probably not)? 
    - nope: `https://github.com/facebookincubator/create-react-app` uses its own `babel-preset-react-app`. But this also installs `babel-preset-react` as a dependency => we're good on this one.
    - nope: https://www.npmjs.com/package/node-jsx Deprecated. points to babel => good on this one as well.
    - nope: react native uses `babel-preset-react-native`; https://github.com/facebook/react-native/tree/master/babel-preset is used => :heavy_multiplication_x:  
  - if not: is it worth while supporting other options?
    - react native seems useful
    - do the various options have a common denominator (e.g. `babel-plugin-jsx` - maybe another one?)
  - ✔️ resolved: `babel-plugin-transform-react-jsx` seems to be a reasonable common denominator. It just doesn't work on its own in most react project I've used it on.

### Alternative: acorn with acorn-jsx (not chosen)
- For this I introduced acorn-jsx in the extraction step. It's a relatively elegant solution; .js is correctly parsed without hitches, as is .jsx. In the latter case abstract syntax tree contains JSXxxx nodes. Also acorn-jsx is the 'official' jsx parser used by facebook. And babel. However ...
- ... for extracting dependencies from the syntax tree I use the tree-walker included in acorn. This - understandably - chokes on the new-fangled JSXxxx nodes acorn-jsx uses. There's some solutions available for this
  - use the `acorn-jsx-walk` package. It isn't updated for quite a long time, and doesn't seem to have a lot of traction (in downloads, stars or otherwise). It also uses quite a lot of dependencies (biggish) and the code base didn't seem as one I'd like to adopt.
  - filter/ transform the parsed tree so it doesn't contain JSXxxx nodes anymore - I'm not interested in those anyway. My estimation is that this will be non-trivial to do right.

**=> not a viable option for the short term**

### Alternative: acorn_loose
Observing
- ... in jsx dependencies typically (and sometimes from language/ listing rules) occur on the top.
- ... I'm not interested in jsx expressions - only imports, exports & requires and their ilk
- ... acorn_loose will in most sane cases pluck out the correct dependencies - especially when they occur at the top.
- ... acorn_loose is 
  - already part of acorn, and an existing dependency of dependency-cruiser
  - fast & stable
- ... implementing & testing this is a doddle ...

**=> acorn_loose it is for now** ; maybe later an elegant solution for one of the above (plugin? passing babelrc?)

## Motivation and Context
To make dependency-cruiser more useful environments that use React.

## How Has This Been Tested?
- [x] Unit tests
- [ ] Against some real live code bases (using https://github.com/enaqx/awesome-react#real-apps)

## Types of changes
- ~~~Bug fix (non-breaking change which fixes an issue)~~~
- [x] New feature (non-breaking change which adds functionality)
- ~~~Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~~My change requires a change to the documentation.~~~ (added transpilers are self documenting)
- ~~~I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.