### PR TITLE
Feature/make severity for allowed rules configurable

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -54,7 +54,7 @@ for each violated rule.
 A list of rules that describe dependencies that are _allowed_. dependency-cruiser
 will emit a 'not-in-allowed' message for each dependency that does not
 satisfy at least one of them. The severity of the message is _warning_ by
-default, but you can override it with `
+default, but you can override it with `allowedSeverity`:
 
 ### `allowedSeverity`
 The severity to use in reports when a dependency is not in the `allowed`

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -19,6 +19,7 @@
 1. [The structure of a dependency-cruiser rules file](#the-structure-of-a-dependency-cruiser-rules-file)
     - [`forbidden`](#forbidden)
     - [`allowed`](#allowed)
+    - [`allowedSeverity`](#allowedSeverity)
     - [`options`](#options)
 2. [The structure of an individual rule](#the-structure-of-an-individual-rule)
 3. [Conditions](#conditions)
@@ -51,8 +52,14 @@ for each violated rule.
 
 ### `allowed`
 A list of rules that describe dependencies that are _allowed_. dependency-cruiser
-will emit the warning message 'not-in-allowed' for each dependency that does not
-satisfy at least one of them.
+will emit a 'not-in-allowed' message for each dependency that does not
+satisfy at least one of them. The severity of the message is _warning_ by
+default, but you can override it with `
+
+### `allowedSeverity`
+The severity to use in reports when a dependency is not in the `allowed`
+list of rules. It takes the same values as other `severity` fields and
+also defaults to `warn`.
 
 ### `options`
 Some of the command line options, so you don't have to specify them on each run.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "3.0.0-beta-3",
+  "version": "3.0.0-beta-4",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "bin": {
     "dependency-cruiser": "bin/dependency-cruise",

--- a/src/main/ruleSet/jsonschema.json
+++ b/src/main/ruleSet/jsonschema.json
@@ -19,6 +19,10 @@
                 "$ref" :"#/definitions/RuleType"
             }
         },
