### PR TITLE
bugfix(cli): if an exception occurs, return 1 as an exit code

### DIFF
--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -11,7 +11,8 @@ if (!semver.satisfies(process.versions.node, $package.engines.node)) {
     process.stderr.write(`\nERROR: your node version (${process.versions.node}) is not recent enough.\n`);
     process.stderr.write(`       dependency-cruiser needs a version of node ${$package.engines.node}\n\n`);
 
-    process.exitCode = 1;
+    /* eslint no-process-exit: 0 */
+    process.exit(1);
 }
 
 program
@@ -45,12 +46,10 @@ program
     .parse(process.argv);
 
 if (Boolean(program.args[0]) || program.info || program.init) {
-    const lExitCode = processCLI(
+    process.exitCode = processCLI(
         program.args,
         program
     );
-
-    process.exitCode = lExitCode;
 } else {
     program.help();
 }

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -46,10 +46,12 @@ program
     .parse(process.argv);
 
 if (Boolean(program.args[0]) || program.info || program.init) {
-    processCLI(
+    const lExitCode = processCLI(
         program.args,
         program
     );
+
+    process.exit(lExitCode);
 } else {
     program.help();
 }

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -11,8 +11,7 @@ if (!semver.satisfies(process.versions.node, $package.engines.node)) {
     process.stderr.write(`\nERROR: your node version (${process.versions.node}) is not recent enough.\n`);
     process.stderr.write(`       dependency-cruiser needs a version of node ${$package.engines.node}\n\n`);
 
-    /* eslint no-process-exit: 0 */
-    process.exit(-1);
+    process.exitCode = 1;
 }
 
 program
@@ -51,7 +50,7 @@ if (Boolean(program.args[0]) || program.info || program.init) {
         program
     );
 
-    process.exit(lExitCode);
+    process.exitCode = lExitCode;
 } else {
     program.help();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.5.2-beta-0",
+  "version": "4.5.2-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.5.2-beta-1",
+  "version": "4.5.2-beta-2",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.5.1",
+  "version": "4.5.2-beta-0",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -45,6 +45,8 @@ function extractTSConfigOptions(pOptions) {
 }
 
 function runCruise(pFileDirArray, pOptions) {
+    let lExitCode = 0;
+
     pFileDirArray
         .filter(pFileOrDir => !glob.hasMagic(pFileOrDir))
         .forEach(validateFileExistence);
@@ -64,14 +66,15 @@ function runCruise(pFileDirArray, pOptions) {
 
     io.write(pOptions.outputTo, lDependencyList.modules);
 
-    /* istanbul ignore if */
     if (lDependencyList.summary.error > 0) {
-        process.exit(lDependencyList.summary.error);
+        lExitCode = lDependencyList.summary.error;
     }
+    return lExitCode;
 }
 
 module.exports = (pFileDirArray, pOptions) => {
     pOptions = pOptions || {};
+    let lExitCode = 0;
 
     try {
         if (pOptions.info === true) {
@@ -79,12 +82,11 @@ module.exports = (pFileDirArray, pOptions) => {
         } else if (pOptions.init === true){
             createRulesFile(pOptions);
         } else {
-            runCruise(pFileDirArray, pOptions);
+            lExitCode = runCruise(pFileDirArray, pOptions);
         }
     } catch (e) {
         process.stderr.write(`\n  ERROR: ${e.message}\n`);
+        lExitCode = -1;
     }
+    return lExitCode;
 };
-
-
-/* eslint no-process-exit: 0 */

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -86,7 +86,7 @@ module.exports = (pFileDirArray, pOptions) => {
         }
     } catch (e) {
         process.stderr.write(`\n  ERROR: ${e.message}\n`);
-        lExitCode = -1;
+        lExitCode = 1;
     }
     return lExitCode;
 };

--- a/src/cli/io.js
+++ b/src/cli/io.js
@@ -9,7 +9,7 @@ function writeToFile(pOutputTo, pDependencyString) {
             {encoding: "utf8", flag: "w"}
         );
     } catch (e) {
-        process.stderr.write(`ERROR: Writing to '${pOutputTo}' didn't work. ${e}`);
+        throw Error(`Writing to '${pOutputTo}' didn't work. ${e}`);
     }
 }
 

