### PR TITLE
fix(extract): parse and analyze only once

### DIFF
--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -81,6 +81,11 @@ function extractTrippleSlashDirectives(pAST) {
     );
 }
 
+function isRequireCallExpression(pASTNode) {
+    return typescript.SyntaxKind[pASTNode.kind] === 'CallExpression' &&
+        typescript.SyntaxKind[pASTNode.expression.originalKeywordKind] === 'RequireKeyword';
+}
+
 /**
  * returns an array of all commonJS in the AST (toplevel or otherwise)
  *
@@ -91,8 +96,7 @@ function extractCommonJS(pAST) {
     let lResult = [];
 
     function walk (pASTNode) {
-        if (typescript.SyntaxKind[pASTNode.kind] === 'CallExpression' &&
-            typescript.SyntaxKind[pASTNode.expression.originalKeywordKind] === 'RequireKeyword') {
+        if (isRequireCallExpression(pASTNode)) {
             const lFirstArgument = pASTNode.arguments.shift();
 
             if (lFirstArgument) {
@@ -123,3 +127,5 @@ module.exports = (pTypeScriptAST) =>
             .concat(extractTrippleSlashDirectives(pTypeScriptAST))
             .concat(extractCommonJS(pTypeScriptAST))
         : [];
+
+

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -1,3 +1,4 @@
+/* eslint-disable valid-jsdoc */
 const tryRequire = require('semver-try-require');
 const $package   = require('../../../package.json');
 
@@ -7,6 +8,14 @@ const typescript = tryRequire('typescript', $package.supportedTranspilers.typesc
  * Both extractImport* assume the imports/ exports can only occur at
  * top level. AFAIK this the only place they're allowed, so we should
  * be good. Otherwise we'll need to walk the tree.
+ */
+
+/**
+ * Get all import and export statements from the top level AST node
+ *
+ * @param {import("typescript").Node} pAST - the (top-level in this case) AST node
+ * @returns {{moduleName: string, moduleSystem: string}[]} - all import and export statements in the
+ *                                  (top level) AST node
  */
 function extractImportsAndExports(pAST) {
     return pAST.statements
@@ -22,6 +31,13 @@ function extractImportsAndExports(pAST) {
         }));
 }
 
+/**
+ * Get all import equals statements from the top level AST node
+ *
+ * @param {import("typescript").Node} pAST - the (top-level in this case) AST node
+ * @returns {{moduleName: string, moduleSystem: string}[]} - all import equals statements in the
+ *                                  (top level) AST node
+ */
 function extractImportEquals(pAST) {
     return pAST.statements
         .filter(pStatement =>
@@ -39,8 +55,8 @@ function extractImportEquals(pAST) {
  * might be wise to distinguish the three types of /// directive that
  * can come out of this as the resolution algorithm might differ
  *
- * @param {*} pAST - typescript syntax tree
- * @returns {object} - 'tripple slash' dependencies
+ * @param {import("typescript").Node} pAST - typescript syntax tree
+ * @returns {{moduleName: string, moduleSystem: string}[]} - 'tripple slash' dependencies
  */
 function extractTrippleSlashDirectives(pAST) {
     return pAST.referencedFiles.map(
@@ -65,9 +81,45 @@ function extractTrippleSlashDirectives(pAST) {
     );
 }
 
+/**
+ * returns an array of all commonJS in the AST (toplevel or otherwise)
+ *
+ * @param {import("typescript").Node} pAST - typescript syntax tree
+ * @returns {{moduleName: string, moduleSystem: string}[]} - all commonJS dependencies
+ */
+function extractCommonJS(pAST) {
+    let lResult = [];
+
+    function walk (pASTNode) {
+        if (typescript.SyntaxKind[pASTNode.kind] === 'CallExpression' &&
+            typescript.SyntaxKind[pASTNode.expression.originalKeywordKind] === 'RequireKeyword') {
+            const lFirstArgument = pASTNode.arguments.shift();
+
+            if (lFirstArgument) {
+                lResult.push({
+                    moduleName: lFirstArgument.text,
+                    moduleSystem: 'cjs'
+                });
+            }
+        }
+        typescript.forEachChild(pASTNode, walk);
+    }
+
+    walk(pAST);
+
+    return lResult;
+}
+
+
+/**
+ * returns all dependencies in the (top level) AST
+ *
+ * @type {(pTypeScriptAST: import("typescript").Node) => {moduleName: string, moduleSystem: string}[]}
+ */
 module.exports = (pTypeScriptAST) =>
     Boolean(typescript)
         ? extractImportsAndExports(pTypeScriptAST)
             .concat(extractImportEquals(pTypeScriptAST))
             .concat(extractTrippleSlashDirectives(pTypeScriptAST))
+            .concat(extractCommonJS(pTypeScriptAST))
         : [];

--- a/test/extract/ast-extractors/extract-typescript-commonjs.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-commonjs.spec.js
@@ -15,4 +15,71 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
             ]
         );
     });
