### PR TITLE
bugfix(dot): output correct url's, also when the prefix is an uri

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -207,7 +207,7 @@ Rule                     | Description
 If you want the links in the svg output to have a prefix (say,
 `https://github.com/you/yourrepo/tree/master/`) so when you click them you'll
 open the link on github instead of the local file - pass that after the
-`--prefix` option.
+`--prefix` option. Typically you want the prefix to end on a `/`.
 
 ```sh
 depcruise --prefix https://github.com/sverweij/dependency-cruiser/tree/develop/ -T dot -x node_modules src | dot -T svg > dependencies.svg

--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -188,7 +188,7 @@
 <!-- package.json -->
 <g id="node1" class="node">
 <title>package.json</title>
-<g id="a_node1"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//package.json" xlink:title="package.json">
+<g id="a_node1"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/package.json" xlink:title="package.json">
 <path fill="#ffee44" stroke="#000000" d="M1382.2379,-17C1382.2379,-17 1324.496,-17 1324.496,-17 1321.6627,-17 1318.8293,-14.1667 1318.8293,-11.3333 1318.8293,-11.3333 1318.8293,-5.6667 1318.8293,-5.6667 1318.8293,-2.8333 1321.6627,0 1324.496,0 1324.496,0 1382.2379,0 1382.2379,0 1385.0712,0 1387.9046,-2.8333 1387.9046,-5.6667 1387.9046,-5.6667 1387.9046,-11.3333 1387.9046,-11.3333 1387.9046,-14.1667 1385.0712,-17 1382.2379,-17"/>
 <text text-anchor="middle" x="1353.3669" y="-5.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">package.json</text>
 </a>
@@ -197,7 +197,7 @@
 <!-- src/cli/compileConfig/index.js -->
 <g id="node2" class="node">
 <title>src/cli/compileConfig/index.js</title>
-<g id="a_node2"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/compileConfig/index.js" xlink:title="index.js">
+<g id="a_node2"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M402.4405,-96C402.4405,-96 359.7738,-96 359.7738,-96 356.9405,-96 354.1072,-93.1667 354.1072,-90.3333 354.1072,-90.3333 354.1072,-84.6667 354.1072,-84.6667 354.1072,-81.8333 356.9405,-79 359.7738,-79 359.7738,-79 402.4405,-79 402.4405,-79 405.2738,-79 408.1072,-81.8333 408.1072,-84.6667 408.1072,-84.6667 408.1072,-90.3333 408.1072,-90.3333 408.1072,-93.1667 405.2738,-96 402.4405,-96"/>
 <text text-anchor="middle" x="381.1072" y="-84.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -206,7 +206,7 @@
 <!-- src/cli/compileConfig/mergeConfigs.js -->
 <g id="node3" class="node">
 <title>src/cli/compileConfig/mergeConfigs.js</title>
-<g id="a_node3"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/compileConfig/mergeConfigs.js" xlink:title="mergeConfigs.js">
+<g id="a_node3"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/mergeConfigs.js" xlink:title="mergeConfigs.js">
 <path fill="#ffffcc" stroke="#000000" d="M540.4896,-67C540.4896,-67 470.7712,-67 470.7712,-67 467.9378,-67 465.1045,-64.1667 465.1045,-61.3333 465.1045,-61.3333 465.1045,-55.6667 465.1045,-55.6667 465.1045,-52.8333 467.9378,-50 470.7712,-50 470.7712,-50 540.4896,-50 540.4896,-50 543.3229,-50 546.1563,-52.8333 546.1563,-55.6667 546.1563,-55.6667 546.1563,-61.3333 546.1563,-61.3333 546.1563,-64.1667 543.3229,-67 540.4896,-67"/>
 <text text-anchor="middle" x="505.6304" y="-55.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">mergeConfigs.js</text>
 </a>
@@ -221,7 +221,7 @@
 <!-- src/cli/compileConfig/readConfig.js -->
 <g id="node4" class="node">
 <title>src/cli/compileConfig/readConfig.js</title>
-<g id="a_node4"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/compileConfig/readConfig.js" xlink:title="readConfig.js">
+<g id="a_node4"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/readConfig.js" xlink:title="readConfig.js">
 <path fill="#ffffcc" stroke="#000000" d="M534.4925,-96C534.4925,-96 476.7682,-96 476.7682,-96 473.9349,-96 471.1016,-93.1667 471.1016,-90.3333 471.1016,-90.3333 471.1016,-84.6667 471.1016,-84.6667 471.1016,-81.8333 473.9349,-79 476.7682,-79 476.7682,-79 534.4925,-79 534.4925,-79 537.3259,-79 540.1592,-81.8333 540.1592,-84.6667 540.1592,-84.6667 540.1592,-90.3333 540.1592,-90.3333 540.1592,-93.1667 537.3259,-96 534.4925,-96"/>
 <text text-anchor="middle" x="505.6304" y="-84.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">readConfig.js</text>
 </a>
@@ -236,7 +236,7 @@
 <!-- src/extract/resolve/resolve.js -->
 <g id="node44" class="node">
 <title>src/extract/resolve/resolve.js</title>
-<g id="a_node44"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve.js" xlink:title="resolve.js">
+<g id="a_node44"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve.js" xlink:title="resolve.js">
 <path fill="#ffffcc" stroke="#000000" d="M1374.713,-1121C1374.713,-1121 1332.0209,-1121 1332.0209,-1121 1329.1876,-1121 1326.3542,-1118.1667 1326.3542,-1115.3333 1326.3542,-1115.3333 1326.3542,-1109.6667 1326.3542,-1109.6667 1326.3542,-1106.8333 1329.1876,-1104 1332.0209,-1104 1332.0209,-1104 1374.713,-1104 1374.713,-1104 1377.5463,-1104 1380.3796,-1106.8333 1380.3796,-1109.6667 1380.3796,-1109.6667 1380.3796,-1115.3333 1380.3796,-1115.3333 1380.3796,-1118.1667 1377.5463,-1121 1374.713,-1121"/>
 <text text-anchor="middle" x="1353.3669" y="-1109.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve.js</text>
 </a>
@@ -255,7 +255,7 @@
 <!-- src/main/resolveOptions/normalize.js -->
 <g id="node59" class="node">
 <title>src/main/resolveOptions/normalize.js</title>
-<g id="a_node59"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/resolveOptions/normalize.js" xlink:title="normalize.js">
+<g id="a_node59"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/resolveOptions/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M531.9784,-448C531.9784,-448 479.2824,-448 479.2824,-448 476.4491,-448 473.6157,-445.1667 473.6157,-442.3333 473.6157,-442.3333 473.6157,-436.6667 473.6157,-436.6667 473.6157,-433.8333 476.4491,-431 479.2824,-431 479.2824,-431 531.9784,-431 531.9784,-431 534.8117,-431 537.645,-433.8333 537.645,-436.6667 537.645,-436.6667 537.645,-442.3333 537.645,-442.3333 537.645,-445.1667 534.8117,-448 531.9784,-448"/>
 <text text-anchor="middle" x="505.6304" y="-436.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -270,7 +270,7 @@
 <!-- src/cli/defaults.json -->
 <g id="node5" class="node">
 <title>src/cli/defaults.json</title>
-<g id="a_node5"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/defaults.json" xlink:title="defaults.json">
+<g id="a_node5"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/defaults.json" xlink:title="defaults.json">
 <path fill="#ffee44" stroke="#000000" d="M408.4749,-147C408.4749,-147 353.7395,-147 353.7395,-147 350.9062,-147 348.0728,-144.1667 348.0728,-141.3333 348.0728,-141.3333 348.0728,-135.6667 348.0728,-135.6667 348.0728,-132.8333 350.9062,-130 353.7395,-130 353.7395,-130 408.4749,-130 408.4749,-130 411.3082,-130 414.1415,-132.8333 414.1415,-135.6667 414.1415,-135.6667 414.1415,-141.3333 414.1415,-141.3333 414.1415,-144.1667 411.3082,-147 408.4749,-147"/>
 <text text-anchor="middle" x="381.1072" y="-135.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">defaults.json</text>
 </a>
@@ -279,7 +279,7 @@
 <!-- src/cli/formatMetaInfo.js -->
 <g id="node6" class="node">
 <title>src/cli/formatMetaInfo.js</title>
-<g id="a_node6"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/formatMetaInfo.js" xlink:title="formatMetaInfo.js">
+<g id="a_node6"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/formatMetaInfo.js" xlink:title="formatMetaInfo.js">
 <path fill="#ffffcc" stroke="#000000" d="M175.8815,-376C175.8815,-376 102.1605,-376 102.1605,-376 99.3271,-376 96.4938,-373.1667 96.4938,-370.3333 96.4938,-370.3333 96.4938,-364.6667 96.4938,-364.6667 96.4938,-361.8333 99.3271,-359 102.1605,-359 102.1605,-359 175.8815,-359 175.8815,-359 178.7148,-359 181.5482,-361.8333 181.5482,-364.6667 181.5482,-364.6667 181.5482,-370.3333 181.5482,-370.3333 181.5482,-373.1667 178.7148,-376 175.8815,-376"/>
 <text text-anchor="middle" x="139.021" y="-364.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">formatMetaInfo.js</text>
 </a>
@@ -288,7 +288,7 @@
 <!-- src/main/index.js -->
 <g id="node55" class="node">
 <title>src/main/index.js</title>
-<g id="a_node55"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/index.js" xlink:title="index.js">
+<g id="a_node55"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M402.4405,-640C402.4405,-640 359.7738,-640 359.7738,-640 356.9405,-640 354.1072,-637.1667 354.1072,-634.3333 354.1072,-634.3333 354.1072,-628.6667 354.1072,-628.6667 354.1072,-625.8333 356.9405,-623 359.7738,-623 359.7738,-623 402.4405,-623 402.4405,-623 405.2738,-623 408.1072,-625.8333 408.1072,-628.6667 408.1072,-628.6667 408.1072,-634.3333 408.1072,-634.3333 408.1072,-637.1667 405.2738,-640 402.4405,-640"/>
 <text text-anchor="middle" x="381.1072" y="-628.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -303,7 +303,7 @@
 <!-- src/cli/getResolveConfig.js -->
 <g id="node7" class="node">
 <title>src/cli/getResolveConfig.js</title>
-<g id="a_node7"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/getResolveConfig.js" xlink:title="getResolveConfig.js">
+<g id="a_node7"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/getResolveConfig.js" xlink:title="getResolveConfig.js">
 <path fill="#ffffcc" stroke="#000000" d="M181.3963,-345C181.3963,-345 96.6457,-345 96.6457,-345 93.8123,-345 90.979,-342.1667 90.979,-339.3333 90.979,-339.3333 90.979,-333.6667 90.979,-333.6667 90.979,-330.8333 93.8123,-328 96.6457,-328 96.6457,-328 181.3963,-328 181.3963,-328 184.2297,-328 187.063,-330.8333 187.063,-333.6667 187.063,-333.6667 187.063,-339.3333 187.063,-339.3333 187.063,-342.1667 184.2297,-345 181.3963,-345"/>
 <text text-anchor="middle" x="139.021" y="-333.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">getResolveConfig.js</text>
 </a>
@@ -312,7 +312,7 @@
 <!-- src/cli/utl/makeAbsolute.js -->
 <g id="node18" class="node">
 <title>src/cli/utl/makeAbsolute.js</title>
-<g id="a_node18"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/utl/makeAbsolute.js" xlink:title="makeAbsolute.js">
+<g id="a_node18"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/utl/makeAbsolute.js" xlink:title="makeAbsolute.js">
 <path fill="#ffffcc" stroke="#000000" d="M293.1786,-356C293.1786,-356 222.4474,-356 222.4474,-356 219.6141,-356 216.7808,-353.1667 216.7808,-350.3333 216.7808,-350.3333 216.7808,-344.6667 216.7808,-344.6667 216.7808,-341.8333 219.6141,-339 222.4474,-339 222.4474,-339 293.1786,-339 293.1786,-339 296.0119,-339 298.8452,-341.8333 298.8452,-344.6667 298.8452,-344.6667 298.8452,-350.3333 298.8452,-350.3333 298.8452,-353.1667 296.0119,-356 293.1786,-356"/>
 <text text-anchor="middle" x="257.813" y="-344.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">makeAbsolute.js</text>
 </a>
@@ -327,7 +327,7 @@
 <!-- src/cli/index.js -->
 <g id="node8" class="node">
 <title>src/cli/index.js</title>
-<g id="a_node8"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/index.js" xlink:title="index.js">
+<g id="a_node8"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M72.3333,-311C72.3333,-311 29.6667,-311 29.6667,-311 26.8333,-311 24,-308.1667 24,-305.3333 24,-305.3333 24,-299.6667 24,-299.6667 24,-296.8333 26.8333,-294 29.6667,-294 29.6667,-294 72.3333,-294 72.3333,-294 75.1667,-294 78,-296.8333 78,-299.6667 78,-299.6667 78,-305.3333 78,-305.3333 78,-308.1667 75.1667,-311 72.3333,-311"/>
 <text text-anchor="middle" x="51" y="-299.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -348,7 +348,7 @@
 <!-- src/cli/initConfig/index.js -->
 <g id="node14" class="node">
 <title>src/cli/initConfig/index.js</title>
-<g id="a_node14"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/index.js" xlink:title="index.js">
+<g id="a_node14"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M160.3543,-210C160.3543,-210 117.6877,-210 117.6877,-210 114.8543,-210 112.021,-207.1667 112.021,-204.3333 112.021,-204.3333 112.021,-198.6667 112.021,-198.6667 112.021,-195.8333 114.8543,-193 117.6877,-193 117.6877,-193 160.3543,-193 160.3543,-193 163.1877,-193 166.021,-195.8333 166.021,-198.6667 166.021,-198.6667 166.021,-204.3333 166.021,-204.3333 166.021,-207.1667 163.1877,-210 160.3543,-210"/>
 <text text-anchor="middle" x="139.021" y="-198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -363,7 +363,7 @@
 <!-- src/cli/normalizeOptions.js -->
 <g id="node15" class="node">
 <title>src/cli/normalizeOptions.js</title>
-<g id="a_node15"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/normalizeOptions.js" xlink:title="normalizeOptions.js">
+<g id="a_node15"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/normalizeOptions.js" xlink:title="normalizeOptions.js">
 <path fill="#ffffcc" stroke="#000000" d="M299.6776,-147C299.6776,-147 215.9484,-147 215.9484,-147 213.1151,-147 210.2817,-144.1667 210.2817,-141.3333 210.2817,-141.3333 210.2817,-135.6667 210.2817,-135.6667 210.2817,-132.8333 213.1151,-130 215.9484,-130 215.9484,-130 299.6776,-130 299.6776,-130 302.5109,-130 305.3442,-132.8333 305.3442,-135.6667 305.3442,-135.6667 305.3442,-141.3333 305.3442,-141.3333 305.3442,-144.1667 302.5109,-147 299.6776,-147"/>
 <text text-anchor="middle" x="257.813" y="-135.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalizeOptions.js</text>
 </a>
@@ -378,7 +378,7 @@
 <!-- src/cli/parseTSConfig.js -->
 <g id="node16" class="node">
 <title>src/cli/parseTSConfig.js</title>
-<g id="a_node16"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/parseTSConfig.js" xlink:title="parseTSConfig.js">
+<g id="a_node16"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/parseTSConfig.js" xlink:title="parseTSConfig.js">
 <path fill="#ffffcc" stroke="#000000" d="M175.8836,-96C175.8836,-96 102.1584,-96 102.1584,-96 99.325,-96 96.4917,-93.1667 96.4917,-90.3333 96.4917,-90.3333 96.4917,-84.6667 96.4917,-84.6667 96.4917,-81.8333 99.325,-79 102.1584,-79 102.1584,-79 175.8836,-79 175.8836,-79 178.717,-79 181.5503,-81.8333 181.5503,-84.6667 181.5503,-84.6667 181.5503,-90.3333 181.5503,-90.3333 181.5503,-93.1667 178.717,-96 175.8836,-96"/>
 <text text-anchor="middle" x="139.021" y="-84.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">parseTSConfig.js</text>
 </a>
@@ -393,7 +393,7 @@
 <!-- src/cli/utl/io.js -->
 <g id="node17" class="node">
 <title>src/cli/utl/io.js</title>
-<g id="a_node17"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/utl/io.js" xlink:title="io.js">
+<g id="a_node17"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/utl/io.js" xlink:title="io.js">
 <path fill="#ffffcc" stroke="#000000" d="M279.1463,-327C279.1463,-327 236.4797,-327 236.4797,-327 233.6463,-327 230.813,-324.1667 230.813,-321.3333 230.813,-321.3333 230.813,-315.6667 230.813,-315.6667 230.813,-312.8333 233.6463,-310 236.4797,-310 236.4797,-310 279.1463,-310 279.1463,-310 281.9797,-310 284.813,-312.8333 284.813,-315.6667 284.813,-315.6667 284.813,-321.3333 284.813,-321.3333 284.813,-324.1667 281.9797,-327 279.1463,-327"/>
 <text text-anchor="middle" x="257.813" y="-315.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">io.js</text>
 </a>
@@ -408,7 +408,7 @@
 <!-- src/cli/utl/validateFileExistence.js -->
 <g id="node19" class="node">
 <title>src/cli/utl/validateFileExistence.js</title>
-<g id="a_node19"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/utl/validateFileExistence.js" xlink:title="validateFileExistence.js">
+<g id="a_node19"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/utl/validateFileExistence.js" xlink:title="validateFileExistence.js">
 <path fill="#ffffcc" stroke="#000000" d="M306.6893,-298C306.6893,-298 208.9367,-298 208.9367,-298 206.1034,-298 203.27,-295.1667 203.27,-292.3333 203.27,-292.3333 203.27,-286.6667 203.27,-286.6667 203.27,-283.8333 206.1034,-281 208.9367,-281 208.9367,-281 306.6893,-281 306.6893,-281 309.5226,-281 312.3559,-283.8333 312.3559,-286.6667 312.3559,-286.6667 312.3559,-292.3333 312.3559,-292.3333 312.3559,-295.1667 309.5226,-298 306.6893,-298"/>
 <text text-anchor="middle" x="257.813" y="-286.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">validateFileExistence.js</text>
 </a>
@@ -429,7 +429,7 @@
 <!-- src/cli/initConfig/config.js.template.js -->
 <g id="node9" class="node">
 <title>src/cli/initConfig/config.js.template.js</title>
-<g id="a_node9"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/config.js.template.js" xlink:title="config.js.template.js">
+<g id="a_node9"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/config.js.template.js" xlink:title="config.js.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M422.9762,-210C422.9762,-210 339.2382,-210 339.2382,-210 336.4049,-210 333.5715,-207.1667 333.5715,-204.3333 333.5715,-204.3333 333.5715,-198.6667 333.5715,-198.6667 333.5715,-195.8333 336.4049,-193 339.2382,-193 339.2382,-193 422.9762,-193 422.9762,-193 425.8095,-193 428.6428,-195.8333 428.6428,-198.6667 428.6428,-198.6667 428.6428,-204.3333 428.6428,-204.3333 428.6428,-207.1667 425.8095,-210 422.9762,-210"/>
 <text text-anchor="middle" x="381.1072" y="-198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">config.js.template.js</text>
 </a>
@@ -438,7 +438,7 @@
 <!-- src/cli/initConfig/config.json.template.js -->
 <g id="node10" class="node">
 <title>src/cli/initConfig/config.json.template.js</title>
-<g id="a_node10"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/config.json.template.js" xlink:title="config.json.template.js">
+<g id="a_node10"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/config.json.template.js" xlink:title="config.json.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M427.9869,-239C427.9869,-239 334.2274,-239 334.2274,-239 331.3941,-239 328.5608,-236.1667 328.5608,-233.3333 328.5608,-233.3333 328.5608,-227.6667 328.5608,-227.6667 328.5608,-224.8333 331.3941,-222 334.2274,-222 334.2274,-222 427.9869,-222 427.9869,-222 430.8202,-222 433.6536,-224.8333 433.6536,-227.6667 433.6536,-227.6667 433.6536,-233.3333 433.6536,-233.3333 433.6536,-236.1667 430.8202,-239 427.9869,-239"/>
 <text text-anchor="middle" x="381.1072" y="-227.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">config.json.template.js</text>
 </a>
@@ -447,7 +447,7 @@
 <!-- src/cli/initConfig/createConfigFile.js -->
 <g id="node11" class="node">
 <title>src/cli/initConfig/createConfigFile.js</title>
-<g id="a_node11"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/createConfigFile.js" xlink:title="createConfigFile.js">
+<g id="a_node11"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/createConfigFile.js" xlink:title="createConfigFile.js">
 <path fill="#ffffcc" stroke="#000000" d="M297.1788,-210C297.1788,-210 218.4472,-210 218.4472,-210 215.6139,-210 212.7805,-207.1667 212.7805,-204.3333 212.7805,-204.3333 212.7805,-198.6667 212.7805,-198.6667 212.7805,-195.8333 215.6139,-193 218.4472,-193 218.4472,-193 297.1788,-193 297.1788,-193 300.0121,-193 302.8454,-195.8333 302.8454,-198.6667 302.8454,-198.6667 302.8454,-204.3333 302.8454,-204.3333 302.8454,-207.1667 300.0121,-210 297.1788,-210"/>
 <text text-anchor="middle" x="257.813" y="-198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">createConfigFile.js</text>
 </a>
@@ -474,7 +474,7 @@
 <!-- src/cli/initConfig/helpers.js -->
 <g id="node13" class="node">
 <title>src/cli/initConfig/helpers.js</title>
-<g id="a_node13"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/helpers.js" xlink:title="helpers.js">
+<g id="a_node13"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/helpers.js" xlink:title="helpers.js">
 <path fill="#ffffcc" stroke="#000000" d="M402.4607,-181C402.4607,-181 359.7537,-181 359.7537,-181 356.9203,-181 354.087,-178.1667 354.087,-175.3333 354.087,-175.3333 354.087,-169.6667 354.087,-169.6667 354.087,-166.8333 356.9203,-164 359.7537,-164 359.7537,-164 402.4607,-164 402.4607,-164 405.294,-164 408.1274,-166.8333 408.1274,-169.6667 408.1274,-169.6667 408.1274,-175.3333 408.1274,-175.3333 408.1274,-178.1667 405.294,-181 402.4607,-181"/>
 <text text-anchor="middle" x="381.1072" y="-169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">helpers.js</text>
 </a>
@@ -489,7 +489,7 @@
 <!-- src/cli/initConfig/getUserInput.js -->
 <g id="node12" class="node">
 <title>src/cli/initConfig/getUserInput.js</title>
-<g id="a_node12"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/getUserInput.js" xlink:title="getUserInput.js">
+<g id="a_node12"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/getUserInput.js" xlink:title="getUserInput.js">
 <path fill="#ffffcc" stroke="#000000" d="M290.178,-181C290.178,-181 225.4479,-181 225.4479,-181 222.6146,-181 219.7813,-178.1667 219.7813,-175.3333 219.7813,-175.3333 219.7813,-169.6667 219.7813,-169.6667 219.7813,-166.8333 222.6146,-164 225.4479,-164 225.4479,-164 290.178,-164 290.178,-164 293.0114,-164 295.8447,-166.8333 295.8447,-169.6667 295.8447,-169.6667 295.8447,-175.3333 295.8447,-175.3333 295.8447,-178.1667 293.0114,-181 290.178,-181"/>
 <text text-anchor="middle" x="257.813" y="-169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">getUserInput.js</text>
 </a>
@@ -540,7 +540,7 @@
 <!-- src/extract/addValidations.js -->
 <g id="node20" class="node">
 <title>src/extract/addValidations.js</title>
-<g id="a_node20"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/addValidations.js" xlink:title="addValidations.js">
+<g id="a_node20"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/addValidations.js" xlink:title="addValidations.js">
 <path fill="#ffffcc" stroke="#000000" d="M691.4895,-1232C691.4895,-1232 619.0584,-1232 619.0584,-1232 616.225,-1232 613.3917,-1229.1667 613.3917,-1226.3333 613.3917,-1226.3333 613.3917,-1220.6667 613.3917,-1220.6667 613.3917,-1217.8333 616.225,-1215 619.0584,-1215 619.0584,-1215 691.4895,-1215 691.4895,-1215 694.3228,-1215 697.1561,-1217.8333 697.1561,-1220.6667 697.1561,-1220.6667 697.1561,-1226.3333 697.1561,-1226.3333 697.1561,-1229.1667 694.3228,-1232 691.4895,-1232"/>
 <text text-anchor="middle" x="655.2739" y="-1220.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">addValidations.js</text>
 </a>
@@ -549,7 +549,7 @@
 <!-- src/validate/index.js -->
 <g id="node81" class="node">
 <title>src/validate/index.js</title>
-<g id="a_node81"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/index.js" xlink:title="index.js">
+<g id="a_node81"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/validate/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M842.5189,-1452C842.5189,-1452 799.8522,-1452 799.8522,-1452 797.0189,-1452 794.1855,-1449.1667 794.1855,-1446.3333 794.1855,-1446.3333 794.1855,-1440.6667 794.1855,-1440.6667 794.1855,-1437.8333 797.0189,-1435 799.8522,-1435 799.8522,-1435 842.5189,-1435 842.5189,-1435 845.3522,-1435 848.1855,-1437.8333 848.1855,-1440.6667 848.1855,-1440.6667 848.1855,-1446.3333 848.1855,-1446.3333 848.1855,-1449.1667 845.3522,-1452 842.5189,-1452"/>
 <text text-anchor="middle" x="821.1855" y="-1440.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -564,7 +564,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;AMD&#45;deps.js -->
 <g id="node21" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;AMD&#45;deps.js</title>
-<g id="a_node21"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-AMD-deps.js" xlink:title="extract&#45;AMD&#45;deps.js">
+<g id="a_node21"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-AMD-deps.js" xlink:title="extract&#45;AMD&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M864.0386,-994C864.0386,-994 778.3325,-994 778.3325,-994 775.4991,-994 772.6658,-991.1667 772.6658,-988.3333 772.6658,-988.3333 772.6658,-982.6667 772.6658,-982.6667 772.6658,-979.8333 775.4991,-977 778.3325,-977 778.3325,-977 864.0386,-977 864.0386,-977 866.872,-977 869.7053,-979.8333 869.7053,-982.6667 869.7053,-982.6667 869.7053,-988.3333 869.7053,-988.3333 869.7053,-991.1667 866.872,-994 864.0386,-994"/>
 <text text-anchor="middle" x="821.1855" y="-982.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;AMD&#45;deps.js</text>
 </a>
@@ -573,7 +573,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;commonJS&#45;deps.js -->
 <g id="node23" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;commonJS&#45;deps.js</title>
-<g id="a_node23"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-commonJS-deps.js" xlink:title="extract&#45;commonJS&#45;deps.js">
+<g id="a_node23"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-commonJS-deps.js" xlink:title="extract&#45;commonJS&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M1036.595,-994C1036.595,-994 925.8621,-994 925.8621,-994 923.0287,-994 920.1954,-991.1667 920.1954,-988.3333 920.1954,-988.3333 920.1954,-982.6667 920.1954,-982.6667 920.1954,-979.8333 923.0287,-977 925.8621,-977 925.8621,-977 1036.595,-977 1036.595,-977 1039.4283,-977 1042.2616,-979.8333 1042.2616,-982.6667 1042.2616,-982.6667 1042.2616,-988.3333 1042.2616,-988.3333 1042.2616,-991.1667 1039.4283,-994 1036.595,-994"/>
 <text text-anchor="middle" x="981.2285" y="-982.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;commonJS&#45;deps.js</text>
 </a>
@@ -588,7 +588,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;ES6&#45;deps.js -->
 <g id="node22" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;ES6&#45;deps.js</title>
-<g id="a_node22"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-ES6-deps.js" xlink:title="extract&#45;ES6&#45;deps.js">
+<g id="a_node22"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-ES6-deps.js" xlink:title="extract&#45;ES6&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M862.5503,-965C862.5503,-965 779.8208,-965 779.8208,-965 776.9874,-965 774.1541,-962.1667 774.1541,-959.3333 774.1541,-959.3333 774.1541,-953.6667 774.1541,-953.6667 774.1541,-950.8333 776.9874,-948 779.8208,-948 779.8208,-948 862.5503,-948 862.5503,-948 865.3836,-948 868.217,-950.8333 868.217,-953.6667 868.217,-953.6667 868.217,-959.3333 868.217,-959.3333 868.217,-962.1667 865.3836,-965 862.5503,-965"/>
 <text text-anchor="middle" x="821.1855" y="-953.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;ES6&#45;deps.js</text>
 </a>
@@ -597,7 +597,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;typescript&#45;deps.js -->
 <g id="node24" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;typescript&#45;deps.js</title>
-<g id="a_node24"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-typescript-deps.js" xlink:title="extract&#45;typescript&#45;deps.js">
+<g id="a_node24"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-typescript-deps.js" xlink:title="extract&#45;typescript&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M873.5516,-936C873.5516,-936 768.8195,-936 768.8195,-936 765.9862,-936 763.1528,-933.1667 763.1528,-930.3333 763.1528,-930.3333 763.1528,-924.6667 763.1528,-924.6667 763.1528,-921.8333 765.9862,-919 768.8195,-919 768.8195,-919 873.5516,-919 873.5516,-919 876.3849,-919 879.2183,-921.8333 879.2183,-924.6667 879.2183,-924.6667 879.2183,-930.3333 879.2183,-930.3333 879.2183,-933.1667 876.3849,-936 873.5516,-936"/>
 <text text-anchor="middle" x="821.1855" y="-924.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;typescript&#45;deps.js</text>
 </a>
@@ -612,7 +612,7 @@
 <!-- src/extract/derive/circular/dependencyEndsUpAtFrom.js -->
 <g id="node25" class="node">
 <title>src/extract/derive/circular/dependencyEndsUpAtFrom.js</title>
-<g id="a_node25"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/circular/dependencyEndsUpAtFrom.js" xlink:title="dependencyEndsUpAtFrom.js">
+<g id="a_node25"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/circular/dependencyEndsUpAtFrom.js" xlink:title="dependencyEndsUpAtFrom.js">
 <path fill="#ffffcc" stroke="#000000" d="M883.0816,-1333C883.0816,-1333 759.2895,-1333 759.2895,-1333 756.4562,-1333 753.6228,-1330.1667 753.6228,-1327.3333 753.6228,-1327.3333 753.6228,-1321.6667 753.6228,-1321.6667 753.6228,-1318.8333 756.4562,-1316 759.2895,-1316 759.2895,-1316 883.0816,-1316 883.0816,-1316 885.9149,-1316 888.7483,-1318.8333 888.7483,-1321.6667 888.7483,-1321.6667 888.7483,-1327.3333 888.7483,-1327.3333 888.7483,-1330.1667 885.9149,-1333 883.0816,-1333"/>
 <text text-anchor="middle" x="821.1855" y="-1321.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">dependencyEndsUpAtFrom.js</text>
 </a>
@@ -621,7 +621,7 @@
 <!-- src/extract/derive/circular/index.js -->
 <g id="node26" class="node">
 <title>src/extract/derive/circular/index.js</title>
-<g id="a_node26"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/circular/index.js" xlink:title="index.js">
+<g id="a_node26"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/circular/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M676.6073,-1333C676.6073,-1333 633.9406,-1333 633.9406,-1333 631.1073,-1333 628.2739,-1330.1667 628.2739,-1327.3333 628.2739,-1327.3333 628.2739,-1321.6667 628.2739,-1321.6667 628.2739,-1318.8333 631.1073,-1316 633.9406,-1316 633.9406,-1316 676.6073,-1316 676.6073,-1316 679.4406,-1316 682.2739,-1318.8333 682.2739,-1321.6667 682.2739,-1321.6667 682.2739,-1327.3333 682.2739,-1327.3333 682.2739,-1330.1667 679.4406,-1333 676.6073,-1333"/>
 <text text-anchor="middle" x="655.2739" y="-1321.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -636,7 +636,7 @@
 <!-- src/extract/derive/orphan/index.js -->
 <g id="node27" class="node">
 <title>src/extract/derive/orphan/index.js</title>
-<g id="a_node27"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/orphan/index.js" xlink:title="index.js">
+<g id="a_node27"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/orphan/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M676.6073,-1274C676.6073,-1274 633.9406,-1274 633.9406,-1274 631.1073,-1274 628.2739,-1271.1667 628.2739,-1268.3333 628.2739,-1268.3333 628.2739,-1262.6667 628.2739,-1262.6667 628.2739,-1259.8333 631.1073,-1257 633.9406,-1257 633.9406,-1257 676.6073,-1257 676.6073,-1257 679.4406,-1257 682.2739,-1259.8333 682.2739,-1262.6667 682.2739,-1262.6667 682.2739,-1268.3333 682.2739,-1268.3333 682.2739,-1271.1667 679.4406,-1274 676.6073,-1274"/>
 <text text-anchor="middle" x="655.2739" y="-1262.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -645,7 +645,7 @@
 <!-- src/extract/derive/orphan/isOrphan.js -->
 <g id="node28" class="node">
 <title>src/extract/derive/orphan/isOrphan.js</title>
-<g id="a_node28"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/orphan/isOrphan.js" xlink:title="isOrphan.js">
+<g id="a_node28"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/orphan/isOrphan.js" xlink:title="isOrphan.js">
 <path fill="#ffffcc" stroke="#000000" d="M846.0393,-1274C846.0393,-1274 796.3318,-1274 796.3318,-1274 793.4985,-1274 790.6651,-1271.1667 790.6651,-1268.3333 790.6651,-1268.3333 790.6651,-1262.6667 790.6651,-1262.6667 790.6651,-1259.8333 793.4985,-1257 796.3318,-1257 796.3318,-1257 846.0393,-1257 846.0393,-1257 848.8726,-1257 851.706,-1259.8333 851.706,-1262.6667 851.706,-1262.6667 851.706,-1268.3333 851.706,-1268.3333 851.706,-1271.1667 848.8726,-1274 846.0393,-1274"/>
 <text text-anchor="middle" x="821.1855" y="-1262.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">isOrphan.js</text>
 </a>
@@ -660,7 +660,7 @@
 <!-- src/extract/extract.js -->
 <g id="node29" class="node">
 <title>src/extract/extract.js</title>
-<g id="a_node29"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/extract.js" xlink:title="extract.js">
+<g id="a_node29"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/extract.js" xlink:title="extract.js">
 <path fill="#ffffcc" stroke="#000000" d="M676.6073,-1005C676.6073,-1005 633.9406,-1005 633.9406,-1005 631.1073,-1005 628.2739,-1002.1667 628.2739,-999.3333 628.2739,-999.3333 628.2739,-993.6667 628.2739,-993.6667 628.2739,-990.8333 631.1073,-988 633.9406,-988 633.9406,-988 676.6073,-988 676.6073,-988 679.4406,-988 682.2739,-990.8333 682.2739,-993.6667 682.2739,-993.6667 682.2739,-999.3333 682.2739,-999.3333 682.2739,-1002.1667 679.4406,-1005 676.6073,-1005"/>
 <text text-anchor="middle" x="655.2739" y="-993.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract.js</text>
 </a>
@@ -693,7 +693,7 @@
 <!-- src/extract/ignore.js -->
 <g id="node31" class="node">
 <title>src/extract/ignore.js</title>
-<g id="a_node31"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ignore.js" xlink:title="ignore.js">
+<g id="a_node31"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ignore.js" xlink:title="ignore.js">
 <path fill="#ffffcc" stroke="#000000" d="M842.5189,-1232C842.5189,-1232 799.8522,-1232 799.8522,-1232 797.0189,-1232 794.1855,-1229.1667 794.1855,-1226.3333 794.1855,-1226.3333 794.1855,-1220.6667 794.1855,-1220.6667 794.1855,-1217.8333 797.0189,-1215 799.8522,-1215 799.8522,-1215 842.5189,-1215 842.5189,-1215 845.3522,-1215 848.1855,-1217.8333 848.1855,-1220.6667 848.1855,-1220.6667 848.1855,-1226.3333 848.1855,-1226.3333 848.1855,-1229.1667 845.3522,-1232 842.5189,-1232"/>
 <text text-anchor="middle" x="821.1855" y="-1220.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">ignore.js</text>
 </a>
@@ -708,7 +708,7 @@
 <!-- src/extract/parse/toJavascriptAST.js -->
 <g id="node33" class="node">
 <title>src/extract/parse/toJavascriptAST.js</title>
-<g id="a_node33"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/parse/toJavascriptAST.js" xlink:title="toJavascriptAST.js">
+<g id="a_node33"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/parse/toJavascriptAST.js" xlink:title="toJavascriptAST.js">
 <path fill="#ffffcc" stroke="#000000" d="M860.045,-867C860.045,-867 782.3261,-867 782.3261,-867 779.4927,-867 776.6594,-864.1667 776.6594,-861.3333 776.6594,-861.3333 776.6594,-855.6667 776.6594,-855.6667 776.6594,-852.8333 779.4927,-850 782.3261,-850 782.3261,-850 860.045,-850 860.045,-850 862.8784,-850 865.7117,-852.8333 865.7117,-855.6667 865.7117,-855.6667 865.7117,-861.3333 865.7117,-861.3333 865.7117,-864.1667 862.8784,-867 860.045,-867"/>
 <text text-anchor="middle" x="821.1855" y="-855.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">toJavascriptAST.js</text>
 </a>
@@ -723,7 +723,7 @@
 <!-- src/extract/parse/toTypescriptAST.js -->
 <g id="node34" class="node">
 <title>src/extract/parse/toTypescriptAST.js</title>
-<g id="a_node34"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/parse/toTypescriptAST.js" xlink:title="toTypescriptAST.js">
+<g id="a_node34"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/parse/toTypescriptAST.js" xlink:title="toTypescriptAST.js">
 <path fill="#ffffcc" stroke="#000000" d="M860.5492,-838C860.5492,-838 781.8219,-838 781.8219,-838 778.9886,-838 776.1553,-835.1667 776.1553,-832.3333 776.1553,-832.3333 776.1553,-826.6667 776.1553,-826.6667 776.1553,-823.8333 778.9886,-821 781.8219,-821 781.8219,-821 860.5492,-821 860.5492,-821 863.3825,-821 866.2158,-823.8333 866.2158,-826.6667 866.2158,-826.6667 866.2158,-832.3333 866.2158,-832.3333 866.2158,-835.1667 863.3825,-838 860.5492,-838"/>
 <text text-anchor="middle" x="821.1855" y="-826.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">toTypescriptAST.js</text>
 </a>
@@ -738,7 +738,7 @@
 <!-- src/extract/resolve/index.js -->
 <g id="node36" class="node">
 <title>src/extract/resolve/index.js</title>
-<g id="a_node36"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/index.js" xlink:title="index.js">
+<g id="a_node36"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M842.5189,-1115C842.5189,-1115 799.8522,-1115 799.8522,-1115 797.0189,-1115 794.1855,-1112.1667 794.1855,-1109.3333 794.1855,-1109.3333 794.1855,-1103.6667 794.1855,-1103.6667 794.1855,-1100.8333 797.0189,-1098 799.8522,-1098 799.8522,-1098 842.5189,-1098 842.5189,-1098 845.3522,-1098 848.1855,-1100.8333 848.1855,-1103.6667 848.1855,-1103.6667 848.1855,-1109.3333 848.1855,-1109.3333 848.1855,-1112.1667 845.3522,-1115 842.5189,-1115"/>
 <text text-anchor="middle" x="821.1855" y="-1103.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -753,7 +753,7 @@
 <!-- src/extract/gatherInitialSources.js -->
 <g id="node30" class="node">
 <title>src/extract/gatherInitialSources.js</title>
-<g id="a_node30"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/gatherInitialSources.js" xlink:title="gatherInitialSources.js">
+<g id="a_node30"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/gatherInitialSources.js" xlink:title="gatherInitialSources.js">
 <path fill="#ffffcc" stroke="#000000" d="M701.6537,-1203C701.6537,-1203 608.8942,-1203 608.8942,-1203 606.0609,-1203 603.2275,-1200.1667 603.2275,-1197.3333 603.2275,-1197.3333 603.2275,-1191.6667 603.2275,-1191.6667 603.2275,-1188.8333 606.0609,-1186 608.8942,-1186 608.8942,-1186 701.6537,-1186 701.6537,-1186 704.487,-1186 707.3203,-1188.8333 707.3203,-1191.6667 707.3203,-1191.6667 707.3203,-1197.3333 707.3203,-1197.3333 707.3203,-1200.1667 704.487,-1203 701.6537,-1203"/>
 <text text-anchor="middle" x="655.2739" y="-1191.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">gatherInitialSources.js</text>
 </a>
@@ -768,7 +768,7 @@
 <!-- src/extract/transpile/meta.js -->
 <g id="node50" class="node">
 <title>src/extract/transpile/meta.js</title>
-<g id="a_node50"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/meta.js" xlink:title="meta.js">
+<g id="a_node50"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/meta.js" xlink:title="meta.js">
 <path fill="#ffffcc" stroke="#000000" d="M1149.6151,-795C1149.6151,-795 1106.9484,-795 1106.9484,-795 1104.1151,-795 1101.2817,-792.1667 1101.2817,-789.3333 1101.2817,-789.3333 1101.2817,-783.6667 1101.2817,-783.6667 1101.2817,-780.8333 1104.1151,-778 1106.9484,-778 1106.9484,-778 1149.6151,-778 1149.6151,-778 1152.4484,-778 1155.2817,-780.8333 1155.2817,-783.6667 1155.2817,-783.6667 1155.2817,-789.3333 1155.2817,-789.3333 1155.2817,-792.1667 1152.4484,-795 1149.6151,-795"/>
 <text text-anchor="middle" x="1128.2817" y="-783.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">meta.js</text>
 </a>
@@ -783,7 +783,7 @@
 <!-- src/extract/index.js -->
 <g id="node32" class="node">
 <title>src/extract/index.js</title>
-<g id="a_node32"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/index.js" xlink:title="index.js">
+<g id="a_node32"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1217C526.9637,-1217 484.297,-1217 484.297,-1217 481.4637,-1217 478.6304,-1214.1667 478.6304,-1211.3333 478.6304,-1211.3333 478.6304,-1205.6667 478.6304,-1205.6667 478.6304,-1202.8333 481.4637,-1200 484.297,-1200 484.297,-1200 526.9637,-1200 526.9637,-1200 529.797,-1200 532.6304,-1202.8333 532.6304,-1205.6667 532.6304,-1205.6667 532.6304,-1211.3333 532.6304,-1211.3333 532.6304,-1214.1667 529.797,-1217 526.9637,-1217"/>
 <text text-anchor="middle" x="505.6304" y="-1205.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -822,7 +822,7 @@
 <!-- src/extract/summarize.js -->
 <g id="node45" class="node">
 <title>src/extract/summarize.js</title>
-<g id="a_node45"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/summarize.js" xlink:title="summarize.js">
+<g id="a_node45"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/summarize.js" xlink:title="summarize.js">
 <path fill="#ffffcc" stroke="#000000" d="M684.1141,-976C684.1141,-976 626.4338,-976 626.4338,-976 623.6004,-976 620.7671,-973.1667 620.7671,-970.3333 620.7671,-970.3333 620.7671,-964.6667 620.7671,-964.6667 620.7671,-961.8333 623.6004,-959 626.4338,-959 626.4338,-959 684.1141,-959 684.1141,-959 686.9474,-959 689.7808,-961.8333 689.7808,-964.6667 689.7808,-964.6667 689.7808,-970.3333 689.7808,-970.3333 689.7808,-973.1667 686.9474,-976 684.1141,-976"/>
 <text text-anchor="middle" x="655.2739" y="-964.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">summarize.js</text>
 </a>
@@ -837,7 +837,7 @@
 <!-- src/extract/utl/pathToPosix.js -->
 <g id="node53" class="node">
 <title>src/extract/utl/pathToPosix.js</title>
-<g id="a_node53"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/utl/pathToPosix.js" xlink:title="pathToPosix.js">
+<g id="a_node53"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/pathToPosix.js" xlink:title="pathToPosix.js">
 <path fill="#ffffcc" stroke="#000000" d="M1474.2542,-1210C1474.2542,-1210 1411.528,-1210 1411.528,-1210 1408.6947,-1210 1405.8613,-1207.1667 1405.8613,-1204.3333 1405.8613,-1204.3333 1405.8613,-1198.6667 1405.8613,-1198.6667 1405.8613,-1195.8333 1408.6947,-1193 1411.528,-1193 1411.528,-1193 1474.2542,-1193 1474.2542,-1193 1477.0876,-1193 1479.9209,-1195.8333 1479.9209,-1198.6667 1479.9209,-1198.6667 1479.9209,-1204.3333 1479.9209,-1204.3333 1479.9209,-1207.1667 1477.0876,-1210 1474.2542,-1210"/>
 <text text-anchor="middle" x="1442.8911" y="-1198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">pathToPosix.js</text>
 </a>
@@ -852,7 +852,7 @@
 <!-- src/extract/transpile/index.js -->
 <g id="node47" class="node">
 <title>src/extract/transpile/index.js</title>
-<g id="a_node47"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/index.js" xlink:title="index.js">
+<g id="a_node47"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M1002.5618,-824C1002.5618,-824 959.8952,-824 959.8952,-824 957.0618,-824 954.2285,-821.1667 954.2285,-818.3333 954.2285,-818.3333 954.2285,-812.6667 954.2285,-812.6667 954.2285,-809.8333 957.0618,-807 959.8952,-807 959.8952,-807 1002.5618,-807 1002.5618,-807 1005.3952,-807 1008.2285,-809.8333 1008.2285,-812.6667 1008.2285,-812.6667 1008.2285,-818.3333 1008.2285,-818.3333 1008.2285,-821.1667 1005.3952,-824 1002.5618,-824"/>
 <text text-anchor="middle" x="981.2285" y="-812.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -867,7 +867,7 @@
 <!-- src/extract/utl/getExtension.js -->
 <g id="node52" class="node">
 <title>src/extract/utl/getExtension.js</title>
-<g id="a_node52"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/utl/getExtension.js" xlink:title="getExtension.js">
+<g id="a_node52"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/getExtension.js" xlink:title="getExtension.js">
 <path fill="#ffffcc" stroke="#000000" d="M1475.7601,-1181C1475.7601,-1181 1410.0221,-1181 1410.0221,-1181 1407.1888,-1181 1404.3555,-1178.1667 1404.3555,-1175.3333 1404.3555,-1175.3333 1404.3555,-1169.6667 1404.3555,-1169.6667 1404.3555,-1166.8333 1407.1888,-1164 1410.0221,-1164 1410.0221,-1164 1475.7601,-1164 1475.7601,-1164 1478.5934,-1164 1481.4268,-1166.8333 1481.4268,-1169.6667 1481.4268,-1169.6667 1481.4268,-1175.3333 1481.4268,-1175.3333 1481.4268,-1178.1667 1478.5934,-1181 1475.7601,-1181"/>
 <text text-anchor="middle" x="1442.8911" y="-1169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">getExtension.js</text>
 </a>
@@ -888,7 +888,7 @@
 <!-- src/extract/resolve/determineDependencyTypes.js -->
 <g id="node35" class="node">
 <title>src/extract/resolve/determineDependencyTypes.js</title>
-<g id="a_node35"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/determineDependencyTypes.js" xlink:title="determineDependencyTypes.js">
+<g id="a_node35"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/determineDependencyTypes.js" xlink:title="determineDependencyTypes.js">
 <path fill="#ffffcc" stroke="#000000" d="M1192.1899,-1082C1192.1899,-1082 1064.3735,-1082 1064.3735,-1082 1061.5402,-1082 1058.7069,-1079.1667 1058.7069,-1076.3333 1058.7069,-1076.3333 1058.7069,-1070.6667 1058.7069,-1070.6667 1058.7069,-1067.8333 1061.5402,-1065 1064.3735,-1065 1064.3735,-1065 1192.1899,-1065 1192.1899,-1065 1195.0233,-1065 1197.8566,-1067.8333 1197.8566,-1070.6667 1197.8566,-1070.6667 1197.8566,-1076.3333 1197.8566,-1076.3333 1197.8566,-1079.1667 1195.0233,-1082 1192.1899,-1082"/>
 <text text-anchor="middle" x="1128.2817" y="-1070.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">determineDependencyTypes.js</text>
 </a>
@@ -897,7 +897,7 @@
 <!-- src/extract/resolve/localNpmHelpers.js -->
 <g id="node38" class="node">
 <title>src/extract/resolve/localNpmHelpers.js</title>
-<g id="a_node38"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/localNpmHelpers.js" xlink:title="localNpmHelpers.js">
+<g id="a_node38"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/localNpmHelpers.js" xlink:title="localNpmHelpers.js">
 <path fill="#ffffcc" stroke="#000000" d="M1298.6893,-1082C1298.6893,-1082 1216.9723,-1082 1216.9723,-1082 1214.139,-1082 1211.3057,-1079.1667 1211.3057,-1076.3333 1211.3057,-1076.3333 1211.3057,-1070.6667 1211.3057,-1070.6667 1211.3057,-1067.8333 1214.139,-1065 1216.9723,-1065 1216.9723,-1065 1298.6893,-1065 1298.6893,-1065 1301.5226,-1065 1304.3559,-1067.8333 1304.3559,-1070.6667 1304.3559,-1070.6667 1304.3559,-1076.3333 1304.3559,-1076.3333 1304.3559,-1079.1667 1301.5226,-1082 1298.6893,-1082"/>
 <text text-anchor="middle" x="1257.8308" y="-1070.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">localNpmHelpers.js</text>
 </a>
@@ -912,7 +912,7 @@
 <!-- src/extract/resolve/resolve&#45;AMD.js -->
 <g id="node41" class="node">
 <title>src/extract/resolve/resolve&#45;AMD.js</title>
-<g id="a_node41"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve-AMD.js" xlink:title="resolve&#45;AMD.js">
+<g id="a_node41"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-AMD.js" xlink:title="resolve&#45;AMD.js">
 <path fill="#ffffcc" stroke="#000000" d="M1014.0711,-1101C1014.0711,-1101 948.3859,-1101 948.3859,-1101 945.5526,-1101 942.7192,-1098.1667 942.7192,-1095.3333 942.7192,-1095.3333 942.7192,-1089.6667 942.7192,-1089.6667 942.7192,-1086.8333 945.5526,-1084 948.3859,-1084 948.3859,-1084 1014.0711,-1084 1014.0711,-1084 1016.9045,-1084 1019.7378,-1086.8333 1019.7378,-1089.6667 1019.7378,-1089.6667 1019.7378,-1095.3333 1019.7378,-1095.3333 1019.7378,-1098.1667 1016.9045,-1101 1014.0711,-1101"/>
 <text text-anchor="middle" x="981.2285" y="-1089.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve&#45;AMD.js</text>
 </a>
@@ -927,7 +927,7 @@
 <!-- src/extract/resolve/resolve&#45;commonJS.js -->
 <g id="node42" class="node">
 <title>src/extract/resolve/resolve&#45;commonJS.js</title>
-<g id="a_node42"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve-commonJS.js" xlink:title="resolve&#45;commonJS.js">
+<g id="a_node42"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-commonJS.js" xlink:title="resolve&#45;commonJS.js">
 <path fill="#ffffcc" stroke="#000000" d="M1026.5848,-1130C1026.5848,-1130 935.8722,-1130 935.8722,-1130 933.0389,-1130 930.2056,-1127.1667 930.2056,-1124.3333 930.2056,-1124.3333 930.2056,-1118.6667 930.2056,-1118.6667 930.2056,-1115.8333 933.0389,-1113 935.8722,-1113 935.8722,-1113 1026.5848,-1113 1026.5848,-1113 1029.4181,-1113 1032.2515,-1115.8333 1032.2515,-1118.6667 1032.2515,-1118.6667 1032.2515,-1124.3333 1032.2515,-1124.3333 1032.2515,-1127.1667 1029.4181,-1130 1026.5848,-1130"/>
 <text text-anchor="middle" x="981.2285" y="-1118.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve&#45;commonJS.js</text>
 </a>
@@ -948,7 +948,7 @@
 <!-- src/extract/resolve/isFollowable.js -->
 <g id="node37" class="node">
 <title>src/extract/resolve/isFollowable.js</title>
-<g id="a_node37"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/isFollowable.js" xlink:title="isFollowable.js">
+<g id="a_node37"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/isFollowable.js" xlink:title="isFollowable.js">
 <path fill="#ffffcc" stroke="#000000" d="M1159.6386,-1181C1159.6386,-1181 1096.9249,-1181 1096.9249,-1181 1094.0916,-1181 1091.2582,-1178.1667 1091.2582,-1175.3333 1091.2582,-1175.3333 1091.2582,-1169.6667 1091.2582,-1169.6667 1091.2582,-1166.8333 1094.0916,-1164 1096.9249,-1164 1096.9249,-1164 1159.6386,-1164 1159.6386,-1164 1162.4719,-1164 1165.3052,-1166.8333 1165.3052,-1169.6667 1165.3052,-1169.6667 1165.3052,-1175.3333 1165.3052,-1175.3333 1165.3052,-1178.1667 1162.4719,-1181 1159.6386,-1181"/>
 <text text-anchor="middle" x="1128.2817" y="-1169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">isFollowable.js</text>
 </a>
@@ -969,7 +969,7 @@
 <!-- src/extract/resolve/readPackageDeps/index.js -->
 <g id="node39" class="node">
 <title>src/extract/resolve/readPackageDeps/index.js</title>
-<g id="a_node39"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/readPackageDeps/index.js" xlink:title="index.js">
+<g id="a_node39"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/readPackageDeps/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M1149.6151,-1116C1149.6151,-1116 1106.9484,-1116 1106.9484,-1116 1104.1151,-1116 1101.2817,-1113.1667 1101.2817,-1110.3333 1101.2817,-1110.3333 1101.2817,-1104.6667 1101.2817,-1104.6667 1101.2817,-1101.8333 1104.1151,-1099 1106.9484,-1099 1106.9484,-1099 1149.6151,-1099 1149.6151,-1099 1152.4484,-1099 1155.2817,-1101.8333 1155.2817,-1104.6667 1155.2817,-1104.6667 1155.2817,-1110.3333 1155.2817,-1110.3333 1155.2817,-1113.1667 1152.4484,-1116 1149.6151,-1116"/>
 <text text-anchor="middle" x="1128.2817" y="-1104.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -978,7 +978,7 @@
 <!-- src/extract/resolve/readPackageDeps/mergePackages.js -->
 <g id="node40" class="node">
 <title>src/extract/resolve/readPackageDeps/mergePackages.js</title>
-<g id="a_node40"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/readPackageDeps/mergePackages.js" xlink:title="mergePackages.js">
+<g id="a_node40"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/readPackageDeps/mergePackages.js" xlink:title="mergePackages.js">
 <path fill="#ffffcc" stroke="#000000" d="M1297.1988,-1116C1297.1988,-1116 1218.4628,-1116 1218.4628,-1116 1215.6295,-1116 1212.7961,-1113.1667 1212.7961,-1110.3333 1212.7961,-1110.3333 1212.7961,-1104.6667 1212.7961,-1104.6667 1212.7961,-1101.8333 1215.6295,-1099 1218.4628,-1099 1218.4628,-1099 1297.1988,-1099 1297.1988,-1099 1300.0322,-1099 1302.8655,-1101.8333 1302.8655,-1104.6667 1302.8655,-1104.6667 1302.8655,-1110.3333 1302.8655,-1110.3333 1302.8655,-1113.1667 1300.0322,-1116 1297.1988,-1116"/>
 <text text-anchor="middle" x="1257.8308" y="-1104.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">mergePackages.js</text>
 </a>
@@ -1005,7 +1005,7 @@
 <!-- src/extract/resolve/resolve&#45;helpers.js -->
 <g id="node43" class="node">
 <title>src/extract/resolve/resolve&#45;helpers.js</title>
-<g id="a_node43"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve-helpers.js" xlink:title="resolve&#45;helpers.js">
+<g id="a_node43"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-helpers.js" xlink:title="resolve&#45;helpers.js">
 <path fill="#ffffcc" stroke="#000000" d="M1165.6442,-1053C1165.6442,-1053 1090.9193,-1053 1090.9193,-1053 1088.086,-1053 1085.2526,-1050.1667 1085.2526,-1047.3333 1085.2526,-1047.3333 1085.2526,-1041.6667 1085.2526,-1041.6667 1085.2526,-1038.8333 1088.086,-1036 1090.9193,-1036 1090.9193,-1036 1165.6442,-1036 1165.6442,-1036 1168.4775,-1036 1171.3109,-1038.8333 1171.3109,-1041.6667 1171.3109,-1041.6667 1171.3109,-1047.3333 1171.3109,-1047.3333 1171.3109,-1050.1667 1168.4775,-1053 1165.6442,-1053"/>
 <text text-anchor="middle" x="1128.2817" y="-1041.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve&#45;helpers.js</text>
 </a>
@@ -1074,7 +1074,7 @@
 <!-- src/extract/transpile/coffeeWrap.js -->
 <g id="node46" class="node">
 <title>src/extract/transpile/coffeeWrap.js</title>
-<g id="a_node46"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/coffeeWrap.js" xlink:title="coffeeWrap.js">
+<g id="a_node46"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/coffeeWrap.js" xlink:title="coffeeWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1287.3679,-766C1287.3679,-766 1228.2937,-766 1228.2937,-766 1225.4604,-766 1222.6271,-763.1667 1222.6271,-760.3333 1222.6271,-760.3333 1222.6271,-754.6667 1222.6271,-754.6667 1222.6271,-751.8333 1225.4604,-749 1228.2937,-749 1228.2937,-749 1287.3679,-749 1287.3679,-749 1290.2012,-749 1293.0346,-751.8333 1293.0346,-754.6667 1293.0346,-754.6667 1293.0346,-760.3333 1293.0346,-760.3333 1293.0346,-763.1667 1290.2012,-766 1287.3679,-766"/>
 <text text-anchor="middle" x="1257.8308" y="-754.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">coffeeWrap.js</text>
 </a>
@@ -1095,7 +1095,7 @@
 <!-- src/extract/transpile/javaScriptWrap.js -->
 <g id="node48" class="node">
 <title>src/extract/transpile/javaScriptWrap.js</title>
-<g id="a_node48"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/javaScriptWrap.js" xlink:title="javaScriptWrap.js">
+<g id="a_node48"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/javaScriptWrap.js" xlink:title="javaScriptWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1295.0241,-824C1295.0241,-824 1220.6375,-824 1220.6375,-824 1217.8042,-824 1214.9708,-821.1667 1214.9708,-818.3333 1214.9708,-818.3333 1214.9708,-812.6667 1214.9708,-812.6667 1214.9708,-809.8333 1217.8042,-807 1220.6375,-807 1220.6375,-807 1295.0241,-807 1295.0241,-807 1297.8575,-807 1300.6908,-809.8333 1300.6908,-812.6667 1300.6908,-812.6667 1300.6908,-818.3333 1300.6908,-818.3333 1300.6908,-821.1667 1297.8575,-824 1295.0241,-824"/>
 <text text-anchor="middle" x="1257.8308" y="-812.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">javaScriptWrap.js</text>
 </a>
@@ -1104,7 +1104,7 @@
 <!-- src/extract/transpile/liveScriptWrap.js -->
 <g id="node49" class="node">
 <title>src/extract/transpile/liveScriptWrap.js</title>
-<g id="a_node49"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/liveScriptWrap.js" xlink:title="liveScriptWrap.js">
+<g id="a_node49"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/liveScriptWrap.js" xlink:title="liveScriptWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1293.5183,-853C1293.5183,-853 1222.1433,-853 1222.1433,-853 1219.31,-853 1216.4767,-850.1667 1216.4767,-847.3333 1216.4767,-847.3333 1216.4767,-841.6667 1216.4767,-841.6667 1216.4767,-838.8333 1219.31,-836 1222.1433,-836 1222.1433,-836 1293.5183,-836 1293.5183,-836 1296.3516,-836 1299.1849,-838.8333 1299.1849,-841.6667 1299.1849,-841.6667 1299.1849,-847.3333 1299.1849,-847.3333 1299.1849,-850.1667 1296.3516,-853 1293.5183,-853"/>
 <text text-anchor="middle" x="1257.8308" y="-841.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">liveScriptWrap.js</text>
 </a>
@@ -1143,7 +1143,7 @@
 <!-- src/extract/transpile/typeScriptWrap.js -->
 <g id="node51" class="node">
 <title>src/extract/transpile/typeScriptWrap.js</title>
-<g id="a_node51"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/typeScriptWrap.js" xlink:title="typeScriptWrap.js">
+<g id="a_node51"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/typeScriptWrap.js" xlink:title="typeScriptWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1295.5257,-795C1295.5257,-795 1220.1359,-795 1220.1359,-795 1217.3025,-795 1214.4692,-792.1667 1214.4692,-789.3333 1214.4692,-789.3333 1214.4692,-783.6667 1214.4692,-783.6667 1214.4692,-780.8333 1217.3025,-778 1220.1359,-778 1220.1359,-778 1295.5257,-778 1295.5257,-778 1298.3591,-778 1301.1924,-780.8333 1301.1924,-783.6667 1301.1924,-783.6667 1301.1924,-789.3333 1301.1924,-789.3333 1301.1924,-792.1667 1298.3591,-795 1295.5257,-795"/>
 <text text-anchor="middle" x="1257.8308" y="-783.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">typeScriptWrap.js</text>
 </a>
@@ -1164,7 +1164,7 @@
 <!-- src/main/filesAndDirs/normalize.js -->
 <g id="node54" class="node">
 <title>src/main/filesAndDirs/normalize.js</title>
-<g id="a_node54"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/filesAndDirs/normalize.js" xlink:title="normalize.js">
+<g id="a_node54"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/filesAndDirs/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M531.9784,-517C531.9784,-517 479.2824,-517 479.2824,-517 476.4491,-517 473.6157,-514.1667 473.6157,-511.3333 473.6157,-511.3333 473.6157,-505.6667 473.6157,-505.6667 473.6157,-502.8333 476.4491,-500 479.2824,-500 479.2824,-500 531.9784,-500 531.9784,-500 534.8117,-500 537.645,-502.8333 537.645,-505.6667 537.645,-505.6667 537.645,-511.3333 537.645,-511.3333 537.645,-514.1667 534.8117,-517 531.9784,-517"/>
 <text text-anchor="middle" x="505.6304" y="-505.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -1191,7 +1191,7 @@
 <!-- src/main/options/normalize.js -->
 <g id="node57" class="node">
 <title>src/main/options/normalize.js</title>
-<g id="a_node57"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/options/normalize.js" xlink:title="normalize.js">
+<g id="a_node57"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/options/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M681.6219,-498C681.6219,-498 628.9259,-498 628.9259,-498 626.0926,-498 623.2593,-495.1667 623.2593,-492.3333 623.2593,-492.3333 623.2593,-486.6667 623.2593,-486.6667 623.2593,-483.8333 626.0926,-481 628.9259,-481 628.9259,-481 681.6219,-481 681.6219,-481 684.4552,-481 687.2886,-483.8333 687.2886,-486.6667 687.2886,-486.6667 687.2886,-492.3333 687.2886,-492.3333 687.2886,-495.1667 684.4552,-498 681.6219,-498"/>
 <text text-anchor="middle" x="655.2739" y="-486.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -1206,7 +1206,7 @@
 <!-- src/main/options/validate.js -->
 <g id="node58" class="node">
 <title>src/main/options/validate.js</title>
-<g id="a_node58"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/options/validate.js" xlink:title="validate.js">
+<g id="a_node58"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/options/validate.js" xlink:title="validate.js">
 <path fill="#ffffcc" stroke="#000000" d="M677.6283,-527C677.6283,-527 632.9196,-527 632.9196,-527 630.0863,-527 627.2529,-524.1667 627.2529,-521.3333 627.2529,-521.3333 627.2529,-515.6667 627.2529,-515.6667 627.2529,-512.8333 630.0863,-510 632.9196,-510 632.9196,-510 677.6283,-510 677.6283,-510 680.4616,-510 683.2949,-512.8333 683.2949,-515.6667 683.2949,-515.6667 683.2949,-521.3333 683.2949,-521.3333 683.2949,-524.1667 680.4616,-527 677.6283,-527"/>
 <text text-anchor="middle" x="655.2739" y="-515.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">validate.js</text>
 </a>
@@ -1227,7 +1227,7 @@
 <!-- src/main/ruleSet/normalize.js -->
 <g id="node61" class="node">
 <title>src/main/ruleSet/normalize.js</title>
-<g id="a_node61"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/ruleSet/normalize.js" xlink:title="normalize.js">
+<g id="a_node61"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/ruleSet/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M531.9784,-615C531.9784,-615 479.2824,-615 479.2824,-615 476.4491,-615 473.6157,-612.1667 473.6157,-609.3333 473.6157,-609.3333 473.6157,-603.6667 473.6157,-603.6667 473.6157,-600.8333 476.4491,-598 479.2824,-598 479.2824,-598 531.9784,-598 531.9784,-598 534.8117,-598 537.645,-600.8333 537.645,-603.6667 537.645,-603.6667 537.645,-609.3333 537.645,-609.3333 537.645,-612.1667 534.8117,-615 531.9784,-615"/>
 <text text-anchor="middle" x="505.6304" y="-603.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -1242,7 +1242,7 @@
 <!-- src/main/ruleSet/validate.js -->
 <g id="node62" class="node">
 <title>src/main/ruleSet/validate.js</title>
-<g id="a_node62"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/ruleSet/validate.js" xlink:title="validate.js">
+<g id="a_node62"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/ruleSet/validate.js" xlink:title="validate.js">
 <path fill="#ffffcc" stroke="#000000" d="M527.9847,-586C527.9847,-586 483.276,-586 483.276,-586 480.4427,-586 477.6094,-583.1667 477.6094,-580.3333 477.6094,-580.3333 477.6094,-574.6667 477.6094,-574.6667 477.6094,-571.8333 480.4427,-569 483.276,-569 483.276,-569 527.9847,-569 527.9847,-569 530.818,-569 533.6514,-571.8333 533.6514,-574.6667 533.6514,-574.6667 533.6514,-580.3333 533.6514,-580.3333 533.6514,-583.1667 530.818,-586 527.9847,-586"/>
 <text text-anchor="middle" x="505.6304" y="-574.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">validate.js</text>
 </a>
@@ -1257,7 +1257,7 @@
 <!-- src/report/csv/index.js -->
 <g id="node64" class="node">
 <title>src/report/csv/index.js</title>
-<g id="a_node64"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/csv/index.js" xlink:title="index.js">
+<g id="a_node64"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/csv/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-2014C526.9637,-2014 484.297,-2014 484.297,-2014 481.4637,-2014 478.6304,-2011.1667 478.6304,-2008.3333 478.6304,-2008.3333 478.6304,-2002.6667 478.6304,-2002.6667 478.6304,-1999.8333 481.4637,-1997 484.297,-1997 484.297,-1997 526.9637,-1997 526.9637,-1997 529.797,-1997 532.6304,-1999.8333 532.6304,-2002.6667 532.6304,-2002.6667 532.6304,-2008.3333 532.6304,-2008.3333 532.6304,-2011.1667 529.797,-2014 526.9637,-2014"/>
 <text text-anchor="middle" x="505.6304" y="-2002.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1272,7 +1272,7 @@
 <!-- src/report/dot/common/richModuleColorScheme.json -->
 <g id="node69" class="node">
 <title>src/report/dot/common/richModuleColorScheme.json</title>
-<g id="a_node69"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/richModuleColorScheme.json" xlink:title="richModuleColorScheme.json">
+<g id="a_node69"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/richModuleColorScheme.json" xlink:title="richModuleColorScheme.json">
 <path fill="#ffee44" stroke="#000000" d="M882.0733,-1769C882.0733,-1769 760.2978,-1769 760.2978,-1769 757.4644,-1769 754.6311,-1766.1667 754.6311,-1763.3333 754.6311,-1763.3333 754.6311,-1757.6667 754.6311,-1757.6667 754.6311,-1754.8333 757.4644,-1752 760.2978,-1752 760.2978,-1752 882.0733,-1752 882.0733,-1752 884.9067,-1752 887.74,-1754.8333 887.74,-1757.6667 887.74,-1757.6667 887.74,-1763.3333 887.74,-1763.3333 887.74,-1766.1667 884.9067,-1769 882.0733,-1769"/>
 <text text-anchor="middle" x="821.1855" y="-1757.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">richModuleColorScheme.json</text>
 </a>
@@ -1287,7 +1287,7 @@
 <!-- src/report/dot/folderLevel/index.js -->
 <g id="node73" class="node">
 <title>src/report/dot/folderLevel/index.js</title>
-<g id="a_node73"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/index.js" xlink:title="index.js">
+<g id="a_node73"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1872C526.9637,-1872 484.297,-1872 484.297,-1872 481.4637,-1872 478.6304,-1869.1667 478.6304,-1866.3333 478.6304,-1866.3333 478.6304,-1860.6667 478.6304,-1860.6667 478.6304,-1857.8333 481.4637,-1855 484.297,-1855 484.297,-1855 526.9637,-1855 526.9637,-1855 529.797,-1855 532.6304,-1857.8333 532.6304,-1860.6667 532.6304,-1860.6667 532.6304,-1866.3333 532.6304,-1866.3333 532.6304,-1869.1667 529.797,-1872 526.9637,-1872"/>
 <text text-anchor="middle" x="505.6304" y="-1860.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1302,7 +1302,7 @@
 <!-- src/report/dot/moduleLevel/index.js -->
 <g id="node75" class="node">
 <title>src/report/dot/moduleLevel/index.js</title>
-<g id="a_node75"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/moduleLevel/index.js" xlink:title="index.js">
+<g id="a_node75"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/moduleLevel/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1696C526.9637,-1696 484.297,-1696 484.297,-1696 481.4637,-1696 478.6304,-1693.1667 478.6304,-1690.3333 478.6304,-1690.3333 478.6304,-1684.6667 478.6304,-1684.6667 478.6304,-1681.8333 481.4637,-1679 484.297,-1679 484.297,-1679 526.9637,-1679 526.9637,-1679 529.797,-1679 532.6304,-1681.8333 532.6304,-1684.6667 532.6304,-1684.6667 532.6304,-1690.3333 532.6304,-1690.3333 532.6304,-1693.1667 529.797,-1696 526.9637,-1696"/>
 <text text-anchor="middle" x="505.6304" y="-1684.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1317,7 +1317,7 @@
 <!-- src/report/err.js -->
 <g id="node76" class="node">
 <title>src/report/err.js</title>
-<g id="a_node76"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/err.js" xlink:title="err.js">
+<g id="a_node76"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/err.js" xlink:title="err.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1569C526.9637,-1569 484.297,-1569 484.297,-1569 481.4637,-1569 478.6304,-1566.1667 478.6304,-1563.3333 478.6304,-1563.3333 478.6304,-1557.6667 478.6304,-1557.6667 478.6304,-1554.8333 481.4637,-1552 484.297,-1552 484.297,-1552 526.9637,-1552 526.9637,-1552 529.797,-1552 532.6304,-1554.8333 532.6304,-1557.6667 532.6304,-1557.6667 532.6304,-1563.3333 532.6304,-1563.3333 532.6304,-1566.1667 529.797,-1569 526.9637,-1569"/>
 <text text-anchor="middle" x="505.6304" y="-1557.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">err.js</text>
 </a>
@@ -1332,7 +1332,7 @@
 <!-- src/report/html/index.js -->
 <g id="node78" class="node">
 <title>src/report/html/index.js</title>
-<g id="a_node78"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/html/index.js" xlink:title="index.js">
+<g id="a_node78"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/html/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1603C526.9637,-1603 484.297,-1603 484.297,-1603 481.4637,-1603 478.6304,-1600.1667 478.6304,-1597.3333 478.6304,-1597.3333 478.6304,-1591.6667 478.6304,-1591.6667 478.6304,-1588.8333 481.4637,-1586 484.297,-1586 484.297,-1586 526.9637,-1586 526.9637,-1586 529.797,-1586 532.6304,-1588.8333 532.6304,-1591.6667 532.6304,-1591.6667 532.6304,-1597.3333 532.6304,-1597.3333 532.6304,-1600.1667 529.797,-1603 526.9637,-1603"/>
 <text text-anchor="middle" x="505.6304" y="-1591.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1347,7 +1347,7 @@
 <!-- src/report/json.js -->
 <g id="node79" class="node">
 <title>src/report/json.js</title>
-<g id="a_node79"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/json.js" xlink:title="json.js">
+<g id="a_node79"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/json.js" xlink:title="json.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1540C526.9637,-1540 484.297,-1540 484.297,-1540 481.4637,-1540 478.6304,-1537.1667 478.6304,-1534.3333 478.6304,-1534.3333 478.6304,-1528.6667 478.6304,-1528.6667 478.6304,-1525.8333 481.4637,-1523 484.297,-1523 484.297,-1523 526.9637,-1523 526.9637,-1523 529.797,-1523 532.6304,-1525.8333 532.6304,-1528.6667 532.6304,-1528.6667 532.6304,-1534.3333 532.6304,-1534.3333 532.6304,-1537.1667 529.797,-1540 526.9637,-1540"/>
 <text text-anchor="middle" x="505.6304" y="-1528.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">json.js</text>
 </a>
@@ -1362,7 +1362,7 @@
 <!-- src/main/options/defaults.json -->
 <g id="node56" class="node">
 <title>src/main/options/defaults.json</title>
-<g id="a_node56"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/options/defaults.json" xlink:title="defaults.json">
+<g id="a_node56"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/options/defaults.json" xlink:title="defaults.json">
 <path fill="#ffee44" stroke="#000000" d="M848.5532,-498C848.5532,-498 793.8179,-498 793.8179,-498 790.9845,-498 788.1512,-495.1667 788.1512,-492.3333 788.1512,-492.3333 788.1512,-486.6667 788.1512,-486.6667 788.1512,-483.8333 790.9845,-481 793.8179,-481 793.8179,-481 848.5532,-481 848.5532,-481 851.3866,-481 854.2199,-483.8333 854.2199,-486.6667 854.2199,-486.6667 854.2199,-492.3333 854.2199,-492.3333 854.2199,-495.1667 851.3866,-498 848.5532,-498"/>
 <text text-anchor="middle" x="821.1855" y="-486.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">defaults.json</text>
 </a>
@@ -1377,7 +1377,7 @@
 <!-- src/utl/safe&#45;regex.js -->
 <g id="node80" class="node">
 <title>src/utl/safe&#45;regex.js</title>
-<g id="a_node80"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/utl/safe-regex.js" xlink:title="safe&#45;regex.js">
+<g id="a_node80"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/utl/safe-regex.js" xlink:title="safe&#45;regex.js">
 <path fill="#ffffcc" stroke="#000000" d="M849.042,-699C849.042,-699 793.329,-699 793.329,-699 790.4957,-699 787.6624,-696.1667 787.6624,-693.3333 787.6624,-693.3333 787.6624,-687.6667 787.6624,-687.6667 787.6624,-684.8333 790.4957,-682 793.329,-682 793.329,-682 849.042,-682 849.042,-682 851.8754,-682 854.7087,-684.8333 854.7087,-687.6667 854.7087,-687.6667 854.7087,-693.3333 854.7087,-693.3333 854.7087,-696.1667 851.8754,-699 849.042,-699"/>
 <text text-anchor="middle" x="821.1855" y="-687.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">safe&#45;regex.js</text>
 </a>
@@ -1398,7 +1398,7 @@
 <!-- src/main/ruleSet/jsonschema.json -->
 <g id="node60" class="node">
 <title>src/main/ruleSet/jsonschema.json</title>
-<g id="a_node60"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/ruleSet/jsonschema.json" xlink:title="jsonschema.json">
+<g id="a_node60"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main/ruleSet/jsonschema.json" xlink:title="jsonschema.json">
 <path fill="#ffee44" stroke="#000000" d="M691.1414,-586C691.1414,-586 619.4064,-586 619.4064,-586 616.5731,-586 613.7397,-583.1667 613.7397,-580.3333 613.7397,-580.3333 613.7397,-574.6667 613.7397,-574.6667 613.7397,-571.8333 616.5731,-569 619.4064,-569 619.4064,-569 691.1414,-569 691.1414,-569 693.9748,-569 696.8081,-571.8333 696.8081,-574.6667 696.8081,-574.6667 696.8081,-580.3333 696.8081,-580.3333 696.8081,-583.1667 693.9748,-586 691.1414,-586"/>
 <text text-anchor="middle" x="655.2739" y="-574.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">jsonschema.json</text>
 </a>
@@ -1425,7 +1425,7 @@
 <!-- src/report/csv/csv.template.js -->
 <g id="node63" class="node">
 <title>src/report/csv/csv.template.js</title>
-<g id="a_node63"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/csv/csv.template.js" xlink:title="csv.template.js">
+<g id="a_node63"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/csv/csv.template.js" xlink:title="csv.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M686.9634,-2014C686.9634,-2014 623.5845,-2014 623.5845,-2014 620.7512,-2014 617.9178,-2011.1667 617.9178,-2008.3333 617.9178,-2008.3333 617.9178,-2002.6667 617.9178,-2002.6667 617.9178,-1999.8333 620.7512,-1997 623.5845,-1997 623.5845,-1997 686.9634,-1997 686.9634,-1997 689.7967,-1997 692.63,-1999.8333 692.63,-2002.6667 692.63,-2002.6667 692.63,-2008.3333 692.63,-2008.3333 692.63,-2011.1667 689.7967,-2014 686.9634,-2014"/>
 <text text-anchor="middle" x="655.2739" y="-2002.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">csv.template.js</text>
 </a>
@@ -1440,7 +1440,7 @@
 <!-- src/report/dependencyToIncidenceTransformer.js -->
 <g id="node65" class="node">
 <title>src/report/dependencyToIncidenceTransformer.js</title>
-<g id="a_node65"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dependencyToIncidenceTransformer.js" xlink:title="dependencyToIncidenceTransformer.js">
+<g id="a_node65"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dependencyToIncidenceTransformer.js" xlink:title="dependencyToIncidenceTransformer.js">
 <path fill="#ffffcc" stroke="#000000" d="M734.8687,-1654C734.8687,-1654 575.6792,-1654 575.6792,-1654 572.8458,-1654 570.0125,-1651.1667 570.0125,-1648.3333 570.0125,-1648.3333 570.0125,-1642.6667 570.0125,-1642.6667 570.0125,-1639.8333 572.8458,-1637 575.6792,-1637 575.6792,-1637 734.8687,-1637 734.8687,-1637 737.702,-1637 740.5354,-1639.8333 740.5354,-1642.6667 740.5354,-1642.6667 740.5354,-1648.3333 740.5354,-1648.3333 740.5354,-1651.1667 737.702,-1654 734.8687,-1654"/>
 <text text-anchor="middle" x="655.2739" y="-1642.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">dependencyToIncidenceTransformer.js</text>
 </a>
@@ -1455,7 +1455,7 @@
 <!-- src/report/dot/common/coloring.js -->
 <g id="node66" class="node">
 <title>src/report/dot/common/coloring.js</title>
-<g id="a_node66"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/coloring.js" xlink:title="coloring.js">
+<g id="a_node66"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/coloring.js" xlink:title="coloring.js">
 <path fill="#ffffcc" stroke="#000000" d="M677.6269,-1784C677.6269,-1784 632.921,-1784 632.921,-1784 630.0876,-1784 627.2543,-1781.1667 627.2543,-1778.3333 627.2543,-1778.3333 627.2543,-1772.6667 627.2543,-1772.6667 627.2543,-1769.8333 630.0876,-1767 632.921,-1767 632.921,-1767 677.6269,-1767 677.6269,-1767 680.4602,-1767 683.2935,-1769.8333 683.2935,-1772.6667 683.2935,-1772.6667 683.2935,-1778.3333 683.2935,-1778.3333 683.2935,-1781.1667 680.4602,-1784 677.6269,-1784"/>
 <text text-anchor="middle" x="655.2739" y="-1772.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">coloring.js</text>
 </a>
@@ -1470,7 +1470,7 @@
 <!-- src/report/dot/common/compareOnSource.js -->
 <g id="node67" class="node">
 <title>src/report/dot/common/compareOnSource.js</title>
-<g id="a_node67"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/compareOnSource.js" xlink:title="compareOnSource.js">
+<g id="a_node67"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/compareOnSource.js" xlink:title="compareOnSource.js">
 <path fill="#ffffcc" stroke="#000000" d="M699.6459,-1755C699.6459,-1755 610.9019,-1755 610.9019,-1755 608.0686,-1755 605.2353,-1752.1667 605.2353,-1749.3333 605.2353,-1749.3333 605.2353,-1743.6667 605.2353,-1743.6667 605.2353,-1740.8333 608.0686,-1738 610.9019,-1738 610.9019,-1738 699.6459,-1738 699.6459,-1738 702.4792,-1738 705.3126,-1740.8333 705.3126,-1743.6667 705.3126,-1743.6667 705.3126,-1749.3333 705.3126,-1749.3333 705.3126,-1752.1667 702.4792,-1755 699.6459,-1755"/>
 <text text-anchor="middle" x="655.2739" y="-1743.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">compareOnSource.js</text>
 </a>
@@ -1479,7 +1479,7 @@
 <!-- src/report/dot/common/folderify.js -->
 <g id="node68" class="node">
 <title>src/report/dot/common/folderify.js</title>
-<g id="a_node68"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/folderify.js" xlink:title="folderify.js">
+<g id="a_node68"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/folderify.js" xlink:title="folderify.js">
 <path fill="#ffffcc" stroke="#000000" d="M677.4571,-1813C677.4571,-1813 633.0908,-1813 633.0908,-1813 630.2574,-1813 627.4241,-1810.1667 627.4241,-1807.3333 627.4241,-1807.3333 627.4241,-1801.6667 627.4241,-1801.6667 627.4241,-1798.8333 630.2574,-1796 633.0908,-1796 633.0908,-1796 677.4571,-1796 677.4571,-1796 680.2904,-1796 683.1237,-1798.8333 683.1237,-1801.6667 683.1237,-1801.6667 683.1237,-1807.3333 683.1237,-1807.3333 683.1237,-1810.1667 680.2904,-1813 677.4571,-1813"/>
 <text text-anchor="middle" x="655.2739" y="-1801.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">folderify.js</text>
 </a>
@@ -1488,7 +1488,7 @@
 <!-- src/report/dot/folderLevel/consolidateModuleDependencies.js -->
 <g id="node70" class="node">
 <title>src/report/dot/folderLevel/consolidateModuleDependencies.js</title>
-<g id="a_node70"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/consolidateModuleDependencies.js" xlink:title="consolidateModuleDependencies.js">
+<g id="a_node70"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/consolidateModuleDependencies.js" xlink:title="consolidateModuleDependencies.js">
 <path fill="#ffffcc" stroke="#000000" d="M728.1996,-1872C728.1996,-1872 582.3483,-1872 582.3483,-1872 579.5149,-1872 576.6816,-1869.1667 576.6816,-1866.3333 576.6816,-1866.3333 576.6816,-1860.6667 576.6816,-1860.6667 576.6816,-1857.8333 579.5149,-1855 582.3483,-1855 582.3483,-1855 728.1996,-1855 728.1996,-1855 731.0329,-1855 733.8662,-1857.8333 733.8662,-1860.6667 733.8662,-1860.6667 733.8662,-1866.3333 733.8662,-1866.3333 733.8662,-1869.1667 731.0329,-1872 728.1996,-1872"/>
 <text text-anchor="middle" x="655.2739" y="-1860.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">consolidateModuleDependencies.js</text>
 </a>
@@ -1497,7 +1497,7 @@
 <!-- src/report/dot/folderLevel/consolidateModules.js -->
 <g id="node71" class="node">
 <title>src/report/dot/folderLevel/consolidateModules.js</title>
-<g id="a_node71"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/consolidateModules.js" xlink:title="consolidateModules.js">
+<g id="a_node71"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/consolidateModules.js" xlink:title="consolidateModules.js">
 <path fill="#ffffcc" stroke="#000000" d="M701.658,-1901C701.658,-1901 608.8898,-1901 608.8898,-1901 606.0565,-1901 603.2232,-1898.1667 603.2232,-1895.3333 603.2232,-1895.3333 603.2232,-1889.6667 603.2232,-1889.6667 603.2232,-1886.8333 606.0565,-1884 608.8898,-1884 608.8898,-1884 701.658,-1884 701.658,-1884 704.4914,-1884 707.3247,-1886.8333 707.3247,-1889.6667 707.3247,-1889.6667 707.3247,-1895.3333 707.3247,-1895.3333 707.3247,-1898.1667 704.4914,-1901 701.658,-1901"/>
 <text text-anchor="middle" x="655.2739" y="-1889.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">consolidateModules.js</text>
 </a>
@@ -1506,7 +1506,7 @@
 <!-- src/report/dot/folderLevel/ddot.template.js -->
 <g id="node72" class="node">
 <title>src/report/dot/folderLevel/ddot.template.js</title>
-<g id="a_node72"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/ddot.template.js" xlink:title="ddot.template.js">
+<g id="a_node72"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/ddot.template.js" xlink:title="ddot.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M689.1447,-1930C689.1447,-1930 621.4031,-1930 621.4031,-1930 618.5698,-1930 615.7364,-1927.1667 615.7364,-1924.3333 615.7364,-1924.3333 615.7364,-1918.6667 615.7364,-1918.6667 615.7364,-1915.8333 618.5698,-1913 621.4031,-1913 621.4031,-1913 689.1447,-1913 689.1447,-1913 691.9781,-1913 694.8114,-1915.8333 694.8114,-1918.6667 694.8114,-1918.6667 694.8114,-1924.3333 694.8114,-1924.3333 694.8114,-1927.1667 691.9781,-1930 689.1447,-1930"/>
 <text text-anchor="middle" x="655.2739" y="-1918.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">ddot.template.js</text>
 </a>
@@ -1551,7 +1551,7 @@
 <!-- src/report/dot/moduleLevel/dot.template.js -->
 <g id="node74" class="node">
 <title>src/report/dot/moduleLevel/dot.template.js</title>
-<g id="a_node74"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/moduleLevel/dot.template.js" xlink:title="dot.template.js">
+<g id="a_node74"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/moduleLevel/dot.template.js" xlink:title="dot.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M686.6395,-1696C686.6395,-1696 623.9084,-1696 623.9084,-1696 621.075,-1696 618.2417,-1693.1667 618.2417,-1690.3333 618.2417,-1690.3333 618.2417,-1684.6667 618.2417,-1684.6667 618.2417,-1681.8333 621.075,-1679 623.9084,-1679 623.9084,-1679 686.6395,-1679 686.6395,-1679 689.4728,-1679 692.3062,-1681.8333 692.3062,-1684.6667 692.3062,-1684.6667 692.3062,-1690.3333 692.3062,-1690.3333 692.3062,-1693.1667 689.4728,-1696 686.6395,-1696"/>
 <text text-anchor="middle" x="655.2739" y="-1684.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">dot.template.js</text>
 </a>
@@ -1584,7 +1584,7 @@
 <!-- src/report/html/html.template.js -->
 <g id="node77" class="node">
 <title>src/report/html/html.template.js</title>
-<g id="a_node77"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/html/html.template.js" xlink:title="html.template.js">
+<g id="a_node77"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/html/html.template.js" xlink:title="html.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M689.1292,-1603C689.1292,-1603 621.4186,-1603 621.4186,-1603 618.5853,-1603 615.752,-1600.1667 615.752,-1597.3333 615.752,-1597.3333 615.752,-1591.6667 615.752,-1591.6667 615.752,-1588.8333 618.5853,-1586 621.4186,-1586 621.4186,-1586 689.1292,-1586 689.1292,-1586 691.9626,-1586 694.7959,-1588.8333 694.7959,-1591.6667 694.7959,-1591.6667 694.7959,-1597.3333 694.7959,-1597.3333 694.7959,-1600.1667 691.9626,-1603 689.1292,-1603"/>
 <text text-anchor="middle" x="655.2739" y="-1591.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">html.template.js</text>
 </a>
@@ -1605,7 +1605,7 @@
 <!-- src/validate/matchDependencyRule.js -->
 <g id="node83" class="node">
 <title>src/validate/matchDependencyRule.js</title>
-<g id="a_node83"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/matchDependencyRule.js" xlink:title="matchDependencyRule.js">
+<g id="a_node83"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/validate/matchDependencyRule.js" xlink:title="matchDependencyRule.js">
 <path fill="#ffffcc" stroke="#000000" d="M1034.6179,-1452C1034.6179,-1452 927.8392,-1452 927.8392,-1452 925.0058,-1452 922.1725,-1449.1667 922.1725,-1446.3333 922.1725,-1446.3333 922.1725,-1440.6667 922.1725,-1440.6667 922.1725,-1437.8333 925.0058,-1435 927.8392,-1435 927.8392,-1435 1034.6179,-1435 1034.6179,-1435 1037.4512,-1435 1040.2845,-1437.8333 1040.2845,-1440.6667 1040.2845,-1440.6667 1040.2845,-1446.3333 1040.2845,-1446.3333 1040.2845,-1449.1667 1037.4512,-1452 1034.6179,-1452"/>
 <text text-anchor="middle" x="981.2285" y="-1440.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">matchDependencyRule.js</text>
 </a>
@@ -1620,7 +1620,7 @@
 <!-- src/validate/matchModuleRule.js -->
 <g id="node84" class="node">
 <title>src/validate/matchModuleRule.js</title>
-<g id="a_node84"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/matchModuleRule.js" xlink:title="matchModuleRule.js">
+<g id="a_node84"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/validate/matchModuleRule.js" xlink:title="matchModuleRule.js">
 <path fill="#ffffcc" stroke="#000000" d="M1024.0991,-1481C1024.0991,-1481 938.358,-1481 938.358,-1481 935.5246,-1481 932.6913,-1478.1667 932.6913,-1475.3333 932.6913,-1475.3333 932.6913,-1469.6667 932.6913,-1469.6667 932.6913,-1466.8333 935.5246,-1464 938.358,-1464 938.358,-1464 1024.0991,-1464 1024.0991,-1464 1026.9324,-1464 1029.7657,-1466.8333 1029.7657,-1469.6667 1029.7657,-1469.6667 1029.7657,-1475.3333 1029.7657,-1475.3333 1029.7657,-1478.1667 1026.9324,-1481 1024.0991,-1481"/>
 <text text-anchor="middle" x="981.2285" y="-1469.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">matchModuleRule.js</text>
 </a>
@@ -1635,7 +1635,7 @@
 <!-- src/validate/isModuleOnlyRule.js -->
 <g id="node82" class="node">
 <title>src/validate/isModuleOnlyRule.js</title>
-<g id="a_node82"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/isModuleOnlyRule.js" xlink:title="isModuleOnlyRule.js">
+<g id="a_node82"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/validate/isModuleOnlyRule.js" xlink:title="isModuleOnlyRule.js">
 <path fill="#ffffcc" stroke="#000000" d="M1171.6478,-1466C1171.6478,-1466 1084.9157,-1466 1084.9157,-1466 1082.0824,-1466 1079.249,-1463.1667 1079.249,-1460.3333 1079.249,-1460.3333 1079.249,-1454.6667 1079.249,-1454.6667 1079.249,-1451.8333 1082.0824,-1449 1084.9157,-1449 1084.9157,-1449 1171.6478,-1449 1171.6478,-1449 1174.4811,-1449 1177.3145,-1451.8333 1177.3145,-1454.6667 1177.3145,-1454.6667 1177.3145,-1460.3333 1177.3145,-1460.3333 1177.3145,-1463.1667 1174.4811,-1466 1171.6478,-1466"/>
 <text text-anchor="middle" x="1128.2817" y="-1454.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">isModuleOnlyRule.js</text>
 </a>

--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -188,7 +188,7 @@
 <!-- package.json -->
 <g id="node1" class="node">
 <title>package.json</title>
-<g id="a_node1"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/package.json" xlink:title="package.json">
+<g id="a_node1"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//package.json" xlink:title="package.json">
 <path fill="#ffee44" stroke="#000000" d="M1382.2379,-17C1382.2379,-17 1324.496,-17 1324.496,-17 1321.6627,-17 1318.8293,-14.1667 1318.8293,-11.3333 1318.8293,-11.3333 1318.8293,-5.6667 1318.8293,-5.6667 1318.8293,-2.8333 1321.6627,0 1324.496,0 1324.496,0 1382.2379,0 1382.2379,0 1385.0712,0 1387.9046,-2.8333 1387.9046,-5.6667 1387.9046,-5.6667 1387.9046,-11.3333 1387.9046,-11.3333 1387.9046,-14.1667 1385.0712,-17 1382.2379,-17"/>
 <text text-anchor="middle" x="1353.3669" y="-5.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">package.json</text>
 </a>
@@ -197,7 +197,7 @@
 <!-- src/cli/compileConfig/index.js -->
 <g id="node2" class="node">
 <title>src/cli/compileConfig/index.js</title>
-<g id="a_node2"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/index.js" xlink:title="index.js">
+<g id="a_node2"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/compileConfig/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M402.4405,-96C402.4405,-96 359.7738,-96 359.7738,-96 356.9405,-96 354.1072,-93.1667 354.1072,-90.3333 354.1072,-90.3333 354.1072,-84.6667 354.1072,-84.6667 354.1072,-81.8333 356.9405,-79 359.7738,-79 359.7738,-79 402.4405,-79 402.4405,-79 405.2738,-79 408.1072,-81.8333 408.1072,-84.6667 408.1072,-84.6667 408.1072,-90.3333 408.1072,-90.3333 408.1072,-93.1667 405.2738,-96 402.4405,-96"/>
 <text text-anchor="middle" x="381.1072" y="-84.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -206,7 +206,7 @@
 <!-- src/cli/compileConfig/mergeConfigs.js -->
 <g id="node3" class="node">
 <title>src/cli/compileConfig/mergeConfigs.js</title>
-<g id="a_node3"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/mergeConfigs.js" xlink:title="mergeConfigs.js">
+<g id="a_node3"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/compileConfig/mergeConfigs.js" xlink:title="mergeConfigs.js">
 <path fill="#ffffcc" stroke="#000000" d="M540.4896,-67C540.4896,-67 470.7712,-67 470.7712,-67 467.9378,-67 465.1045,-64.1667 465.1045,-61.3333 465.1045,-61.3333 465.1045,-55.6667 465.1045,-55.6667 465.1045,-52.8333 467.9378,-50 470.7712,-50 470.7712,-50 540.4896,-50 540.4896,-50 543.3229,-50 546.1563,-52.8333 546.1563,-55.6667 546.1563,-55.6667 546.1563,-61.3333 546.1563,-61.3333 546.1563,-64.1667 543.3229,-67 540.4896,-67"/>
 <text text-anchor="middle" x="505.6304" y="-55.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">mergeConfigs.js</text>
 </a>
@@ -221,7 +221,7 @@
 <!-- src/cli/compileConfig/readConfig.js -->
 <g id="node4" class="node">
 <title>src/cli/compileConfig/readConfig.js</title>
-<g id="a_node4"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/readConfig.js" xlink:title="readConfig.js">
+<g id="a_node4"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/compileConfig/readConfig.js" xlink:title="readConfig.js">
 <path fill="#ffffcc" stroke="#000000" d="M534.4925,-96C534.4925,-96 476.7682,-96 476.7682,-96 473.9349,-96 471.1016,-93.1667 471.1016,-90.3333 471.1016,-90.3333 471.1016,-84.6667 471.1016,-84.6667 471.1016,-81.8333 473.9349,-79 476.7682,-79 476.7682,-79 534.4925,-79 534.4925,-79 537.3259,-79 540.1592,-81.8333 540.1592,-84.6667 540.1592,-84.6667 540.1592,-90.3333 540.1592,-90.3333 540.1592,-93.1667 537.3259,-96 534.4925,-96"/>
 <text text-anchor="middle" x="505.6304" y="-84.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">readConfig.js</text>
 </a>
@@ -236,7 +236,7 @@
 <!-- src/extract/resolve/resolve.js -->
 <g id="node44" class="node">
 <title>src/extract/resolve/resolve.js</title>
-<g id="a_node44"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve.js" xlink:title="resolve.js">
+<g id="a_node44"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve.js" xlink:title="resolve.js">
 <path fill="#ffffcc" stroke="#000000" d="M1374.713,-1121C1374.713,-1121 1332.0209,-1121 1332.0209,-1121 1329.1876,-1121 1326.3542,-1118.1667 1326.3542,-1115.3333 1326.3542,-1115.3333 1326.3542,-1109.6667 1326.3542,-1109.6667 1326.3542,-1106.8333 1329.1876,-1104 1332.0209,-1104 1332.0209,-1104 1374.713,-1104 1374.713,-1104 1377.5463,-1104 1380.3796,-1106.8333 1380.3796,-1109.6667 1380.3796,-1109.6667 1380.3796,-1115.3333 1380.3796,-1115.3333 1380.3796,-1118.1667 1377.5463,-1121 1374.713,-1121"/>
 <text text-anchor="middle" x="1353.3669" y="-1109.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve.js</text>
 </a>
@@ -255,7 +255,7 @@
 <!-- src/main/resolveOptions/normalize.js -->
 <g id="node59" class="node">
 <title>src/main/resolveOptions/normalize.js</title>
-<g id="a_node59"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/resolveOptions/normalize.js" xlink:title="normalize.js">
+<g id="a_node59"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/resolveOptions/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M531.9784,-448C531.9784,-448 479.2824,-448 479.2824,-448 476.4491,-448 473.6157,-445.1667 473.6157,-442.3333 473.6157,-442.3333 473.6157,-436.6667 473.6157,-436.6667 473.6157,-433.8333 476.4491,-431 479.2824,-431 479.2824,-431 531.9784,-431 531.9784,-431 534.8117,-431 537.645,-433.8333 537.645,-436.6667 537.645,-436.6667 537.645,-442.3333 537.645,-442.3333 537.645,-445.1667 534.8117,-448 531.9784,-448"/>
 <text text-anchor="middle" x="505.6304" y="-436.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -270,7 +270,7 @@
 <!-- src/cli/defaults.json -->
 <g id="node5" class="node">
 <title>src/cli/defaults.json</title>
-<g id="a_node5"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/defaults.json" xlink:title="defaults.json">
+<g id="a_node5"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/defaults.json" xlink:title="defaults.json">
 <path fill="#ffee44" stroke="#000000" d="M408.4749,-147C408.4749,-147 353.7395,-147 353.7395,-147 350.9062,-147 348.0728,-144.1667 348.0728,-141.3333 348.0728,-141.3333 348.0728,-135.6667 348.0728,-135.6667 348.0728,-132.8333 350.9062,-130 353.7395,-130 353.7395,-130 408.4749,-130 408.4749,-130 411.3082,-130 414.1415,-132.8333 414.1415,-135.6667 414.1415,-135.6667 414.1415,-141.3333 414.1415,-141.3333 414.1415,-144.1667 411.3082,-147 408.4749,-147"/>
 <text text-anchor="middle" x="381.1072" y="-135.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">defaults.json</text>
 </a>
@@ -279,7 +279,7 @@
 <!-- src/cli/formatMetaInfo.js -->
 <g id="node6" class="node">
 <title>src/cli/formatMetaInfo.js</title>
-<g id="a_node6"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/formatMetaInfo.js" xlink:title="formatMetaInfo.js">
+<g id="a_node6"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/formatMetaInfo.js" xlink:title="formatMetaInfo.js">
 <path fill="#ffffcc" stroke="#000000" d="M175.8815,-376C175.8815,-376 102.1605,-376 102.1605,-376 99.3271,-376 96.4938,-373.1667 96.4938,-370.3333 96.4938,-370.3333 96.4938,-364.6667 96.4938,-364.6667 96.4938,-361.8333 99.3271,-359 102.1605,-359 102.1605,-359 175.8815,-359 175.8815,-359 178.7148,-359 181.5482,-361.8333 181.5482,-364.6667 181.5482,-364.6667 181.5482,-370.3333 181.5482,-370.3333 181.5482,-373.1667 178.7148,-376 175.8815,-376"/>
 <text text-anchor="middle" x="139.021" y="-364.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">formatMetaInfo.js</text>
 </a>
@@ -288,7 +288,7 @@
 <!-- src/main/index.js -->
 <g id="node55" class="node">
 <title>src/main/index.js</title>
-<g id="a_node55"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/index.js" xlink:title="index.js">
+<g id="a_node55"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M402.4405,-640C402.4405,-640 359.7738,-640 359.7738,-640 356.9405,-640 354.1072,-637.1667 354.1072,-634.3333 354.1072,-634.3333 354.1072,-628.6667 354.1072,-628.6667 354.1072,-625.8333 356.9405,-623 359.7738,-623 359.7738,-623 402.4405,-623 402.4405,-623 405.2738,-623 408.1072,-625.8333 408.1072,-628.6667 408.1072,-628.6667 408.1072,-634.3333 408.1072,-634.3333 408.1072,-637.1667 405.2738,-640 402.4405,-640"/>
 <text text-anchor="middle" x="381.1072" y="-628.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -303,7 +303,7 @@
 <!-- src/cli/getResolveConfig.js -->
 <g id="node7" class="node">
 <title>src/cli/getResolveConfig.js</title>
-<g id="a_node7"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/getResolveConfig.js" xlink:title="getResolveConfig.js">
+<g id="a_node7"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/getResolveConfig.js" xlink:title="getResolveConfig.js">
 <path fill="#ffffcc" stroke="#000000" d="M181.3963,-345C181.3963,-345 96.6457,-345 96.6457,-345 93.8123,-345 90.979,-342.1667 90.979,-339.3333 90.979,-339.3333 90.979,-333.6667 90.979,-333.6667 90.979,-330.8333 93.8123,-328 96.6457,-328 96.6457,-328 181.3963,-328 181.3963,-328 184.2297,-328 187.063,-330.8333 187.063,-333.6667 187.063,-333.6667 187.063,-339.3333 187.063,-339.3333 187.063,-342.1667 184.2297,-345 181.3963,-345"/>
 <text text-anchor="middle" x="139.021" y="-333.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">getResolveConfig.js</text>
 </a>
@@ -312,7 +312,7 @@
 <!-- src/cli/utl/makeAbsolute.js -->
 <g id="node18" class="node">
 <title>src/cli/utl/makeAbsolute.js</title>
-<g id="a_node18"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/utl/makeAbsolute.js" xlink:title="makeAbsolute.js">
+<g id="a_node18"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/utl/makeAbsolute.js" xlink:title="makeAbsolute.js">
 <path fill="#ffffcc" stroke="#000000" d="M293.1786,-356C293.1786,-356 222.4474,-356 222.4474,-356 219.6141,-356 216.7808,-353.1667 216.7808,-350.3333 216.7808,-350.3333 216.7808,-344.6667 216.7808,-344.6667 216.7808,-341.8333 219.6141,-339 222.4474,-339 222.4474,-339 293.1786,-339 293.1786,-339 296.0119,-339 298.8452,-341.8333 298.8452,-344.6667 298.8452,-344.6667 298.8452,-350.3333 298.8452,-350.3333 298.8452,-353.1667 296.0119,-356 293.1786,-356"/>
 <text text-anchor="middle" x="257.813" y="-344.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">makeAbsolute.js</text>
 </a>
@@ -327,7 +327,7 @@
 <!-- src/cli/index.js -->
 <g id="node8" class="node">
 <title>src/cli/index.js</title>
-<g id="a_node8"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/index.js" xlink:title="index.js">
+<g id="a_node8"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M72.3333,-311C72.3333,-311 29.6667,-311 29.6667,-311 26.8333,-311 24,-308.1667 24,-305.3333 24,-305.3333 24,-299.6667 24,-299.6667 24,-296.8333 26.8333,-294 29.6667,-294 29.6667,-294 72.3333,-294 72.3333,-294 75.1667,-294 78,-296.8333 78,-299.6667 78,-299.6667 78,-305.3333 78,-305.3333 78,-308.1667 75.1667,-311 72.3333,-311"/>
 <text text-anchor="middle" x="51" y="-299.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -348,7 +348,7 @@
 <!-- src/cli/initConfig/index.js -->
 <g id="node14" class="node">
 <title>src/cli/initConfig/index.js</title>
-<g id="a_node14"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/index.js" xlink:title="index.js">
+<g id="a_node14"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M160.3543,-210C160.3543,-210 117.6877,-210 117.6877,-210 114.8543,-210 112.021,-207.1667 112.021,-204.3333 112.021,-204.3333 112.021,-198.6667 112.021,-198.6667 112.021,-195.8333 114.8543,-193 117.6877,-193 117.6877,-193 160.3543,-193 160.3543,-193 163.1877,-193 166.021,-195.8333 166.021,-198.6667 166.021,-198.6667 166.021,-204.3333 166.021,-204.3333 166.021,-207.1667 163.1877,-210 160.3543,-210"/>
 <text text-anchor="middle" x="139.021" y="-198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -363,7 +363,7 @@
 <!-- src/cli/normalizeOptions.js -->
 <g id="node15" class="node">
 <title>src/cli/normalizeOptions.js</title>
-<g id="a_node15"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/normalizeOptions.js" xlink:title="normalizeOptions.js">
+<g id="a_node15"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/normalizeOptions.js" xlink:title="normalizeOptions.js">
 <path fill="#ffffcc" stroke="#000000" d="M299.6776,-147C299.6776,-147 215.9484,-147 215.9484,-147 213.1151,-147 210.2817,-144.1667 210.2817,-141.3333 210.2817,-141.3333 210.2817,-135.6667 210.2817,-135.6667 210.2817,-132.8333 213.1151,-130 215.9484,-130 215.9484,-130 299.6776,-130 299.6776,-130 302.5109,-130 305.3442,-132.8333 305.3442,-135.6667 305.3442,-135.6667 305.3442,-141.3333 305.3442,-141.3333 305.3442,-144.1667 302.5109,-147 299.6776,-147"/>
 <text text-anchor="middle" x="257.813" y="-135.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalizeOptions.js</text>
 </a>
@@ -378,7 +378,7 @@
 <!-- src/cli/parseTSConfig.js -->
 <g id="node16" class="node">
 <title>src/cli/parseTSConfig.js</title>
-<g id="a_node16"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/parseTSConfig.js" xlink:title="parseTSConfig.js">
+<g id="a_node16"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/parseTSConfig.js" xlink:title="parseTSConfig.js">
 <path fill="#ffffcc" stroke="#000000" d="M175.8836,-96C175.8836,-96 102.1584,-96 102.1584,-96 99.325,-96 96.4917,-93.1667 96.4917,-90.3333 96.4917,-90.3333 96.4917,-84.6667 96.4917,-84.6667 96.4917,-81.8333 99.325,-79 102.1584,-79 102.1584,-79 175.8836,-79 175.8836,-79 178.717,-79 181.5503,-81.8333 181.5503,-84.6667 181.5503,-84.6667 181.5503,-90.3333 181.5503,-90.3333 181.5503,-93.1667 178.717,-96 175.8836,-96"/>
 <text text-anchor="middle" x="139.021" y="-84.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">parseTSConfig.js</text>
 </a>
@@ -393,7 +393,7 @@
 <!-- src/cli/utl/io.js -->
 <g id="node17" class="node">
 <title>src/cli/utl/io.js</title>
-<g id="a_node17"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/utl/io.js" xlink:title="io.js">
+<g id="a_node17"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/utl/io.js" xlink:title="io.js">
 <path fill="#ffffcc" stroke="#000000" d="M279.1463,-327C279.1463,-327 236.4797,-327 236.4797,-327 233.6463,-327 230.813,-324.1667 230.813,-321.3333 230.813,-321.3333 230.813,-315.6667 230.813,-315.6667 230.813,-312.8333 233.6463,-310 236.4797,-310 236.4797,-310 279.1463,-310 279.1463,-310 281.9797,-310 284.813,-312.8333 284.813,-315.6667 284.813,-315.6667 284.813,-321.3333 284.813,-321.3333 284.813,-324.1667 281.9797,-327 279.1463,-327"/>
 <text text-anchor="middle" x="257.813" y="-315.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">io.js</text>
 </a>
@@ -408,7 +408,7 @@
 <!-- src/cli/utl/validateFileExistence.js -->
 <g id="node19" class="node">
 <title>src/cli/utl/validateFileExistence.js</title>
-<g id="a_node19"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/utl/validateFileExistence.js" xlink:title="validateFileExistence.js">
+<g id="a_node19"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/utl/validateFileExistence.js" xlink:title="validateFileExistence.js">
 <path fill="#ffffcc" stroke="#000000" d="M306.6893,-298C306.6893,-298 208.9367,-298 208.9367,-298 206.1034,-298 203.27,-295.1667 203.27,-292.3333 203.27,-292.3333 203.27,-286.6667 203.27,-286.6667 203.27,-283.8333 206.1034,-281 208.9367,-281 208.9367,-281 306.6893,-281 306.6893,-281 309.5226,-281 312.3559,-283.8333 312.3559,-286.6667 312.3559,-286.6667 312.3559,-292.3333 312.3559,-292.3333 312.3559,-295.1667 309.5226,-298 306.6893,-298"/>
 <text text-anchor="middle" x="257.813" y="-286.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">validateFileExistence.js</text>
 </a>
@@ -429,7 +429,7 @@
 <!-- src/cli/initConfig/config.js.template.js -->
 <g id="node9" class="node">
 <title>src/cli/initConfig/config.js.template.js</title>
-<g id="a_node9"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/config.js.template.js" xlink:title="config.js.template.js">
+<g id="a_node9"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/config.js.template.js" xlink:title="config.js.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M422.9762,-210C422.9762,-210 339.2382,-210 339.2382,-210 336.4049,-210 333.5715,-207.1667 333.5715,-204.3333 333.5715,-204.3333 333.5715,-198.6667 333.5715,-198.6667 333.5715,-195.8333 336.4049,-193 339.2382,-193 339.2382,-193 422.9762,-193 422.9762,-193 425.8095,-193 428.6428,-195.8333 428.6428,-198.6667 428.6428,-198.6667 428.6428,-204.3333 428.6428,-204.3333 428.6428,-207.1667 425.8095,-210 422.9762,-210"/>
 <text text-anchor="middle" x="381.1072" y="-198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">config.js.template.js</text>
 </a>
@@ -438,7 +438,7 @@
 <!-- src/cli/initConfig/config.json.template.js -->
 <g id="node10" class="node">
 <title>src/cli/initConfig/config.json.template.js</title>
-<g id="a_node10"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/config.json.template.js" xlink:title="config.json.template.js">
+<g id="a_node10"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/config.json.template.js" xlink:title="config.json.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M427.9869,-239C427.9869,-239 334.2274,-239 334.2274,-239 331.3941,-239 328.5608,-236.1667 328.5608,-233.3333 328.5608,-233.3333 328.5608,-227.6667 328.5608,-227.6667 328.5608,-224.8333 331.3941,-222 334.2274,-222 334.2274,-222 427.9869,-222 427.9869,-222 430.8202,-222 433.6536,-224.8333 433.6536,-227.6667 433.6536,-227.6667 433.6536,-233.3333 433.6536,-233.3333 433.6536,-236.1667 430.8202,-239 427.9869,-239"/>
 <text text-anchor="middle" x="381.1072" y="-227.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">config.json.template.js</text>
 </a>
@@ -447,7 +447,7 @@
 <!-- src/cli/initConfig/createConfigFile.js -->
 <g id="node11" class="node">
 <title>src/cli/initConfig/createConfigFile.js</title>
-<g id="a_node11"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/createConfigFile.js" xlink:title="createConfigFile.js">
+<g id="a_node11"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/createConfigFile.js" xlink:title="createConfigFile.js">
 <path fill="#ffffcc" stroke="#000000" d="M297.1788,-210C297.1788,-210 218.4472,-210 218.4472,-210 215.6139,-210 212.7805,-207.1667 212.7805,-204.3333 212.7805,-204.3333 212.7805,-198.6667 212.7805,-198.6667 212.7805,-195.8333 215.6139,-193 218.4472,-193 218.4472,-193 297.1788,-193 297.1788,-193 300.0121,-193 302.8454,-195.8333 302.8454,-198.6667 302.8454,-198.6667 302.8454,-204.3333 302.8454,-204.3333 302.8454,-207.1667 300.0121,-210 297.1788,-210"/>
 <text text-anchor="middle" x="257.813" y="-198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">createConfigFile.js</text>
 </a>
@@ -474,7 +474,7 @@
 <!-- src/cli/initConfig/helpers.js -->
 <g id="node13" class="node">
 <title>src/cli/initConfig/helpers.js</title>
-<g id="a_node13"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/helpers.js" xlink:title="helpers.js">
+<g id="a_node13"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/helpers.js" xlink:title="helpers.js">
 <path fill="#ffffcc" stroke="#000000" d="M402.4607,-181C402.4607,-181 359.7537,-181 359.7537,-181 356.9203,-181 354.087,-178.1667 354.087,-175.3333 354.087,-175.3333 354.087,-169.6667 354.087,-169.6667 354.087,-166.8333 356.9203,-164 359.7537,-164 359.7537,-164 402.4607,-164 402.4607,-164 405.294,-164 408.1274,-166.8333 408.1274,-169.6667 408.1274,-169.6667 408.1274,-175.3333 408.1274,-175.3333 408.1274,-178.1667 405.294,-181 402.4607,-181"/>
 <text text-anchor="middle" x="381.1072" y="-169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">helpers.js</text>
 </a>
@@ -489,7 +489,7 @@
 <!-- src/cli/initConfig/getUserInput.js -->
 <g id="node12" class="node">
 <title>src/cli/initConfig/getUserInput.js</title>
-<g id="a_node12"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/cli/initConfig/getUserInput.js" xlink:title="getUserInput.js">
+<g id="a_node12"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/cli/initConfig/getUserInput.js" xlink:title="getUserInput.js">
 <path fill="#ffffcc" stroke="#000000" d="M290.178,-181C290.178,-181 225.4479,-181 225.4479,-181 222.6146,-181 219.7813,-178.1667 219.7813,-175.3333 219.7813,-175.3333 219.7813,-169.6667 219.7813,-169.6667 219.7813,-166.8333 222.6146,-164 225.4479,-164 225.4479,-164 290.178,-164 290.178,-164 293.0114,-164 295.8447,-166.8333 295.8447,-169.6667 295.8447,-169.6667 295.8447,-175.3333 295.8447,-175.3333 295.8447,-178.1667 293.0114,-181 290.178,-181"/>
 <text text-anchor="middle" x="257.813" y="-169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">getUserInput.js</text>
 </a>
@@ -540,7 +540,7 @@
 <!-- src/extract/addValidations.js -->
 <g id="node20" class="node">
 <title>src/extract/addValidations.js</title>
-<g id="a_node20"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/addValidations.js" xlink:title="addValidations.js">
+<g id="a_node20"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/addValidations.js" xlink:title="addValidations.js">
 <path fill="#ffffcc" stroke="#000000" d="M691.4895,-1232C691.4895,-1232 619.0584,-1232 619.0584,-1232 616.225,-1232 613.3917,-1229.1667 613.3917,-1226.3333 613.3917,-1226.3333 613.3917,-1220.6667 613.3917,-1220.6667 613.3917,-1217.8333 616.225,-1215 619.0584,-1215 619.0584,-1215 691.4895,-1215 691.4895,-1215 694.3228,-1215 697.1561,-1217.8333 697.1561,-1220.6667 697.1561,-1220.6667 697.1561,-1226.3333 697.1561,-1226.3333 697.1561,-1229.1667 694.3228,-1232 691.4895,-1232"/>
 <text text-anchor="middle" x="655.2739" y="-1220.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">addValidations.js</text>
 </a>
@@ -549,7 +549,7 @@
 <!-- src/validate/index.js -->
 <g id="node81" class="node">
 <title>src/validate/index.js</title>
-<g id="a_node81"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/validate/index.js" xlink:title="index.js">
+<g id="a_node81"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M842.5189,-1452C842.5189,-1452 799.8522,-1452 799.8522,-1452 797.0189,-1452 794.1855,-1449.1667 794.1855,-1446.3333 794.1855,-1446.3333 794.1855,-1440.6667 794.1855,-1440.6667 794.1855,-1437.8333 797.0189,-1435 799.8522,-1435 799.8522,-1435 842.5189,-1435 842.5189,-1435 845.3522,-1435 848.1855,-1437.8333 848.1855,-1440.6667 848.1855,-1440.6667 848.1855,-1446.3333 848.1855,-1446.3333 848.1855,-1449.1667 845.3522,-1452 842.5189,-1452"/>
 <text text-anchor="middle" x="821.1855" y="-1440.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -564,7 +564,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;AMD&#45;deps.js -->
 <g id="node21" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;AMD&#45;deps.js</title>
-<g id="a_node21"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-AMD-deps.js" xlink:title="extract&#45;AMD&#45;deps.js">
+<g id="a_node21"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-AMD-deps.js" xlink:title="extract&#45;AMD&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M864.0386,-994C864.0386,-994 778.3325,-994 778.3325,-994 775.4991,-994 772.6658,-991.1667 772.6658,-988.3333 772.6658,-988.3333 772.6658,-982.6667 772.6658,-982.6667 772.6658,-979.8333 775.4991,-977 778.3325,-977 778.3325,-977 864.0386,-977 864.0386,-977 866.872,-977 869.7053,-979.8333 869.7053,-982.6667 869.7053,-982.6667 869.7053,-988.3333 869.7053,-988.3333 869.7053,-991.1667 866.872,-994 864.0386,-994"/>
 <text text-anchor="middle" x="821.1855" y="-982.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;AMD&#45;deps.js</text>
 </a>
@@ -573,7 +573,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;commonJS&#45;deps.js -->
 <g id="node23" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;commonJS&#45;deps.js</title>
-<g id="a_node23"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-commonJS-deps.js" xlink:title="extract&#45;commonJS&#45;deps.js">
+<g id="a_node23"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-commonJS-deps.js" xlink:title="extract&#45;commonJS&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M1036.595,-994C1036.595,-994 925.8621,-994 925.8621,-994 923.0287,-994 920.1954,-991.1667 920.1954,-988.3333 920.1954,-988.3333 920.1954,-982.6667 920.1954,-982.6667 920.1954,-979.8333 923.0287,-977 925.8621,-977 925.8621,-977 1036.595,-977 1036.595,-977 1039.4283,-977 1042.2616,-979.8333 1042.2616,-982.6667 1042.2616,-982.6667 1042.2616,-988.3333 1042.2616,-988.3333 1042.2616,-991.1667 1039.4283,-994 1036.595,-994"/>
 <text text-anchor="middle" x="981.2285" y="-982.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;commonJS&#45;deps.js</text>
 </a>
@@ -588,7 +588,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;ES6&#45;deps.js -->
 <g id="node22" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;ES6&#45;deps.js</title>
-<g id="a_node22"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-ES6-deps.js" xlink:title="extract&#45;ES6&#45;deps.js">
+<g id="a_node22"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-ES6-deps.js" xlink:title="extract&#45;ES6&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M862.5503,-965C862.5503,-965 779.8208,-965 779.8208,-965 776.9874,-965 774.1541,-962.1667 774.1541,-959.3333 774.1541,-959.3333 774.1541,-953.6667 774.1541,-953.6667 774.1541,-950.8333 776.9874,-948 779.8208,-948 779.8208,-948 862.5503,-948 862.5503,-948 865.3836,-948 868.217,-950.8333 868.217,-953.6667 868.217,-953.6667 868.217,-959.3333 868.217,-959.3333 868.217,-962.1667 865.3836,-965 862.5503,-965"/>
 <text text-anchor="middle" x="821.1855" y="-953.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;ES6&#45;deps.js</text>
 </a>
@@ -597,7 +597,7 @@
 <!-- src/extract/ast&#45;extractors/extract&#45;typescript&#45;deps.js -->
 <g id="node24" class="node">
 <title>src/extract/ast&#45;extractors/extract&#45;typescript&#45;deps.js</title>
-<g id="a_node24"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ast-extractors/extract-typescript-deps.js" xlink:title="extract&#45;typescript&#45;deps.js">
+<g id="a_node24"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ast-extractors/extract-typescript-deps.js" xlink:title="extract&#45;typescript&#45;deps.js">
 <path fill="#ffffcc" stroke="#000000" d="M873.5516,-936C873.5516,-936 768.8195,-936 768.8195,-936 765.9862,-936 763.1528,-933.1667 763.1528,-930.3333 763.1528,-930.3333 763.1528,-924.6667 763.1528,-924.6667 763.1528,-921.8333 765.9862,-919 768.8195,-919 768.8195,-919 873.5516,-919 873.5516,-919 876.3849,-919 879.2183,-921.8333 879.2183,-924.6667 879.2183,-924.6667 879.2183,-930.3333 879.2183,-930.3333 879.2183,-933.1667 876.3849,-936 873.5516,-936"/>
 <text text-anchor="middle" x="821.1855" y="-924.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract&#45;typescript&#45;deps.js</text>
 </a>
@@ -612,7 +612,7 @@
 <!-- src/extract/derive/circular/dependencyEndsUpAtFrom.js -->
 <g id="node25" class="node">
 <title>src/extract/derive/circular/dependencyEndsUpAtFrom.js</title>
-<g id="a_node25"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/circular/dependencyEndsUpAtFrom.js" xlink:title="dependencyEndsUpAtFrom.js">
+<g id="a_node25"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/circular/dependencyEndsUpAtFrom.js" xlink:title="dependencyEndsUpAtFrom.js">
 <path fill="#ffffcc" stroke="#000000" d="M883.0816,-1333C883.0816,-1333 759.2895,-1333 759.2895,-1333 756.4562,-1333 753.6228,-1330.1667 753.6228,-1327.3333 753.6228,-1327.3333 753.6228,-1321.6667 753.6228,-1321.6667 753.6228,-1318.8333 756.4562,-1316 759.2895,-1316 759.2895,-1316 883.0816,-1316 883.0816,-1316 885.9149,-1316 888.7483,-1318.8333 888.7483,-1321.6667 888.7483,-1321.6667 888.7483,-1327.3333 888.7483,-1327.3333 888.7483,-1330.1667 885.9149,-1333 883.0816,-1333"/>
 <text text-anchor="middle" x="821.1855" y="-1321.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">dependencyEndsUpAtFrom.js</text>
 </a>
@@ -621,7 +621,7 @@
 <!-- src/extract/derive/circular/index.js -->
 <g id="node26" class="node">
 <title>src/extract/derive/circular/index.js</title>
-<g id="a_node26"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/circular/index.js" xlink:title="index.js">
+<g id="a_node26"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/circular/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M676.6073,-1333C676.6073,-1333 633.9406,-1333 633.9406,-1333 631.1073,-1333 628.2739,-1330.1667 628.2739,-1327.3333 628.2739,-1327.3333 628.2739,-1321.6667 628.2739,-1321.6667 628.2739,-1318.8333 631.1073,-1316 633.9406,-1316 633.9406,-1316 676.6073,-1316 676.6073,-1316 679.4406,-1316 682.2739,-1318.8333 682.2739,-1321.6667 682.2739,-1321.6667 682.2739,-1327.3333 682.2739,-1327.3333 682.2739,-1330.1667 679.4406,-1333 676.6073,-1333"/>
 <text text-anchor="middle" x="655.2739" y="-1321.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -636,7 +636,7 @@
 <!-- src/extract/derive/orphan/index.js -->
 <g id="node27" class="node">
 <title>src/extract/derive/orphan/index.js</title>
-<g id="a_node27"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/orphan/index.js" xlink:title="index.js">
+<g id="a_node27"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/orphan/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M676.6073,-1274C676.6073,-1274 633.9406,-1274 633.9406,-1274 631.1073,-1274 628.2739,-1271.1667 628.2739,-1268.3333 628.2739,-1268.3333 628.2739,-1262.6667 628.2739,-1262.6667 628.2739,-1259.8333 631.1073,-1257 633.9406,-1257 633.9406,-1257 676.6073,-1257 676.6073,-1257 679.4406,-1257 682.2739,-1259.8333 682.2739,-1262.6667 682.2739,-1262.6667 682.2739,-1268.3333 682.2739,-1268.3333 682.2739,-1271.1667 679.4406,-1274 676.6073,-1274"/>
 <text text-anchor="middle" x="655.2739" y="-1262.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -645,7 +645,7 @@
 <!-- src/extract/derive/orphan/isOrphan.js -->
 <g id="node28" class="node">
 <title>src/extract/derive/orphan/isOrphan.js</title>
-<g id="a_node28"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/orphan/isOrphan.js" xlink:title="isOrphan.js">
+<g id="a_node28"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/derive/orphan/isOrphan.js" xlink:title="isOrphan.js">
 <path fill="#ffffcc" stroke="#000000" d="M846.0393,-1274C846.0393,-1274 796.3318,-1274 796.3318,-1274 793.4985,-1274 790.6651,-1271.1667 790.6651,-1268.3333 790.6651,-1268.3333 790.6651,-1262.6667 790.6651,-1262.6667 790.6651,-1259.8333 793.4985,-1257 796.3318,-1257 796.3318,-1257 846.0393,-1257 846.0393,-1257 848.8726,-1257 851.706,-1259.8333 851.706,-1262.6667 851.706,-1262.6667 851.706,-1268.3333 851.706,-1268.3333 851.706,-1271.1667 848.8726,-1274 846.0393,-1274"/>
 <text text-anchor="middle" x="821.1855" y="-1262.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">isOrphan.js</text>
 </a>
@@ -660,7 +660,7 @@
 <!-- src/extract/extract.js -->
 <g id="node29" class="node">
 <title>src/extract/extract.js</title>
-<g id="a_node29"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/extract.js" xlink:title="extract.js">
+<g id="a_node29"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/extract.js" xlink:title="extract.js">
 <path fill="#ffffcc" stroke="#000000" d="M676.6073,-1005C676.6073,-1005 633.9406,-1005 633.9406,-1005 631.1073,-1005 628.2739,-1002.1667 628.2739,-999.3333 628.2739,-999.3333 628.2739,-993.6667 628.2739,-993.6667 628.2739,-990.8333 631.1073,-988 633.9406,-988 633.9406,-988 676.6073,-988 676.6073,-988 679.4406,-988 682.2739,-990.8333 682.2739,-993.6667 682.2739,-993.6667 682.2739,-999.3333 682.2739,-999.3333 682.2739,-1002.1667 679.4406,-1005 676.6073,-1005"/>
 <text text-anchor="middle" x="655.2739" y="-993.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">extract.js</text>
 </a>
@@ -693,7 +693,7 @@
 <!-- src/extract/ignore.js -->
 <g id="node31" class="node">
 <title>src/extract/ignore.js</title>
-<g id="a_node31"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/ignore.js" xlink:title="ignore.js">
+<g id="a_node31"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/ignore.js" xlink:title="ignore.js">
 <path fill="#ffffcc" stroke="#000000" d="M842.5189,-1232C842.5189,-1232 799.8522,-1232 799.8522,-1232 797.0189,-1232 794.1855,-1229.1667 794.1855,-1226.3333 794.1855,-1226.3333 794.1855,-1220.6667 794.1855,-1220.6667 794.1855,-1217.8333 797.0189,-1215 799.8522,-1215 799.8522,-1215 842.5189,-1215 842.5189,-1215 845.3522,-1215 848.1855,-1217.8333 848.1855,-1220.6667 848.1855,-1220.6667 848.1855,-1226.3333 848.1855,-1226.3333 848.1855,-1229.1667 845.3522,-1232 842.5189,-1232"/>
 <text text-anchor="middle" x="821.1855" y="-1220.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">ignore.js</text>
 </a>
@@ -708,7 +708,7 @@
 <!-- src/extract/parse/toJavascriptAST.js -->
 <g id="node33" class="node">
 <title>src/extract/parse/toJavascriptAST.js</title>
-<g id="a_node33"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/parse/toJavascriptAST.js" xlink:title="toJavascriptAST.js">
+<g id="a_node33"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/parse/toJavascriptAST.js" xlink:title="toJavascriptAST.js">
 <path fill="#ffffcc" stroke="#000000" d="M860.045,-867C860.045,-867 782.3261,-867 782.3261,-867 779.4927,-867 776.6594,-864.1667 776.6594,-861.3333 776.6594,-861.3333 776.6594,-855.6667 776.6594,-855.6667 776.6594,-852.8333 779.4927,-850 782.3261,-850 782.3261,-850 860.045,-850 860.045,-850 862.8784,-850 865.7117,-852.8333 865.7117,-855.6667 865.7117,-855.6667 865.7117,-861.3333 865.7117,-861.3333 865.7117,-864.1667 862.8784,-867 860.045,-867"/>
 <text text-anchor="middle" x="821.1855" y="-855.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">toJavascriptAST.js</text>
 </a>
@@ -723,7 +723,7 @@
 <!-- src/extract/parse/toTypescriptAST.js -->
 <g id="node34" class="node">
 <title>src/extract/parse/toTypescriptAST.js</title>
-<g id="a_node34"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/parse/toTypescriptAST.js" xlink:title="toTypescriptAST.js">
+<g id="a_node34"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/parse/toTypescriptAST.js" xlink:title="toTypescriptAST.js">
 <path fill="#ffffcc" stroke="#000000" d="M860.5492,-838C860.5492,-838 781.8219,-838 781.8219,-838 778.9886,-838 776.1553,-835.1667 776.1553,-832.3333 776.1553,-832.3333 776.1553,-826.6667 776.1553,-826.6667 776.1553,-823.8333 778.9886,-821 781.8219,-821 781.8219,-821 860.5492,-821 860.5492,-821 863.3825,-821 866.2158,-823.8333 866.2158,-826.6667 866.2158,-826.6667 866.2158,-832.3333 866.2158,-832.3333 866.2158,-835.1667 863.3825,-838 860.5492,-838"/>
 <text text-anchor="middle" x="821.1855" y="-826.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">toTypescriptAST.js</text>
 </a>
@@ -738,7 +738,7 @@
 <!-- src/extract/resolve/index.js -->
 <g id="node36" class="node">
 <title>src/extract/resolve/index.js</title>
-<g id="a_node36"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/index.js" xlink:title="index.js">
+<g id="a_node36"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M842.5189,-1115C842.5189,-1115 799.8522,-1115 799.8522,-1115 797.0189,-1115 794.1855,-1112.1667 794.1855,-1109.3333 794.1855,-1109.3333 794.1855,-1103.6667 794.1855,-1103.6667 794.1855,-1100.8333 797.0189,-1098 799.8522,-1098 799.8522,-1098 842.5189,-1098 842.5189,-1098 845.3522,-1098 848.1855,-1100.8333 848.1855,-1103.6667 848.1855,-1103.6667 848.1855,-1109.3333 848.1855,-1109.3333 848.1855,-1112.1667 845.3522,-1115 842.5189,-1115"/>
 <text text-anchor="middle" x="821.1855" y="-1103.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -753,7 +753,7 @@
 <!-- src/extract/gatherInitialSources.js -->
 <g id="node30" class="node">
 <title>src/extract/gatherInitialSources.js</title>
-<g id="a_node30"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/gatherInitialSources.js" xlink:title="gatherInitialSources.js">
+<g id="a_node30"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/gatherInitialSources.js" xlink:title="gatherInitialSources.js">
 <path fill="#ffffcc" stroke="#000000" d="M701.6537,-1203C701.6537,-1203 608.8942,-1203 608.8942,-1203 606.0609,-1203 603.2275,-1200.1667 603.2275,-1197.3333 603.2275,-1197.3333 603.2275,-1191.6667 603.2275,-1191.6667 603.2275,-1188.8333 606.0609,-1186 608.8942,-1186 608.8942,-1186 701.6537,-1186 701.6537,-1186 704.487,-1186 707.3203,-1188.8333 707.3203,-1191.6667 707.3203,-1191.6667 707.3203,-1197.3333 707.3203,-1197.3333 707.3203,-1200.1667 704.487,-1203 701.6537,-1203"/>
 <text text-anchor="middle" x="655.2739" y="-1191.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">gatherInitialSources.js</text>
 </a>
@@ -768,7 +768,7 @@
 <!-- src/extract/transpile/meta.js -->
 <g id="node50" class="node">
 <title>src/extract/transpile/meta.js</title>
-<g id="a_node50"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/meta.js" xlink:title="meta.js">
+<g id="a_node50"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/meta.js" xlink:title="meta.js">
 <path fill="#ffffcc" stroke="#000000" d="M1149.6151,-795C1149.6151,-795 1106.9484,-795 1106.9484,-795 1104.1151,-795 1101.2817,-792.1667 1101.2817,-789.3333 1101.2817,-789.3333 1101.2817,-783.6667 1101.2817,-783.6667 1101.2817,-780.8333 1104.1151,-778 1106.9484,-778 1106.9484,-778 1149.6151,-778 1149.6151,-778 1152.4484,-778 1155.2817,-780.8333 1155.2817,-783.6667 1155.2817,-783.6667 1155.2817,-789.3333 1155.2817,-789.3333 1155.2817,-792.1667 1152.4484,-795 1149.6151,-795"/>
 <text text-anchor="middle" x="1128.2817" y="-783.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">meta.js</text>
 </a>
@@ -783,7 +783,7 @@
 <!-- src/extract/index.js -->
 <g id="node32" class="node">
 <title>src/extract/index.js</title>
-<g id="a_node32"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/index.js" xlink:title="index.js">
+<g id="a_node32"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1217C526.9637,-1217 484.297,-1217 484.297,-1217 481.4637,-1217 478.6304,-1214.1667 478.6304,-1211.3333 478.6304,-1211.3333 478.6304,-1205.6667 478.6304,-1205.6667 478.6304,-1202.8333 481.4637,-1200 484.297,-1200 484.297,-1200 526.9637,-1200 526.9637,-1200 529.797,-1200 532.6304,-1202.8333 532.6304,-1205.6667 532.6304,-1205.6667 532.6304,-1211.3333 532.6304,-1211.3333 532.6304,-1214.1667 529.797,-1217 526.9637,-1217"/>
 <text text-anchor="middle" x="505.6304" y="-1205.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -822,7 +822,7 @@
 <!-- src/extract/summarize.js -->
 <g id="node45" class="node">
 <title>src/extract/summarize.js</title>
-<g id="a_node45"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/summarize.js" xlink:title="summarize.js">
+<g id="a_node45"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/summarize.js" xlink:title="summarize.js">
 <path fill="#ffffcc" stroke="#000000" d="M684.1141,-976C684.1141,-976 626.4338,-976 626.4338,-976 623.6004,-976 620.7671,-973.1667 620.7671,-970.3333 620.7671,-970.3333 620.7671,-964.6667 620.7671,-964.6667 620.7671,-961.8333 623.6004,-959 626.4338,-959 626.4338,-959 684.1141,-959 684.1141,-959 686.9474,-959 689.7808,-961.8333 689.7808,-964.6667 689.7808,-964.6667 689.7808,-970.3333 689.7808,-970.3333 689.7808,-973.1667 686.9474,-976 684.1141,-976"/>
 <text text-anchor="middle" x="655.2739" y="-964.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">summarize.js</text>
 </a>
@@ -837,7 +837,7 @@
 <!-- src/extract/utl/pathToPosix.js -->
 <g id="node53" class="node">
 <title>src/extract/utl/pathToPosix.js</title>
-<g id="a_node53"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/pathToPosix.js" xlink:title="pathToPosix.js">
+<g id="a_node53"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/utl/pathToPosix.js" xlink:title="pathToPosix.js">
 <path fill="#ffffcc" stroke="#000000" d="M1474.2542,-1210C1474.2542,-1210 1411.528,-1210 1411.528,-1210 1408.6947,-1210 1405.8613,-1207.1667 1405.8613,-1204.3333 1405.8613,-1204.3333 1405.8613,-1198.6667 1405.8613,-1198.6667 1405.8613,-1195.8333 1408.6947,-1193 1411.528,-1193 1411.528,-1193 1474.2542,-1193 1474.2542,-1193 1477.0876,-1193 1479.9209,-1195.8333 1479.9209,-1198.6667 1479.9209,-1198.6667 1479.9209,-1204.3333 1479.9209,-1204.3333 1479.9209,-1207.1667 1477.0876,-1210 1474.2542,-1210"/>
 <text text-anchor="middle" x="1442.8911" y="-1198.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">pathToPosix.js</text>
 </a>
@@ -852,7 +852,7 @@
 <!-- src/extract/transpile/index.js -->
 <g id="node47" class="node">
 <title>src/extract/transpile/index.js</title>
-<g id="a_node47"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/index.js" xlink:title="index.js">
+<g id="a_node47"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M1002.5618,-824C1002.5618,-824 959.8952,-824 959.8952,-824 957.0618,-824 954.2285,-821.1667 954.2285,-818.3333 954.2285,-818.3333 954.2285,-812.6667 954.2285,-812.6667 954.2285,-809.8333 957.0618,-807 959.8952,-807 959.8952,-807 1002.5618,-807 1002.5618,-807 1005.3952,-807 1008.2285,-809.8333 1008.2285,-812.6667 1008.2285,-812.6667 1008.2285,-818.3333 1008.2285,-818.3333 1008.2285,-821.1667 1005.3952,-824 1002.5618,-824"/>
 <text text-anchor="middle" x="981.2285" y="-812.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -867,7 +867,7 @@
 <!-- src/extract/utl/getExtension.js -->
 <g id="node52" class="node">
 <title>src/extract/utl/getExtension.js</title>
-<g id="a_node52"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/getExtension.js" xlink:title="getExtension.js">
+<g id="a_node52"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/utl/getExtension.js" xlink:title="getExtension.js">
 <path fill="#ffffcc" stroke="#000000" d="M1475.7601,-1181C1475.7601,-1181 1410.0221,-1181 1410.0221,-1181 1407.1888,-1181 1404.3555,-1178.1667 1404.3555,-1175.3333 1404.3555,-1175.3333 1404.3555,-1169.6667 1404.3555,-1169.6667 1404.3555,-1166.8333 1407.1888,-1164 1410.0221,-1164 1410.0221,-1164 1475.7601,-1164 1475.7601,-1164 1478.5934,-1164 1481.4268,-1166.8333 1481.4268,-1169.6667 1481.4268,-1169.6667 1481.4268,-1175.3333 1481.4268,-1175.3333 1481.4268,-1178.1667 1478.5934,-1181 1475.7601,-1181"/>
 <text text-anchor="middle" x="1442.8911" y="-1169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">getExtension.js</text>
 </a>
@@ -888,7 +888,7 @@
 <!-- src/extract/resolve/determineDependencyTypes.js -->
 <g id="node35" class="node">
 <title>src/extract/resolve/determineDependencyTypes.js</title>
-<g id="a_node35"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/determineDependencyTypes.js" xlink:title="determineDependencyTypes.js">
+<g id="a_node35"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/determineDependencyTypes.js" xlink:title="determineDependencyTypes.js">
 <path fill="#ffffcc" stroke="#000000" d="M1192.1899,-1082C1192.1899,-1082 1064.3735,-1082 1064.3735,-1082 1061.5402,-1082 1058.7069,-1079.1667 1058.7069,-1076.3333 1058.7069,-1076.3333 1058.7069,-1070.6667 1058.7069,-1070.6667 1058.7069,-1067.8333 1061.5402,-1065 1064.3735,-1065 1064.3735,-1065 1192.1899,-1065 1192.1899,-1065 1195.0233,-1065 1197.8566,-1067.8333 1197.8566,-1070.6667 1197.8566,-1070.6667 1197.8566,-1076.3333 1197.8566,-1076.3333 1197.8566,-1079.1667 1195.0233,-1082 1192.1899,-1082"/>
 <text text-anchor="middle" x="1128.2817" y="-1070.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">determineDependencyTypes.js</text>
 </a>
@@ -897,7 +897,7 @@
 <!-- src/extract/resolve/localNpmHelpers.js -->
 <g id="node38" class="node">
 <title>src/extract/resolve/localNpmHelpers.js</title>
-<g id="a_node38"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/localNpmHelpers.js" xlink:title="localNpmHelpers.js">
+<g id="a_node38"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/localNpmHelpers.js" xlink:title="localNpmHelpers.js">
 <path fill="#ffffcc" stroke="#000000" d="M1298.6893,-1082C1298.6893,-1082 1216.9723,-1082 1216.9723,-1082 1214.139,-1082 1211.3057,-1079.1667 1211.3057,-1076.3333 1211.3057,-1076.3333 1211.3057,-1070.6667 1211.3057,-1070.6667 1211.3057,-1067.8333 1214.139,-1065 1216.9723,-1065 1216.9723,-1065 1298.6893,-1065 1298.6893,-1065 1301.5226,-1065 1304.3559,-1067.8333 1304.3559,-1070.6667 1304.3559,-1070.6667 1304.3559,-1076.3333 1304.3559,-1076.3333 1304.3559,-1079.1667 1301.5226,-1082 1298.6893,-1082"/>
 <text text-anchor="middle" x="1257.8308" y="-1070.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">localNpmHelpers.js</text>
 </a>
@@ -912,7 +912,7 @@
 <!-- src/extract/resolve/resolve&#45;AMD.js -->
 <g id="node41" class="node">
 <title>src/extract/resolve/resolve&#45;AMD.js</title>
-<g id="a_node41"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-AMD.js" xlink:title="resolve&#45;AMD.js">
+<g id="a_node41"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve-AMD.js" xlink:title="resolve&#45;AMD.js">
 <path fill="#ffffcc" stroke="#000000" d="M1014.0711,-1101C1014.0711,-1101 948.3859,-1101 948.3859,-1101 945.5526,-1101 942.7192,-1098.1667 942.7192,-1095.3333 942.7192,-1095.3333 942.7192,-1089.6667 942.7192,-1089.6667 942.7192,-1086.8333 945.5526,-1084 948.3859,-1084 948.3859,-1084 1014.0711,-1084 1014.0711,-1084 1016.9045,-1084 1019.7378,-1086.8333 1019.7378,-1089.6667 1019.7378,-1089.6667 1019.7378,-1095.3333 1019.7378,-1095.3333 1019.7378,-1098.1667 1016.9045,-1101 1014.0711,-1101"/>
 <text text-anchor="middle" x="981.2285" y="-1089.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve&#45;AMD.js</text>
 </a>
@@ -927,7 +927,7 @@
 <!-- src/extract/resolve/resolve&#45;commonJS.js -->
 <g id="node42" class="node">
 <title>src/extract/resolve/resolve&#45;commonJS.js</title>
-<g id="a_node42"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-commonJS.js" xlink:title="resolve&#45;commonJS.js">
+<g id="a_node42"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve-commonJS.js" xlink:title="resolve&#45;commonJS.js">
 <path fill="#ffffcc" stroke="#000000" d="M1026.5848,-1130C1026.5848,-1130 935.8722,-1130 935.8722,-1130 933.0389,-1130 930.2056,-1127.1667 930.2056,-1124.3333 930.2056,-1124.3333 930.2056,-1118.6667 930.2056,-1118.6667 930.2056,-1115.8333 933.0389,-1113 935.8722,-1113 935.8722,-1113 1026.5848,-1113 1026.5848,-1113 1029.4181,-1113 1032.2515,-1115.8333 1032.2515,-1118.6667 1032.2515,-1118.6667 1032.2515,-1124.3333 1032.2515,-1124.3333 1032.2515,-1127.1667 1029.4181,-1130 1026.5848,-1130"/>
 <text text-anchor="middle" x="981.2285" y="-1118.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve&#45;commonJS.js</text>
 </a>
@@ -948,7 +948,7 @@
 <!-- src/extract/resolve/isFollowable.js -->
 <g id="node37" class="node">
 <title>src/extract/resolve/isFollowable.js</title>
-<g id="a_node37"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/isFollowable.js" xlink:title="isFollowable.js">
+<g id="a_node37"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/isFollowable.js" xlink:title="isFollowable.js">
 <path fill="#ffffcc" stroke="#000000" d="M1159.6386,-1181C1159.6386,-1181 1096.9249,-1181 1096.9249,-1181 1094.0916,-1181 1091.2582,-1178.1667 1091.2582,-1175.3333 1091.2582,-1175.3333 1091.2582,-1169.6667 1091.2582,-1169.6667 1091.2582,-1166.8333 1094.0916,-1164 1096.9249,-1164 1096.9249,-1164 1159.6386,-1164 1159.6386,-1164 1162.4719,-1164 1165.3052,-1166.8333 1165.3052,-1169.6667 1165.3052,-1169.6667 1165.3052,-1175.3333 1165.3052,-1175.3333 1165.3052,-1178.1667 1162.4719,-1181 1159.6386,-1181"/>
 <text text-anchor="middle" x="1128.2817" y="-1169.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">isFollowable.js</text>
 </a>
@@ -969,7 +969,7 @@
 <!-- src/extract/resolve/readPackageDeps/index.js -->
 <g id="node39" class="node">
 <title>src/extract/resolve/readPackageDeps/index.js</title>
-<g id="a_node39"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/readPackageDeps/index.js" xlink:title="index.js">
+<g id="a_node39"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/readPackageDeps/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M1149.6151,-1116C1149.6151,-1116 1106.9484,-1116 1106.9484,-1116 1104.1151,-1116 1101.2817,-1113.1667 1101.2817,-1110.3333 1101.2817,-1110.3333 1101.2817,-1104.6667 1101.2817,-1104.6667 1101.2817,-1101.8333 1104.1151,-1099 1106.9484,-1099 1106.9484,-1099 1149.6151,-1099 1149.6151,-1099 1152.4484,-1099 1155.2817,-1101.8333 1155.2817,-1104.6667 1155.2817,-1104.6667 1155.2817,-1110.3333 1155.2817,-1110.3333 1155.2817,-1113.1667 1152.4484,-1116 1149.6151,-1116"/>
 <text text-anchor="middle" x="1128.2817" y="-1104.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -978,7 +978,7 @@
 <!-- src/extract/resolve/readPackageDeps/mergePackages.js -->
 <g id="node40" class="node">
 <title>src/extract/resolve/readPackageDeps/mergePackages.js</title>
-<g id="a_node40"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/readPackageDeps/mergePackages.js" xlink:title="mergePackages.js">
+<g id="a_node40"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/readPackageDeps/mergePackages.js" xlink:title="mergePackages.js">
 <path fill="#ffffcc" stroke="#000000" d="M1297.1988,-1116C1297.1988,-1116 1218.4628,-1116 1218.4628,-1116 1215.6295,-1116 1212.7961,-1113.1667 1212.7961,-1110.3333 1212.7961,-1110.3333 1212.7961,-1104.6667 1212.7961,-1104.6667 1212.7961,-1101.8333 1215.6295,-1099 1218.4628,-1099 1218.4628,-1099 1297.1988,-1099 1297.1988,-1099 1300.0322,-1099 1302.8655,-1101.8333 1302.8655,-1104.6667 1302.8655,-1104.6667 1302.8655,-1110.3333 1302.8655,-1110.3333 1302.8655,-1113.1667 1300.0322,-1116 1297.1988,-1116"/>
 <text text-anchor="middle" x="1257.8308" y="-1104.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">mergePackages.js</text>
 </a>
@@ -1005,7 +1005,7 @@
 <!-- src/extract/resolve/resolve&#45;helpers.js -->
 <g id="node43" class="node">
 <title>src/extract/resolve/resolve&#45;helpers.js</title>
-<g id="a_node43"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-helpers.js" xlink:title="resolve&#45;helpers.js">
+<g id="a_node43"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/resolve/resolve-helpers.js" xlink:title="resolve&#45;helpers.js">
 <path fill="#ffffcc" stroke="#000000" d="M1165.6442,-1053C1165.6442,-1053 1090.9193,-1053 1090.9193,-1053 1088.086,-1053 1085.2526,-1050.1667 1085.2526,-1047.3333 1085.2526,-1047.3333 1085.2526,-1041.6667 1085.2526,-1041.6667 1085.2526,-1038.8333 1088.086,-1036 1090.9193,-1036 1090.9193,-1036 1165.6442,-1036 1165.6442,-1036 1168.4775,-1036 1171.3109,-1038.8333 1171.3109,-1041.6667 1171.3109,-1041.6667 1171.3109,-1047.3333 1171.3109,-1047.3333 1171.3109,-1050.1667 1168.4775,-1053 1165.6442,-1053"/>
 <text text-anchor="middle" x="1128.2817" y="-1041.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">resolve&#45;helpers.js</text>
 </a>
@@ -1074,7 +1074,7 @@
 <!-- src/extract/transpile/coffeeWrap.js -->
 <g id="node46" class="node">
 <title>src/extract/transpile/coffeeWrap.js</title>
-<g id="a_node46"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/coffeeWrap.js" xlink:title="coffeeWrap.js">
+<g id="a_node46"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/coffeeWrap.js" xlink:title="coffeeWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1287.3679,-766C1287.3679,-766 1228.2937,-766 1228.2937,-766 1225.4604,-766 1222.6271,-763.1667 1222.6271,-760.3333 1222.6271,-760.3333 1222.6271,-754.6667 1222.6271,-754.6667 1222.6271,-751.8333 1225.4604,-749 1228.2937,-749 1228.2937,-749 1287.3679,-749 1287.3679,-749 1290.2012,-749 1293.0346,-751.8333 1293.0346,-754.6667 1293.0346,-754.6667 1293.0346,-760.3333 1293.0346,-760.3333 1293.0346,-763.1667 1290.2012,-766 1287.3679,-766"/>
 <text text-anchor="middle" x="1257.8308" y="-754.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">coffeeWrap.js</text>
 </a>
@@ -1095,7 +1095,7 @@
 <!-- src/extract/transpile/javaScriptWrap.js -->
 <g id="node48" class="node">
 <title>src/extract/transpile/javaScriptWrap.js</title>
-<g id="a_node48"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/javaScriptWrap.js" xlink:title="javaScriptWrap.js">
+<g id="a_node48"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/javaScriptWrap.js" xlink:title="javaScriptWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1295.0241,-824C1295.0241,-824 1220.6375,-824 1220.6375,-824 1217.8042,-824 1214.9708,-821.1667 1214.9708,-818.3333 1214.9708,-818.3333 1214.9708,-812.6667 1214.9708,-812.6667 1214.9708,-809.8333 1217.8042,-807 1220.6375,-807 1220.6375,-807 1295.0241,-807 1295.0241,-807 1297.8575,-807 1300.6908,-809.8333 1300.6908,-812.6667 1300.6908,-812.6667 1300.6908,-818.3333 1300.6908,-818.3333 1300.6908,-821.1667 1297.8575,-824 1295.0241,-824"/>
 <text text-anchor="middle" x="1257.8308" y="-812.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">javaScriptWrap.js</text>
 </a>
@@ -1104,7 +1104,7 @@
 <!-- src/extract/transpile/liveScriptWrap.js -->
 <g id="node49" class="node">
 <title>src/extract/transpile/liveScriptWrap.js</title>
-<g id="a_node49"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/liveScriptWrap.js" xlink:title="liveScriptWrap.js">
+<g id="a_node49"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/liveScriptWrap.js" xlink:title="liveScriptWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1293.5183,-853C1293.5183,-853 1222.1433,-853 1222.1433,-853 1219.31,-853 1216.4767,-850.1667 1216.4767,-847.3333 1216.4767,-847.3333 1216.4767,-841.6667 1216.4767,-841.6667 1216.4767,-838.8333 1219.31,-836 1222.1433,-836 1222.1433,-836 1293.5183,-836 1293.5183,-836 1296.3516,-836 1299.1849,-838.8333 1299.1849,-841.6667 1299.1849,-841.6667 1299.1849,-847.3333 1299.1849,-847.3333 1299.1849,-850.1667 1296.3516,-853 1293.5183,-853"/>
 <text text-anchor="middle" x="1257.8308" y="-841.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">liveScriptWrap.js</text>
 </a>
@@ -1143,7 +1143,7 @@
 <!-- src/extract/transpile/typeScriptWrap.js -->
 <g id="node51" class="node">
 <title>src/extract/transpile/typeScriptWrap.js</title>
-<g id="a_node51"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/extract/transpile/typeScriptWrap.js" xlink:title="typeScriptWrap.js">
+<g id="a_node51"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/extract/transpile/typeScriptWrap.js" xlink:title="typeScriptWrap.js">
 <path fill="#ffffcc" stroke="#000000" d="M1295.5257,-795C1295.5257,-795 1220.1359,-795 1220.1359,-795 1217.3025,-795 1214.4692,-792.1667 1214.4692,-789.3333 1214.4692,-789.3333 1214.4692,-783.6667 1214.4692,-783.6667 1214.4692,-780.8333 1217.3025,-778 1220.1359,-778 1220.1359,-778 1295.5257,-778 1295.5257,-778 1298.3591,-778 1301.1924,-780.8333 1301.1924,-783.6667 1301.1924,-783.6667 1301.1924,-789.3333 1301.1924,-789.3333 1301.1924,-792.1667 1298.3591,-795 1295.5257,-795"/>
 <text text-anchor="middle" x="1257.8308" y="-783.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">typeScriptWrap.js</text>
 </a>
@@ -1164,7 +1164,7 @@
 <!-- src/main/filesAndDirs/normalize.js -->
 <g id="node54" class="node">
 <title>src/main/filesAndDirs/normalize.js</title>
-<g id="a_node54"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/filesAndDirs/normalize.js" xlink:title="normalize.js">
+<g id="a_node54"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/filesAndDirs/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M531.9784,-517C531.9784,-517 479.2824,-517 479.2824,-517 476.4491,-517 473.6157,-514.1667 473.6157,-511.3333 473.6157,-511.3333 473.6157,-505.6667 473.6157,-505.6667 473.6157,-502.8333 476.4491,-500 479.2824,-500 479.2824,-500 531.9784,-500 531.9784,-500 534.8117,-500 537.645,-502.8333 537.645,-505.6667 537.645,-505.6667 537.645,-511.3333 537.645,-511.3333 537.645,-514.1667 534.8117,-517 531.9784,-517"/>
 <text text-anchor="middle" x="505.6304" y="-505.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -1191,7 +1191,7 @@
 <!-- src/main/options/normalize.js -->
 <g id="node57" class="node">
 <title>src/main/options/normalize.js</title>
-<g id="a_node57"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/options/normalize.js" xlink:title="normalize.js">
+<g id="a_node57"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/options/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M681.6219,-498C681.6219,-498 628.9259,-498 628.9259,-498 626.0926,-498 623.2593,-495.1667 623.2593,-492.3333 623.2593,-492.3333 623.2593,-486.6667 623.2593,-486.6667 623.2593,-483.8333 626.0926,-481 628.9259,-481 628.9259,-481 681.6219,-481 681.6219,-481 684.4552,-481 687.2886,-483.8333 687.2886,-486.6667 687.2886,-486.6667 687.2886,-492.3333 687.2886,-492.3333 687.2886,-495.1667 684.4552,-498 681.6219,-498"/>
 <text text-anchor="middle" x="655.2739" y="-486.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -1206,7 +1206,7 @@
 <!-- src/main/options/validate.js -->
 <g id="node58" class="node">
 <title>src/main/options/validate.js</title>
-<g id="a_node58"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/options/validate.js" xlink:title="validate.js">
+<g id="a_node58"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/options/validate.js" xlink:title="validate.js">
 <path fill="#ffffcc" stroke="#000000" d="M677.6283,-527C677.6283,-527 632.9196,-527 632.9196,-527 630.0863,-527 627.2529,-524.1667 627.2529,-521.3333 627.2529,-521.3333 627.2529,-515.6667 627.2529,-515.6667 627.2529,-512.8333 630.0863,-510 632.9196,-510 632.9196,-510 677.6283,-510 677.6283,-510 680.4616,-510 683.2949,-512.8333 683.2949,-515.6667 683.2949,-515.6667 683.2949,-521.3333 683.2949,-521.3333 683.2949,-524.1667 680.4616,-527 677.6283,-527"/>
 <text text-anchor="middle" x="655.2739" y="-515.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">validate.js</text>
 </a>
@@ -1227,7 +1227,7 @@
 <!-- src/main/ruleSet/normalize.js -->
 <g id="node61" class="node">
 <title>src/main/ruleSet/normalize.js</title>
-<g id="a_node61"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/ruleSet/normalize.js" xlink:title="normalize.js">
+<g id="a_node61"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/ruleSet/normalize.js" xlink:title="normalize.js">
 <path fill="#ffffcc" stroke="#000000" d="M531.9784,-615C531.9784,-615 479.2824,-615 479.2824,-615 476.4491,-615 473.6157,-612.1667 473.6157,-609.3333 473.6157,-609.3333 473.6157,-603.6667 473.6157,-603.6667 473.6157,-600.8333 476.4491,-598 479.2824,-598 479.2824,-598 531.9784,-598 531.9784,-598 534.8117,-598 537.645,-600.8333 537.645,-603.6667 537.645,-603.6667 537.645,-609.3333 537.645,-609.3333 537.645,-612.1667 534.8117,-615 531.9784,-615"/>
 <text text-anchor="middle" x="505.6304" y="-603.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">normalize.js</text>
 </a>
@@ -1242,7 +1242,7 @@
 <!-- src/main/ruleSet/validate.js -->
 <g id="node62" class="node">
 <title>src/main/ruleSet/validate.js</title>
-<g id="a_node62"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/ruleSet/validate.js" xlink:title="validate.js">
+<g id="a_node62"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/ruleSet/validate.js" xlink:title="validate.js">
 <path fill="#ffffcc" stroke="#000000" d="M527.9847,-586C527.9847,-586 483.276,-586 483.276,-586 480.4427,-586 477.6094,-583.1667 477.6094,-580.3333 477.6094,-580.3333 477.6094,-574.6667 477.6094,-574.6667 477.6094,-571.8333 480.4427,-569 483.276,-569 483.276,-569 527.9847,-569 527.9847,-569 530.818,-569 533.6514,-571.8333 533.6514,-574.6667 533.6514,-574.6667 533.6514,-580.3333 533.6514,-580.3333 533.6514,-583.1667 530.818,-586 527.9847,-586"/>
 <text text-anchor="middle" x="505.6304" y="-574.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">validate.js</text>
 </a>
@@ -1257,7 +1257,7 @@
 <!-- src/report/csv/index.js -->
 <g id="node64" class="node">
 <title>src/report/csv/index.js</title>
-<g id="a_node64"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/csv/index.js" xlink:title="index.js">
+<g id="a_node64"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/csv/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-2014C526.9637,-2014 484.297,-2014 484.297,-2014 481.4637,-2014 478.6304,-2011.1667 478.6304,-2008.3333 478.6304,-2008.3333 478.6304,-2002.6667 478.6304,-2002.6667 478.6304,-1999.8333 481.4637,-1997 484.297,-1997 484.297,-1997 526.9637,-1997 526.9637,-1997 529.797,-1997 532.6304,-1999.8333 532.6304,-2002.6667 532.6304,-2002.6667 532.6304,-2008.3333 532.6304,-2008.3333 532.6304,-2011.1667 529.797,-2014 526.9637,-2014"/>
 <text text-anchor="middle" x="505.6304" y="-2002.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1272,7 +1272,7 @@
 <!-- src/report/dot/common/richModuleColorScheme.json -->
 <g id="node69" class="node">
 <title>src/report/dot/common/richModuleColorScheme.json</title>
-<g id="a_node69"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/richModuleColorScheme.json" xlink:title="richModuleColorScheme.json">
+<g id="a_node69"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/richModuleColorScheme.json" xlink:title="richModuleColorScheme.json">
 <path fill="#ffee44" stroke="#000000" d="M882.0733,-1769C882.0733,-1769 760.2978,-1769 760.2978,-1769 757.4644,-1769 754.6311,-1766.1667 754.6311,-1763.3333 754.6311,-1763.3333 754.6311,-1757.6667 754.6311,-1757.6667 754.6311,-1754.8333 757.4644,-1752 760.2978,-1752 760.2978,-1752 882.0733,-1752 882.0733,-1752 884.9067,-1752 887.74,-1754.8333 887.74,-1757.6667 887.74,-1757.6667 887.74,-1763.3333 887.74,-1763.3333 887.74,-1766.1667 884.9067,-1769 882.0733,-1769"/>
 <text text-anchor="middle" x="821.1855" y="-1757.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">richModuleColorScheme.json</text>
 </a>
@@ -1287,7 +1287,7 @@
 <!-- src/report/dot/folderLevel/index.js -->
 <g id="node73" class="node">
 <title>src/report/dot/folderLevel/index.js</title>
-<g id="a_node73"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/index.js" xlink:title="index.js">
+<g id="a_node73"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1872C526.9637,-1872 484.297,-1872 484.297,-1872 481.4637,-1872 478.6304,-1869.1667 478.6304,-1866.3333 478.6304,-1866.3333 478.6304,-1860.6667 478.6304,-1860.6667 478.6304,-1857.8333 481.4637,-1855 484.297,-1855 484.297,-1855 526.9637,-1855 526.9637,-1855 529.797,-1855 532.6304,-1857.8333 532.6304,-1860.6667 532.6304,-1860.6667 532.6304,-1866.3333 532.6304,-1866.3333 532.6304,-1869.1667 529.797,-1872 526.9637,-1872"/>
 <text text-anchor="middle" x="505.6304" y="-1860.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1302,7 +1302,7 @@
 <!-- src/report/dot/moduleLevel/index.js -->
 <g id="node75" class="node">
 <title>src/report/dot/moduleLevel/index.js</title>
-<g id="a_node75"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/moduleLevel/index.js" xlink:title="index.js">
+<g id="a_node75"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/moduleLevel/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1696C526.9637,-1696 484.297,-1696 484.297,-1696 481.4637,-1696 478.6304,-1693.1667 478.6304,-1690.3333 478.6304,-1690.3333 478.6304,-1684.6667 478.6304,-1684.6667 478.6304,-1681.8333 481.4637,-1679 484.297,-1679 484.297,-1679 526.9637,-1679 526.9637,-1679 529.797,-1679 532.6304,-1681.8333 532.6304,-1684.6667 532.6304,-1684.6667 532.6304,-1690.3333 532.6304,-1690.3333 532.6304,-1693.1667 529.797,-1696 526.9637,-1696"/>
 <text text-anchor="middle" x="505.6304" y="-1684.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1317,7 +1317,7 @@
 <!-- src/report/err.js -->
 <g id="node76" class="node">
 <title>src/report/err.js</title>
-<g id="a_node76"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/err.js" xlink:title="err.js">
+<g id="a_node76"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/err.js" xlink:title="err.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1569C526.9637,-1569 484.297,-1569 484.297,-1569 481.4637,-1569 478.6304,-1566.1667 478.6304,-1563.3333 478.6304,-1563.3333 478.6304,-1557.6667 478.6304,-1557.6667 478.6304,-1554.8333 481.4637,-1552 484.297,-1552 484.297,-1552 526.9637,-1552 526.9637,-1552 529.797,-1552 532.6304,-1554.8333 532.6304,-1557.6667 532.6304,-1557.6667 532.6304,-1563.3333 532.6304,-1563.3333 532.6304,-1566.1667 529.797,-1569 526.9637,-1569"/>
 <text text-anchor="middle" x="505.6304" y="-1557.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">err.js</text>
 </a>
@@ -1332,7 +1332,7 @@
 <!-- src/report/html/index.js -->
 <g id="node78" class="node">
 <title>src/report/html/index.js</title>
-<g id="a_node78"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/html/index.js" xlink:title="index.js">
+<g id="a_node78"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/html/index.js" xlink:title="index.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1603C526.9637,-1603 484.297,-1603 484.297,-1603 481.4637,-1603 478.6304,-1600.1667 478.6304,-1597.3333 478.6304,-1597.3333 478.6304,-1591.6667 478.6304,-1591.6667 478.6304,-1588.8333 481.4637,-1586 484.297,-1586 484.297,-1586 526.9637,-1586 526.9637,-1586 529.797,-1586 532.6304,-1588.8333 532.6304,-1591.6667 532.6304,-1591.6667 532.6304,-1597.3333 532.6304,-1597.3333 532.6304,-1600.1667 529.797,-1603 526.9637,-1603"/>
 <text text-anchor="middle" x="505.6304" y="-1591.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">index.js</text>
 </a>
@@ -1347,7 +1347,7 @@
 <!-- src/report/json.js -->
 <g id="node79" class="node">
 <title>src/report/json.js</title>
-<g id="a_node79"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/json.js" xlink:title="json.js">
+<g id="a_node79"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/json.js" xlink:title="json.js">
 <path fill="#ffffcc" stroke="#000000" d="M526.9637,-1540C526.9637,-1540 484.297,-1540 484.297,-1540 481.4637,-1540 478.6304,-1537.1667 478.6304,-1534.3333 478.6304,-1534.3333 478.6304,-1528.6667 478.6304,-1528.6667 478.6304,-1525.8333 481.4637,-1523 484.297,-1523 484.297,-1523 526.9637,-1523 526.9637,-1523 529.797,-1523 532.6304,-1525.8333 532.6304,-1528.6667 532.6304,-1528.6667 532.6304,-1534.3333 532.6304,-1534.3333 532.6304,-1537.1667 529.797,-1540 526.9637,-1540"/>
 <text text-anchor="middle" x="505.6304" y="-1528.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">json.js</text>
 </a>
@@ -1362,7 +1362,7 @@
 <!-- src/main/options/defaults.json -->
 <g id="node56" class="node">
 <title>src/main/options/defaults.json</title>
-<g id="a_node56"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/options/defaults.json" xlink:title="defaults.json">
+<g id="a_node56"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/options/defaults.json" xlink:title="defaults.json">
 <path fill="#ffee44" stroke="#000000" d="M848.5532,-498C848.5532,-498 793.8179,-498 793.8179,-498 790.9845,-498 788.1512,-495.1667 788.1512,-492.3333 788.1512,-492.3333 788.1512,-486.6667 788.1512,-486.6667 788.1512,-483.8333 790.9845,-481 793.8179,-481 793.8179,-481 848.5532,-481 848.5532,-481 851.3866,-481 854.2199,-483.8333 854.2199,-486.6667 854.2199,-486.6667 854.2199,-492.3333 854.2199,-492.3333 854.2199,-495.1667 851.3866,-498 848.5532,-498"/>
 <text text-anchor="middle" x="821.1855" y="-486.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">defaults.json</text>
 </a>
@@ -1377,7 +1377,7 @@
 <!-- src/utl/safe&#45;regex.js -->
 <g id="node80" class="node">
 <title>src/utl/safe&#45;regex.js</title>
-<g id="a_node80"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/utl/safe-regex.js" xlink:title="safe&#45;regex.js">
+<g id="a_node80"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/utl/safe-regex.js" xlink:title="safe&#45;regex.js">
 <path fill="#ffffcc" stroke="#000000" d="M849.042,-699C849.042,-699 793.329,-699 793.329,-699 790.4957,-699 787.6624,-696.1667 787.6624,-693.3333 787.6624,-693.3333 787.6624,-687.6667 787.6624,-687.6667 787.6624,-684.8333 790.4957,-682 793.329,-682 793.329,-682 849.042,-682 849.042,-682 851.8754,-682 854.7087,-684.8333 854.7087,-687.6667 854.7087,-687.6667 854.7087,-693.3333 854.7087,-693.3333 854.7087,-696.1667 851.8754,-699 849.042,-699"/>
 <text text-anchor="middle" x="821.1855" y="-687.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">safe&#45;regex.js</text>
 </a>
@@ -1398,7 +1398,7 @@
 <!-- src/main/ruleSet/jsonschema.json -->
 <g id="node60" class="node">
 <title>src/main/ruleSet/jsonschema.json</title>
-<g id="a_node60"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/main/ruleSet/jsonschema.json" xlink:title="jsonschema.json">
+<g id="a_node60"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/main/ruleSet/jsonschema.json" xlink:title="jsonschema.json">
 <path fill="#ffee44" stroke="#000000" d="M691.1414,-586C691.1414,-586 619.4064,-586 619.4064,-586 616.5731,-586 613.7397,-583.1667 613.7397,-580.3333 613.7397,-580.3333 613.7397,-574.6667 613.7397,-574.6667 613.7397,-571.8333 616.5731,-569 619.4064,-569 619.4064,-569 691.1414,-569 691.1414,-569 693.9748,-569 696.8081,-571.8333 696.8081,-574.6667 696.8081,-574.6667 696.8081,-580.3333 696.8081,-580.3333 696.8081,-583.1667 693.9748,-586 691.1414,-586"/>
 <text text-anchor="middle" x="655.2739" y="-574.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">jsonschema.json</text>
 </a>
@@ -1425,7 +1425,7 @@
 <!-- src/report/csv/csv.template.js -->
 <g id="node63" class="node">
 <title>src/report/csv/csv.template.js</title>
-<g id="a_node63"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/csv/csv.template.js" xlink:title="csv.template.js">
+<g id="a_node63"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/csv/csv.template.js" xlink:title="csv.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M686.9634,-2014C686.9634,-2014 623.5845,-2014 623.5845,-2014 620.7512,-2014 617.9178,-2011.1667 617.9178,-2008.3333 617.9178,-2008.3333 617.9178,-2002.6667 617.9178,-2002.6667 617.9178,-1999.8333 620.7512,-1997 623.5845,-1997 623.5845,-1997 686.9634,-1997 686.9634,-1997 689.7967,-1997 692.63,-1999.8333 692.63,-2002.6667 692.63,-2002.6667 692.63,-2008.3333 692.63,-2008.3333 692.63,-2011.1667 689.7967,-2014 686.9634,-2014"/>
 <text text-anchor="middle" x="655.2739" y="-2002.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">csv.template.js</text>
 </a>
@@ -1440,7 +1440,7 @@
 <!-- src/report/dependencyToIncidenceTransformer.js -->
 <g id="node65" class="node">
 <title>src/report/dependencyToIncidenceTransformer.js</title>
-<g id="a_node65"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dependencyToIncidenceTransformer.js" xlink:title="dependencyToIncidenceTransformer.js">
+<g id="a_node65"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dependencyToIncidenceTransformer.js" xlink:title="dependencyToIncidenceTransformer.js">
 <path fill="#ffffcc" stroke="#000000" d="M734.8687,-1654C734.8687,-1654 575.6792,-1654 575.6792,-1654 572.8458,-1654 570.0125,-1651.1667 570.0125,-1648.3333 570.0125,-1648.3333 570.0125,-1642.6667 570.0125,-1642.6667 570.0125,-1639.8333 572.8458,-1637 575.6792,-1637 575.6792,-1637 734.8687,-1637 734.8687,-1637 737.702,-1637 740.5354,-1639.8333 740.5354,-1642.6667 740.5354,-1642.6667 740.5354,-1648.3333 740.5354,-1648.3333 740.5354,-1651.1667 737.702,-1654 734.8687,-1654"/>
 <text text-anchor="middle" x="655.2739" y="-1642.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">dependencyToIncidenceTransformer.js</text>
 </a>
@@ -1455,7 +1455,7 @@
 <!-- src/report/dot/common/coloring.js -->
 <g id="node66" class="node">
 <title>src/report/dot/common/coloring.js</title>
-<g id="a_node66"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/coloring.js" xlink:title="coloring.js">
+<g id="a_node66"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/coloring.js" xlink:title="coloring.js">
 <path fill="#ffffcc" stroke="#000000" d="M677.6269,-1784C677.6269,-1784 632.921,-1784 632.921,-1784 630.0876,-1784 627.2543,-1781.1667 627.2543,-1778.3333 627.2543,-1778.3333 627.2543,-1772.6667 627.2543,-1772.6667 627.2543,-1769.8333 630.0876,-1767 632.921,-1767 632.921,-1767 677.6269,-1767 677.6269,-1767 680.4602,-1767 683.2935,-1769.8333 683.2935,-1772.6667 683.2935,-1772.6667 683.2935,-1778.3333 683.2935,-1778.3333 683.2935,-1781.1667 680.4602,-1784 677.6269,-1784"/>
 <text text-anchor="middle" x="655.2739" y="-1772.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">coloring.js</text>
 </a>
@@ -1470,7 +1470,7 @@
 <!-- src/report/dot/common/compareOnSource.js -->
 <g id="node67" class="node">
 <title>src/report/dot/common/compareOnSource.js</title>
-<g id="a_node67"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/compareOnSource.js" xlink:title="compareOnSource.js">
+<g id="a_node67"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/compareOnSource.js" xlink:title="compareOnSource.js">
 <path fill="#ffffcc" stroke="#000000" d="M699.6459,-1755C699.6459,-1755 610.9019,-1755 610.9019,-1755 608.0686,-1755 605.2353,-1752.1667 605.2353,-1749.3333 605.2353,-1749.3333 605.2353,-1743.6667 605.2353,-1743.6667 605.2353,-1740.8333 608.0686,-1738 610.9019,-1738 610.9019,-1738 699.6459,-1738 699.6459,-1738 702.4792,-1738 705.3126,-1740.8333 705.3126,-1743.6667 705.3126,-1743.6667 705.3126,-1749.3333 705.3126,-1749.3333 705.3126,-1752.1667 702.4792,-1755 699.6459,-1755"/>
 <text text-anchor="middle" x="655.2739" y="-1743.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">compareOnSource.js</text>
 </a>
@@ -1479,7 +1479,7 @@
 <!-- src/report/dot/common/folderify.js -->
 <g id="node68" class="node">
 <title>src/report/dot/common/folderify.js</title>
-<g id="a_node68"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/common/folderify.js" xlink:title="folderify.js">
+<g id="a_node68"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/common/folderify.js" xlink:title="folderify.js">
 <path fill="#ffffcc" stroke="#000000" d="M677.4571,-1813C677.4571,-1813 633.0908,-1813 633.0908,-1813 630.2574,-1813 627.4241,-1810.1667 627.4241,-1807.3333 627.4241,-1807.3333 627.4241,-1801.6667 627.4241,-1801.6667 627.4241,-1798.8333 630.2574,-1796 633.0908,-1796 633.0908,-1796 677.4571,-1796 677.4571,-1796 680.2904,-1796 683.1237,-1798.8333 683.1237,-1801.6667 683.1237,-1801.6667 683.1237,-1807.3333 683.1237,-1807.3333 683.1237,-1810.1667 680.2904,-1813 677.4571,-1813"/>
 <text text-anchor="middle" x="655.2739" y="-1801.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">folderify.js</text>
 </a>
@@ -1488,7 +1488,7 @@
 <!-- src/report/dot/folderLevel/consolidateModuleDependencies.js -->
 <g id="node70" class="node">
 <title>src/report/dot/folderLevel/consolidateModuleDependencies.js</title>
-<g id="a_node70"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/consolidateModuleDependencies.js" xlink:title="consolidateModuleDependencies.js">
+<g id="a_node70"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/consolidateModuleDependencies.js" xlink:title="consolidateModuleDependencies.js">
 <path fill="#ffffcc" stroke="#000000" d="M728.1996,-1872C728.1996,-1872 582.3483,-1872 582.3483,-1872 579.5149,-1872 576.6816,-1869.1667 576.6816,-1866.3333 576.6816,-1866.3333 576.6816,-1860.6667 576.6816,-1860.6667 576.6816,-1857.8333 579.5149,-1855 582.3483,-1855 582.3483,-1855 728.1996,-1855 728.1996,-1855 731.0329,-1855 733.8662,-1857.8333 733.8662,-1860.6667 733.8662,-1860.6667 733.8662,-1866.3333 733.8662,-1866.3333 733.8662,-1869.1667 731.0329,-1872 728.1996,-1872"/>
 <text text-anchor="middle" x="655.2739" y="-1860.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">consolidateModuleDependencies.js</text>
 </a>
@@ -1497,7 +1497,7 @@
 <!-- src/report/dot/folderLevel/consolidateModules.js -->
 <g id="node71" class="node">
 <title>src/report/dot/folderLevel/consolidateModules.js</title>
-<g id="a_node71"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/consolidateModules.js" xlink:title="consolidateModules.js">
+<g id="a_node71"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/consolidateModules.js" xlink:title="consolidateModules.js">
 <path fill="#ffffcc" stroke="#000000" d="M701.658,-1901C701.658,-1901 608.8898,-1901 608.8898,-1901 606.0565,-1901 603.2232,-1898.1667 603.2232,-1895.3333 603.2232,-1895.3333 603.2232,-1889.6667 603.2232,-1889.6667 603.2232,-1886.8333 606.0565,-1884 608.8898,-1884 608.8898,-1884 701.658,-1884 701.658,-1884 704.4914,-1884 707.3247,-1886.8333 707.3247,-1889.6667 707.3247,-1889.6667 707.3247,-1895.3333 707.3247,-1895.3333 707.3247,-1898.1667 704.4914,-1901 701.658,-1901"/>
 <text text-anchor="middle" x="655.2739" y="-1889.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">consolidateModules.js</text>
 </a>
@@ -1506,7 +1506,7 @@
 <!-- src/report/dot/folderLevel/ddot.template.js -->
 <g id="node72" class="node">
 <title>src/report/dot/folderLevel/ddot.template.js</title>
-<g id="a_node72"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/folderLevel/ddot.template.js" xlink:title="ddot.template.js">
+<g id="a_node72"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/folderLevel/ddot.template.js" xlink:title="ddot.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M689.1447,-1930C689.1447,-1930 621.4031,-1930 621.4031,-1930 618.5698,-1930 615.7364,-1927.1667 615.7364,-1924.3333 615.7364,-1924.3333 615.7364,-1918.6667 615.7364,-1918.6667 615.7364,-1915.8333 618.5698,-1913 621.4031,-1913 621.4031,-1913 689.1447,-1913 689.1447,-1913 691.9781,-1913 694.8114,-1915.8333 694.8114,-1918.6667 694.8114,-1918.6667 694.8114,-1924.3333 694.8114,-1924.3333 694.8114,-1927.1667 691.9781,-1930 689.1447,-1930"/>
 <text text-anchor="middle" x="655.2739" y="-1918.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">ddot.template.js</text>
 </a>
@@ -1551,7 +1551,7 @@
 <!-- src/report/dot/moduleLevel/dot.template.js -->
 <g id="node74" class="node">
 <title>src/report/dot/moduleLevel/dot.template.js</title>
-<g id="a_node74"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/moduleLevel/dot.template.js" xlink:title="dot.template.js">
+<g id="a_node74"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/dot/moduleLevel/dot.template.js" xlink:title="dot.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M686.6395,-1696C686.6395,-1696 623.9084,-1696 623.9084,-1696 621.075,-1696 618.2417,-1693.1667 618.2417,-1690.3333 618.2417,-1690.3333 618.2417,-1684.6667 618.2417,-1684.6667 618.2417,-1681.8333 621.075,-1679 623.9084,-1679 623.9084,-1679 686.6395,-1679 686.6395,-1679 689.4728,-1679 692.3062,-1681.8333 692.3062,-1684.6667 692.3062,-1684.6667 692.3062,-1690.3333 692.3062,-1690.3333 692.3062,-1693.1667 689.4728,-1696 686.6395,-1696"/>
 <text text-anchor="middle" x="655.2739" y="-1684.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">dot.template.js</text>
 </a>
@@ -1584,7 +1584,7 @@
 <!-- src/report/html/html.template.js -->
 <g id="node77" class="node">
 <title>src/report/html/html.template.js</title>
-<g id="a_node77"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/report/html/html.template.js" xlink:title="html.template.js">
+<g id="a_node77"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/report/html/html.template.js" xlink:title="html.template.js">
 <path fill="#ffffcc" stroke="#000000" d="M689.1292,-1603C689.1292,-1603 621.4186,-1603 621.4186,-1603 618.5853,-1603 615.752,-1600.1667 615.752,-1597.3333 615.752,-1597.3333 615.752,-1591.6667 615.752,-1591.6667 615.752,-1588.8333 618.5853,-1586 621.4186,-1586 621.4186,-1586 689.1292,-1586 689.1292,-1586 691.9626,-1586 694.7959,-1588.8333 694.7959,-1591.6667 694.7959,-1591.6667 694.7959,-1597.3333 694.7959,-1597.3333 694.7959,-1600.1667 691.9626,-1603 689.1292,-1603"/>
 <text text-anchor="middle" x="655.2739" y="-1591.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">html.template.js</text>
 </a>
@@ -1605,7 +1605,7 @@
 <!-- src/validate/matchDependencyRule.js -->
 <g id="node83" class="node">
 <title>src/validate/matchDependencyRule.js</title>
-<g id="a_node83"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/validate/matchDependencyRule.js" xlink:title="matchDependencyRule.js">
+<g id="a_node83"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/matchDependencyRule.js" xlink:title="matchDependencyRule.js">
 <path fill="#ffffcc" stroke="#000000" d="M1034.6179,-1452C1034.6179,-1452 927.8392,-1452 927.8392,-1452 925.0058,-1452 922.1725,-1449.1667 922.1725,-1446.3333 922.1725,-1446.3333 922.1725,-1440.6667 922.1725,-1440.6667 922.1725,-1437.8333 925.0058,-1435 927.8392,-1435 927.8392,-1435 1034.6179,-1435 1034.6179,-1435 1037.4512,-1435 1040.2845,-1437.8333 1040.2845,-1440.6667 1040.2845,-1440.6667 1040.2845,-1446.3333 1040.2845,-1446.3333 1040.2845,-1449.1667 1037.4512,-1452 1034.6179,-1452"/>
 <text text-anchor="middle" x="981.2285" y="-1440.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">matchDependencyRule.js</text>
 </a>
@@ -1620,7 +1620,7 @@
 <!-- src/validate/matchModuleRule.js -->
 <g id="node84" class="node">
 <title>src/validate/matchModuleRule.js</title>
-<g id="a_node84"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/validate/matchModuleRule.js" xlink:title="matchModuleRule.js">
+<g id="a_node84"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/matchModuleRule.js" xlink:title="matchModuleRule.js">
 <path fill="#ffffcc" stroke="#000000" d="M1024.0991,-1481C1024.0991,-1481 938.358,-1481 938.358,-1481 935.5246,-1481 932.6913,-1478.1667 932.6913,-1475.3333 932.6913,-1475.3333 932.6913,-1469.6667 932.6913,-1469.6667 932.6913,-1466.8333 935.5246,-1464 938.358,-1464 938.358,-1464 1024.0991,-1464 1024.0991,-1464 1026.9324,-1464 1029.7657,-1466.8333 1029.7657,-1469.6667 1029.7657,-1469.6667 1029.7657,-1475.3333 1029.7657,-1475.3333 1029.7657,-1478.1667 1026.9324,-1481 1024.0991,-1481"/>
 <text text-anchor="middle" x="981.2285" y="-1469.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">matchModuleRule.js</text>
 </a>
@@ -1635,7 +1635,7 @@
 <!-- src/validate/isModuleOnlyRule.js -->
 <g id="node82" class="node">
 <title>src/validate/isModuleOnlyRule.js</title>
-<g id="a_node82"><a xlink:href="https:/github.com/sverweij/dependency-cruiser/blob/develop/src/validate/isModuleOnlyRule.js" xlink:title="isModuleOnlyRule.js">
+<g id="a_node82"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop//src/validate/isModuleOnlyRule.js" xlink:title="isModuleOnlyRule.js">
 <path fill="#ffffcc" stroke="#000000" d="M1171.6478,-1466C1171.6478,-1466 1084.9157,-1466 1084.9157,-1466 1082.0824,-1466 1079.249,-1463.1667 1079.249,-1460.3333 1079.249,-1460.3333 1079.249,-1454.6667 1079.249,-1454.6667 1079.249,-1451.8333 1082.0824,-1449 1084.9157,-1449 1084.9157,-1449 1171.6478,-1449 1171.6478,-1449 1174.4811,-1449 1177.3145,-1451.8333 1177.3145,-1454.6667 1177.3145,-1454.6667 1177.3145,-1460.3333 1177.3145,-1460.3333 1177.3145,-1463.1667 1174.4811,-1466 1171.6478,-1466"/>
 <text text-anchor="middle" x="1128.2817" y="-1454.8" font-family="Helvetica,sans-Serif" font-size="9.00" fill="#000000">isModuleOnlyRule.js</text>
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.13.3-beta-1",
+  "version": "4.13.3-beta-2",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.13.3-beta-2",
+  "version": "4.13.3-beta-3",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/report/dot/moduleLevel/index.js
+++ b/src/report/dot/moduleLevel/index.js
@@ -53,7 +53,7 @@ function extractFirstTransgression(pModule){
  */
 function concatenateify(pPrefix, pSource) {
     if (pPrefix.match(/^[a-z]+:\/\//)) {
-        return `${pPrefix}/${pSource}`;
+        return `${pPrefix}${pSource}`;
     } else {
         return path.join(pPrefix, pSource);
     }

--- a/src/report/dot/moduleLevel/index.js
+++ b/src/report/dot/moduleLevel/index.js
@@ -1,5 +1,6 @@
 const path            = require('path').posix;
-const Handlebars      = require("handlebars/runtime");
+const Handlebars      = require('handlebars/runtime');
+const _get            = require('lodash/get');
 const coloring        = require('../common/coloring');
 const folderify       = require('../common/folderify');
 const compareOnSource = require("../common/compareOnSource");
@@ -38,14 +39,34 @@ function extractFirstTransgression(pModule){
     );
 }
 
+/**
+ * Sort of smartly concatenate the given prefix and source:
+ *
+ * if it's an uri pattern (e.g. https://yadda, file://snorkel/bla)
+ * simply concat.
+ *
+ * in all other cases path.posix.join the two
+ *
+ * @param {string} pPrefix - prefix
+ * @param {string} pSource - filename
+ * @return {string} prefix and filename concatenated
+ */
+function concatenateify(pPrefix, pSource) {
+    if (pPrefix.match(/^[a-z]+:\/\//)) {
+        return `${pPrefix}/${pSource}`;
+    } else {
+        return path.join(pPrefix, pSource);
+    }
+}
+
 function addURL(pInput) {
-    const lPrefix = pInput.summary.optionsUsed ? pInput.summary.optionsUsed.prefix || "" : "";
+    const lPrefix = _get(pInput, "summary.optionsUsed.prefix", '');
 
     return (pModule) =>
         Object.assign(
             {},
             pModule,
-            (pModule.coreModule || pModule.couldNotResolve) ? {} : {url: `${path.join(lPrefix, pModule.source)}`}
+            (pModule.coreModule || pModule.couldNotResolve) ? {} : {url: concatenateify(lPrefix, pModule.source)}
         );
 }
 

--- a/test/report/dot/moduleLevel/index.spec.js
+++ b/test/report/dot/moduleLevel/index.spec.js
@@ -5,11 +5,15 @@ const deps             = require('../../fixtures/cjs-no-dependency-valid.json');
 const unresolvableDeps = require('../../fixtures/es6-unresolvable-deps.json');
 const doNotFollowDeps  = require('../../fixtures/do-not-follow-deps.json');
 const orphanDeps       = require('../../fixtures/orphan-deps.json');
+const prefixUri        = require('../../fixtures/prefix-uri.json');
+const prefixNonUri     = require('../../fixtures/prefix-non-uri.json');
 
 const clusterlessFixture  = fs.readFileSync('test/report/fixtures/clusterless.dot', 'utf8');
 const unresolvableFixture = fs.readFileSync('test/report/fixtures/unresolvable.dot', 'utf8');
 const doNotFollowFixture  = fs.readFileSync('test/report/fixtures/donotfollow.dot', 'utf8');
 const orphanFixture       = fs.readFileSync('test/report/fixtures/orphan-deps.dot', 'utf8');
+const prefixUriFixture    = fs.readFileSync('test/report/fixtures/prefix-uri.dot', 'utf8');
+const prefixNonUriFixture = fs.readFileSync('test/report/fixtures/prefix-non-uri.dot', 'utf8');
 
 describe("report/dot/moduleLevel reporter", () => {
     it("renders a dot - modules in the root don't come in a cluster", () => {
@@ -28,6 +32,13 @@ describe("report/dot/moduleLevel reporter", () => {
         expect(render(orphanDeps).modules).to.deep.equal(orphanFixture);
     });
 
+    it("renders a dot - uri prefix get concatenated", () => {
+        expect(render(prefixUri).modules).to.deep.equal(prefixUriFixture);
+    });
+
+    it("renders a dot - non-ur prefixes get path.posix.joined", () => {
+        expect(render(prefixNonUri).modules).to.deep.equal(prefixNonUriFixture);
+    });
 });
 
 /* eslint max-len: 0 */

--- a/test/report/fixtures/prefix-non-uri.dot
+++ b/test/report/fixtures/prefix-non-uri.dot
@@ -1,0 +1,17 @@
+digraph "dependency-cruiser output"{
+    ordering=out
+    rankdir=LR
+    splines=true
+    overlap=false
+    nodesep=0.16
+    ranksep=0.18
+    fontname="Helvetica-bold"
+    fontsize=9
+    style="rounded,bold"
+    compound=true
+    node [shape=box style="rounded, filled" fillcolor="#ffffcc" height=0.2 fontname=Helvetica fontsize=9]
+    edge [color=black arrowhead=normal fontname=Helvetica fontsize=9]
+
+    "remi.js" [label="remi.js" color="red" fontcolor="red" tooltip="no-orphans" URL="ladida/remi.js"]
+
+}

--- a/test/report/fixtures/prefix-non-uri.json
+++ b/test/report/fixtures/prefix-non-uri.json
@@ -1,0 +1,47 @@
+{
+    "modules": [
+        {
+            "source": "remi.js",
+            "dependencies": [],
+            "orphan": true,
+            "valid": false,
+            "rules": [
+                {
+                    "severity": "error",
+                    "name": "no-orphans"
+                }
+            ]
+        }
+    ],
+    "summary": {
+        "violations": [
+            {
+                "from": "remi.js",
+                "to": "remi.js",
+                "rule": {
+                    "severity": "error",
+                    "name": "no-orphans"
+                }
+            }
+        ],
+        "error": 1,
+        "warn": 0,
+        "info": 0,
+        "totalCruised": 1,
+        "optionsUsed": {
+            "rulesFile": ".dependency-cruiser-custom.json",
+            "prefix": "ladida/",
+            "outputTo": "-",
+            "doNotFollow": "^node_modules",
+            "exclude": "fixtures",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "outputType": "json",
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
+        }
+    }
+}

--- a/test/report/fixtures/prefix-uri.dot
+++ b/test/report/fixtures/prefix-uri.dot
@@ -12,6 +12,6 @@ digraph "dependency-cruiser output"{
     node [shape=box style="rounded, filled" fillcolor="#ffffcc" height=0.2 fontname=Helvetica fontsize=9]
     edge [color=black arrowhead=normal fontname=Helvetica fontsize=9]
 
-    "remi.js" [label="remi.js" color="red" fontcolor="red" tooltip="no-orphans" URL="testprefix://ladida//remi.js"]
+    "remi.js" [label="remi.js" color="red" fontcolor="red" tooltip="no-orphans" URL="testprefix://ladida/remi.js"]
 
 }

--- a/test/report/fixtures/prefix-uri.dot
+++ b/test/report/fixtures/prefix-uri.dot
@@ -1,0 +1,17 @@
+digraph "dependency-cruiser output"{
+    ordering=out
+    rankdir=LR
+    splines=true
+    overlap=false
+    nodesep=0.16
+    ranksep=0.18
+    fontname="Helvetica-bold"
+    fontsize=9
+    style="rounded,bold"
+    compound=true
+    node [shape=box style="rounded, filled" fillcolor="#ffffcc" height=0.2 fontname=Helvetica fontsize=9]
+    edge [color=black arrowhead=normal fontname=Helvetica fontsize=9]
+
+    "remi.js" [label="remi.js" color="red" fontcolor="red" tooltip="no-orphans" URL="testprefix://ladida//remi.js"]
+
+}

--- a/test/report/fixtures/prefix-uri.json
+++ b/test/report/fixtures/prefix-uri.json
@@ -1,0 +1,47 @@
+{
+    "modules": [
+        {
+            "source": "remi.js",
+            "dependencies": [],
+            "orphan": true,
+            "valid": false,
+            "rules": [
+                {
+                    "severity": "error",
+                    "name": "no-orphans"
+                }
+            ]
+        }
+    ],
+    "summary": {
+        "violations": [
+            {
+                "from": "remi.js",
+                "to": "remi.js",
+                "rule": {
+                    "severity": "error",
+                    "name": "no-orphans"
+                }
+            }
+        ],
+        "error": 1,
+        "warn": 0,
+        "info": 0,
+        "totalCruised": 1,
+        "optionsUsed": {
+            "rulesFile": ".dependency-cruiser-custom.json",
+            "prefix": "testprefix://ladida/",
+            "outputTo": "-",
+            "doNotFollow": "^node_modules",
+            "exclude": "fixtures",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "outputType": "json",
+            "tsPreCompilationDeps": false,
+            "preserveSymlinks": false
+        }
+    }
+}


### PR DESCRIPTION
## Current situation
Prefixes in links in the dot output get `path.posix.join`ed to the source path. That works fine for regular file prefixes, but doesn't for uri's; `path.join` transforms `https://www.aapnootmies.org` to `https:/www.aapnootmies.org`.

## Situation after merging this PR
To resolve that:
- uri like prefixes just get concatenated
- all others retain the existing treatment

## How Has This Been Tested?
- [x] automated non-regression tests
- [x] unit tests for new code

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
