### PR TITLE
Add option to preserve/resolve symlinks

### DIFF
--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -33,12 +33,12 @@ program
     .option("-T, --output-type <type>", `output type - html|dot|err|json
                               (default: err)`)
     .option("-P, --prefix <prefix>", "prefix to use for links in the svg reporter")
+    .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
     .option("--ts-pre-compilation-deps", `detect dependencies that only exist before
                               typescript-to-javascript compilation
                               (off by default)`)
     .option("--init", `write a .dependency-cruiser.json with basic
                               validations to the current folder.`)
-    .option("--preserve-symlinks <enabled>", `leave symlinks unchanged, defaults to true`, (arg) => arg !== 'false')
     .arguments("<files-or-directories>")
     .parse(process.argv);
 

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -15,17 +15,6 @@ if (!semver.satisfies(process.versions.node, $package.engines.node)) {
     process.exit(-1);
 }
 
-function boolean(arg) {
-    switch (arg) {
-        case 'true':
-            return true;
-        case 'false':
-            return false;
-        default:
-            return undefined;
-    }
-}
-
 program
     .version($package.version)
     .option("-i, --info", `shows what languages and extensions
@@ -49,7 +38,7 @@ program
                               (off by default)`)
     .option("--init", `write a .dependency-cruiser.json with basic
                               validations to the current folder.`)
-    .option("--preserve-symlinks <enabled>", `leave symlinks unchanged, defaults to true`, boolean)
+    .option("--preserve-symlinks <enabled>", `leave symlinks unchanged, defaults to true`, (arg) => arg !== 'false')
     .arguments("<files-or-directories>")
     .parse(process.argv);
 

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -15,6 +15,17 @@ if (!semver.satisfies(process.versions.node, $package.engines.node)) {
     process.exit(-1);
 }
 
+function boolean(arg) {
+    switch (arg) {
+        case 'true':
+            return true;
+        case 'false':
+            return false;
+        default:
+            return undefined;
+    }
+}
+
 program
     .version($package.version)
     .option("-i, --info", `shows what languages and extensions
@@ -38,6 +49,7 @@ program
                               (off by default)`)
     .option("--init", `write a .dependency-cruiser.json with basic
                               validations to the current folder.`)
+    .option("--preserve-symlinks <enabled>", `leave symlinks unchanged, defaults to true`, boolean)
     .arguments("<files-or-directories>")
     .parse(process.argv);
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -63,8 +63,10 @@ These are all the options:
  prefix      : a string to insert before links (in dot/ svg output) so with
                cruising local dependencies it is possible to point to sources
                elsewhere (e.g. in an online repository)
- tsPreCompilationDeps: if true detect dependencies that only exist before 
+ tsPreCompilationDeps: if true detect dependencies that only exist before
                typescript-to-javascript compilation.
+ preserveSymlinks: if true does not resolve symlinks.
+               Defaults to true for backwards compatibility.
 }
 ```
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -65,8 +65,7 @@ These are all the options:
                elsewhere (e.g. in an online repository)
  tsPreCompilationDeps: if true detect dependencies that only exist before
                typescript-to-javascript compilation.
- preserveSymlinks: if true does not resolve symlinks.
-               Defaults to true for backwards compatibility.
+ preserveSymlinks: if true does not resolve symlinks; defaults to false
 }
 ```
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -313,6 +313,11 @@ output will look like this:
 
 <img alt="'no import use' with typescript pre-compilation dependencies" src="real-world-samples/no-use-with-pre-compilation-deps.png">
 
+### `--preserve-symlinks`
+Whether to leave symlinks as is or resolve them to their realpath. This option defaults
+to `true` for backwards compatibility. This will change in a future major release,
+because Node resolves symlinks by default.
+
 ### Cruising multiple files and directories in one go
 Just pass them as arguments. This, e.g. will cruise every file in the folders
 src, test and lib (recursively) + the file called index.ts in the root.

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -23,6 +23,7 @@ Options:
   -T, --output-type <type>      output type - html|dot|err|json
                                 (default: err)
   -P, --prefix <prefix>         prefix to use for links in the svg reporter
