### PR TITLE
bugfix(cli): don't return a nonzero exit code when there's transgressions and the reporter !== 'err'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.6.3-beta-1",
+  "version": "4.6.3-beta-2",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.6.2",
+  "version": "4.6.3-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -66,7 +66,7 @@ function runCruise(pFileDirArray, pOptions) {
 
     io.write(pOptions.outputTo, lDependencyList.modules);
 
-    if (lDependencyList.summary.error > 0) {
+    if (lDependencyList.summary.error > 0 && pOptions.outputType === "err") {
         lExitCode = lDependencyList.summary.error;
     }
     return lExitCode;

--- a/test/cli/index.spec.js
+++ b/test/cli/index.spec.js
@@ -199,7 +199,7 @@ describe("#processCLI", () => {
             );
         });
 
-        it("returns the number of transgressions", () => {
+        it("returns 0 even if there's transgressions when outputType !== 'err' ", () => {
             const lOutputFileName = "transgression-count.json";
             const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
             const lExitCode = processCLI(
@@ -209,6 +209,24 @@ describe("#processCLI", () => {
                 {
                     outputTo: lOutputTo,
                     outputType: "json",
+                    validate: "test/cli/fixtures/rules.sub-not-allowed-error.json"
+                }
+            );
+            const lExpectedTransgressions = 0;
+
+            expect(lExitCode).to.equal(lExpectedTransgressions);
+        });
+
+        it("returns the number of transgressions if outputType === 'err' ", () => {
+            const lOutputFileName = "transgression-count.json";
+            const lOutputTo       = path.join(OUT_DIR, lOutputFileName);
+            const lExitCode = processCLI(
+                [
+                    "test/cli/fixtures/cjs"
+                ],
+                {
+                    outputTo: lOutputTo,
+                    outputType: "err",
                     validate: "test/cli/fixtures/rules.sub-not-allowed-error.json"
                 }
             );


### PR DESCRIPTION
## Description, Motivation and Context
- The `err` reporter (which is meant for running as part of scripts or on the ci) returns non-zero exit codes when there's > 1 error level transgression found
- Before this fix other reports did this as well, which makes e.g. running an `npm run depcruise:graph` error, while it definitely should not.
- After this fix `err` again is the only reporter doing this 

## How Has This Been Tested?
- [x] non-regression unit tests
- [x] new unit test for this specific case

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.