### PR TITLE
feature(transpile): support mjs

### DIFF
--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -21,6 +21,7 @@ const litCoffeeWrap        = require("./coffeeWrap")(true);
  */
 const extension2wrapper = {
     ".js"        : javaScriptWrap,
+    ".mjs"       : javaScriptWrap,
     ".jsx"       : javaScriptWrap,
     ".vue"       : javaScriptWrap,
     ".ts"        : typeScriptWrap,

--- a/test/extract/transpile/fixtures/mjs.js
+++ b/test/extract/transpile/fixtures/mjs.js
@@ -1,0 +1,10 @@
+const version = "1.2.3";
+
+function doSomething(pString) {
+    console.log(pString);
+}
+
+export {
+    version,
+    doSomething
+};

--- a/test/extract/transpile/fixtures/mjs.mjs
+++ b/test/extract/transpile/fixtures/mjs.mjs
@@ -1,0 +1,10 @@
+const version = "1.2.3";
+
+function doSomething(pString) {
+    console.log(pString);
+}
+
+export {
+    version,
+    doSomething
+};

--- a/test/extract/transpile/javascriptWrap.spec.js
+++ b/test/extract/transpile/javascriptWrap.spec.js
@@ -30,4 +30,14 @@ describe("jsx transpiler (the plain old javascript one)", () => {
             fs.readFileSync("./test/extract/transpile/fixtures/vue.js", 'utf8')
         );
     });
+
+    it("transpiles mjs", () => {
+        expect(
+            wrap.transpile(
+                fs.readFileSync("./test/extract/transpile/fixtures/mjs.mjs", 'utf8')
+            )
+        ).to.equal(
+            fs.readFileSync("./test/extract/transpile/fixtures/mjs.js", 'utf8')
+        );
+    });
 });

--- a/test/extract/transpile/meta.spec.js
+++ b/test/extract/transpile/meta.spec.js
@@ -10,7 +10,8 @@ describe("transpiler meta", () => {
         expect(
             meta.scannableExtensions
         ).to.deep.equal([
-            ".js", ".jsx", ".vue", ".ts", ".tsx", ".d.ts", ".coffee", ".litcoffee", ".coffee.md", ".csx", ".cjsx"
+            ".js", ".mjs", ".jsx", ".vue", ".ts", ".tsx",
+            ".d.ts", ".coffee", ".litcoffee", ".coffee.md", ".csx", ".cjsx"
         ]);
     });
 


### PR DESCRIPTION
## Motivation and Context
Even though node's es6 module support is expiremental (`--experimental-modules`) - dependency-cruiser should support it.

## How Has This Been Tested?
- [x] unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~~[ ] My change requires a change to the documentation.~~~
- ~~~[ ] I have updated the documentation accordingly.~~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.