### PR TITLE
refactor(report): simplify the reporter contract

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -154,12 +154,12 @@ _externalModuleResolutionStrategy_ key:
 - In `src/report`:
   - add a module that exports a default function that
     - takes a dependency cruiser output object
-      ([json schema](../src/extract/jsonschema.json))
-    - returns that same object with the values of the 'dependencies' attribute
-      replaced by the string containing the output you want.
+      ([json schema](../src/extract/results-schema.json))
+    - returns the string containing the output you want.
 - In `main/index.js`
     - require that module and
     - add a key to the to the `TYPE2REPORTER` object with that module as value
+- In `main/options/validate.js` add the key to the `OUTPUT_TYPES_RE`
 - In `bin/dependency-cruise`
     - add it to the documentation of the -T option
 - In `test/report` add unit tests that prove your reporter does what it

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -25,6 +25,21 @@ const TYPE2REPORTER      = {
     "err"   : reportErr
 };
 
+function wrapInDependencyList(pExtractResult, pReporterOutput, pOutputType) {
+    let lRetval = pExtractResult;
+
+    if (pOutputType) {
+        lRetval = Object.assign(
+            {},
+            pExtractResult,
+            {
+                modules: pReporterOutput
+            }
+        );
+    }
+    return lRetval;
+}
+
 function getReporter(pOutputType) {
     // eslint-disable-next-line security/detect-object-injection
     return TYPE2REPORTER[pOutputType] || ((x) => x);
@@ -101,14 +116,17 @@ function cruise (pFileDirArray, pOptions, pResolveOptions, pTSConfig) {
         );
     }
 
-    return getReporter(pOptions.outputType)(
-        extract(
-            normalizeFilesAndDirs(pFileDirArray),
-            pOptions,
-            normalizeResolveOptions(pResolveOptions, pOptions, pTSConfig),
-            pTSConfig
-        )
+    const lExtractionResult = extract(
+        normalizeFilesAndDirs(pFileDirArray),
+        pOptions,
+        normalizeResolveOptions(pResolveOptions, pOptions, pTSConfig),
+        pTSConfig
     );
+    const lReporterOutput = getReporter(pOptions.outputType)(
+        lExtractionResult
+    );
+
+    return wrapInDependencyList(lExtractionResult, lReporterOutput, pOptions.outputType);
 }
 
 module.exports = {

--- a/src/report/csv/index.js
+++ b/src/report/csv/index.js
@@ -3,15 +3,10 @@ const dependencyToIncidenceTransformer = require("../dependencyToIncidenceTransf
 
 require("./csv.template");
 
-module.exports = pInput =>
-    Object.assign(
-        {},
-        pInput,
-        {
-            modules: Handlebars.templates['csv.template.hbs']({
-                "things" : dependencyToIncidenceTransformer(pInput.modules)
-            })
-        }
-    );
+module.exports = pInput => Handlebars.templates['csv.template.hbs'](
+    {
+        "things" : dependencyToIncidenceTransformer(pInput.modules)
+    }
+);
 
 /* eslint import/no-unassigned-import: 0 */

--- a/src/report/dot/folderLevel/index.js
+++ b/src/report/dot/folderLevel/index.js
@@ -60,20 +60,15 @@ function squashToDir (pModules) {
         );
 }
 
-module.exports = (pInput) =>
-    Object.assign(
-        {},
-        pInput,
-        {
-            modules: Handlebars.templates['ddot.template.hbs']({
-                "things" : consolidateModules(squashToDir(pInput.modules))
-                    .map(consolidateModuleDependencies)
-                    .sort(compareOnSource)
-                    .map(extractRelevantTransgressions)
-                    .map(folderify)
-                    .map(colorize)
-            })
-        }
-    );
+module.exports = (pInput) => Handlebars.templates['ddot.template.hbs'](
+    {
+        "things" : consolidateModules(squashToDir(pInput.modules))
+            .map(consolidateModuleDependencies)
+            .sort(compareOnSource)
+            .map(extractRelevantTransgressions)
+            .map(folderify)
+            .map(colorize)
+    }
+);
 
 /* eslint import/no-unassigned-import: 0 */

--- a/src/report/dot/moduleLevel/index.js
+++ b/src/report/dot/moduleLevel/index.js
@@ -70,20 +70,15 @@ function addURL(pInput) {
         );
 }
 