+  --preserve-symlinks           leave symlinks unchanged (off by default)
   --ts-pre-compilation-deps     detect dependencies that only exist before
                                 typescript-to-javascript compilation
                                 (off by default)
@@ -315,8 +316,7 @@ output will look like this:
 
 ### `--preserve-symlinks`
 Whether to leave symlinks as is or resolve them to their realpath. This option defaults
-to `true` for backwards compatibility. This will change in a future major release,
-because Node resolves symlinks by default.
+to `false` (which is also nodejs' default behavior since release 6).
 
 ### arguments
 You can pass a bunch of files, directories and 'glob' patterns. 

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -60,8 +60,9 @@ The currently supported options are
 [`doNotFollow`](./cli.md#--do-not-follow-dont-cruise-modules-adhering-to-this-pattern-any-further),
 [`exclude`](./cli.md#--exclude-exclude-modules-from-being-cruised),
 [`moduleSystems`](./cli.md#--module-systems),
-[`prefix`](./cli.md#--prefix-prefixing-links) and
-[`tsPreCompilationDeps`](/cli.md#--ts-pre-compilation-deps-typescript-only).
+[`prefix`](./cli.md#--prefix-prefixing-links),
+[`tsPreCompilationDeps`](/cli.md#--ts-pre-compilation-deps-typescript-only) and
+[`preserveSymlinks`](/cli.md#--preserve-symlinks).
 See the [command line documentation](./cli.md) for details.
 
 ## The structure of an individual rule

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "normalize-newline": "3.0.0",
     "npm-check-updates": "2.14.0",
     "nsp": "3.2.1",
+    "symlink-dir": "^1.1.2",
     "tslint": "5.9.1",
     "typescript": "2.7.2"
   },

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -24,15 +24,16 @@ const toTypescriptAST             = require('./parse/toTypescriptAST');
  *
  * @param  {string} pFileName path to the file
  * @param  {object} pOptions  an object with one or more of these properties:
- *                            - baseDir       - the directory to consider as the
- *                                              base for all files
- *                                              Default: the current working directory
- *                            - moduleSystems - an array of module systems to
- *                                              consider.
- *                                              Default: ["cjs", "es6", "amd"]
- *                            - exclude       - a regular expression string
- *                              with a pattern of modules to exclude (e.g.
- *                              "(node_modules)"). Default: none
+ *                            - baseDir         - the directory to consider as the
+ *                                                base for all files
+ *                                                Default: the current working directory
+ *                            - moduleSystems   - an array of module systems to
+ *                                                consider.
+ *                                                Default: ["cjs", "es6", "amd"]
+ *                            - exclude         - a regular expression string
+ *                                                with a pattern of modules to exclude
+ *                                                (e.g. "(node_modules)"). Default: none
+ *                            - preserveSymlink - don't resolve symlinks.
  * @return {array}           an array of dependency objects (see above)
  */
 module.exports = (pFileName, pOptions) => {
@@ -41,7 +42,8 @@ module.exports = (pFileName, pOptions) => {
             {
                 baseDir: process.cwd(),
                 moduleSystems: ["cjs", "es6", "amd"],
-                tsPreCompilationDeps: false
+                tsPreCompilationDeps: false,
+                preserveSymlinks: true
             },
             pOptions
         );
@@ -83,7 +85,8 @@ module.exports = (pFileName, pOptions) => {
                     const lResolved = resolve(
                         pDependency,
                         lOptions.baseDir,
-                        path.join(lOptions.baseDir, path.dirname(pFileName))
+                        path.join(lOptions.baseDir, path.dirname(pFileName)),
+                        lOptions.preserveSymlinks
                     );
                     const lMatchesDoNotFollow = Boolean(lOptions.doNotFollow)
                         ? RegExp(lOptions.doNotFollow, "g").test(lResolved.resolved)

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -43,7 +43,7 @@ module.exports = (pFileName, pOptions) => {
                 baseDir: process.cwd(),
                 moduleSystems: ["cjs", "es6", "amd"],
                 tsPreCompilationDeps: false,
-                preserveSymlinks: true
+                preserveSymlinks: false
             },
             pOptions
         );

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -90,7 +90,8 @@ function makeOptionsPresentable(pOptions) {
         "moduleSystems",
         "outputType",
         "prefix",
-        "tsPreCompilationDeps"
+        "tsPreCompilationDeps",
+        "preserveSymlinks"
     ];
 
     return SHARABLE_OPTIONS

--- a/src/extract/jsonschema.json
+++ b/src/extract/jsonschema.json
@@ -245,6 +245,9 @@
                 },
                 "tsPreCompilationDeps": {
                     "type": "boolean"
+                },
+                "preserveSymlinks": {
+                    "type": "boolean"
                 }
             }
         }

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const fs               = require('fs');
+const path             = require('path');
+const pathToPosix      = require('../../utl/pathToPosix');
 const resolveAMDModule = require('./resolve-AMD');
 const resolveCJSModule = require('./resolve-commonJS');
 
@@ -14,6 +17,7 @@ const isRelativeModuleName = pString => pString.startsWith(".");
  *                              for resolved files.
  * @param  {string} pFileDir    the directory of the file the dependency was
  *                              detected in
+ * @param  {boolean} pPreserveSymlinks whether to use `fs.realpath` to resolve symlinks
  * @return {object}             an object with as attributes:
  *                              - resolved: a string representing the pDependency
  *                                  resolved to a file on disk (or the pDependency
@@ -29,12 +33,23 @@ const isRelativeModuleName = pString => pString.startsWith(".");
  *                              - dependencyTypes: an array of dependencyTypes
  *
  */
-module.exports = (pDependency, pBaseDir, pFileDir) => {
+module.exports = (pDependency, pBaseDir, pFileDir, pPreserveSymlinks) => {
+    let lResolvedModule = null;
+
     if (isRelativeModuleName(pDependency.moduleName)){
-        return resolveCJSModule(pDependency.moduleName, pBaseDir, pFileDir);
+        lResolvedModule = resolveCJSModule(pDependency.moduleName, pBaseDir, pFileDir);
     } else if (["cjs", "es6"].indexOf(pDependency.moduleSystem) > -1){
-        return resolveCJSModule(pDependency.moduleName, pBaseDir, pFileDir);
+        lResolvedModule = resolveCJSModule(pDependency.moduleName, pBaseDir, pFileDir);
     } else {
-        return resolveAMDModule(pDependency.moduleName, pBaseDir, pFileDir);
+        lResolvedModule = resolveAMDModule(pDependency.moduleName, pBaseDir, pFileDir);
     }
+    if (!pPreserveSymlinks && !lResolvedModule.coreModule && !lResolvedModule.couldNotResolve) {
+        try {
+            lResolvedModule.resolved =
+                pathToPosix(path.relative(pBaseDir, fs.realpathSync(lResolvedModule.resolved)));
+        } catch (e) {
+            lResolvedModule.couldNotResolve = true;
+        }
+    }
+    return lResolvedModule;
 };

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -46,7 +46,7 @@ module.exports = (pDependency, pBaseDir, pFileDir, pPreserveSymlinks) => {
     if (!pPreserveSymlinks && !lResolvedModule.coreModule && !lResolvedModule.couldNotResolve) {
         try {
             lResolvedModule.resolved =
-                pathToPosix(path.relative(pBaseDir, fs.realpathSync(lResolvedModule.resolved)));
+                pathToPosix(path.relative(pBaseDir, fs.realpathSync(path.resolve(pBaseDir, lResolvedModule.resolved))));
         } catch (e) {
             lResolvedModule.couldNotResolve = true;
         }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,6 +46,7 @@ const TYPE2REPORTER      = {
  *                defaults to ["es6", "cjs", "amd"]
  *  outputType  : one of "json", "html", "dot", "csv" or "err". When left
  *                out the function will return a javascript object as dependencies
+ *  preserveSymlinks: if true does not resolve symlinks, defaults to true
  * }
  *
  * @param  {array}  pFileDirArray An array of (names of) files and directories to

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,7 +46,7 @@ const TYPE2REPORTER      = {
  *                defaults to ["es6", "cjs", "amd"]
  *  outputType  : one of "json", "html", "dot", "csv" or "err". When left
  *                out the function will return a javascript object as dependencies
- *  preserveSymlinks: if true does not resolve symlinks, defaults to true
+ *  preserveSymlinks: if true does not resolve symlinks, defaults to false
  * }
  *
  * @param  {array}  pFileDirArray An array of (names of) files and directories to

--- a/src/main/options/defaults.json
+++ b/src/main/options/defaults.json
@@ -3,5 +3,5 @@
     "maxDepth": 0,
     "moduleSystems": ["amd", "cjs", "es6"],
     "tsPreCompilationDeps": false,
-    "preserveSymlinks": true
+    "preserveSymlinks": false
 }

--- a/src/main/options/defaults.json
+++ b/src/main/options/defaults.json
@@ -2,5 +2,6 @@
     "validate": false,
     "maxDepth": 0,
     "moduleSystems": ["amd", "cjs", "es6"],
-    "tsPreCompilationDeps": false
+    "tsPreCompilationDeps": false,
+    "preserveSymlinks": true
 }

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -44,7 +44,7 @@ function validateMaxDepth(pDepth) {
 function validatePreserveSymlinks(pOption) {
     if (typeof pOption !== "undefined" && typeof pOption !== 'boolean') {
         throw Error(
-            `'${pOption}' is not a valid option for preserveSymlinks.`
+            `'${pOption}' is not a valid option for preserveSymlinks - use either true or false`
         );
     }
 }

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -41,6 +41,14 @@ function validateMaxDepth(pDepth) {
     }
 }
 
+function validatePreserveSymlinks(pOption) {
+    if (pOption !== undefined && typeof pOption !== 'boolean') {
+        throw Error(
+            `'${pOption}' is not a valid option for preserveSymlinks.`
+        );
+    }
+}
+
 function validate(pOptions) {
     let lRetval = {};
 
@@ -50,6 +58,7 @@ function validate(pOptions) {
         isSafeRegExp(pOptions.doNotFollow);
         validateOutputType(pOptions.outputType);
         validateMaxDepth(pOptions.maxDepth);
+        validatePreserveSymlinks(pOptions.preserveSymlinks);
         if (pOptions.hasOwnProperty('ruleSet') && pOptions.ruleSet.options) {
             lRetval = module.exports(pOptions.ruleSet.options);
         }

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -42,7 +42,7 @@ function validateMaxDepth(pDepth) {
 }
 
 function validatePreserveSymlinks(pOption) {
-    if (pOption !== undefined && typeof pOption !== 'boolean') {
+    if (typeof pOption !== "undefined" && typeof pOption !== 'boolean') {
         throw Error(
             `'${pOption}' is not a valid option for preserveSymlinks.`
         );

--- a/src/main/ruleSet/jsonschema.json
+++ b/src/main/ruleSet/jsonschema.json
@@ -51,6 +51,9 @@
                 "tsPreCompilationDeps": {
                     "type": "boolean",
                     "description": "if true detect dependencies that only exist before typescript-to-javascript compilation."
+                },
+                "preserveSymlinks": {
+                    "type": "boolean"
                 }
             }
         }

--- a/src/main/ruleSet/jsonschema.json
+++ b/src/main/ruleSet/jsonschema.json
@@ -53,7 +53,8 @@
                     "description": "if true detect dependencies that only exist before typescript-to-javascript compilation."
                 },
                 "preserveSymlinks": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "if true leave symlinks untouched, otherwise use the realpath. Defaults to `false` (which is also nodejs's default behavior since version 6)"
                 }
             }
         }

--- a/test/cli/fixtures/cjs.dir.filtered.json
+++ b/test/cli/fixtures/cjs.dir.filtered.json
@@ -324,7 +324,8 @@
                 "es6"
             ],
             "outputType": "json",
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/cli/fixtures/cjs.dir.json
+++ b/test/cli/fixtures/cjs.dir.json
@@ -378,7 +378,8 @@
                 "es6"
             ],
             "outputType": "json",
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/cli/fixtures/cjs.file.json
+++ b/test/cli/fixtures/cjs.file.json
@@ -276,7 +276,8 @@
                 "es6"
             ],
             "outputType": "json",
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/cli/fixtures/multiple-in-one-go.json
+++ b/test/cli/fixtures/multiple-in-one-go.json
@@ -137,7 +137,8 @@
                 "es6"
             ],
             "outputType": "json",
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/extract/extract.spec.js
+++ b/test/extract/extract.spec.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const path              = require('path');
+const fs                = require('fs');
+const symlinkDir        = require('symlink-dir');
 const expect            = require('chai').expect;
 const extract           = require('../../src/extract/extract');
 const cjsFixtures       = require('./fixtures/cjs.json');
@@ -12,6 +15,18 @@ const cjsBang           = require('./fixtures/cjs-bang.json');
 const amdBangRequirejs  = require('./fixtures/amd-bang-requirejs.json');
 const amdBangCJSWrapper = require('./fixtures/amd-bang-CJSWrapper.json');
 
+var symlinkDirectory = path.join(__dirname, 'fixtures', 'symlinked');
+before((cb) => {
+    symlinkDir(path.join(__dirname, 'fixtures', 'symlinkTarget'), symlinkDirectory)
+        .then(() => cb(), (err) => cb(err));
+});
+
+after(() => {
+    try {
+        fs.unlinkSync(symlinkDirectory);
+    } catch (e) {}
+});
+
 function runFixture(pFixture) {
     const lOptions = {};
 
@@ -20,6 +35,9 @@ function runFixture(pFixture) {
     }
     if (pFixture.input.moduleSystems) {
         lOptions.moduleSystems = pFixture.input.moduleSystems;
+    }
+    if (pFixture.input.preserveSymlinks !== undefined) {
+        lOptions.preserveSymlinks = pFixture.input.preserveSymlinks;
     }
 
     it(pFixture.title, () => {

--- a/test/extract/extract.spec.js
+++ b/test/extract/extract.spec.js
@@ -15,7 +15,9 @@ const cjsBang           = require('./fixtures/cjs-bang.json');
 const amdBangRequirejs  = require('./fixtures/amd-bang-requirejs.json');
 const amdBangCJSWrapper = require('./fixtures/amd-bang-CJSWrapper.json');
 
-var symlinkDirectory = path.join(__dirname, 'fixtures', 'symlinked');
+let symlinkDirectory = path.join(__dirname, 'fixtures', 'symlinked');
+
+/* eslint-disable mocha/no-top-level-hooks */
 before((cb) => {
     symlinkDir(path.join(__dirname, 'fixtures', 'symlinkTarget'), symlinkDirectory)
         .then(() => cb(), (err) => cb(err));
@@ -24,7 +26,9 @@ before((cb) => {
 after(() => {
     try {
         fs.unlinkSync(symlinkDirectory);
-    } catch (e) {}
+    } catch (e) {
+        // just swallow the error, there's nothing we can do about it
+    }
 });
 
 function runFixture(pFixture) {
@@ -36,7 +40,7 @@ function runFixture(pFixture) {
     if (pFixture.input.moduleSystems) {
         lOptions.moduleSystems = pFixture.input.moduleSystems;
     }
-    if (pFixture.input.preserveSymlinks !== undefined) {
+    if (typeof pFixture.input.preserveSymlinks !== "undefined") {
         lOptions.preserveSymlinks = pFixture.input.preserveSymlinks;
     }
 

--- a/test/extract/fixtures/amd.json
+++ b/test/extract/fixtures/amd.json
@@ -247,5 +247,67 @@
             "fileName": "test/extract/fixtures/amd/looks-like-amd-but-isnt.js"
         },
         "expected": []
+    },
+    {
+        "title": "require a symlinked module",
+        "input": {
+            "fileName": "test/extract/fixtures/amd/symlink.js"
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "test/extract/fixtures/symlinked/index.js",
+                "moduleSystem": "amd",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
+    },
+    {
+        "title": "require a symlinked module -- with preserveSymlinks=true",
+        "input": {
+            "fileName": "test/extract/fixtures/amd/symlink.js",
+            "preserveSymlinks": true
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "test/extract/fixtures/symlinked/index.js",
+                "moduleSystem": "amd",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
+    },
+    {
+        "title": "require a symlinked module -- with preserveSymlinks=false",
+        "input": {
+            "fileName": "test/extract/fixtures/amd/symlink.js",
+            "preserveSymlinks": false
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "test/extract/fixtures/symlinkTarget/index.js",
+                "moduleSystem": "amd",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
     }
 ]

--- a/test/extract/fixtures/amd.json
+++ b/test/extract/fixtures/amd.json
@@ -256,7 +256,7 @@
         "expected": [
             {
                 "module": "../symlinked",
-                "resolved": "test/extract/fixtures/symlinked/index.js",
+                "resolved": "test/extract/fixtures/symlinkTarget/index.js",
                 "moduleSystem": "amd",
                 "coreModule": false,
                 "dependencyTypes": [

--- a/test/extract/fixtures/amd/symlink.js
+++ b/test/extract/fixtures/amd/symlink.js
@@ -1,0 +1,3 @@
+define(["../symlinked"], function(path){
+// do stuff
+});

--- a/test/extract/fixtures/cjs.json
+++ b/test/extract/fixtures/cjs.json
@@ -321,5 +321,27 @@
                 "couldNotResolve": false
             }
         ]
+    },
+    {
+        "title": "require a symlinked module -- with preserveSymlinks=false and baseDir",
+        "input": {
+            "fileName": "symlink.js",
+            "baseDir": "test/extract/fixtures/cjs",
+            "preserveSymlinks": false
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "../symlinkTarget/index.js",
+                "moduleSystem": "cjs",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
     }
 ]

--- a/test/extract/fixtures/cjs.json
+++ b/test/extract/fixtures/cjs.json
@@ -259,5 +259,67 @@
                 "couldNotResolve": true
             }
         ]
+    },
+    {
+        "title": "require a symlinked module",
+        "input": {
+            "fileName": "test/extract/fixtures/cjs/symlink.js"
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "test/extract/fixtures/symlinked/index.js",
+                "moduleSystem": "cjs",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
+    },
+    {
+        "title": "require a symlinked module -- with preserveSymlinks=true",
+        "input": {
+            "fileName": "test/extract/fixtures/cjs/symlink.js",
+            "preserveSymlinks": true
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "test/extract/fixtures/symlinked/index.js",
+                "moduleSystem": "cjs",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
+    },
+    {
+        "title": "require a symlinked module -- with preserveSymlinks=false",
+        "input": {
+            "fileName": "test/extract/fixtures/cjs/symlink.js",
+            "preserveSymlinks": false
+        },
+        "expected": [
+            {
+                "module": "../symlinked",
+                "resolved": "test/extract/fixtures/symlinkTarget/index.js",
+                "moduleSystem": "cjs",
+                "coreModule": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "followable": true,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            }
+        ]
     }
 ]

--- a/test/extract/fixtures/cjs.json
+++ b/test/extract/fixtures/cjs.json
@@ -268,7 +268,7 @@
         "expected": [
             {
                 "module": "../symlinked",
-                "resolved": "test/extract/fixtures/symlinked/index.js",
+                "resolved": "test/extract/fixtures/symlinkTarget/index.js",
                 "moduleSystem": "cjs",
                 "coreModule": false,
                 "dependencyTypes": [

--- a/test/extract/fixtures/cjs/symlink.js
+++ b/test/extract/fixtures/cjs/symlink.js
@@ -1,0 +1,1 @@
+require('../symlinked');

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -176,7 +176,8 @@
         "totalCruised": 8,
         "optionsUsed": {
             "moduleSystems": ["amd", "cjs", "es6"],
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/main/fixtures/ts.json
+++ b/test/main/fixtures/ts.json
@@ -120,7 +120,8 @@
         "totalCruised": 6,
         "optionsUsed":{
             "moduleSystems": ["amd", "cjs", "es6"],
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/main/fixtures/tsx.json
+++ b/test/main/fixtures/tsx.json
@@ -56,7 +56,8 @@
         "totalCruised": 3,
         "optionsUsed": {
             "moduleSystems": ["amd", "cjs", "es6"],
-            "tsPreCompilationDeps": false
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
         }
     }
 }

--- a/test/main/options/validate.spec.js
+++ b/test/main/options/validate.spec.js
@@ -44,6 +44,26 @@ describe("validateOptions", () => {
         }
     });
 
+    it("passes when boolean is passed for preserveSymlinks ", () => {
+        try {
+            validateOptions({"preserveSymlinks": true});
+            expect("to be here without throws happening").to.equal("to be here without throws happening");
+        } catch (e) {
+            expect("not to be here").to.equal(`still here, though: ${e}`);
+        }
+    });
+
+    it("throws when non-boolean is passed for preserveSymlinks ", () => {
+        try {
+            validateOptions({"preserveSymlinks": 481});
+            expect("not to be here").to.equal("still here, though");
+        } catch (e) {
+            expect(e.toString()).to.deep.equal(
+                "Error: '481' is not a valid option for preserveSymlinks - use either true or false"
+            );
+        }
+    });
+
     it("throws when a non-integer is passed as maxDepth", () => {
         try {
             validateOptions({"maxDepth": "not an integer"});
@@ -125,6 +145,7 @@ describe("validateOptions", () => {
             );
         }
     });
+
 
     it("command line options trump those passed in --validate ruleSet", () => {
         const lOptions = validateOptions(

--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -206,6 +206,11 @@ export interface ICruiseOptions {
      * typescript-to-javascript compilation.
      */
     tsPreCompilationDeps?: boolean;
+    /**
+     * if true leave symlinks untouched, otherwise use the realpath.
+     * Defaults to `true`
+     */
+    preserveSymlinks?: boolean;
 }
 
 /**

--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -208,7 +208,8 @@ export interface ICruiseOptions {
     tsPreCompilationDeps?: boolean;
     /**
      * if true leave symlinks untouched, otherwise use the realpath.
-     * Defaults to `true`
+     * Defaults to `false` (which is also nodejs's default behavior 
+     * since version 6)
      */
     preserveSymlinks?: boolean;
 }


### PR DESCRIPTION
## Description
Add option `preserveSymlinks` everywhere:
* resolve/index.js
  * works for both AMD and CJS
* extract.js
* validate.js
* defaults.json
* jsonschema (twice, don't know why)
* CLI
* docs
* tests

The option (currently) defaults to `true` which leaves the old behavior unchanged. This can and probably should be changed in a future major version to be consistent with Node's default behavior.
To disable this option, either specify it in the config file or use the CLI argument `--preserve-symlinks false`.

## Motivation and Context
Fixes: #33 

## How Has This Been Tested?
Tested in the unit tests. (needed to add a devDependency on `symlink-dir` for easier handling of symlinks on windows)
Also tested locally with in my project https://github.com/fimbullinter/wotan. Tested config file and CLI option.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~~[ ] Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- ~~[ ] Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project. (I hope so, this is not always obvious)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
