### PR TITLE
Add jsx support

### DIFF
--- a/src/extract/transpile/jsxImplementationRationale.md
+++ b/src/extract/transpile/jsxImplementationRationale.md
@@ -1,0 +1,45 @@
+# JSX in dependency-cruiser: mplementation rationale
+I've tried three options to implement cruising jsx. I've chosen to go with acorn_loose (the third option) - here's the rationale, so those who want to make another implementation for it don't have to do the same digging.
+
+## Alternative: babel (not chosen - possibility for later)
+- For this I introduced jsx as a new alt-js language - with babel-core as the transpiler.
+- babel-core needs plugins to be able to do anything. For react there is:
+  - `babel-plugin-transform-react-jsx` - this should suffice for purely jsx additions to no-frills javascript (sorta es3). Most react projects uses fancier javascript (es6 or better, with classes, proper module support etc), so without the plugins supporting those the transpilation would fail.
+  - `babel-preset-react` - this is a collection of plugins. It contains transform-react-jsx, and some nice stuff for typical react projects (a.o. es6+ support).
+- The philosophy of dependency-cruiser is to use the already available transpiler. While babel-core is likely to be part of the project, neither `babel-preset-react` nor `babel-plugin-transform-react-jsx` are guaranteed to be available _or even used_:
+  - react-native projects typically use a different set of plugins
+  - projects have complete liberty to use whatever plugins they want and there's no fixed set that's going to work for all projects.
+- Alternatively I could _damn the philosophy_ and package a superset of babel plugins with dependency-cruiser. But even that won't cover all cases - and the cost (in download size) is not small- (7.2Mb for the core-js library, 1.1Mb for babel-core and a few bits and bobs for plugins & other deps).
+
+**=> not a viable option for the short term**
+
+More react research:
+- `babel` and `babel-preset-react` seem to be the prevalent way to get from jsx to something digestible, but...
+  - is it the only one (probably not)?
+    - nope: `https://github.com/facebookincubator/create-react-app` uses its own `babel-preset-react-app`. But this also installs `babel-preset-react` as a dependency => we're good on this one.
+    - nope: https://www.npmjs.com/package/node-jsx Deprecated. points to babel => good on this one as well.
+    - nope: react native uses `babel-preset-react-native`; https://github.com/facebook/react-native/tree/master/babel-preset is used => :heavy_multiplication_x:  
+  - if not: is it worth while supporting other options?
+    - react native seems useful
+    - do the various options have a common denominator (e.g. `babel-plugin-jsx` - maybe another one?)
+  - `babel-plugin-transform-react-jsx` seems to be a reasonable common denominator. It just doesn't work on its own in most react project I've used it on.
+
+## Alternative: acorn with acorn-jsx (not chosen)
+- For this I introduced acorn-jsx in the extraction step. It's a relatively elegant solution; .js is correctly parsed without hitches, as is .jsx. In the latter case abstract syntax tree contains JSXxxx nodes. Also acorn-jsx is the 'official' jsx parser used by facebook. And babel. However ...
+- ... for extracting dependencies from the syntax tree I use the tree-walker included in acorn. This - understandably - chokes on the new-fangled JSXxxx nodes acorn-jsx uses. There's some solutions available for this
+  - use the `acorn-jsx-walk` package. It isn't updated for quite a long time, and doesn't seem to have a lot of traction (in downloads, stars or otherwise). It also uses quite a lot of dependencies (biggish) and the code base didn't seem as one I'd like to adopt.
+  - filter/ transform the parsed tree so it doesn't contain JSXxxx nodes anymore - I'm not interested in those anyway. My estimation is that this will be non-trivial to do right.
+
+**=> not a viable option for the short term**
+
+## Alternative: acorn_loose
+Observing
+- ... in jsx dependencies typically (and sometimes from language/ listing rules) occur on the top.
+- ... I'm not interested in jsx expressions - only imports, exports & requires and their ilk
+- ... acorn_loose will in most sane cases pluck out the correct dependencies - especially when they occur at the top (and likely also when they occur below jsx statements)
+- ... acorn_loose is
+  - already part of acorn, and an existing dependency of dependency-cruiser
+  - fast & stable
+- ... implementing & testing this is a doddle ...
+
+**=> acorn_loose it is for now** ; maybe later an elegant solution for one of the above (plugin? passing babelrc?)

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -7,8 +7,17 @@ const coffeeWrap           = require("./coffeeWrap")();
 const litCoffeeWrap        = require("./coffeeWrap")(true);
 const supportedTranspilers = require("../../../package.json").supportedTranspilers;
 
