### PR TITLE
feature(cli): allow comments in .dependency-cruiser.json config files

### DIFF
--- a/.dependency-cruiser-custom.json
+++ b/.dependency-cruiser-custom.json
@@ -103,8 +103,20 @@
             "to": { "license": "GPL|APL" }
         }],
     "options": {
-        "exclude": "fixtures",
-        "doNotFollow": "^node_modules",
-        "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/"
+        "exclude": "fixtures",                           /* pattern specifying which files to exclude (regular expression) */
+        "doNotFollow": "^node_modules",                  /* pattern specifying which files not to follow further when encountered*/
+        "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/" /* prefix for links in html and svg output */
+        // "moduleSystems: ["amd", "cjs", "es6", "tsd"], /* list of module systems to cruise */
+        // "prefix": "",                                 /* prefix for links in html and svg output (e.g. https://github.com/you/yourrepo/blob/develop/) */
+        // "tsPreCompilationDeps: false,                 /* if true detect dependencies that only exist before typescript-to-javascript compilation */
+        // "preserveSymlinks": false,                    /* if true leave symlinks untouched, otherwise use the realpath */
+        // "tsConfig": {                                 /* Typescript project file ('tsconfig.json') to use for (1) compilation and (2) resolution (e.g. with the paths property) */
+        //    "fileName": "./tsconfig.json"              /* The typescript project file to use. The fileName is relative to dependency-cruiser's current working directory.*/
+        //},
+        // "webpackConfig": {                            /* Webpack configuration to use to get resolve options from */
+        //    "fileName": "./webpack.conf.js"            /* The webpack conf file to use (typically something like 'webpack.conf.js'). The fileName is relative to dependency-cruiser's current working directory. When not provided defaults to './webpack.conf.js'. */
+        //    "env": {},                                 /* Environment to pass if your config file returns a function */
+        //    "args": {}                                 /* Arguments to pass if your config file returns a function. E.g. {mode: 'production'} if you want to use webpack 4's 'mode' feature */
+        //}
     }
 }

--- a/src/cli/initRules.js
+++ b/src/cli/initRules.js
@@ -1,7 +1,9 @@
 "use strict";
 
-const fs           = require('fs');
-const starterRules = require('./rules.starter.json');
+const fs   = require('fs');
+const path = require('path');
+
+const STARTER_RULES_FILENAME = path.join(__dirname, './rules.starter.json');
 
 /*
   We could have used utl.fileExists - but that one is cached.
@@ -33,10 +35,10 @@ module.exports = (pFileName) => {
         throw Error(`A '${pFileName}' already exists here - leaving it be.\n`);
     } else {
         try {
-            fs.writeFileSync(
+            fs.copyFileSync(
+                STARTER_RULES_FILENAME,
                 pFileName,
-                JSON.stringify(starterRules, null, "  "),
-                {encoding: "utf8", flag: "w"}
+                fs.constants.COPYFILE_EXCL
             );
         } catch (e) {
 

--- a/src/cli/initRules.js
+++ b/src/cli/initRules.js
@@ -35,10 +35,15 @@ module.exports = (pFileName) => {
         throw Error(`A '${pFileName}' already exists here - leaving it be.\n`);
     } else {
         try {
-            fs.copyFileSync(
-                STARTER_RULES_FILENAME,
+            // when dropping node 6 support use this in stead:
+            // fs.copyFileSync(STARTER_RULES_FILENAME, pFileName, fs.constants.COPYFILE_EXCL);
+            fs.writeFileSync(
                 pFileName,
-                fs.constants.COPYFILE_EXCL
+                fs.readFileSync(
+                    STARTER_RULES_FILENAME,
+                    {encoding: "utf8", flag: "r"}
+                ),
+                {encoding: "utf8", flag: "w"}
             );
         } catch (e) {
 

--- a/src/cli/normalizeOptions.js
+++ b/src/cli/normalizeOptions.js
@@ -4,6 +4,7 @@ const fs       = require('fs');
 const _set     = require('lodash/set');
 const _get     = require('lodash/get');
 const _clone   = require('lodash/clone');
+const stripJSONComments = require('strip-json-comments');
 const defaults = require('./defaults.json');
 
 function getOptionValue(pDefault) {
@@ -63,7 +64,11 @@ module.exports = (pOptions) => {
 
     if (pOptions.hasOwnProperty("validate")){
         pOptions.rulesFile = module.exports.determineRulesFileName(pOptions.validate);
-        pOptions.ruleSet   = JSON.parse(fs.readFileSync(pOptions.rulesFile, 'utf8'));
+        pOptions.ruleSet   = JSON.parse(
+            stripJSONComments(
+                fs.readFileSync(pOptions.rulesFile, 'utf8')
+            )
+        );
     }
 
     pOptions = normalizeConfigFile(pOptions, "webpackConfig", defaults.WEBPACK_CONFIG);

--- a/src/cli/rules.starter.json
+++ b/src/cli/rules.starter.json
@@ -73,6 +73,19 @@
         "to": { "moreThanOneDependencyType": true }
     }],
     "options": {
-        "doNotFollow": "node_modules"
+        "doNotFollow": "node_modules"                    /* pattern specifying which files not to follow further when encountered*/
+        // "exclude" : "",                               /* pattern specifying which files to exclude (regular expression) */
+        // "moduleSystems: ["amd", "cjs", "es6", "tsd"], /* list of module systems to cruise */
+        // "prefix": "",                                 /* prefix for links in html and svg output (e.g. https://github.com/you/yourrepo/blob/develop/) */
+        // "tsPreCompilationDeps: false,                 /* if true detect dependencies that only exist before typescript-to-javascript compilation */
+        // "preserveSymlinks": false,                    /* if true leave symlinks untouched, otherwise use the realpath */
+        // "tsConfig": {                                 /* Typescript project file ('tsconfig.json') to use for (1) compilation and (2) resolution (e.g. with the paths property) */
+        //    "fileName": "./tsconfig.json"              /* The typescript project file to use. The fileName is relative to dependency-cruiser's current working directory. When not provided defaults to './tsconfig.json'.*/
+        //},
+        // "webpackConfig": {                            /* Webpack configuration to use to get resolve options from */
+        //    "fileName": "./webpack.conf.js"            /* The webpack conf file to use (typically something like 'webpack.conf.js'). The fileName is relative to dependency-cruiser's current working directory. When not provided defaults to './webpack.conf.js'. */
+        //    "env": {},                                 /* Environment to pass if your config file returns a function */
+        //    "args": {}                                 /* Arguments to pass if your config file returns a function. E.g. {mode: 'production'} if you want to use webpack 4's 'mode' feature */
+        //}
     }
 }