+
+    it("extracts regular require as a const, let or var", () => {
+        expect(
+            extractTypescript(
+                `const lala1 = require('legit-one');
+                 let lala2 = require('legit-two');
+                 var lala3 = require('legit-three');`
+            )
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: 'legit-one',
+                    moduleSystem: 'cjs'
+                },
+                {
+                    moduleName: 'legit-two',
+                    moduleSystem: 'cjs'
+                },
+                {
+                    moduleName: 'legit-three',
+                    moduleSystem: 'cjs'
+                }
+            ]
+        );
+    });
+
+    it("extracts regular requires that are not on the top level in the AST", () => {
+        expect(
+            extractTypescript(
+                `function f(x) {
+                    if(x > 0) {
+                        return require('midash')
+                    } else {
+                        const hi = require('slodash').splut();
+                        for (i=0;i<10;i++) {
+                            if (hi(i)) {
+                                return require('hidash');
+                            }
+                        }
+                    }
+                }`
+            )
+        ).to.deep.equal(
+            [{
+                moduleName: 'midash',
+                moduleSystem: 'cjs'
+            },
+            {
+                moduleName: 'slodash',
+                moduleSystem: 'cjs'
+            },
+            {
+                moduleName: 'hidash',
+                moduleSystem: 'cjs'
+            }]
+        );
+    });
+
+    it("ignores regular require without parameters", () => {
+        expect(
+            extractTypescript(
+                "const lala = require()"
+            )
+        ).to.deep.equal(
+            []
+        );
+    });
 });

--- a/test/extract/fixtures/ts-recursive.json
+++ b/test/extract/fixtures/ts-recursive.json
@@ -69,6 +69,20 @@
                         "circular": false
                     },
                     {
+                        "resolved": "fs",
+                        "coreModule": true,
+                        "dependencyTypes": [
+                            "core"
+                        ],
+                        "followable": false,
+                        "matchesDoNotFollow": false,
+                        "couldNotResolve": false,
+                        "module": "fs",
+                        "moduleSystem": "cjs",
+                        "valid": true,
+                        "circular": false
+                    },
+                    {
                         "resolved": "path",
                         "coreModule": true,
                         "dependencyTypes": [
@@ -83,6 +97,18 @@
                         "circular": false
                     }
                 ],
+                "valid": true
+            },
+            {
+                "source": "fs",
+                "followable": false,
+                "matchesDoNotFollow": false,
+                "coreModule": true,
+                "couldNotResolve": false,
+                "dependencyTypes": [
+                    "core"
+                ],
+                "dependencies": [],
                 "valid": true
             },
             {

--- a/test/extract/fixtures/ts.json
+++ b/test/extract/fixtures/ts.json
@@ -54,6 +54,18 @@
                 "couldNotResolve": false
             },
             {
+                "module": "fs",
+                "resolved": "fs",
+                "moduleSystem": "cjs",
+                "coreModule": true,
+                "dependencyTypes": [
+                    "core"
+                ],
+                "followable": false,
+                "matchesDoNotFollow": false,
+                "couldNotResolve": false
+            },
+            {
                 "module": "path",
                 "resolved": "path",
                 "moduleSystem": "es6",

--- a/test/extract/fixtures/ts/index.ts
+++ b/test/extract/fixtures/ts/index.ts
@@ -4,5 +4,6 @@ import {Ka, Ching} from "./sub/kaching";
 export { Ka, Ching };
 export * from "./sub/willBeReExported";
 import * as path from "path";
+const fs = require('fs');
 
 console.log(sub.version, thing(2), '=== 8', path.delimiter);

--- a/test/main/fixtures/ts-no-precomp-cjs.json
+++ b/test/main/fixtures/ts-no-precomp-cjs.json
@@ -1,0 +1,68 @@
+{
+    "modules": [
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/imported-from-index-but-not-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./also-used",
+                    "moduleSystem": "cjs",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts",
+                    "valid": true
+                },
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./definitely-used",
+                    "moduleSystem": "cjs",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts",
+                    "valid": true
+                }
+            ],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/index.ts",
+            "valid": true
+        }
+    ],
+    "summary": {
+        "error": 0,
+        "info": 0,
+        "optionsUsed": {
+            "externalModuleResolutionStrategy": "node_modules",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "preserveSymlinks": false,
+            "tsPreCompilationDeps": false
+        },
+        "totalCruised": 4,
+        "violations": [],
+        "warn": 0
+    }
+}

