### PR TITLE
Feature: allow tsconfig spec in dependency cruiser.json

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -326,6 +326,26 @@ depcruise --ts-config --validate src
 depcruise --ts-config tsconfig.prod.json --validate src
 ```
 
+Useful things to know:
+- The configuration file you can pass as an argument to this option is
+  relative to the current working directory.
+- As an alternative to this command line parameter you can pass the
+  typescript project file name in in your .dependency-cruiser.json like this:
+  ```json
+  "options": {
+    "tsConfig": {
+      "fileName": "tsconfig.json"
+    }
+  }
+  ```
+  or even more minimalistically like so (in which case dependency-cruiser will
+  assume the fileName to be `tsconfig.json`)
+  ```json
+  "options": {
+    "tsConfig": {}
+  }
+  ```
+
 > note: dependency-cruiser currently only looks at the `compilerOptions` key
 > in the tsconfig.json and not at other keys (e.g. `files`, `include` and
 > `exclude`).

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -71,7 +71,8 @@ The currently supported options are
 [`moduleSystems`](./cli.md#--module-systems),
 [`prefix`](./cli.md#--prefix-prefixing-links),
 [`tsPreCompilationDeps`](./cli.md#--ts-pre-compilation-deps-typescript-only),
-[`preserveSymlinks`](./cli.md#--preserve-symlinks) and 
+[`preserveSymlinks`](./cli.md#--preserve-symlinks),
+[`tsConfig`](./cli.md#--ts-config-use-a-typescript-configuration-file-project) and 
 [`webpackConfig`](./cli.md#--webpack-config-use-the-resolution-options-of-a-webpack-configuration).
 See the [command line documentation](./cli.md) for details.
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -10,7 +10,6 @@ const normalizeOptions        = require('./normalizeOptions');
 const initRules               = require('./initRules');
 const io                      = require('./io');
 const formatMetaInfo          = require('./formatMetaInfo');
-const defaults                = require('./defaults.json');
 
 
 function createRulesFile(pOptions) {
@@ -22,12 +21,11 @@ function createRulesFile(pOptions) {
 
 function extractResolveOptions(pOptions) {
     let lResolveOptions = {};
+    const lWebPackConfigFileName = _get(pOptions, 'ruleSet.options.webpackConfig.fileName', null);
 
-    if (pOptions.hasOwnProperty("webpackConfig") || _get(pOptions, 'ruleSet.options.webpackConfig', null)) {
+    if (lWebPackConfigFileName) {
         lResolveOptions = getResolveConfig(
-            normalizeOptions.determineWebpackConfigFileName(
-                _get(pOptions, 'ruleSet.options.webpackConfig.fileName', defaults.webpackConfig)
-            ),
+            lWebPackConfigFileName,
             _get(pOptions, 'ruleSet.options.webpackConfig.env', null),
             _get(pOptions, 'ruleSet.options.webpackConfig.arguments', null)
         );
@@ -37,11 +35,10 @@ function extractResolveOptions(pOptions) {
 
 function extractTSConfigOptions(pOptions) {
     let lRetval = {};
+    const lTSConfigFileName = _get(pOptions, "ruleSet.options.tsConfig.fileName", null);
 
-    if (pOptions.hasOwnProperty("tsConfig")) {
-        lRetval = flattenTypeScriptConfig(
-            normalizeOptions.determineTSConfigFileName(pOptions.tsConfig)
-        );
+    if (lTSConfigFileName) {
+        lRetval = flattenTypeScriptConfig(lTSConfigFileName);
     }
 
     return lRetval;

--- a/src/cli/normalizeOptions.js
+++ b/src/cli/normalizeOptions.js
@@ -17,53 +17,30 @@ function getOptionValue(pDefault) {
     };
 }
 
-function normalizeWebPackConfig(pOptions) {
+function normalizeConfigFile(pOptions, pConfigWrapperName, pDefault) {
     let lOptions = _clone(pOptions);
 
-    if (lOptions.hasOwnProperty("webpackConfig")) {
+    if (lOptions.hasOwnProperty(pConfigWrapperName)) {
         _set(
-            lOptions, "ruleSet.options.webpackConfig.fileName",
-            getOptionValue(defaults.WEBPACK_CONFIG)(lOptions.webpackConfig)
+            lOptions, `ruleSet.options.${pConfigWrapperName}.fileName`,
+            getOptionValue(pDefault)(lOptions[pConfigWrapperName])
         );
-        Reflect.deleteProperty(lOptions, "webpackConfig");
+        Reflect.deleteProperty(lOptions, pConfigWrapperName);
     }
 
-    if (_get(lOptions, "ruleSet.options.webpackConfig", null)) {
-        if (!_get(lOptions, "ruleSet.options.webpackConfig.fileName", null)) {
+    if (_get(lOptions, `ruleSet.options.${pConfigWrapperName}`, null)) {
+        if (!_get(lOptions, `ruleSet.options.${pConfigWrapperName}.fileName`, null)) {
             _set(
-                lOptions, "ruleSet.options.webpackConfig.fileName",
-                defaults.WEBPACK_CONFIG
+                lOptions, `ruleSet.options.${pConfigWrapperName}.fileName`,
+                pDefault
             );
         }
     }
 
     return lOptions;
 }
+/* eslint security/detect-object-injection: 0 */
 
-
-function normalizeTSConfig(pOptions) {
-    let lOptions = _clone(pOptions);
-
-    if (lOptions.hasOwnProperty("tsConfig")) {
-        _set(
-            lOptions, "ruleSet.options.tsConfig.fileName",
-            getOptionValue(defaults.TYPESCRIPT_CONFIG)(lOptions.tsConfig)
-        );
-        Reflect.deleteProperty(lOptions, "tsConfig");
-    }
-
-    if (_get(lOptions, "ruleSet.options.tsConfig", null)) {
-        if (!_get(lOptions, "ruleSet.options.tsConfig.fileName", null)) {
-            _set(
-                lOptions, "ruleSet.options.tsConfig.fileName",
-                defaults.TYPESCRIPT_CONFIG
-            );
-        }
-    }
-
-    return lOptions;
-}
-/* eslint complexity:0 */
 /**
  * returns the pOptions, so that the returned value contains a
  * valid value for each possible option
@@ -89,8 +66,8 @@ module.exports = (pOptions) => {
         pOptions.ruleSet   = JSON.parse(fs.readFileSync(pOptions.rulesFile, 'utf8'));
     }
 
-    pOptions = normalizeWebPackConfig(pOptions);
-    pOptions = normalizeTSConfig(pOptions);
+    pOptions = normalizeConfigFile(pOptions, "webpackConfig", defaults.WEBPACK_CONFIG);
+    pOptions = normalizeConfigFile(pOptions, "tsConfig", defaults.TYPESCRIPT_CONFIG);
 
     pOptions.validate = pOptions.hasOwnProperty("validate");
 

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -114,7 +114,7 @@ module.exports = (pFileName, pOptions, pResolveOptions, pTSConfig) => {
             {},
             pResolveOptions,
             {symlinks: lOptions.preserveSymlinks},
-            {tsConfig: lOptions.tsConfig}
+            {tsConfig: _.get(lOptions, "ruleSet.options.tsConfig.fileName", null)}
         );
 
         return _(extractDependencies(lOptions, pFileName, pTSConfig))

--- a/src/extract/jsonschema.json
+++ b/src/extract/jsonschema.json
@@ -268,6 +268,15 @@
                 "preserveSymlinks": {
                     "type": "boolean"
                 },
+                "tsConfig": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "fileName": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "webpackConfig": {
                     "type": "object",
                     "additionalProperties": false,

--- a/src/main/ruleSet/jsonschema.json
+++ b/src/main/ruleSet/jsonschema.json
@@ -60,6 +60,17 @@
                     "type": "boolean",
                     "description": "if true leave symlinks untouched, otherwise use the realpath. Defaults to `false` (which is also nodejs's default behavior since version 6)"
                 },
+                "tsConfig": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Typescript project file ('tsconfig.json') to use for (1) compilation and (2) resolution (e.g. with the paths property)",
+                    "properties": {
+                        "fileName": {
+                            "description": "The typescript project file to use. The fileName is relative to dependency-cruiser's current working directory. When not provided defaults to './tsconfig.json'.",
+                            "type": "string"
+                        }
+                    }
+                },
                 "webpackConfig": {
                     "type": "object",
                     "additionalProperties": false,
@@ -67,7 +78,7 @@
                     "properties": {
                         "fileName": {
                             "type": "string",
-                            "description": "The webpack conf file to use (typically something like 'webpack.conf.js')"
+                            "description": "The webpack conf file to use (typically something like 'webpack.conf.js'). The fileName is relative to dependency-cruiser's current working directory. When not provided defaults to './webpack.conf.js'."
                         },
                         "env": {
                             "description": "Environment to pass if your config file returns a function",

--- a/test/cli/fixtures/rules.tsConfigNoFileName.json
+++ b/test/cli/fixtures/rules.tsConfigNoFileName.json
@@ -1,0 +1,5 @@
+{
+    "options": {
+        "tsConfig": {}
+    }
+}

--- a/test/cli/fixtures/rules.webpackConfigNoFileName.json
+++ b/test/cli/fixtures/rules.webpackConfigNoFileName.json
@@ -1,0 +1,5 @@
+{
+    "options": {
+        "webpackConfig": {}
+    }
+}

--- a/test/cli/normalizeOptions.spec.js
+++ b/test/cli/normalizeOptions.spec.js
@@ -1,4 +1,3 @@
-"use strict";
 const expect           = require('chai').expect;
 const normalizeOptions = require('../../src/cli/normalizeOptions');
 
@@ -57,18 +56,44 @@ describe("normalizeOptions", () => {
             }
         );
     });
+
+    it("defaults tsConfig.fileName to 'tsconfig.json' if it wasn't specified", () => {
+        expect(
+            normalizeOptions({validate: "./test/cli/fixtures/rules.tsConfigNoFileName.json"})
+        ).to.deep.equal(
+            {
+                outputTo: "-",
+                outputType: "err",
+                rulesFile: "./test/cli/fixtures/rules.tsConfigNoFileName.json",
+                "ruleSet": {
+                    options: {
+                        tsConfig: {
+                            fileName: "tsconfig.json"
+                        }
+                    }
+                },
+                validate: true
+            }
+        );
+    });
+    it("defaults webpackConfig.fileName to 'tsconfig.json' if it wasn't specified", () => {
+        expect(
+            normalizeOptions({validate: "./test/cli/fixtures/rules.webpackConfigNoFileName.json"})
+        ).to.deep.equal(
+            {
+                outputTo: "-",
+                outputType: "err",
+                rulesFile: "./test/cli/fixtures/rules.webpackConfigNoFileName.json",
+                "ruleSet": {
+                    options: {
+                        webpackConfig: {
+                            fileName: "webpack.config.js"
+                        }
+                    }
+                },
+                validate: true
+            }
+        );
+    });
 });
 
-describe("normalizeOptions.determineWebpackConfigFileName", () => {
-    it("returns webpack.config.js when passed nothing", () => {
-        expect(
-            normalizeOptions.determineWebpackConfigFileName()
-        ).to.equal('webpack.config.js');
-    });
-
-    it("returns the passed config when passed", () => {
-        expect(
-            normalizeOptions.determineWebpackConfigFileName('config/production.webpack.config.js')
-        ).to.equal('config/production.webpack.config.js');
-    });
-});

--- a/test/main/ruleSet/normalize.spec.js
+++ b/test/main/ruleSet/normalize.spec.js
@@ -22,7 +22,7 @@ describe("ruleSet/normalize", () => {
         });
     });
 
-    it("allowed: leaves allowedSeverity alone when it wasn filled out; does not add severity/ name to the rule", () => {
+    it("allowed: leaves allowedSeverity alone when it wasn't filled; doesn't add severity/ name to the rule", () => {
         expect(normalizer({
             "allowed": [{
                 "from": ".+",


### PR DESCRIPTION
## Description
Adds the `--ts-config` command line option as a .dependency-cruiser.json `option`.

## Motivation and Context
- to remain consistent how webpack.config.js is handled,
- to declutter command line typing each time

## How Has This Been Tested?
- [x] unit tests
- [x] manually on dependency cruiser itself
- [x] on some bigger projects out there

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.