### PR TITLE
Introduce 'localmodule' dependency type

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -376,6 +376,7 @@ This is a list of dependency types dependency-cruiser currently detects.
  dependency type | meaning | example
  ---             | ---| ---
  local           | a module in your own ('local') package            | "./klont"
+ localmodule     | a module in your own ('local') package, but which was in the `resolve.modules` attribute of the webpack config you passed| "shared/stuff.ts"
  npm             | it's a module in package.json's `dependencies`    | "lodash"
  npm-dev         | it's a module in package.json's `devDependencies`      | "chai"
  npm-optional    | it's a module in package.json's `optionalDependencies` | "livescript"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.2.0-beta-1",
+  "version": "4.2.0-beta-2",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "bin": {
     "dependency-cruiser": "bin/dependency-cruise",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "mocha test/*/*.spec.js test/*/*/*.spec.js test/*/*/*/*.spec.js",
     "test:cover": "nyc --check-coverage npm test",
     "test:glob": "set -f && test \"`bin/dependency-cruise test/extract/fixtures/gather-globbing/packages/**/src/**/*.js | grep \"no dependency violations found\"`\" = \"✔ no dependency violations found (6 modules cruised)\"",
-    "test:long": "mocha test/*/*.spec.js test/*/*/*.spec.js test/*/*/*/*.spec.js",
     "test:watch": "mocha --watch --watch-extensions=json --reporter=min test/*/*.spec.js test/*/*/*.spec.js test/*/*/*/*.spec.js",
     "update-dependencies": "npm-run-all npm-check-updates npm-install build:clean build lint:fix depcruise test:cover"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.1.1",
+  "version": "4.2.0-beta-0",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "bin": {
     "dependency-cruiser": "bin/dependency-cruise",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.2.0-beta-0",
+  "version": "4.2.0-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "bin": {
     "dependency-cruiser": "bin/dependency-cruise",

--- a/src/extract/jsonschema.json
+++ b/src/extract/jsonschema.json
@@ -217,6 +217,7 @@
                 "core",
                 "deprecated",
                 "local",
+                "localmodule",
                 "npm",
                 "npm-bundled",
                 "npm-dev",

--- a/src/extract/resolve/determineDependencyTypes.js
+++ b/src/extract/resolve/determineDependencyTypes.js
@@ -40,13 +40,13 @@ function dependencyIsBundled(pModule, pPackageDeps) {
     return lRetval;
 }
 
-function determineNodeModuleDependencyTypes(pModuleName, pPackageDeps, pBaseDir) {
+function determineNodeModuleDependencyTypes(pModuleName, pPackageDeps, pFileDir) {
     let lRetval = determineNpmDependencyTypes(
         localNpmHelpers.getPackageRoot(pModuleName),
         pPackageDeps
     );
 
-    if (localNpmHelpers.dependencyIsDeprecated(pModuleName, pBaseDir)) {
+    if (localNpmHelpers.dependencyIsDeprecated(pModuleName, pFileDir)) {
         lRetval.push("deprecated");
     }
     if (dependencyIsBundled(pModuleName, pPackageDeps)) {
@@ -59,11 +59,11 @@ function isNodeModule(pDependency) {
     return pDependency.resolved.includes("node_modules");
 }
 
-function determineModuleDependencyTypes(pDependency, pModuleName, pPackageDeps, pBaseDir) {
+function determineModuleDependencyTypes(pDependency, pModuleName, pPackageDeps, pFileDir) {
     let lRetval = [];
 
     if (isNodeModule(pDependency)) {
-        lRetval = determineNodeModuleDependencyTypes(pModuleName, pPackageDeps, pBaseDir);
+        lRetval = determineNodeModuleDependencyTypes(pModuleName, pPackageDeps, pFileDir);
     } else {
         lRetval = ["localmodule"];
     }
@@ -104,12 +104,13 @@ function isAliased(pModuleName, pAliasObject) {
  * @param {any} pDependency the dependency object with all information found hitherto
  * @param {string} pModuleName the module name as found in the source
  * @param {any} pPackageDeps a package.json, in object format
- * @param {string} pBaseDir the directory relative to which to resolve (only used for npm deps here)
+ * @param {string} pFileDir the directory relative to which to resolve (only used for npm deps here)
  * @param {any} pResolveOptions an enhanced resolve 'resolve' key
+ * @param {string} pBaseDir the base directory dependency cruise is run on
  *
  * @return {string[]} an array of dependency types for the dependency
  */
-function determineDependencyTypes (pDependency, pModuleName, pPackageDeps, pBaseDir, pResolveOptions) {
+function determineDependencyTypes (pDependency, pModuleName, pPackageDeps, pFileDir, pResolveOptions, pBaseDir) {
     let lRetval = ["undetermined"];
 
     pResolveOptions = pResolveOptions || {};
@@ -130,7 +131,7 @@ function determineDependencyTypes (pDependency, pModuleName, pPackageDeps, pBase
             pDependency,
             pModuleName,
             pPackageDeps,
-            pBaseDir
+            pFileDir
         );
     } else if (isAliased(pModuleName, pResolveOptions.alias)){
         lRetval = ["aliased"];

--- a/src/extract/resolve/resolve-commonJS.js
+++ b/src/extract/resolve/resolve-commonJS.js
@@ -108,7 +108,8 @@ module.exports = (pModuleName, pBaseDir, pFileDir, pResolveOptions) => {
                 pModuleName,
                 readPackageDeps(pFileDir),
                 pFileDir,
-                pResolveOptions
+                pResolveOptions,
+                pBaseDir
             )
         }
     );

--- a/src/main/ruleSet/jsonschema.json
+++ b/src/main/ruleSet/jsonschema.json
@@ -201,6 +201,7 @@
                 "core",
                 "deprecated",
                 "local",
+                "localmodule",
                 "npm",
                 "npm-bundled",
                 "npm-dev",

--- a/test/extract/resolve/determineDependencyTypes.spec.js
+++ b/test/extract/resolve/determineDependencyTypes.spec.js
@@ -195,4 +195,38 @@ describe("determine dependencyTypes", () => {
         ).to.deep.equal(["undetermined"]);
     });
 
+    it("classifies local, non-node_modules modules as local (and module)", () => {
+        expect(
+            determine(
+                {
+                    couldNotResolve: false,
+                    resolved: "src/bla/somethinglocal.ts"
+                },
+                "bla/somethinglocal",
+                {},
+                "whatever",
+                {
+                    modules: ["node_modules", "src"]
+                }
+            )
+        ).to.deep.equal(["localmodule"]);
+    });
+
+    it("classifies local, non-node_modules non-modules as undetermined", () => {
+        expect(
+            determine(
+                {
+                    couldNotResolve: false,
+                    resolved: "test/bla/localthing.spec.js"
+                },
+                "test/bla/localthing.spec",
+                {},
+                "whatever",
+                {
+                    modules: ["node_modules", "src"]
+                }
+            )
+        ).to.deep.equal(["undetermined"]);
+    });
+
 });

--- a/test/extract/resolve/determineDependencyTypes.spec.js
+++ b/test/extract/resolve/determineDependencyTypes.spec.js
@@ -222,10 +222,11 @@ describe("determine dependencyTypes", () => {
                 },
                 "bla/somethinglocal",
                 {},
-                path.resolve(__dirname, "socrates", "hemlock"),
+                path.resolve(__dirname, "socrates", "hemlock", "src", "bla"),
                 {
                     modules: ["node_modules", path.resolve(__dirname, "socrates", "hemlock", "src")]
-                }
+                },
+                path.resolve(__dirname, "socrates", "hemlock", "src", "bla")
             )
         ).to.deep.equal(["localmodule"]);
     });

--- a/test/extract/resolve/determineDependencyTypes.spec.js
+++ b/test/extract/resolve/determineDependencyTypes.spec.js
@@ -168,7 +168,7 @@ describe("determine dependencyTypes", () => {
                 },
                 "@wappie",
                 {},
-                null,
+                ".",
                 {
                     alias: {
                         "@": "src"
@@ -195,7 +195,7 @@ describe("determine dependencyTypes", () => {
         ).to.deep.equal(["undetermined"]);
     });
 
-    it("classifies local, non-node_modules modules as local (and module)", () => {
+    it("classifies local, non-node_modules modules as localmodule", () => {
         expect(
             determine(
                 {
@@ -207,6 +207,23 @@ describe("determine dependencyTypes", () => {
                 "whatever",
                 {
                     modules: ["node_modules", "src"]
+                }
+            )
+        ).to.deep.equal(["localmodule"]);
+    });
+
+    it("classifies local, non-node_modules modules with an absolute path as localmodule", () => {
+        expect(
+            determine(
+                {
+                    couldNotResolve: false,
+                    resolved: "src/bla/somethinglocal.ts"
+                },
+                "bla/somethinglocal",
+                {},
+                "/home/socrates/hemlock/",
+                {
+                    modules: ["node_modules", "/home/socrates/hemlock/src"]
                 }
             )
         ).to.deep.equal(["localmodule"]);

--- a/test/extract/resolve/determineDependencyTypes.spec.js
+++ b/test/extract/resolve/determineDependencyTypes.spec.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const path      = require("path");
 const expect    = require("chai").expect;
 const determine = require("../../../src/extract/resolve/determineDependencyTypes");
 
@@ -212,7 +213,7 @@ describe("determine dependencyTypes", () => {
         ).to.deep.equal(["localmodule"]);
     });
 
-    it("classifies local, non-node_modules modules with an absolute path as localmodule", () => {
+    it("classifies local, non-node_modules modules with an absolute path as localmodule (posix & win32 paths)", () => {
         expect(
             determine(
                 {
@@ -221,13 +222,14 @@ describe("determine dependencyTypes", () => {
                 },
                 "bla/somethinglocal",
                 {},
-                "/home/socrates/hemlock/",
+                path.resolve(__dirname, "socrates", "hemlock"),
                 {
-                    modules: ["node_modules", "/home/socrates/hemlock/src"]
+                    modules: ["node_modules", path.resolve(__dirname, "socrates", "hemlock", "src")]
                 }
             )
         ).to.deep.equal(["localmodule"]);
     });
+
 
     it("classifies local, non-node_modules non-modules as undetermined", () => {
         expect(

--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -37,9 +37,9 @@ export type OutputType = "json" | "html" | "dot" | "csv" | "err";
 export type SeverityType = "error" | "warn" | "info";
 
 export type DependencyType = "aliased"       | "core"        | "deprecated"  | "local"
-                            | "npm"          | "npm-bundled" | "npm-dev"     | "npm-no-pkg"
-                            | "npm-optional" | "npm-peer"    | "npm-unknown" | "undetermined"
-                            | "unknown";
+                            | "localmodule"  | "npm"         | "npm-bundled" | "npm-dev"
+                            | "npm-no-pkg"   | "npm-optional" | "npm-peer"   | "npm-unknown"
+                            | "undetermined" | "unknown";
 
 export interface IFromRestriction {
     /**


### PR DESCRIPTION
## Description
- Introduces the `localmodule` `dependencyType` for modules that are in the (webpack type) `resolve.modules` array, but which are not `node_modules`

This solves issue #51 and it enables distinguisinging local dependencies and local dependencies in the resolve module array.

## Motivation and Context
fixes #51 

## How Has This Been Tested?
- unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- ~~~Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
