### PR TITLE
bugfix(cli): specify utf8 charset when writing to stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.7.0-beta-1",
+  "version": "4.7.1-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/cli/utl/io.js
+++ b/src/cli/utl/io.js
@@ -33,7 +33,10 @@ function writeToStdOut(pString, pBufferSize) {
 
     /* eslint no-plusplus: 0 */
     for (i = 0; i < lNumberOfChunks; i++) {
-        process.stdout.write(pString.substr(i * pBufferSize, pBufferSize));
+        process.stdout.write(
+            pString.substr(i * pBufferSize, pBufferSize),
+            "utf8"
+        );
     }
 
 }


### PR DESCRIPTION
so node doesn't get seduced to use something different (e.g. apparantly on win10 UTF16-blah?



## Description, Motivation and Context
addresses #76

## How Has This Been Tested?
- [x] non-regression unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.