### PR TITLE
feature(cli): add simple tsconfig and webpack config detection to --init

### DIFF
--- a/src/cli/initConfig/createConfigFile.js
+++ b/src/cli/initConfig/createConfigFile.js
@@ -1,23 +1,12 @@
-const fs         = require('fs');
-const Handlebars = require('handlebars/runtime');
-const $package   = require('../../../package.json');
+const fs             = require('fs');
+const Handlebars     = require('handlebars/runtime');
+const $package       = require('../../../package.json');
+const {fileExists} = require('./helpers');
 
 /* eslint import/no-unassigned-import: 0 */
 require("./config.json.template");
 require("./config.js.template");
 
-/*
-  We could have used utl.fileExists - but that one is cached.
-  Not typically what we want for this util.
- */
-function fileExists(pFile) {
-    try {
-        fs.accessSync(pFile, fs.R_OK);
-    } catch (e) {
-        return false;
-    }
-    return true;
-}
 
 function getFileName(pInitOptions) {
     return `.dependency-cruiser${pInitOptions.configFormat}`;
@@ -73,7 +62,9 @@ function normalizeInitOptions(pInitOptions){
  *
  * @returns {void}  Nothing
  * @param  {any}    pInitOptions Options that influence the shape of the
- *                  config
+ *                  configFormat - file format to use either ".json" or ".js"
+ *                  configType   - "self-contained" or "preset"
+ *                  preset       -
  * @throws {Error}  An error object with the root cause of the problem
  *                  as a description:
  *                  - file already exists

--- a/src/cli/initConfig/getUserInput.js
+++ b/src/cli/initConfig/getUserInput.js
@@ -1,4 +1,10 @@
-const inquirer = require('inquirer');
+const inquirer     = require('inquirer');
+const $defaults    = require('../defaults.json');
+const {fileExists} = require('./helpers');
+
+
+const TYPESCRIPT_CONFIG = `./${$defaults.TYPESCRIPT_CONFIG}`;
+const WEBPACK_CONFIG    = `./${$defaults.WEBPACK_CONFIG}`;
 
 const INQUIRER_QUESTIONS = [
     {
@@ -38,6 +44,36 @@ const INQUIRER_QUESTIONS = [
         ],
         default: "dependency-cruiser/configs/recommended-warn-only",
         when: pAnswers => pAnswers.configType === "preset"
+    },
+    {
+        name: "useTsConfig",
+        type: "confirm",
+        message: "Looks like you're using TypeScript. Use a 'tsconfig.json'?",
+        default: true,
+        when: () => fileExists(TYPESCRIPT_CONFIG)
+    },
+    {
+        name: "tsConfig",
+        type: "input",
+        message: "Full path to 'tsconfig.json':",
+        default: TYPESCRIPT_CONFIG,
+        validate: (pInput) => fileExists(pInput) || `hmm, '${pInput}' doesn't seem to exist - try again?`,
+        when: (pAnswers) => pAnswers.useTsConfig
+    },
+    {
+        name: "useWebpackConfig",
+        type: "confirm",
+        message: "Looks like you're using webpack - specify a webpack config?",
+        default: true,
+        when: () => fileExists(WEBPACK_CONFIG)
+    },
+    {
+        name: "webpackConfig",
+        type: "input",
+        message: "Full path to webpack config:",
+        default: WEBPACK_CONFIG,
+        validate: (pInput) => fileExists(pInput) || `hmm, '${pInput}' doesn't seem to exist - try again?`,
+        when: (pAnswers) => pAnswers.useWebpackConfig
     }
 ];
 

--- a/src/cli/initConfig/helpers.js
+++ b/src/cli/initConfig/helpers.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+
+/*
+  We could have used utl.fileExists - but that one is cached.
+  Not typically what we want for this util.
+ */
+function fileExists(pFile) {
+    try {
+        fs.accessSync(pFile, fs.R_OK);
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
+module.exports = {
+    fileExists
+};


### PR DESCRIPTION
## Description
Adds two questions to the `--init` script that
- get asked when there's a tsconfig or webpack config respectively
- add a tsconfig and/ or webpack config to the .dependency-cruiser-config

## Motivation and Context
- makes enrolment easier
- either config needs to be specified in order to be taken into account - this might not be apparent from the documentation

## How Has This Been Tested?
- [x] automated non regression tests
- [x] manual tests (inquirer is notoriously hard to test automated ...)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.