--- a/test/cli/fixtures/rules.sub-not-allowed-error.json
+++ b/test/cli/fixtures/rules.sub-not-allowed-error.json
@@ -1,0 +1,21 @@
+{
+    "allowed": [
+        {
+            "from": {
+            },
+            "to": {
+            }
+        }
+    ],
+    "forbidden": [
+        {
+            "name": "sub-not-allowed",
+            "severity": "error",
+            "from": {
+            },
+            "to": {
+                "path": "sub"
+            }
+        }
+    ]
+}

--- a/test/cli/index.spec.js
+++ b/test/cli/index.spec.js
@@ -124,6 +124,7 @@ function resetOutputDir() {
         });
 
     deleteDammit(path.join(OUT_DIR, "multiple-in-one-go.json"));
+    deleteDammit(path.join(OUT_DIR, "transgression-count.json"));
     deleteDammit(path.join(OUT_DIR, "webpack-config-alias.json"));
     deleteDammit(path.join(OUT_DIR, "webpack-config-alias-cruiser-config.json"));
     deleteDammit(path.join(OUT_DIR, "dynamic-import-ok.json"));
@@ -137,6 +138,7 @@ function setModuleType(pTestPairs, pModuleType) {
             description: pTestPair.description.replace(/{{moduleType}}/g, pModuleType),
             dirOrFile: pTestPair.dirOrFile.replace(/{{moduleType}}/g, pModuleType),
             expect: pTestPair.expect.replace(/{{moduleType}}/g, pModuleType),
+            expectExitCode: pTestPair.expectExitCode || 0,
             cleanup: pTestPair.cleanup
         };
 