-module.exports = (pColoringScheme) => (pInput) =>
-    Object.assign(
-        {},
-        pInput,
-        {
-            modules: Handlebars.templates['dot.template.hbs']({
-                "things" : pInput.modules
-                    .sort(compareOnSource)
-                    .map(extractFirstTransgression)
-                    .map(folderify)
-                    .map(colorize(pColoringScheme))
-                    .map(addURL(pInput))
-            })
-        }
-    );
+module.exports = (pColoringScheme) => (pInput) => Handlebars.templates['dot.template.hbs'](
+    {
+        "things" : pInput.modules
+            .sort(compareOnSource)
+            .map(extractFirstTransgression)
+            .map(folderify)
+            .map(colorize(pColoringScheme))
+            .map(addURL(pInput))
+    }
+);
 
 /* eslint import/no-unassigned-import: 0 */

--- a/src/report/err.js
+++ b/src/report/err.js
@@ -31,26 +31,14 @@ function formatSummary(pMeta) {
 module.exports = (pInput) => {
 
     if (pInput.summary.violations.length === 0){
-        return Object.assign(
-            pInput,
-            {
-                modules:
-                    `\n${chalk.green(figures.tick)} no dependency violations found (${pInput.summary.totalCruised} modules cruised)\n\n`
-            }
-        );
+        return `\n${chalk.green(figures.tick)} no dependency violations found (${pInput.summary.totalCruised} modules cruised)\n\n`;
     }
 
-    return Object.assign(
-        {},
-        pInput,
-        {
-            modules: pInput.summary.violations.reduce(
-                (pAll, pThis) => `${pAll}  ${formatError(pThis)}\n`,
-                "\n"
-            ).concat(
-                formatSummary(pInput.summary)
-            )
-        }
+    return pInput.summary.violations.reduce(
+        (pAll, pThis) => `${pAll}  ${formatError(pThis)}\n`,
+        "\n"
+    ).concat(
+        formatSummary(pInput.summary)
     );
 
 };

--- a/src/report/html/index.js
+++ b/src/report/html/index.js
@@ -19,16 +19,11 @@ function addShowTitle(pDependencyEntry) {
     );
 }
 
-module.exports = pInput =>
-    Object.assign(
-        {},
-        pInput,
-        {
-            modules: Handlebars.templates['html.template.hbs']({
-                "things" : dependencyToIncidenceTransformer(pInput.modules).map(addShowTitle)
-            })
-        }
-    );
+module.exports = pInput => Handlebars.templates['html.template.hbs'](
+    {
+        "things" : dependencyToIncidenceTransformer(pInput.modules).map(addShowTitle)
+    }
+);
 
 
 /* eslint import/no-unassigned-import: 0 */

--- a/src/report/json.js
+++ b/src/report/json.js
@@ -1,8 +1,1 @@
-module.exports = pInput =>
-    Object.assign(
-        {},
-        pInput,
-        {
-            modules: JSON.stringify(pInput, null, "  ")
-        }
-    );
+module.exports = pInput => JSON.stringify(pInput, null, "  ");

--- a/test/report/dot/folderLevel/index.spec.js
+++ b/test/report/dot/folderLevel/index.spec.js
@@ -11,15 +11,15 @@ const consolidatedRxJs       = fs.readFileSync('test/report/dot/folderLevel/fixt
 
 describe("report/dot/folderLevel reporter", () => {
     it("consolidates to folder level", () => {
-        expect(render(deps).modules).to.deep.equal(consolidatedDot);
+        expect(render(deps)).to.deep.equal(consolidatedDot);
     });
 
     it("consolidates module only transgressions correctly", () => {
-        expect(render(orphans).modules).to.deep.equal(consolidatedOrphansDot);
+        expect(render(orphans)).to.deep.equal(consolidatedOrphansDot);
     });
 
     it("consolidates a slightly larger code base in a timely fashion", () => {
-        expect(render(rxjs).modules).to.deep.equal(consolidatedRxJs);
+        expect(render(rxjs)).to.deep.equal(consolidatedRxJs);
     });
 });
 

--- a/test/report/dot/moduleLevel/index.spec.js
+++ b/test/report/dot/moduleLevel/index.spec.js
@@ -17,27 +17,27 @@ const prefixNonUriFixture = fs.readFileSync('test/report/fixtures/prefix-non-uri
 
 describe("report/dot/moduleLevel reporter", () => {
     it("renders a dot - modules in the root don't come in a cluster", () => {
-        expect(render(deps).modules).to.deep.equal(clusterlessFixture);
+        expect(render(deps)).to.deep.equal(clusterlessFixture);
     });
 
     it("renders a dot - unresolvable in a sub folder (either existing or not) get labeled as unresolvable", () => {
-        expect(render(unresolvableDeps).modules).to.deep.equal(unresolvableFixture);
+        expect(render(unresolvableDeps)).to.deep.equal(unresolvableFixture);
     });
 
     it("renders a dot - matchesDoNotFollow rendered as folders", () => {
-        expect(render(doNotFollowDeps).modules).to.deep.equal(doNotFollowFixture);
+        expect(render(doNotFollowDeps)).to.deep.equal(doNotFollowFixture);
     });
 
     it("renders a dot - renders modules with module level transgression with a severity deduced color", () => {
-        expect(render(orphanDeps).modules).to.deep.equal(orphanFixture);
+        expect(render(orphanDeps)).to.deep.equal(orphanFixture);
     });
 
     it("renders a dot - uri prefix get concatenated", () => {
-        expect(render(prefixUri).modules).to.deep.equal(prefixUriFixture);
+        expect(render(prefixUri)).to.deep.equal(prefixUriFixture);
     });
 
     it("renders a dot - non-ur prefixes get path.posix.joined", () => {
-        expect(render(prefixNonUri).modules).to.deep.equal(prefixNonUriFixture);
+        expect(render(prefixNonUri)).to.deep.equal(prefixNonUriFixture);
     });
 });
 

--- a/test/report/dot/moduleLevel/rcdot.spec.js
+++ b/test/report/dot/moduleLevel/rcdot.spec.js
@@ -12,12 +12,12 @@ const boringColorFixture = fs.readFileSync('test/report/fixtures/defaultmoduleco
 
 describe("report/dot reporter coloring", () => {
     it("richly colors when passed a rich color scheme", () => {
-        expect(renderRCDot(deps).modules).to.deep.equal(richColorFixture);
+        expect(renderRCDot(deps)).to.deep.equal(richColorFixture);
     });
     it("defaultly colors when passed no color scheme", () => {
-        expect(renderDot(deps).modules).to.deep.equal(richColorFixture);
+        expect(renderDot(deps)).to.deep.equal(richColorFixture);
     });
     it("colors boringly when passed the boring color scheme", () => {
-        expect(renderBoringDot(deps).modules).to.deep.equal(boringColorFixture);
+        expect(renderBoringDot(deps)).to.deep.equal(boringColorFixture);
     });
 });

--- a/test/report/err.spec.js
+++ b/test/report/err.spec.js
@@ -7,16 +7,16 @@ const erradds  = require('./fixtures/err-with-additional-information.json');
 
 describe("report/err", () => {
     it("says everything fine", () => {
-        expect(render(okdeps).modules).to.contain('no dependency violations found');
+        expect(render(okdeps)).to.contain('no dependency violations found');
     });
     it("renders a bunch of errors", () => {
-        expect(render(deps).modules).to.contain('2 dependency violations (2 errors, 0 warnings)');
+        expect(render(deps)).to.contain('2 dependency violations (2 errors, 0 warnings)');
     });
     it("renders a bunch of warnings", () => {
-        expect(render(warndeps).modules).to.contain('1 dependency violations (0 errors, 1 warnings)');
+        expect(render(warndeps)).to.contain('1 dependency violations (0 errors, 1 warnings)');
     });
     it("renders addtional information", () => {
-        const lResult = render(erradds).modules;
+        const lResult = render(erradds);
 
         expect(lResult).to.contain('\n  aap -> noot -> mies -> aap');
     });

--- a/test/report/html.spec.js
+++ b/test/report/html.spec.js
@@ -269,7 +269,7 @@ const elFixture = `<!DOCTYPE html>
 
 describe("report/html reporter", () => {
     it("renders html - modules in the root don't come in a cluster; and one module could not be resolved", () => {
-        expect(render(deps).modules).to.deep.equal(elFixture);
+        expect(render(deps)).to.deep.equal(elFixture);
         // console.log(render(deps));
         // expect(1).to.equal(1);
     });


### PR DESCRIPTION
## Description
Reporters now take a dependency list object and return their output. Previously they wrapped it in the 'modules' section of the 

## Motivation and Context
The 'hack' to wrap the output in the modules section is there for a specific case in the cli. The hack itself is not necessary but removing it will constitute a breaking change to the cruise API. Removing that hack will be done in the future - this PR is groundwork for that. Side effects are that it makes writing reporters easier and that it enables the use of a different composition pattern if necessary.

## How Has This Been Tested?
- [x] automated non-regression tests

## Types of changes
- [x] Refactoring (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.