+        "allowedSeverity": {
+            "$ref": "#/definitions/SeverityType",
+            "description": "Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'"
+        },
         "options": {
             "type": "object",
             "description": "Runtime configuration options",

--- a/src/main/ruleSet/normalize.js
+++ b/src/main/ruleSet/normalize.js
@@ -35,7 +35,7 @@ function normalizeRule(pRule) {
  */
 module.exports = (pRuleSet) => {
     if (pRuleSet.hasOwnProperty("allowed")){
-        pRuleSet.allowed = pRuleSet.allowed.map(normalizeRule);
+        pRuleSet.allowedSeverity = normalizeSeverity(pRuleSet.allowedSeverity);
     }
 
     if (pRuleSet.hasOwnProperty("forbidden")){

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -88,7 +88,7 @@ function validateAgainstRules(pRuleSet, pFrom, pTo) {
             return {
                 valid: false,
                 rule: {
-                    severity: "warn",
+                    severity: pRuleSet.allowedSeverity,
                     name: "not-in-allowed"
                 }
             };

--- a/test/main/ruleSet/normalize.spec.js
+++ b/test/main/ruleSet/normalize.spec.js
@@ -2,12 +2,12 @@
 const expect     = require('chai').expect;
 const normalizer = require('../../../src/main/ruleSet/normalize');
 
-describe("validator", () => {
+describe("ruleSet/normalize", () => {
     it("leaves the empty ruleset alone", () => {
         expect(normalizer({})).to.deep.equal({});
     });
 
-    it("adds defaults for severity and warn when they're not filled", () => {
+    it("allowed: adds allowedSeverity when it wasn't filled out; does not add severity/ name to the rule", () => {
         expect(normalizer({
             "allowed": [{
                 "from": ".+",
@@ -16,23 +16,38 @@ describe("validator", () => {
         })).to.deep.equal({
             "allowed": [{
                 "from": ".+",
-                "to": ".+",
-                "severity": "warn",
-                "name": "unnamed"
-            }]
+                "to": ".+"
+            }],
+            "allowedSeverity": "warn"
+        });
+    });
+
+    it("allowed: leaves allowedSeverity alone when it wasn filled out; does not add severity/ name to the rule", () => {
+        expect(normalizer({
+            "allowed": [{
+                "from": ".+",
+                "to": ".+"
+            }],
+            "allowedSeverity": "error"
+        })).to.deep.equal({
+            "allowed": [{
+                "from": ".+",
+                "to": ".+"
+            }],
+            "allowedSeverity": "error"
         });
     });
 
     it("corrects the severity to a default when it's not a recognized one", () => {
         expect(normalizer({
-            "allowed": [{
+            "forbidden": [{
                 "from": ".+",
                 "to": ".+",
                 "severity": "unrecognized",
                 "name": "all-ok"
             }]
         })).to.deep.equal({
-            "allowed": [{
+            "forbidden": [{
                 "from": ".+",
                 "to": ".+",
                 "severity": "warn",
@@ -43,14 +58,14 @@ describe("validator", () => {
 
     it("keeps the severity if it's a recognized one", () => {
         expect(normalizer({
-            "allowed": [{
+            "forbidden": [{
                 "from": ".+",
                 "to": ".+",
                 "severity": "error",
                 "name": "all-ok"
             }]
         })).to.deep.equal({
-            "allowed": [{
+            "forbidden": [{
                 "from": ".+",
                 "to": ".+",
                 "severity": "error",

--- a/test/validate/fixtures/rules.impossible-to-match-error.allowed.json
+++ b/test/validate/fixtures/rules.impossible-to-match-error.allowed.json
@@ -1,0 +1,13 @@
+{
+    "allowed": [
+        {
+            "from": {
+                "path": "only-this-one"
+            },
+            "to": {
+                "path": "only-that-one"
+            }
+        }
+    ],
+    "allowedSeverity": "error"
+}

--- a/test/validate/index.spec.js
+++ b/test/validate/index.spec.js
@@ -48,6 +48,16 @@ describe("validate - generic tests", () => {
         ).to.deep.equal({valid: false, rule: {severity: "warn", "name": "not-in-allowed"}});
     });
 
+    it("is ok with the 'impossible to match allowed' validation - errors when configured so", () => {
+        expect(
+            validate(
+                true,
+                _readRuleSet("./test/validate/fixtures/rules.impossible-to-match-error.allowed.json"),
+                "koos koets",
+                {"resolved": "robby van de kerkhof"}
+            )
+        ).to.deep.equal({valid: false, rule: {severity: "error", "name": "not-in-allowed"}});
+    });
 
     it("is ok with the 'nothing allowed' validation", () => {
         expect(


### PR DESCRIPTION
## Description
Adds an `allowedSeverity` attribute to the rule set format to so you can set the severity of the `allowed` rule (which was hitherto fixed to "warn")

Example `dependency-cruiser.json` (adapted from [fimbullinter/wotan/.dependency-cruiser.json](https://github.com/fimbullinter/wotan/.dependency-cruiser.json)):
```json
{
  "allowedSeverity": "error",
  "allowed": [
    {
      "from": {
        "path": "^packages/[^/]+/(src/|bin/|index.[jt]s$)"
      },
      "to": {
        "dependencyTypes": ["local", "npm", "npm-optional", "npm-peer", "core"]
      }
    },
    {
      "from": {
        "path": "^(packages/[^/]+/test|scripts)/"
      },
      "to": {
        "dependencyTypes": ["local", "npm", "npm-optional", "npm-dev", "core"]
      }
    },
    {
      "from": {
        "path": "^packages/[^/]+/test/"
      },
      "to": {
        "path": "^(node_modules/(typescript|ava|tslint)|packages)/"
      }
    }
  ],
  "options": {
    "doNotFollow": "(^|/)node_modules/",
    "moduleSystems": ["cjs", "es6"]
  }
}
```

## Motivation and Context
fixes #34 

There's a few options configuring the severity of 'allowed' rules could've gone:
- in the options section
Not the best one; it's actually a property of a rule (/ group of rules) and not a general rule.
- in the `allowed` section
Semantically correct and I'm still tempted to do this, but it's backward incompatible - every ruleset with an _allowed_ section should be transformed from this
```json
"allowed": [
    {"from": {"path": "something"}, "to": {"path": "somethingElse"}},
    {"from": {"path": "somethingElse},"to": {"dependencyTypes": ["local", "npm", "core"]}}
]
```
to this:
```json
"allowed": {
    "severity": "error",
    "rules": [
        {"from": {"path": "something"}, "to": {"path": "somethingElse"}},
        {"from": {"path": "somethingElse}, "to": {"dependencyTypes": ["local", "npm", "core"]}}
    ]
}
```
(which could be (semi) automated with a utility b.t.w.)
- in the rules part add a `allowedSeverity` attribute
Not as clean, but less of a pain to migrate to.

## How Has This Been Tested?
- [x] unit tests
- [x] the [fimbullinter/wotan](https://github.com/fimbullinter/wotan) repo

## Types of changes
- ~~~[ ] Bug fix (non-breaking change which fixes an issue)~~~
- [x] New feature (non-breaking change which adds functionality)
- ~~~[ ] Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.