### PR TITLE
feature(main): only load the ts paths plugin when the tsconfig contains a baseUrl

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -100,7 +100,7 @@ function cruise (pFileDirArray, pOptions, pResolveOptions, pTSConfig) {
         normalizeFilesAndDirs(pFileDirArray),
         pOptions,
         TYPE2REPORTER[pOptions.outputType],
-        normalizeResolveOptions(pResolveOptions, pOptions),
+        normalizeResolveOptions(pResolveOptions, pOptions, pTSConfig),
         pTSConfig
     );
 }

--- a/test/extract/resolve/index.spec.js
+++ b/test/extract/resolve/index.spec.js
@@ -1,7 +1,12 @@
 const path                    = require('path');
 const expect                  = require('chai').expect;
+const parseTSConfig           = require('../../../src/cli/parseTSConfig');
 const resolve                 = require('../../../src/extract/resolve');
 const normalizeResolveOptions = require('../../../src/main/resolveOptions/normalize');
+
+
+const TSCONFIG = path.join(__dirname, 'fixtures', 'ts-config-with-path', 'tsconfig.json');
+const PARSED_TSCONFIG = parseTSConfig(TSCONFIG);
 
 describe("extract/resolve/index", () => {
     it("resolves a local dependency to a file on disk", () => {
@@ -224,10 +229,11 @@ describe("extract/resolve/index", () => {
                 path.join(__dirname, 'fixtures', 'ts-config-with-path'),
                 normalizeResolveOptions(
                     {
-                        tsConfig: path.join(__dirname, 'fixtures', 'ts-config-with-path', 'tsconfig.json'),
+                        tsConfig: TSCONFIG,
                         bustTheCache: true
                     },
-                    {}
+                    {},
+                    PARSED_TSCONFIG
                 )
             )
         ).to.deep.equal({
@@ -252,10 +258,11 @@ describe("extract/resolve/index", () => {
                 path.join(__dirname, 'fixtures', 'ts-config-with-path'),
                 normalizeResolveOptions(
                     {
-                        tsConfig: path.join(__dirname, 'fixtures', 'ts-config-with-path', 'tsconfig.json'),
+                        tsConfig: TSCONFIG,
                         bustTheCache: true
                     },
-                    {}
+                    {},
+                    PARSED_TSCONFIG
                 )
             )
         ).to.deep.equal({
@@ -280,10 +287,11 @@ describe("extract/resolve/index", () => {
                 path.join(__dirname, 'fixtures', 'ts-config-with-path'),
                 normalizeResolveOptions(
                     {
-                        tsConfig: path.join(__dirname, 'fixtures', 'ts-config-with-path', 'tsconfig.json'),
+                        tsConfig: TSCONFIG,
                         bustTheCache: true
                     },
-                    {}
+                    {},
+                    PARSED_TSCONFIG
                 )
             )
         ).to.deep.equal({

--- a/test/main/resolveOptions/normalize.spec.js
+++ b/test/main/resolveOptions/normalize.spec.js
@@ -1,14 +1,16 @@
-const path             = require('path');
-const expect           = require('chai').expect;
-const normalizeOptions = require('../../../src/main/options/normalize');
-const normalize        = require('../../../src/main/resolveOptions/normalize');
+const path                    = require('path');
+const expect                  = require('chai').expect;
+const normalizeOptions        = require('../../../src/main/options/normalize');
+const normalizeResolveOptions = require('../../../src/main/resolveOptions/normalize');
 
 describe("main/resolveOptions/normalize", () => {
     const DEFAULT_NO_OF_RESOLVE_OPTIONS = 7;
-    const A_TEST_TSCONFIG = path.join(__dirname, "..", "fixtures", "tsconfig.test.json");
+    const TEST_TSCONFIG = path.join(__dirname, "..", "fixtures", "tsconfig.test.json");
+    const TSCONFIG_CONTENTS = {};
+    const TSCONFIG_CONTENTS_WITH_BASEURL = {options:{baseUrl:""}};
 
     it("comes with a set of defaults when passed with no options at all", () => {
-        const lNormalizedOptions = normalize({}, normalizeOptions({}));
+        const lNormalizedOptions = normalizeResolveOptions({}, normalizeOptions({}));
 
         expect(Object.keys(lNormalizedOptions).length).to.equal(DEFAULT_NO_OF_RESOLVE_OPTIONS);
         expect(lNormalizedOptions.symlinks).to.equal(false);
@@ -20,7 +22,10 @@ describe("main/resolveOptions/normalize", () => {
     });
 
     it("adds the pnp plugin to the resolver plugins for externalModuleResolutionStrategy yarn-pnp", () => {
-        const lNormalizedOptions = normalize({}, normalizeOptions({externalModuleResolutionStrategy: "yarn-pnp"}));
+        const lNormalizedOptions = normalizeResolveOptions(
+            {},
+            normalizeOptions({externalModuleResolutionStrategy: "yarn-pnp"})
+        );
 
         expect(Object.keys(lNormalizedOptions).length).to.equal(DEFAULT_NO_OF_RESOLVE_OPTIONS + 1);
         expect(lNormalizedOptions.symlinks).to.equal(false);
@@ -32,17 +37,37 @@ describe("main/resolveOptions/normalize", () => {
         expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
     });
 
-    it("adds the typescript plugin to the resolver plugins if a tsConfig is specified ", () => {
-        const lNormalizedOptions = normalize(
+    it("does not add the typescript paths plugin to the plugins if a tsConfig is specified without a baseUrl", () => {
+        const lNormalizedOptions = normalizeResolveOptions(
             {},
             normalizeOptions(
-                {ruleSet: {options: {tsConfig: {fileName: A_TEST_TSCONFIG}}}}
-            )
+                {ruleSet: {options: {tsConfig: {fileName: TEST_TSCONFIG}}}}
+            ),
+            TSCONFIG_CONTENTS
+        );
+
+        expect(Object.keys(lNormalizedOptions).length).to.equal(DEFAULT_NO_OF_RESOLVE_OPTIONS);
+        expect(lNormalizedOptions.symlinks).to.equal(false);
+        expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
+        expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+        expect(lNormalizedOptions).to.ownProperty('extensions');
+        expect(lNormalizedOptions).to.ownProperty('fileSystem');
+        expect((lNormalizedOptions.plugins || []).length).to.equal(0);
+        expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+    });
+
+    it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl", () => {
+        const lNormalizedOptions = normalizeResolveOptions(
+            {},
+            normalizeOptions(
+                {ruleSet: {options: {tsConfig: {fileName: TEST_TSCONFIG}}}}
+            ),
+            TSCONFIG_CONTENTS_WITH_BASEURL
         );
 
         expect(Object.keys(lNormalizedOptions).length).to.equal(DEFAULT_NO_OF_RESOLVE_OPTIONS + 1);
         expect(lNormalizedOptions.symlinks).to.equal(false);
-        expect(lNormalizedOptions.tsConfig).to.equal(A_TEST_TSCONFIG);
+        expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
         expect(lNormalizedOptions.combinedDependencies).to.equal(false);
         expect(lNormalizedOptions).to.ownProperty('extensions');
         expect(lNormalizedOptions).to.ownProperty('fileSystem');
@@ -51,20 +76,21 @@ describe("main/resolveOptions/normalize", () => {
     });
 
     it("adds the typescript plugin and pnp plugins if a tsConfig and pnp resolution strategy are specified", () => {
-        const lNormalizedOptions = normalize(
+        const lNormalizedOptions = normalizeResolveOptions(
             {},
             normalizeOptions(
                 {
-                    ruleSet: {options: {tsConfig: {fileName: A_TEST_TSCONFIG}}},
+                    ruleSet: {options: {tsConfig: {fileName: TEST_TSCONFIG}}},
                     externalModuleResolutionStrategy: "yarn-pnp"
                 }
-            )
+            ),
+            TSCONFIG_CONTENTS_WITH_BASEURL
         );
 
         expect(Object.keys(lNormalizedOptions).length).to.equal(DEFAULT_NO_OF_RESOLVE_OPTIONS + 1);
 
         /* eslint no-magic-numbers:0 */
         expect(lNormalizedOptions.plugins.length).to.equal(2);
-        expect(lNormalizedOptions.tsConfig).to.equal(A_TEST_TSCONFIG);
+        expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
     });
 });


### PR DESCRIPTION
## Description
See title

## Motivation and Context
This should prevent some confusion - the ts paths plugin will complain at runtime it doesn't want to load the tsconfig if there's no baseUrl. This runtime message looks like it's coming from dependency-cruiser, while it isn't. Actually everything is fine; just the paths resolution isn't done with the paths plugin (which is ok - there was no baseUrl and likely no pathsin the tsconfig in the first place).

Solution: just don't load the ts paths plugin when there's no baseUrl in the tsconfig.

## How Has This Been Tested?
- [x] automated non-regression tests
- [x] adapted + new unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
