### PR TITLE
Replace lodash with native variants

### DIFF
--- a/src/cli/normalizeOptions.js
+++ b/src/cli/normalizeOptions.js
@@ -1,20 +1,23 @@
 "use strict";
 
-const _ = require("lodash");
-
 const DEFAULT_MODULE_SYSTEMS = ["cjs", "amd", "es6"];
 const DEFAULT_RULES_FILE_NAME = ".dependency-cruiser.json";
 
+function uniq(pArray) {
+    return Array.from(new Set(pArray));
+}
+
 function normalizeModuleSystems(pSystemList) {
-    if (_.isString(pSystemList)) {
-        return _(pSystemList.split(",")).sort().uniq().valueOf();
+    let lRetval = DEFAULT_MODULE_SYSTEMS;
+
+    if (typeof pSystemList === "string") {
+        lRetval = pSystemList.split(",");
     }
-    // istanbul ignore else
-    if (_.isArray(pSystemList)) {
-        return _(pSystemList).sort().uniq().valueOf();
+    if (Array.isArray(pSystemList)) {
+        lRetval = pSystemList;
     }
-    // istanbul ignore next
-    return DEFAULT_MODULE_SYSTEMS;
+
+    return uniq(lRetval.sort());
 }
 
 function determineRulesFileName(pValidate) {
@@ -33,13 +36,16 @@ function determineRulesFileName(pValidate) {
  * @return {object}          [description]
  */
 module.exports = (pOptions) => {
-    pOptions = _.defaults(pOptions, {
-        doNotFollow: "",
-        exclude: "",
-        outputTo: "-",
-        outputType: "err",
-        system: DEFAULT_MODULE_SYSTEMS
-    });
+    pOptions = Object.assign(
+        {
+            doNotFollow: "",
+            exclude: "",
+            outputTo: "-",
+            outputType: "err",
+            system: DEFAULT_MODULE_SYSTEMS
+        },
+        pOptions
+    );
 
     pOptions.moduleSystems = normalizeModuleSystems(pOptions.system);
 

--- a/src/cli/validateParameters.js
+++ b/src/cli/validateParameters.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _         = require("lodash");
 const fs        = require('fs');
 const safeRegex = require('safe-regex');
 
@@ -17,7 +16,7 @@ function validateFileExistence(pDirOrFile) {
 }
 
 function validateSystems(pSystem) {
-    if (Boolean(pSystem) && _.isString(pSystem)) {
+    if (Boolean(pSystem) && typeof pSystem === 'string') {
         const lParamArray = pSystem.match(MODULE_SYSTEM_LIST_RE);
 
         if (!lParamArray || lParamArray.length !== 1) {

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -69,19 +69,26 @@ module.exports = (pFileName, pOptions) => {
                 moduleSystems: ["cjs", "es6", "amd"]
             }
         );
+        // pOptions = Object.assign(
+        //     {
+        //         baseDir: process.cwd(),
+        //         moduleSystems: ["cjs", "es6", "amd"]
+        //     },
+        //     pOptions
+        // );
 
         const lAST = getAST(path.join(pOptions.baseDir, pFileName));
         let lDependencies = [];
 
-        if (_.includes(pOptions.moduleSystems, "cjs")){
+        if (pOptions.moduleSystems.indexOf("cjs") > -1){
             extractCommonJSDependencies(lAST, lDependencies);
         }
 
-        if (_.includes(pOptions.moduleSystems, "es6")){
+        if (pOptions.moduleSystems.indexOf("es6") > -1){
             extractES6Dependencies(lAST, lDependencies);
         }
 
-        if (_.includes(pOptions.moduleSystems, "amd")){
+        if (pOptions.moduleSystems.indexOf("amd") > -1){
             extractAMDDependencies(lAST, lDependencies);
         }
 

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -160,13 +160,13 @@ function addCircularityCheckToGraph (pDependencies) {
 module.exports = (pFileDirArray, pOptions, pCallback) => {
     const lCallback = pCallback ? pCallback : (pInput => pInput);
 
-    pOptions = _.defaults(
-        pOptions,
+    pOptions = Object.assign(
         {
             baseDir: process.cwd(),
             moduleSystems: ["cjs", "es6", "amd"],
             maxDepth: 0
-        }
+        },
+        pOptions
     );
 
     let lDependencies = _(

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _                = require('lodash');
 const resolveAMDModule = require('./resolve-AMD');
 const resolveCJSModule = require('./resolve-commonJS');
 
@@ -33,7 +32,7 @@ const isRelativeModuleName = pString => pString.startsWith(".");
 module.exports = (pDependency, pBaseDir, pFileDir) => {
     if (isRelativeModuleName(pDependency.moduleName)){
         return resolveCJSModule(pDependency.moduleName, pBaseDir, pFileDir);
-    } else if (_.includes(["cjs", "es6"], pDependency.moduleSystem)){
+    } else if (["cjs", "es6"].indexOf(pDependency.moduleSystem) > -1){
         return resolveCJSModule(pDependency.moduleName, pBaseDir, pFileDir);
     } else {
         return resolveAMDModule(pDependency.moduleName, pBaseDir, pFileDir);

--- a/src/extract/resolve/resolve-AMD.js
+++ b/src/extract/resolve/resolve-AMD.js
@@ -3,11 +3,11 @@
 const path                     = require('path');
 const resolve                  = require('resolve');
 const fs                       = require('fs');
-const _                        = require('lodash');
+const memoize                  = require('lodash/memoize');
 const determineDependencyTypes = require('./determineDependencyTypes');
 const readPackageDeps          = require('./readPackageDeps');
 
-const fileExists = _.memoize(pFile => {
+const fileExists = memoize(pFile => {
     try {
         fs.accessSync(pFile, fs.R_OK);
     } catch (e) {


### PR DESCRIPTION
## Motivation and Context
In some cases the code used lodash where out of the box javascript would've done just as well (_.isArray, _.isString, _.defaults, _.sort _.uniq). This cleans that up so these spots are easier to maintain.

## How Has This Been Tested?
Non-regression with the unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~~~New feature (non-breaking change which adds functionality)~~~
- ~~~Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~~My change requires a change to the documentation.~~~
- ~~~I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.