### PR TITLE
feature(typescript): use a passed tsconfig for module resolution as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "dependencies": {
     "acorn": "5.7.1",
     "ajv": "6.5.2",
+    "awesome-typescript-loader": "5.2.0",
     "chalk": "2.4.1",
     "commander": "2.17.0",
     "enhanced-resolve": "4.1.0",

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -113,7 +113,8 @@ module.exports = (pFileName, pOptions, pResolveOptions, pTSConfig) => {
         const lResolveOptions = Object.assign(
             {},
             pResolveOptions,
-            {symlinks: lOptions.preserveSymlinks}
+            {symlinks: lOptions.preserveSymlinks},
+            {tsConfig: lOptions.tsConfig}
         );
 
         return _(extractDependencies(lOptions, pFileName, pTSConfig))

--- a/src/extract/resolve/determineDependencyTypes.js
+++ b/src/extract/resolve/determineDependencyTypes.js
@@ -97,6 +97,9 @@ function isAliased(pModuleName, pAliasObject) {
     return Object.keys(pAliasObject || {}).some(pAliasLHS => pModuleName.startsWith(pAliasLHS));
 }
 
+function isLikelyTSAliased(pModule, pResolved, pTsConfig) {
+    return pTsConfig && !isLocal(pModule) && pResolved && !pResolved.includes("node_modules");
+}
 
 /* eslint max-params:0, complexity:0 */
 /**
@@ -133,7 +136,9 @@ function determineDependencyTypes (pDependency, pModuleName, pPackageDeps, pFile
             pPackageDeps,
             pFileDir
         );
-    } else if (isAliased(pModuleName, pResolveOptions.alias)){
+    } else if (
+        isAliased(pModuleName, pResolveOptions.alias) ||
+        isLikelyTSAliased(pModuleName, pDependency.resolved, pResolveOptions.tsConfig)){
         lRetval = ["aliased"];
     }
 

--- a/src/extract/resolve/resolve-commonJS.js
+++ b/src/extract/resolve/resolve-commonJS.js
@@ -3,6 +3,7 @@
 const path                     = require('path');
 const resolve                  = require('resolve');
 const enhancedResolve          = require('enhanced-resolve');
+const {TsConfigPathsPlugin}    = require('awesome-typescript-loader');
 const pathToPosix              = require('../../utl/pathToPosix');
 const getExtension             = require('../../utl/getExtension');
 const transpileMeta            = require('../transpile/meta');
@@ -44,8 +45,17 @@ function compileResolveOptions(pResolveOptions){
         useSyncFileSystemCalls: true
     };
 
+    let lResolveOptions = {};
+
+    if (pResolveOptions.tsConfig) {
+        lResolveOptions.plugins = [
+            new TsConfigPathsPlugin({configFileName: pResolveOptions.tsConfig})
+        ];
+    }
+
     return Object.assign(
         DEFAULT_RESOLVE_OPTIONS,
+        lResolveOptions,
         pResolveOptions,
         NON_OVERRIDABLE_RESOLVE_OPTIONS
     );

--- a/test/cli/fixtures/typescript-path-resolution.json
+++ b/test/cli/fixtures/typescript-path-resolution.json
@@ -1,0 +1,68 @@
+{
+    "modules": [
+        {
+            "source": "test/cli/fixtures/typescriptconfig/cli-config-with-path/src/index.ts",
+            "dependencies": [
+                {
+                    "resolved": "test/cli/fixtures/typescriptconfig/cli-config-with-path/src/shared/index.ts",
+                    "coreModule": false,
+                    "followable": true,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "aliased"
+                    ],
+                    "module": "shared",
+                    "moduleSystem": "cjs",
+                    "matchesDoNotFollow": false,
+                    "valid": true
+                }
+            ],
+            "valid": true
+        },
+        {
+            "source": "test/cli/fixtures/typescriptconfig/cli-config-with-path/src/shared/index.ts",
+            "dependencies": [],
+            "valid": true
+        },
+        {
+            "source": "test/cli/fixtures/typescriptconfig/cli-config-with-path/src/something/else.ts",
+            "dependencies": [
+                {
+                    "resolved": "test/cli/fixtures/typescriptconfig/cli-config-with-path/src/shared/index.ts",
+                    "coreModule": false,
+                    "followable": true,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "aliased"
+                    ],
+                    "module": "shared",
+                    "moduleSystem": "cjs",
+                    "matchesDoNotFollow": false,
+                    "valid": true
+                }
+            ],
+            "valid": true
+        }
+    ],
+    "summary": {
+        "violations": [],
+        "error": 0,
+        "warn": 0,
+        "info": 0,
+        "totalCruised": 3,
+        "optionsUsed": {
+            "outputTo": "test/cli/output/typescript-path-resolution.json",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "outputType": "json",
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false,
+            "webpackConfig": {
+                "fileName": "test/cli/fixtures/typescriptconfig/cli-config-with-path/webpack.config.js"
+            }
+        }
+    }
+}

--- a/test/cli/fixtures/typescriptconfig/cli-config-with-path/src/index.ts
+++ b/test/cli/fixtures/typescriptconfig/cli-config-with-path/src/index.ts
@@ -1,0 +1,5 @@
+import * as shared from 'shared';
+
+console.log(
+    shared.version
+)

--- a/test/cli/fixtures/typescriptconfig/cli-config-with-path/src/shared/index.ts
+++ b/test/cli/fixtures/typescriptconfig/cli-config-with-path/src/shared/index.ts
@@ -1,0 +1,1 @@
+export const version = "4.8.1";

--- a/test/cli/fixtures/typescriptconfig/cli-config-with-path/src/something/else.ts
+++ b/test/cli/fixtures/typescriptconfig/cli-config-with-path/src/something/else.ts
@@ -1,0 +1,5 @@
+import * as shared from 'shared';
+
+console.log(
+    'from someting else', shared.version
+)

--- a/test/cli/fixtures/typescriptconfig/cli-config-with-path/tsconfig.json
+++ b/test/cli/fixtures/typescriptconfig/cli-config-with-path/tsconfig.json
@@ -1,0 +1,59 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {"shared": ["./shared"]},        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/test/cli/fixtures/typescriptconfig/cli-config-with-path/webpack.config.js
+++ b/test/cli/fixtures/typescriptconfig/cli-config-with-path/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = () => ({
+    resolve: {
+        bustTheCache: true
+    }
+    
+})

--- a/test/cli/index.spec.js
+++ b/test/cli/index.spec.js
@@ -128,6 +128,7 @@ function resetOutputDir() {
     deleteDammit(path.join(OUT_DIR, "webpack-config-alias-cruiser-config.json"));
     deleteDammit(path.join(OUT_DIR, "dynamic-import-ok.json"));
     deleteDammit(path.join(OUT_DIR, "dynamic-import-nok.json"));
+    deleteDammit(path.join(OUT_DIR, "typescript-path-resolution.json"));
 }
 
 function setModuleType(pTestPairs, pModuleType) {
@@ -391,6 +392,27 @@ describe("#processCLI", () => {
                 outputTo: lOutputTo,
                 outputType: "json",
                 tsConfig: "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/tsconfig.error_on_compile_dynamic_imports.json"
+            }
+        );
+        tst.assertFileEqual(
+            lOutputTo,
+            path.join(FIX_DIR, lOutputFileName)
+        );
+    });
+
+    it("dependency-cruise with a --ts-config with a path will resolve 'path' things", () => {
+        const lOutputFileName = "typescript-path-resolution.json";
+        const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
+
+        processCLI(
+            [
+                "test/cli/fixtures/typescriptconfig/cli-config-with-path/src"
+            ],
+            {
+                outputTo: lOutputTo,
+                outputType: "json",
+                tsConfig: "test/cli/fixtures/typescriptconfig/cli-config-with-path/tsconfig.json",
+                webpackConfig: "test/cli/fixtures/typescriptconfig/cli-config-with-path/webpack.config.js"
             }
         );
         tst.assertFileEqual(

--- a/test/extract/resolve/fixtures/ts-config-with-path/src/shared/index.ts
+++ b/test/extract/resolve/fixtures/ts-config-with-path/src/shared/index.ts
@@ -1,0 +1,1 @@
+export const version = "4.8.1";

--- a/test/extract/resolve/fixtures/ts-config-with-path/tsconfig.json
+++ b/test/extract/resolve/fixtures/ts-config-with-path/tsconfig.json
@@ -1,0 +1,59 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {"shared": ["./shared"]},        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/test/extract/resolve/index.spec.js
+++ b/test/extract/resolve/index.spec.js
@@ -196,5 +196,54 @@ describe("resolve/index", () => {
             resolved: 'localmodulesfix/localmoduleshere/shared/index.js'
         });
     });
+
+    it("considers a webpack config", () => {
+        expect(
+            resolve(
+                {
+                    moduleName: 'shared',
+                    moduleSystem: 'es6'
+                },
+                path.join(__dirname, 'fixtures'),
+                path.join(__dirname, 'fixtures', 'ts-config-with-path'),
+                {
+                    tsConfig: path.join(__dirname, 'fixtures', 'ts-config-with-path', 'tsconfig.json'),
+                    bustTheCache: true
+                }
+            )
+        ).to.deep.equal({
+            coreModule: false,
+            couldNotResolve: false,
+            dependencyTypes: [
+                "aliased"
+            ],
+            followable: true,
+            resolved: 'ts-config-with-path/src/shared/index.ts'
+        });
+    });
+
+    it("considers gives a different result for the same input without a webpack config", () => {
+        expect(
+            resolve(
+                {
+                    moduleName: 'shared',
+                    moduleSystem: 'es6'
+                },
+                path.join(__dirname, 'fixtures'),
+                path.join(__dirname, 'fixtures', 'ts-config-with-path'),
+                {
+                    bustTheCache: true
+                }
+            )
+        ).to.deep.equal({
+            coreModule: false,
+            couldNotResolve: true,
+            dependencyTypes: [
+                "unknown"
+            ],
+            followable: false,
+            resolved: 'shared'
+        });
+    });
 });
 


### PR DESCRIPTION
## Description
Pass a passed tsconfig to the resolver, so any `baseDir`/ `path` (and other resolution influencing options) is taken into account when resolving modules

## Motivation and Context
- 2nd part to solve #55 

`[nerdtalk]`
There were a few ways to skin this cat:
- manually translate path/ baseDir etc to their webpack equivalents and pass that to enhanced-resolve => lots of work and hard to keep in sync with the (fast moving) typescript compiler, that implements this itself as well => not a serious option => ❌ 
- use the typescript resolver  to do that for us => good plan; looks elegant and simple (thanks @ajafff  for this and the next suggestion I used it in a [PoC](https://gist.github.com/sverweij/abbd3c3f135f603d69ed1095cc3673a8) and it works great). Combining it properly with what enhanced-resolve is doing will require some work, probably best by writing an enhanced-resolve plugin => interesting challenge, but first check if there's a more lazy option available => 🤔 
- same as the previous but instead use an existing package => still needs integration into the resolver algorithm => 🤔 

The last two made me realise that webpack typescript loaders might already have done the heavy lifting. Both ts-loader and awesome-typescript-loader did => 😎 
- It has all pro's of using a separate ts resolve package, and none of the headache of properly integrating it with enhanced-resolve.
- The plugin (awesome-typescript-loader) is widely used =>  likely to be used in case you're working with tsconfig paths/ baseDirs => and likely to yield the results you'd expect. 

`[/nerdtalk]`

## How Has This Been Tested?
- [x] Unit tests
- [ ] some bigger code bases

## Screenshots (if appropriate):
With these sources...
```
tsconfig.json
src/shared/index.ts
src/index.ts
src/something/else.ts
```
... this tsconfig.json:
```json
{
  "compilerOptions": {
    "target": "ES2015",
    "module": "commonjs",
    "outDir": "./dist",
    "baseUrl": "./src",
    "paths": {"shared": ["./shared"]},
  }
}
```
... and this command line...

```sh
depcruise -T dot --ts-config tsconfig.json src | dot -T svg > tmp_deps.svg
```
### before
<img width="232" alt="before - sad polar bear" src="https://user-images.githubusercontent.com/4822597/43801513-9a052aaa-9a93-11e8-9ab7-0c98b59b0bfe.png">

### after
<img width="253" alt="after - manic pinguin" src="https://user-images.githubusercontent.com/4822597/43801469-795bb378-9a93-11e8-9163-7550b696c950.png">

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.