--- a/test/cli/fixtures/rules.withcomments.json
+++ b/test/cli/fixtures/rules.withcomments.json
@@ -1,0 +1,16 @@
+{
+    // this is a comment
+    "forbidden": [
+        {
+            /* this is another comment*/
+            "name": "sub-not-allowed",
+            "severity": "warn",
+            "from": {
+                // left empty on poipos
+            },
+            "to": {
+                "path": "sub"
+            }
+        }
+    ]
+}

--- a/test/cli/initRules.spec.js
+++ b/test/cli/initRules.spec.js
@@ -1,16 +1,17 @@
 "use strict";
-const fs           = require('fs');
-const chai         = require('chai');
-const initRules    = require("../../src/cli/initRules");
-const rulesSchema  = require('../../src/main/ruleSet/jsonschema.json');
-const deleteDammit = require("./deleteDammit.utl");
+const fs                = require('fs');
+const chai              = require('chai');
+const stripJSONComments = require('strip-json-comments');
+const initRules         = require("../../src/cli/initRules");
+const rulesSchema       = require('../../src/main/ruleSet/jsonschema.json');
+const deleteDammit      = require("./deleteDammit.utl");
 
 const expect       = chai.expect;
 const RULES_FILE = ".dependency-cruiser.json";
 
 chai.use(require('chai-json-schema'));
 
-describe("normalizeOptions", () => {
+describe("initRules", () => {
 
     beforeEach("set up", () => {
         deleteDammit(RULES_FILE);
@@ -23,7 +24,11 @@ describe("normalizeOptions", () => {
     it("writes a valid rules file to .dependency-cruiser.json", () => {
         initRules(RULES_FILE);
         expect(
-            JSON.parse(fs.readFileSync(RULES_FILE, "utf8"))
+            JSON.parse(
+                stripJSONComments(
+                    fs.readFileSync(RULES_FILE, "utf8")
+                )
+            )
         ).to.be.jsonSchema(rulesSchema);
     });
 

--- a/test/cli/normalizeOptions.spec.js
+++ b/test/cli/normalizeOptions.spec.js
@@ -57,6 +57,32 @@ describe("normalizeOptions", () => {
         );
     });
 
+    it("a rules file with comments gets the comments stripped out & parsed", () => {
+        expect(
+            normalizeOptions({validate: "./test/cli/fixtures/rules.withcomments.json"})
+        ).to.deep.equal(
+            {
+                outputTo: "-",
+                outputType: "err",
+                rulesFile: "./test/cli/fixtures/rules.withcomments.json",
+                "ruleSet": {
+                    "forbidden": [
+                        {
+                            "name": "sub-not-allowed",
+                            "severity": "warn",
+                            "from": {
+                            },
+                            "to": {
+                                "path": "sub"
+                            }
+                        }
+                    ]
+                },
+                validate: true
+            }
+        );
+    });
+
     it("defaults tsConfig.fileName to 'tsconfig.json' if it wasn't specified", () => {
         expect(
             normalizeOptions({validate: "./test/cli/fixtures/rules.tsConfigNoFileName.json"})


### PR DESCRIPTION
## Description
- allow comments in .dependency-cruiser.json config files
- 🐶 🥘 : add comments to dependency-cruiser's own rule file
- add comments to the rule file created with --init

## Motivation and Context
I've found comments in e.g. typescript and eslint configs to be very helpful. Assuming it'd be useful for dependency-cruiser users as well & given Implementing it is a doddle => let's add it.

## How Has This Been Tested?
- [x] unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.