### PR TITLE
bugfix(cli): trims spaces from passed module systems

### DIFF
--- a/src/cli/normalizeOptions.js
+++ b/src/cli/normalizeOptions.js
@@ -12,6 +12,10 @@ function determineRulesFileName(pValidate) {
     return lRetval;
 }
 
+function trim(pString) {
+    return pString.trim();
+}
+
 /**
  * returns the pOptions, so that the returned value contains a
  * valid value for each possible option
@@ -33,7 +37,7 @@ module.exports = (pOptions) => {
     }
 
     if (pOptions.hasOwnProperty("moduleSystems")) {
-        pOptions.moduleSystems = pOptions.moduleSystems.split(",");
+        pOptions.moduleSystems = pOptions.moduleSystems.split(",").map(trim);
     }
 
     if (pOptions.hasOwnProperty("validate")){

--- a/test/cli/normalizeOptions.spec.js
+++ b/test/cli/normalizeOptions.spec.js
@@ -28,6 +28,14 @@ describe("normalizeOptions", () => {
         );
     });
 
+    it("trims module system strings", () => {
+        expect(
+            normalizeOptions({
+                moduleSystems: " amd,cjs ,  es6 "
+            }).moduleSystems
+        ).to.deep.equal(["amd", "cjs", "es6"]);
+    });
+
     it("--system acts as an alias for --module-systems", () => {
         expect(
             normalizeOptions({system: "something,something"}).moduleSystems


### PR DESCRIPTION
## Description
--module-systems "cjs, amd, es6" used to complain about module systems not being invalid. We now just strip the spaces

## How Has This Been Tested?
unit test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~~~[ ] New feature (non-breaking change which adds functionality)~~~
- ~~~[ ] Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~~[ ] My change requires a change to the documentation.~~~
- ~~~[ ] I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.