### PR TITLE
specify which path we're matching

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -137,7 +137,9 @@ out dependency-cruiser will assume it to be `warn`.
 A regular expression an end of a dependency should match to be catched by this
 rule.
 
-In `from`, this is the path from project root to the file containing a dependency. In `to`, this is the path from project root to the file the dependency resolves to.
+In `from`, this is the path from the current working directory (typically your 
+project root) to the file containing a dependency. In `to`, this is the path from
+the current working directory to the file the dependency resolves to.
 
 When path is in a `to` part of a rule it accepts the regular expression
 'group matching' special variables `$0`, `$1`, `$2`, ...  as well. See

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -137,6 +137,8 @@ out dependency-cruiser will assume it to be `warn`.
 A regular expression an end of a dependency should match to be catched by this
 rule.
 
+In `from`, this is the path from project root to the file containing a dependency. In `to`, this is the path from project root to the file the dependency resolves to.
+
 When path is in a `to` part of a rule it accepts the regular expression
 'group matching' special variables `$0`, `$1`, `$2`, ...  as well. See
 'group matching' below for an explanation & example.


### PR DESCRIPTION
This wasn't clear to me, when I run `depcruise --validate .dependency-cruiser.json src`, exactly what I was trying to match in that regex. (relative to here? relative to src? relative to the file, as passed to `import` ?)

Thank you for making this tool and publishing and documenting it! This was really useful yesterday in identifying a circular dependency in TypeScript, which mocha totally barfs on.

<!--- Provide a general summary of your changes in the Title above -->

> Plan to do something drastic?     
> Leave an [issue](https://github.com/sverweij/dependency-cruiser/issues/new) with a
> summary of the changes you propose + some context on why you'd want to
> do that.


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