--- a/test/main/fixtures/ts-no-precomp-es.json
+++ b/test/main/fixtures/ts-no-precomp-es.json
@@ -1,0 +1,68 @@
+{
+    "modules": [
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-es/imported-from-index-but-not-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./also-used",
+                    "moduleSystem": "cjs",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts",
+                    "valid": true
+                },
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./definitely-used",
+                    "moduleSystem": "es6",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts",
+                    "valid": true
+                }
+            ],
+            "source": "test/main/fixtures/ts-precompilation-deps-off-es/index.ts",
+            "valid": true
+        }
+    ],
+    "summary": {
+        "error": 0,
+        "info": 0,
+        "optionsUsed": {
+            "externalModuleResolutionStrategy": "node_modules",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "preserveSymlinks": false,
+            "tsPreCompilationDeps": false
+        },
+        "totalCruised": 4,
+        "violations": [],
+        "warn": 0
+    }
+}

--- a/test/main/fixtures/ts-precomp-cjs.json
+++ b/test/main/fixtures/ts-precomp-cjs.json
@@ -1,0 +1,81 @@
+{
+    "modules": [
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./also-used",
+                    "moduleSystem": "cjs",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts",
+                    "valid": true
+                },
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./definitely-used",
+                    "moduleSystem": "es6",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts",
+                    "valid": true
+                },
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./imported-from-index-but-not-used",
+                    "moduleSystem": "es6",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts",
+                    "valid": true
+                }
+            ],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/index.ts",
+            "valid": true
+        }
+    ],
+    "summary": {
+        "error": 0,
+        "info": 0,
+        "optionsUsed": {
+            "externalModuleResolutionStrategy": "node_modules",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "preserveSymlinks": false,
+            "tsPreCompilationDeps": true
+        },
+        "totalCruised": 4,
+        "violations": [],
+        "warn": 0
+    }
+}

--- a/test/main/fixtures/ts-precomp-es.json
+++ b/test/main/fixtures/ts-precomp-es.json
@@ -1,0 +1,81 @@
+{
+    "modules": [
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts",
+            "valid": true
+        },
+        {
+            "dependencies": [
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./also-used",
+                    "moduleSystem": "cjs",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts",
+                    "valid": true
+                },
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./definitely-used",
+                    "moduleSystem": "es6",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts",
+                    "valid": true
+                },
+                {
+                    "coreModule": false,
+                    "couldNotResolve": false,
+                    "dependencyTypes": [
+                        "local"
+                    ],
+                    "followable": true,
+                    "matchesDoNotFollow": false,
+                    "module": "./imported-from-index-but-not-used",
+                    "moduleSystem": "es6",
+                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts",
+                    "valid": true
+                }
+            ],
+            "source": "test/main/fixtures/ts-precompilation-deps-on-es/index.ts",
+            "valid": true
+        }
+    ],
+    "summary": {
+        "error": 0,
+        "info": 0,
+        "optionsUsed": {
+            "externalModuleResolutionStrategy": "node_modules",
+            "moduleSystems": [
+                "amd",
+                "cjs",
+                "es6"
+            ],
+            "preserveSymlinks": false,
+            "tsPreCompilationDeps": true
+        },
+        "totalCruised": 4,
+        "violations": [],
+        "warn": 0
+    }
+}

--- a/test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts
@@ -1,0 +1,1 @@
+export const x = 3;

--- a/test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/test/main/fixtures/ts-precompilation-deps-off-cjs/imported-from-index-but-not-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-cjs/imported-from-index-but-not-used.ts
@@ -1,0 +1,1 @@
+export default () => 'not used';

--- a/test/main/fixtures/ts-precompilation-deps-off-cjs/index.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-cjs/index.ts
@@ -1,0 +1,6 @@
+import * as unused from './imported-from-index-but-not-used';
+import * as definitlyUsed from './definitely-used';
+const alsoUsed = require('./also-used');
+
+console.log(definitlyUsed.x, alsoUsed.x);
+

--- a/test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts
@@ -1,0 +1,1 @@
+export const x = 3;

--- a/test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/test/main/fixtures/ts-precompilation-deps-off-es/imported-from-index-but-not-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-es/imported-from-index-but-not-used.ts
@@ -1,0 +1,1 @@
+export default () => 'not used';

--- a/test/main/fixtures/ts-precompilation-deps-off-es/index.ts
+++ b/test/main/fixtures/ts-precompilation-deps-off-es/index.ts
@@ -1,0 +1,6 @@
+import * as unused from './imported-from-index-but-not-used';
+import * as definitlyUsed from './definitely-used';
+const alsoUsed = require('./also-used');
+
+console.log(definitlyUsed.x, alsoUsed.x);
+

