### PR TITLE
feature(rules): adds the 'ignore' severity level

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -197,8 +197,13 @@ some reporters (at least the `err` one) return a non-zero exit
 code, so if you want e.g. a build to stop when there's a rule
 violated: use that.
 
-The other values you can use are `info` and `warn`. If you leave it
-out dependency-cruiser will assume it to be `warn`.
+The other values you can use are `info`, `warn` and `ignore`. If you
+leave it out dependency-cruiser will assume it to be `warn`.
+
+With the severity set to `ignore` dependency-cruiser will not check
+the rule at all. This can be useful if you want to temporarily 
+disable a rule or disable a rule you inherited from a rule set you
+extended.
 
 ## Conditions
 ### `path`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.8.0",
+  "version": "4.9.0-beta-0",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/extract/jsonschema.json
+++ b/src/extract/jsonschema.json
@@ -158,7 +158,7 @@
     "definitions": {
         "SeverityType": {
             "type": "string",
-            "description": "How severe a violation of a rule is. The 'error' severity will make some reporters return a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated: use that.",
+            "description": "How severe a violation of a rule is. The 'error' severity will make some reporters return a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated: use that. The absence of the 'ignore' severity here is by design; ignored rules don't show up in the output.",
             "enum": [
                 "error",
                 "warn",

--- a/src/main/ruleSet/jsonschema.json
+++ b/src/main/ruleSet/jsonschema.json
@@ -206,7 +206,8 @@
             "enum": [
                 "error",
                 "warn",
-                "info"
+                "info",
+                "ignore"
             ]
         },
         "DependencyType": {

--- a/src/main/ruleSet/normalize.js
+++ b/src/main/ruleSet/normalize.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const VALID_SEVERITIES = /^(error|warn|info)$/;
+const VALID_SEVERITIES = /^(error|warn|info|ignore)$/;
 const DEFAULT_SEVERITY = 'warn';
 const DEFAULT_RULE     = 'unnamed';
 
@@ -36,10 +36,16 @@ function normalizeRule(pRule) {
 module.exports = (pRuleSet) => {
     if (pRuleSet.hasOwnProperty("allowed")){
         pRuleSet.allowedSeverity = normalizeSeverity(pRuleSet.allowedSeverity);
+        if (pRuleSet.allowedSeverity === 'ignore') {
+            Reflect.deleteProperty(pRuleSet, 'allowed');
+            Reflect.deleteProperty(pRuleSet, 'allowedSeverity');
+        }
     }
 
     if (pRuleSet.hasOwnProperty("forbidden")){
-        pRuleSet.forbidden = pRuleSet.forbidden.map(normalizeRule);
+        pRuleSet.forbidden = pRuleSet.forbidden
+            .map(normalizeRule)
+            .filter(pRule => pRule.severity !== 'ignore');
     }
 
     return pRuleSet;

--- a/test/main/ruleSet/normalize.spec.js
+++ b/test/main/ruleSet/normalize.spec.js
@@ -1,14 +1,14 @@
 "use strict";
-const expect     = require('chai').expect;
-const normalizer = require('../../../src/main/ruleSet/normalize');
+const expect    = require('chai').expect;
+const normalize = require('../../../src/main/ruleSet/normalize');
 
 describe("ruleSet/normalize", () => {
     it("leaves the empty ruleset alone", () => {
-        expect(normalizer({})).to.deep.equal({});
+        expect(normalize({})).to.deep.equal({});
     });
 
     it("allowed: adds allowedSeverity when it wasn't filled out; does not add severity/ name to the rule", () => {
-        expect(normalizer({
+        expect(normalize({
             "allowed": [{
                 "from": ".+",
                 "to": ".+"
@@ -23,7 +23,7 @@ describe("ruleSet/normalize", () => {
     });
 
     it("allowed: leaves allowedSeverity alone when it wasn't filled; doesn't add severity/ name to the rule", () => {
-        expect(normalizer({
+        expect(normalize({
             "allowed": [{
                 "from": ".+",
                 "to": ".+"
@@ -39,7 +39,7 @@ describe("ruleSet/normalize", () => {
     });
 
     it("corrects the severity to a default when it's not a recognized one", () => {
-        expect(normalizer({
+        expect(normalize({
             "forbidden": [{
                 "from": ".+",
                 "to": ".+",
@@ -57,7 +57,7 @@ describe("ruleSet/normalize", () => {
     });
 
     it("keeps the severity if it's a recognized one", () => {
-        expect(normalizer({
+        expect(normalize({
             "forbidden": [{
                 "from": ".+",
                 "to": ".+",
@@ -75,7 +75,7 @@ describe("ruleSet/normalize", () => {
     });
 
     it("also works for 'forbidden' rules", () => {
-        expect(normalizer({
+        expect(normalize({
             "forbidden": [{
                 "from": ".+",
                 "to": ".+",
@@ -91,6 +91,31 @@ describe("ruleSet/normalize", () => {
                 "name": "all-ok",
                 "comment": "this comment is kept"
             }]
+        });
+    });
+
+    it("filters out forbidden rules with severity 'ignore'", () => {
+        expect(normalize({
+            "forbidden": [{
+                "from": ".+",
+                "to": ".+",
+                "severity": "ignore",
+                "name": "all-ok",
+                "comment": "this comment is kept"
+            }]
+        })).to.deep.equal({
+            "forbidden": []
+        });
+    });
+
+    it("removes the allowed rules & allowedSeverity when allowedSeverity === 'ignore'", () => {
+        expect(normalize({
+            "allowed": [{
+                "from": ".+",
+                "to": ".+"
+            }],
+            "allowedSeverity": "ignore"
+        })).to.deep.equal({
         });
     });
 });

--- a/test/main/ruleSet/validate.spec.js
+++ b/test/main/ruleSet/validate.spec.js
@@ -31,7 +31,45 @@ function shouldBeOK(pRulesFile){
     );
 }
 
+
 describe("ruleSetReader - regular", () => {
+    it("barfs on an invalid rules file", () => {
+        shouldBarfWithMessage(
+            "./test/validate/fixtures/rules.not-a-valid-rulesfile.json",
+            "The rules file is not valid: data should NOT have additional properties."
+        );
+    });
+
+    it("accepts an empty 'options' object", () => {
+        shouldBeOK("./test/validate/fixtures/rules.empty-options-section.json");
+    });
+
+    it("accepts a 'webpackConfig' config", () => {
+        shouldBeOK("./test/validate/fixtures/rules.options-section-webpack-config.json");
+    });
+
+    it("accepts a 'dependencyTypes' with value 'aliased'", () => {
+        shouldBeOK("./test/validate/fixtures/rules.no-aliased-dependency-types.json");
+    });
+
+    it("accepts some command line options in a 'options' object", () => {
+        shouldBeOK("./test/validate/fixtures/rules.options-section.json");
+    });
+
+    it("accepts the 'extends' attribute (string)", () => {
+        shouldBeOK("./test/validate/fixtures/extends/extending.as.string.json");
+    });
+
+    it("bails out on non-strings in the 'extends' attribute (array)", () => {
+        shouldBarfWithMessage(
+            "./test/validate/fixtures/extends/extending.as.array.json",
+            "The rules file is not valid: data.extends should be string."
+        );
+    });
+
+});
+
+describe("ruleSetReader - regexp safety checks", () => {
     it("bails out on scary regexps in paths", () => {
         shouldBarfWithMessage(
             "./test/validate/fixtures/rules.scary-regex.json",
@@ -61,30 +99,6 @@ describe("ruleSetReader - regular", () => {
         );
     });
 
-    it("barfs on an invalid rules file", () => {
-        shouldBarfWithMessage(
-            "./test/validate/fixtures/rules.not-a-valid-rulesfile.json",
-            "The rules file is not valid: data should NOT have additional properties."
-        );
-    });
-
-    it("accepts an empty 'options' object", () => {
-        shouldBeOK("./test/validate/fixtures/rules.empty-options-section.json");
-    });
-
-    it("accepts a 'webpackConfig' config", () => {
-        shouldBeOK("./test/validate/fixtures/rules.options-section-webpack-config.json");
-    });
-
-    it("accepts a 'dependencyTypes' with value 'aliased'", () => {
-        shouldBeOK("./test/validate/fixtures/rules.no-aliased-dependency-types.json");
-    });
-
-
-    it("accepts some command line options in a 'options' object", () => {
-        shouldBeOK("./test/validate/fixtures/rules.options-section.json");
-    });
-
     it("bails out on scary regexps in options.doNotFollow", () => {
         shouldBarfWithMessage(
             "./test/validate/fixtures/rules.options-section-scary-regex-do-not-follow.json",
@@ -96,20 +110,6 @@ describe("ruleSetReader - regular", () => {
         shouldBarfWithMessage(
             "./test/validate/fixtures/rules.options-section-scary-regex-exclude.json",
             'The pattern \'(.*)*\' will probably run very slowly - cowardly refusing to run.\n'
-        );
-    });
-
-});
-
-describe("ruleSetReader - extends", () => {
-    it("accepts the 'extends' attribute (string)", () => {
-        shouldBeOK("./test/validate/fixtures/extends/extending.as.string.json");
-    });
-
-    it("bails out on non-strings in the 'extends' attribute (array)", () => {
-        shouldBarfWithMessage(
-            "./test/validate/fixtures/extends/extending.as.array.json",
-            "The rules file is not valid: data.extends should be string."
         );
     });
 });

--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -34,7 +34,7 @@ export type ModuleSystemType = "cjs" | "amd" | "es6"  | "tsd";
 
 export type OutputType = "json" | "html" | "dot" | "rcdot" | "csv" | "err";
 
-export type SeverityType = "error" | "warn" | "info";
+export type SeverityType = "error" | "warn" | "info" | "ignore";
 
 export type DependencyType = "aliased"       | "core"        | "deprecated"  | "local"
                             | "localmodule"  | "npm"         | "npm-bundled" | "npm-dev"
@@ -254,14 +254,14 @@ export interface ICruiseOptions {
  *
  * @param pFileDirArray   An array of (names of) files, directories and/ or glob patterns
  *                        to start the cruise with
- * @param pOptions        Options that influence the way the dependencies are cruised - and 
+ * @param pOptions        Options that influence the way the dependencies are cruised - and
  *                        how they are returned.
  * @param pResolveOptions Options that influence how dependency references are resolved to disk.
  *                        See https://webpack.js.org/configuration/resolve/ for the details.
  * @param pTSConfig       An object with with a typescript config object. Note that the
  *                        API will not take any 'extends' keys there into account, so
  *                        before calling make sure to flatten them out if you want them
- *                        used (the dependency-cruiser cli does this 
+ *                        used (the dependency-cruiser cli does this
  *                        [here](../src/cli/flattenTypeScriptConfig.js))
  * @returns any
  */
@@ -269,7 +269,7 @@ export function cruise(
     pFileDirArray: string[],
     pOptions?: ICruiseOptions,
     pResolveOptions?: any,
-    pTSConfig?: any
+    pTSConfig?: any,
 ): any;
 
 /**


### PR DESCRIPTION
## Description, Motivation and Context
When extending a rule set, you might need or want to ignore some of the rules - e.g. because it's not applicable in the current situation. To enable this the `severity` of _forbidden_ rules and the `allowedSeverity` for _allowed_ rules can now have the value `ignore` - in which case dependency-cruiser disregards them completely.

## How Has This Been Tested?
- [x] unit tests
- [x] non-regression unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