@@ -153,7 +155,9 @@ function setModuleType(pTestPairs, pModuleType) {
 function runFileBasedTests(pModuleType) {
     setModuleType(testPairs, pModuleType).forEach(pPair => {
         it(pPair.description, () => {
-            processCLI([pPair.dirOrFile], pPair.options);
+            const lExitCode = processCLI([pPair.dirOrFile], pPair.options);
+
+            expect(lExitCode).to.equal(pPair.expectExitCode);
             tst.assertFileEqual(
                 pPair.options.outputTo,
                 path.join(FIX_DIR, pPair.expect)
@@ -175,8 +179,7 @@ describe("#processCLI", () => {
         it("dependency-cruises multiple files and folders in one go", () => {
             const lOutputFileName = "multiple-in-one-go.json";
             const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
-
-            processCLI(
+            const lExitCode = processCLI(
                 [
                     "test/cli/fixtures/cjs/sub",
                     "test/cli/fixtures/duplicate-subs/sub/more-in-sub.js",
@@ -188,10 +191,30 @@ describe("#processCLI", () => {
                     forceCircular: true
                 }
             );
+
+            expect(lExitCode).to.equal(0);
             tst.assertFileEqual(
                 lOutputTo,
                 path.join(FIX_DIR, lOutputFileName)
             );
+        });
+
+        it("returns the number of transgressions", () => {
+            const lOutputFileName = "transgression-count.json";
+            const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
+            const lExitCode = processCLI(
+                [
+                    "test/cli/fixtures/cjs"
+                ],
+                {
+                    outputTo: lOutputTo,
+                    outputType: "json",
+                    validate: "test/cli/fixtures/rules.sub-not-allowed-error.json"
+                }
+            );
+            const lExpectedTransgressions = 3;
+
+            expect(lExitCode).to.equal(lExpectedTransgressions);
         });
 
         it("dependency-cruise -i shows meta info about the current environment", () => {
@@ -199,10 +222,11 @@ describe("#processCLI", () => {
             const unhookIntercept = intercept(pText => {
                 lCapturedStdout += pText;
             });
+            const lExitCode = processCLI(null, ({info: true}));
 
-            processCLI(null, ({info: true}));
             unhookIntercept();
 
+            expect(lExitCode).to.equal(0);
             expect(
                 lCapturedStdout
             ).to.contain(
@@ -215,15 +239,20 @@ describe("#processCLI", () => {
             const unhookInterceptStdOut = intercept(() => {
                 // This space intentionally left empty
             });
-
             const unhookInterceptStdErr = intercept(pText => {
                 lCapturedStderr += pText;
             });
+            const lExitCode = processCLI(
+                ["this-doesnot-exist"],
+                {
+                    outputTo: path.join(OUT_DIR, "cjs.dir.wontmarch.json"),
+                    forceCircular: true}
+            );
 
-            processCLI(["this-doesnot-exist"], {outputTo: path.join(OUT_DIR, "cjs.dir.wontmarch.json"), forceCircular: true});
             unhookInterceptStdOut();
             unhookInterceptStdErr();
 
+            expect(lExitCode).to.equal(-1);
             return expect(
                 lCapturedStderr
             ).to.contain(
@@ -231,29 +260,28 @@ describe("#processCLI", () => {
             );
         });
 
-        it("dependency-cruise -f file/you/cant/write/to - generates error", () => {
+        it("dependency-cruise -f file/you/cant/write/to - generates an error", () => {
             let lCapturedStderr = "";
             const unhookInterceptStdOut = intercept(() => {
                 // This space intentionally left empty
             });
-
             const unhookInterceptStdErr = intercept(pText => {
                 lCapturedStderr += pText;
             });
-
-            processCLI(
+            const lExitCode = processCLI(
                 ["test/cli/fixtures"],
                 {
-                    outputTo: path.join(OUT_DIR, "file/you/cant/write/to"),
-                    forceCircular: true
+                    outputTo: path.join(OUT_DIR, "file/you/cant/write/to")
                 }
             );
+
             unhookInterceptStdOut();
             unhookInterceptStdErr();
             intercept(pText => {
                 lCapturedStderr += pText;
             })();
 
+            expect(lExitCode).to.equal(-1);
             return expect(
                 lCapturedStderr
             ).to.contain(
@@ -266,20 +294,20 @@ describe("#processCLI", () => {
             const unhookInterceptStdOut = intercept(() => {
                 // This space intentionally left empty
             });
-
             const unhookInterceptStdErr = intercept(pText => {
                 lCapturedStderr += pText;
             });
-
-            processCLI(
+            const lExitCode = processCLI(
                 ["test/cli/fixtures"]
             );
+
             unhookInterceptStdOut();
             unhookInterceptStdErr();
             intercept(pText => {
                 lCapturedStderr += pText;
             })();
 
+            expect(lExitCode).to.equal(0);
             return expect(
                 lCapturedStderr
             ).to.contain(
@@ -298,19 +326,21 @@ describe("#processCLI", () => {
             });
 
             deleteDammit(lValidationFileName);
-            processCLI(
+            const lExitCode = processCLI(
                 ["test/cli/fixtures"],
                 {
                     validate: lValidationFileName,
                     init: true
                 }
             );
+
             unhookInterceptStdOut();
             unhookInterceptStdErr();
             intercept(pText => {
                 lCapturedStdout += pText;
             })();
 
+            expect(lExitCode).to.equal(0);
             expect(
                 lCapturedStdout
             ).to.contain(
@@ -322,8 +352,7 @@ describe("#processCLI", () => {
         it("dependency-cruise with a --webpack-config with an object export will respect the resolve stuff in there", () => {
             const lOutputFileName = "webpack-config-alias.json";
             const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
-
-            processCLI(
+            const lExitCode = processCLI(
                 [
                     "test/cli/fixtures/webpackconfig/aliassy/src"
                 ],
@@ -333,6 +362,8 @@ describe("#processCLI", () => {
                     webpackConfig: "test/cli/fixtures/webpackconfig/aliassy/webpack.regularexport.config.js"
                 }
             );
+
+            expect(lExitCode).to.equal(0);
             tst.assertFileEqual(
                 lOutputTo,
                 path.join(FIX_DIR, lOutputFileName)
@@ -342,8 +373,7 @@ describe("#processCLI", () => {
         it("dependency-cruise with a .dependency-cruiser config with a webpackConfig section will respect that config", () => {
             const lOutputFileName = "webpack-config-alias-cruiser-config.json";
             const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
-
-            processCLI(
+            const lExitCode = processCLI(
                 [
                     "test/cli/fixtures/webpackconfig/aliassy/src"
                 ],
@@ -353,6 +383,8 @@ describe("#processCLI", () => {
                     validate: "test/cli/fixtures/webpackconfig/aliassy/dependency-cruiser-json-with-webpack-config.json"
                 }
             );
+
+            expect(lExitCode).to.equal(0);
             tst.assertFileEqual(
                 lOutputTo,
                 path.join(FIX_DIR, lOutputFileName)
@@ -363,8 +395,7 @@ describe("#processCLI", () => {
     it("dependency-cruise with a --ts-config will respect the configuration in there (working dynamic imports)", () => {
         const lOutputFileName = "dynamic-import-ok.json";
         const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
-
-        processCLI(
+        const lExitCode = processCLI(
             [
                 "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/import_dynamically.ts"
             ],
@@ -374,6 +405,8 @@ describe("#processCLI", () => {
                 tsConfig: "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/tsconfig.compile_dynamic_imports.json"
             }
         );
+
+        expect(lExitCode).to.equal(0);
         tst.assertFileEqual(
             lOutputTo,
             path.join(FIX_DIR, lOutputFileName)
@@ -383,8 +416,7 @@ describe("#processCLI", () => {
     it("dependency-cruise with a --ts-config will respect the configuration in there", () => {
         const lOutputFileName = "dynamic-import-nok.json";
         const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
-
-        processCLI(
+        const lExitCode = processCLI(
             [
                 "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/import_dynamically2.ts"
             ],
@@ -394,6 +426,8 @@ describe("#processCLI", () => {
                 tsConfig: "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/tsconfig.error_on_compile_dynamic_imports.json"
             }
         );
+
+        expect(lExitCode).to.equal(0);
         tst.assertFileEqual(
             lOutputTo,
             path.join(FIX_DIR, lOutputFileName)
@@ -404,7 +438,7 @@ describe("#processCLI", () => {
         const lOutputFileName = "typescript-path-resolution.json";
         const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
 
-        processCLI(
+        const lExitCode = processCLI(
             [
                 "test/cli/fixtures/typescriptconfig/cli-config-with-path/src"
             ],
@@ -415,6 +449,8 @@ describe("#processCLI", () => {
                 webpackConfig: "test/cli/fixtures/typescriptconfig/cli-config-with-path/webpack.config.js"
             }
         );
+
+        expect(lExitCode).to.equal(0);
         tst.assertFileEqual(
             lOutputTo,
             path.join(FIX_DIR, lOutputFileName)

--- a/test/cli/index.spec.js
+++ b/test/cli/index.spec.js
@@ -252,7 +252,7 @@ describe("#processCLI", () => {
             unhookInterceptStdOut();
             unhookInterceptStdErr();
 
-            expect(lExitCode).to.equal(-1);
+            expect(lExitCode).to.equal(1);
             return expect(
                 lCapturedStderr
             ).to.contain(
@@ -281,7 +281,7 @@ describe("#processCLI", () => {
                 lCapturedStderr += pText;
             })();
 
-            expect(lExitCode).to.equal(-1);
+            expect(lExitCode).to.equal(1);
             return expect(
                 lCapturedStderr
             ).to.contain(


### PR DESCRIPTION
## Description
Set the exit code to 1 if an exception occurs, instead of keeping it on 0.

## Motivation and Context
Currently, if an exception occurs (e.g. config file not found, can't write to output, error in the config file, ...) dependency-cruiser happily returns 0 as the exit code - it just outputs the error message on stderr. This means it's easier for those exceptions like that to remain undetected - e.g. running on your ci, or as part of a build script, both of which expect non-zero exit codes when something is wrong.

This PR corrects that, so that if something is amiss with running dependency-cruiser it's obvious immediately.

This PR also
- makes sure cli error messages get written to stderr in less spots
- refactors the process exiting so it's unit testable

## How Has This Been Tested?
- [x] additional unit tests
- [x] non regressing unit tests in the rest of the code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.