--- a/test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts
@@ -1,0 +1,1 @@
+export const x = 3;

--- a/test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts
@@ -1,0 +1,1 @@
+export default () => 'not used';

--- a/test/main/fixtures/ts-precompilation-deps-on-cjs/index.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-cjs/index.ts
@@ -1,0 +1,6 @@
+import * as unused from './imported-from-index-but-not-used';
+import * as definitlyUsed from './definitely-used';
+const alsoUsed = require('./also-used');
+
+console.log(definitlyUsed.x, alsoUsed.x);
+

--- a/test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts
@@ -1,0 +1,1 @@
+export const x = 3;

--- a/test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts
@@ -1,0 +1,1 @@
+export default () => 'not used';

--- a/test/main/fixtures/ts-precompilation-deps-on-es/index.ts
+++ b/test/main/fixtures/ts-precompilation-deps-on-es/index.ts
@@ -1,0 +1,6 @@
+import * as unused from './imported-from-index-but-not-used';
+import * as definitlyUsed from './definitely-used';
+const alsoUsed = require('./also-used');
+
+console.log(definitlyUsed.x, alsoUsed.x);
+

--- a/test/main/fixtures/tsconfig.targetcjs.json
+++ b/test/main/fixtures/tsconfig.targetcjs.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "module": "commonjs"
+    }
+}

--- a/test/main/fixtures/tsconfig.targetes.json
+++ b/test/main/fixtures/tsconfig.targetes.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "module": "es6"
+    }
+}

--- a/test/main/main.spec.js
+++ b/test/main/main.spec.js
@@ -4,6 +4,10 @@ const depSchema  = require('../../src/extract/jsonschema.json');
 const tsFixture  = require('./fixtures/ts.json');
 const tsxFixture = require('./fixtures/tsx.json');
 const jsxFixture = require('./fixtures/jsx.json');
+const tsPreCompFixtureCJS = require('./fixtures/ts-precomp-cjs.json');
+const tsPreCompFixtureES = require('./fixtures/ts-precomp-es.json');
+const tsNoPrecompFixtureCJS = require('./fixtures/ts-no-precomp-cjs.json');
+const tsNoPrecompFixtureES = require('./fixtures/ts-no-precomp-es.json');
 
 const expect     = chai.expect;
 
@@ -23,13 +27,13 @@ describe("main", () => {
         expect(lResult).to.be.jsonSchema(depSchema);
     });
     it("Also processes tsx correctly", () => {
-        const lResult = main.cruise(["test/main/fixtures/tsx"]);
+        const lResult = main.cruise(["test/main/fixtures/tsx"], {}, {bustTheCache:true});
 
         expect(lResult).to.deep.equal(tsxFixture);
         expect(lResult).to.be.jsonSchema(depSchema);
     });
     it("And jsx", () => {
-        const lResult = main.cruise(["test/main/fixtures/jsx"]);
+        const lResult = main.cruise(["test/main/fixtures/jsx"], {}, {bustTheCache:true});
 
         expect(lResult).to.deep.equal(jsxFixture);
         expect(lResult).to.be.jsonSchema(depSchema);
@@ -39,10 +43,95 @@ describe("main", () => {
             ["test/main/fixtures/jsx"],
             {
                 ruleSet : {}
-            }
+            },
+            {bustTheCache:true}
         );
 
         expect(lResult).to.deep.equal(jsxFixture);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: on, target CJS", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-on-cjs"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetcjs.json"
+                },
+                tsPreCompilationDeps: true
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "commonjs"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsPreCompFixtureCJS);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: on, target ES", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-on-es"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetes.json"
+                },
+                tsPreCompilationDeps: true
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "es6"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsPreCompFixtureES);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: off, target CJS", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-off-cjs"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetcjs.json"
+                },
+                tsPreCompilationDeps: false
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "commonjs"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsNoPrecompFixtureCJS);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: off, target ES", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-off-es"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetes.json"
+                },
+                tsPreCompilationDeps: false
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "es6"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsNoPrecompFixtureES);
         expect(lResult).to.be.jsonSchema(depSchema);
     });
 });


### PR DESCRIPTION
## Description, Motivation and Context
- Adds extraction of commonJS dependencies to the typescript extractor
- The extraction function now either uses the typescript AST or the javascript one, making things possibly faster, but also fixing issues like #111 

## How Has This Been Tested?
- [x] new unit tests
- [x] automated mini-integration test
- [x] automated non-regression tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.