+/*
+  jsx - acorn_loose will handle this correctly when imports
+        etc are on top, which is the most likely use case.
+        Alternatives (making a jsxWrap with babel-core & a bunch
+        of plugins or using acorn-jsx) might be more correct in
+        edge cases but are either much harder to implement or
+        likely to fail in basic use cases.
+ */
 const extension2wrapper = {
     ".js"        : javaScriptWrap,
+    ".jsx"       : javaScriptWrap,
     ".ts"        : typeScriptWrap,
     ".tsx"       : typeScriptWrap,
     ".d.ts"      : typeScriptWrap,

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -14,6 +14,9 @@ const supportedTranspilers = require("../../../package.json").supportedTranspile
         of plugins or using acorn-jsx) might be more correct in
         edge cases but are either much harder to implement or
         likely to fail in basic use cases.
+
+        See ./jsxImplementationRationale.md for an implementation
+        rationale on jsx ...
  */
 const extension2wrapper = {
     ".js"        : javaScriptWrap,

--- a/test/extract/transpile/fixtures/jsx.js
+++ b/test/extract/transpile/fixtures/jsx.js
@@ -1,0 +1,63 @@
+// 1:1 copied from https://github.com/mozilla/payments-ui
+import React, { Component, PropTypes } from 'react';
+
+import PayMethodChoice from 'components/pay-method-choice';
+import ProductDetail from 'components/product-detail';
+
+import * as products from 'products';
+import { gettext } from 'utils';
+import tracking from 'tracking';
+
+
+export default class ProductPayChooser extends Component {
+
+  static propTypes = {
+    payMethods: PropTypes.array.isRequired,
+    payWithNewCard: PropTypes.func.isRequired,
+    processPayment: PropTypes.func.isRequired,
+    productId: PropTypes.string.isRequired,
+    userDefinedAmount: PropTypes.string,
+  }
+
+  componentDidMount() {
+    tracking.setPage('/product-pay-chooser');
+  }
+
+  handleSubmit = (payMethodUri, processingId) => {
+    this.props.processPayment({productId: this.props.productId,
+                               userDefinedAmount: this.props.userDefinedAmount,
+                               payMethodUri: payMethodUri,
+                               processingId: processingId});
+  }
+
+  render() {
+    var product = products.get(this.props.productId);
+    var submitPrompt;
+    if (product.seller.kind === 'donations') {
+      submitPrompt = gettext('Donate now');
+    } else {
+      // TODO: also handle non-recurring, non-donations here.
+      submitPrompt = gettext('Subscribe');
+    }
+
+    return (
+      <div>
+        <ProductDetail
+          productId={this.props.productId}
+          userDefinedAmount={this.props.userDefinedAmount}
+        />
+        <PayMethodChoice
+          payMethods={this.props.payMethods}
+          productId={this.props.productId}
+          submitButtonText={submitPrompt}
+          submitHandler={this.handleSubmit}
+          useDropDown
+        />
+        <a className="add-card" href="#"
+          onClick={this.props.payWithNewCard}>
+          {gettext('Add new credit card')}
+        </a>
+      </div>
+    );
+  }
+}

--- a/test/extract/transpile/fixtures/jsx.jsx
+++ b/test/extract/transpile/fixtures/jsx.jsx
@@ -1,0 +1,63 @@
+// 1:1 copied from https://github.com/mozilla/payments-ui
+import React, { Component, PropTypes } from 'react';
+
+import PayMethodChoice from 'components/pay-method-choice';
+import ProductDetail from 'components/product-detail';
+
+import * as products from 'products';
+import { gettext } from 'utils';
+import tracking from 'tracking';
+
+
+export default class ProductPayChooser extends Component {
+
+  static propTypes = {
+    payMethods: PropTypes.array.isRequired,
+    payWithNewCard: PropTypes.func.isRequired,
+    processPayment: PropTypes.func.isRequired,
+    productId: PropTypes.string.isRequired,
+    userDefinedAmount: PropTypes.string,
+  }
+
+  componentDidMount() {
+    tracking.setPage('/product-pay-chooser');
+  }
+
+  handleSubmit = (payMethodUri, processingId) => {
+    this.props.processPayment({productId: this.props.productId,
+                               userDefinedAmount: this.props.userDefinedAmount,
+                               payMethodUri: payMethodUri,
+                               processingId: processingId});
+  }
+
+  render() {
+    var product = products.get(this.props.productId);
+    var submitPrompt;
+    if (product.seller.kind === 'donations') {
+      submitPrompt = gettext('Donate now');
+    } else {
+      // TODO: also handle non-recurring, non-donations here.
+      submitPrompt = gettext('Subscribe');
+    }
+
+    return (
+      <div>
+        <ProductDetail
+          productId={this.props.productId}
+          userDefinedAmount={this.props.userDefinedAmount}
+        />
+        <PayMethodChoice
+          payMethods={this.props.payMethods}
+          productId={this.props.productId}
+          submitButtonText={submitPrompt}
+          submitHandler={this.handleSubmit}
+          useDropDown
+        />
+        <a className="add-card" href="#"
+          onClick={this.props.payWithNewCard}>
+          {gettext('Add new credit card')}
+        </a>
+      </div>
+    );
+  }
+}

--- a/test/extract/transpile/jsxWrap.spec.js
+++ b/test/extract/transpile/jsxWrap.spec.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const expect = require("chai").expect;
+const fs     = require('fs');
+const wrap   = require("../../../src/extract/transpile/javaScriptWrap");
+
+describe("jsx transpiler (the plain old javascript one)", () => {
+    it("tells the jsx transpiler is available", () => {
+        expect(
+            wrap.isAvailable()
+        ).to.equal(true);
+    });
+
+    it("transpiles jsx", () => {
+        expect(
+            wrap.transpile(
+                fs.readFileSync("./test/extract/transpile/fixtures/jsx.jsx", 'utf8')
+            )
+        ).to.equal(
+            fs.readFileSync("./test/extract/transpile/fixtures/jsx.js", 'utf8')
+        );
+    });
+});

--- a/test/extract/transpile/meta.spec.js
+++ b/test/extract/transpile/meta.spec.js
@@ -9,7 +9,7 @@ describe("transpiler meta", () => {
     it("tells which extensions can be scanned", () => {
         expect(
             meta.scannableExtensions
-        ).to.deep.equal([".js", ".ts", ".tsx", ".d.ts", ".coffee", ".litcoffee", ".coffee.md"]);
+        ).to.deep.equal([".js", ".jsx", ".ts", ".tsx", ".d.ts", ".coffee", ".litcoffee", ".coffee.md"]);
     });
 
     it("returns the 'js' wrapper for unknown extensions", () => {

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -1,0 +1,166 @@
+{
+    "dependencies": [
+        {
+            "source": "test/main/fixtures/jsx/index.js",
+            "dependencies": [
+                {
+                    "resolved": "test/main/fixtures/jsx/jsx.jsx",
+                    "coreModule": false,
+                    "followable": true,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "module": "./jsx",
+                    "moduleSystem": "cjs",
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "source": "test/main/fixtures/jsx/jsx.jsx",
+            "dependencies": [
+                {
+                    "resolved": "components/pay-method-choice",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "components/pay-method-choice",
+                    "moduleSystem": "es6",
+                    "valid": true
+                },
+                {
+                    "resolved": "components/product-detail",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "components/product-detail",
+                    "moduleSystem": "es6",
+                    "valid": true
+                },
+                {
+                    "resolved": "products",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "products",
+                    "moduleSystem": "es6",
+                    "valid": true
+                },
+                {
+                    "resolved": "react",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "react",
+                    "moduleSystem": "es6",
+                    "valid": true
+                },
+                {
+                    "resolved": "tracking",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "tracking",
+                    "moduleSystem": "es6",
+                    "valid": true
+                },
+                {
+                    "resolved": "utils",
+                    "coreModule": false,
+                    "followable": false,
+                    "couldNotResolve": true,
+                    "dependencyTypes": [
+                        "unknown"
+                    ],
+                    "module": "utils",
+                    "moduleSystem": "es6",
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "source": "components/pay-method-choice",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        },
+        {
+            "source": "components/product-detail",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        },
+        {
+            "source": "products",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        },
+        {
+            "source": "react",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        },
+        {
+            "source": "tracking",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        },
+        {
+            "source": "utils",
+            "followable": false,
+            "coreModule": false,
+            "couldNotResolve": true,
+            "dependencyTypes": [
+                "unknown"
+            ],
+            "dependencies": []
+        }
+    ],
+    "summary": {
+        "violations": [],
+        "error": 0,
+        "warn": 0,
+        "info": 0,
+        "totalCruised": 8,
+        "optionsUsed": {}
+    }
+}

--- a/test/main/fixtures/jsx/index.js
+++ b/test/main/fixtures/jsx/index.js
@@ -1,0 +1,3 @@
+const jsx = require('./jsx');
+
+console.log(jsx);

--- a/test/main/fixtures/jsx/jsx.jsx
+++ b/test/main/fixtures/jsx/jsx.jsx
@@ -1,0 +1,63 @@
+// 1:1 copied from https://github.com/mozilla/payments-ui
+import React, { Component, PropTypes } from 'react';
+
+import PayMethodChoice from 'components/pay-method-choice';
+import ProductDetail from 'components/product-detail';
+
+import * as products from 'products';
+import { gettext } from 'utils';
+import tracking from 'tracking';
+
+
+export default class ProductPayChooser extends Component {
+
+  static propTypes = {
+    payMethods: PropTypes.array.isRequired,
+    payWithNewCard: PropTypes.func.isRequired,
+    processPayment: PropTypes.func.isRequired,
+    productId: PropTypes.string.isRequired,
+    userDefinedAmount: PropTypes.string,
+  }
+
+  componentDidMount() {
+    tracking.setPage('/product-pay-chooser');
+  }
+
+  handleSubmit = (payMethodUri, processingId) => {
+    this.props.processPayment({productId: this.props.productId,
+                               userDefinedAmount: this.props.userDefinedAmount,
+                               payMethodUri: payMethodUri,
+                               processingId: processingId});
+  }
+
+  render() {
+    var product = products.get(this.props.productId);
+    var submitPrompt;
+    if (product.seller.kind === 'donations') {
+      submitPrompt = gettext('Donate now');
+    } else {
+      // TODO: also handle non-recurring, non-donations here.
+      submitPrompt = gettext('Subscribe');
+    }
+
+    return (
+      <div>
+        <ProductDetail
+          productId={this.props.productId}
+          userDefinedAmount={this.props.userDefinedAmount}
+        />
+        <PayMethodChoice
+          payMethods={this.props.payMethods}
+          productId={this.props.productId}
+          submitButtonText={submitPrompt}
+          submitHandler={this.handleSubmit}
+          useDropDown
+        />
+        <a className="add-card" href="#"
+          onClick={this.props.payWithNewCard}>
+          {gettext('Add new credit card')}
+        </a>
+      </div>
+    );
+  }
+}

--- a/test/main/main.spec.js
+++ b/test/main/main.spec.js
@@ -4,6 +4,7 @@ const expect     = chai.expect;
 const main       = require("../../src/main");
 const tsFixture  = require('./fixtures/ts.json');
 const tsxFixture = require('./fixtures/tsx.json');
+const jsxFixture = require('./fixtures/jsx.json');
 const depSchema  = require('../../src/extract/jsonschema.json');
 
 chai.use(require('chai-json-schema'));
@@ -19,6 +20,12 @@ describe("main", () => {
         const lResult = main.cruise(["test/main/fixtures/tsx"]);
 
         expect(lResult).to.deep.equal(tsxFixture);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("And jsx", () => {
+        const lResult = main.cruise(["test/main/fixtures/jsx"]);
+
+        expect(lResult).to.deep.equal(jsxFixture);
         expect(lResult).to.be.jsonSchema(depSchema);
     });
 });


### PR DESCRIPTION
## Description
- adds support for .jsx
- uses acorn_loose for parsing. This might seem a strange choice - see _alternatives_ for reasons

## Implementation rationale
### Alternative: babel (not chosen - possibility for later)
- For this I introduced jsx as a new alt-js language - with babel-core as the transpiler. 
- babel-core needs plugins to be able to do anything. For react there is:
  - `babel-plugin-transform-react-jsx` - this should suffice for purely jsx additions to no-frills javascript (sorta es3). Most react projects uses fancier javascript (es6 or better, with classes, proper module support etc), so without the plugins supporting those the transpilation would fail.
  - `babel-preset-react` - this is a collection of plugins. It contains transform-react-jsx, and some nice stuff for typical react projects (a.o. es6+ support). 
- The philosophy of dependency-cruiser is to use the already available transpiler. While babel-core is likely to be part of the project, neither `babel-preset-react` nor `babel-plugin-transform-react-jsx` are guaranteed to be available _or even used_:
  - react-native projects typically use a different set of plugins
  - projects have complete liberty to use whatever plugins they want and there's no fixed set that's going to work for all projects.
- Alternatively I could _damn the philosophy_ and package a superset of babel plugins with dependency-cruiser. But even that won't cover all cases - and the cost (in download size) is not small- (7.2Mb for the core-js library, 1.1Mb for babel-core and a few bits and bobs for plugins & other deps). 

**=> not a viable option for the short term**

More react research:
- `babel` and `babel-preset-react` seem to be the prevalent way to get from jsx to something digestible, but...
  - is it the only one (probably not)? 
    - nope: `https://github.com/facebookincubator/create-react-app` uses its own `babel-preset-react-app`. But this also installs `babel-preset-react` as a dependency => we're good on this one.
    - nope: https://www.npmjs.com/package/node-jsx Deprecated. points to babel => good on this one as well.
    - nope: react native uses `babel-preset-react-native`; https://github.com/facebook/react-native/tree/master/babel-preset is used => :heavy_multiplication_x:  
  - if not: is it worth while supporting other options?
    - react native seems useful
    - do the various options have a common denominator (e.g. `babel-plugin-jsx` - maybe another one?)
  - `babel-plugin-transform-react-jsx` seems to be a reasonable common denominator. It just doesn't work on its own in most react project I've used it on.

### Alternative: acorn with acorn-jsx (not chosen)
- For this I introduced acorn-jsx in the extraction step. It's a relatively elegant solution; .js is correctly parsed without hitches, as is .jsx. In the latter case abstract syntax tree contains JSXxxx nodes. Also acorn-jsx is the 'official' jsx parser used by facebook. And babel. However ...
- ... for extracting dependencies from the syntax tree I use the tree-walker included in acorn. This - understandably - chokes on the new-fangled JSXxxx nodes acorn-jsx uses. There's some solutions available for this
  - use the `acorn-jsx-walk` package. It isn't updated for quite a long time, and doesn't seem to have a lot of traction (in downloads, stars or otherwise). It also uses quite a lot of dependencies (biggish) and the code base didn't seem as one I'd like to adopt.
  - filter/ transform the parsed tree so it doesn't contain JSXxxx nodes anymore - I'm not interested in those anyway. My estimation is that this will be non-trivial to do right.

**=> not a viable option for the short term**

### Alternative: acorn_loose
Observing
- ... in jsx dependencies typically (and sometimes from language/ listing rules) occur on the top.
- ... I'm not interested in jsx expressions - only imports, exports & requires and their ilk
- ... acorn_loose will in most sane cases pluck out the correct dependencies - especially when they occur at the top.
- ... acorn_loose is 
  - already part of acorn, and an existing dependency of dependency-cruiser
  - fast & stable
- ... implementing & testing this is a doddle ...

**=> acorn_loose it is for now** ; maybe later an elegant solution for one of the above (plugin? passing babelrc?)

## Motivation and Context
To make dependency-cruiser more useful environments that use React.

## How Has This Been Tested?
- [x] Unit tests
- [x] Against some real live code bases (using https://github.com/enaqx/awesome-react#real-apps)

## Types of changes
- ~~~Bug fix (non-breaking change which fixes an issue)~~~
- [x] New feature (non-breaking change which adds functionality)
- ~~~Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~~My change requires a change to the documentation.~~~ (added transpilers are self documenting)
- ~~~I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.