### PR TITLE
feature(report): adds an eslint-json reporter

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -74,6 +74,10 @@ If you supply `csv` it will write the dependency matrix to a comma
 separated file - so you can import it into a spreadsheet program
 and analyze from there.
 
+#### eslint
+*experimental* emits [eslint json format](https://eslint.org/docs/developer-guide/working-with-custom-formatters#the-results-object)
+so you can integrate it with your own eslint formatters.
+
 ### `--do-not-follow`: don't cruise modules adhering to this pattern any further
 If you _do_ want to see certain modules in your reports, but are not interested
 in these modules' dependencies, you'd pass the regular expression for those

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -8,6 +8,7 @@ const RCScheme                = require('../report/dot/common/richModuleColorSch
 const reportRCDot             = require("../report/dot/moduleLevel")(RCScheme);
 const reportCsv               = require("../report/csv");
 const reportErr               = require("../report/err");
+const reportEslint            = require("../report/eslint");
 const normalizeFilesAndDirs   = require("./filesAndDirs/normalize");
 const validateRuleSet         = require("./ruleSet/validate");
 const normalizeRuleSet        = require("./ruleSet/normalize");
@@ -22,7 +23,8 @@ const TYPE2REPORTER      = {
     "ddot"  : reportDDot,
     "rcdot" : reportRCDot,
     "csv"   : reportCsv,
-    "err"   : reportErr
+    "err"   : reportErr,
+    "eslint": reportEslint
 };
 
 function wrapInDependencyList(pExtractResult, pReporterOutput, pOutputType) {

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -2,7 +2,7 @@ const _get      = require('lodash/get');
 const safeRegex = require('../../utl/safe-regex');
 
 const MODULE_SYSTEM_LIST_RE  = /^((cjs|amd|es6|tsd)(,|$))+$/gi;
-const OUTPUT_TYPES_RE        = /^(html|dot|rcdot|ddot|csv|err|json)$/g;
+const OUTPUT_TYPES_RE        = /^(html|dot|rcdot|ddot|csv|err|json|eslint)$/g;
 const VALID_DEPTH_RE         = /^[0-9]{1,2}$/g;
 
 function validateSystems(pModuleSystems) {

--- a/src/report/eslint.js
+++ b/src/report/eslint.js
@@ -1,0 +1,93 @@
+const _get = require('lodash/get');
+
+const ESLINT_SEVERITY_ERROR = 2;
+const ESLINT_SEVERITY_WARN = 1;
+
+const SEVERITY2ESLINTSEVERITY = {
+    "error": ESLINT_SEVERITY_ERROR,
+    "warn": ESLINT_SEVERITY_WARN,
+    "info": ESLINT_SEVERITY_WARN
+};
+
+function translateSeverity(pSeverity) {
+    // eslint-disable-next-line security/detect-object-injection
+    return SEVERITY2ESLINTSEVERITY[pSeverity];
+}
+
+function transformModuleTransgression(pModule) {
+    return _get(pModule, "rules", []).map(
+        pRule => (
+            {
+                ruleId: pRule.name,
+                severity: translateSeverity(pRule.severity),
+                message: "",
+                line: 0,
+                column: 0
+            }
+        )
+    );
+}
+
+function transformDependencyTransgressions(pModule) {
+    return _get(pModule, "dependencies", [])
+        .filter(pDep => pDep.hasOwnProperty("rules"))
+        .reduce(
+            (pAll, pCurrent) => {
+                const lMappedRules = pCurrent.rules.map(
+                    pRule => (
+                        {
+                            ruleId: pRule.name,
+                            severity: translateSeverity(pRule.severity),
+                            message: `-> ${pCurrent.resolved}`,
+                            line: 0,
+                            column: 0
+                        }
+                    )
+                );
+
+                return pAll.concat(lMappedRules);
+            },
+            []
+        );
+}
+
+function transformTransgressions(pModule) {
+    return transformModuleTransgression(pModule)
+        .concat(
+            transformDependencyTransgressions(pModule)
+        );
+}
+
+function transform(pInput) {
+    return pInput.modules
+        .filter(
+            pModule => transformTransgressions(pModule).length > 0
+        )
+        .map(
+            pOffendingModule => {
+                const lTransgressions = transformTransgressions(pOffendingModule);
+
+                return {
+                    filePath: pOffendingModule.source,
+                    messages: lTransgressions,
+                    errorCount: lTransgressions.filter(
+                        pTransgression => pTransgression.severity === ESLINT_SEVERITY_ERROR
+                    ).length,
+                    warningCount: lTransgressions.filter(
+                        pTransgression => pTransgression.severity === ESLINT_SEVERITY_WARN
+                    ).length,
+                    fixableErrorCount: 0,
+                    fixableWarningCount: 0
+                };
+            }
+        );
+}
+
+/**
+ * Returns a json string as documented
+ * [on eslint.org ](https://eslint.org/docs/developer-guide/working-with-custom-formatters#the-results-object)
+ *
+ * @param {any} pInput - dependency graph adhering to ../../extract/results-schema.json
+ * @returns {string} - eslint json format
+ */
+module.exports = pInput => JSON.stringify(transform(pInput), null, "  ");

--- a/test/report/eslint.spec.js
+++ b/test/report/eslint.spec.js
@@ -1,0 +1,19 @@
+const expect       = require('chai').expect;
+const render       = require('../../src/report/eslint');
+const okdeps       = require('./fixtures/everything-fine.json');
+const deps         = require('./fixtures/cjs-no-dependency-valid.json');
+const depsES       = require('./fixtures/cjs-no-dependency-valid-eslint-format.json');
+const moduleErrs   = require('./fixtures/module-errors.json');
+const moduleErrsES = require('./fixtures/module-errors-eslint-format.json');
+
+describe("report/eslint", () => {
+    it("says everything fine", () => {
+        expect(JSON.parse(render(okdeps))).to.deep.equal([]);
+    });
+    it("renders a bunch of errors", () => {
+        expect(JSON.parse(render(deps))).to.deep.equal(depsES);
+    });
+    it("renders module only transgressions", () => {
+        expect(JSON.parse(render(moduleErrs))).to.deep.equal(moduleErrsES);
+    });
+});

--- a/test/report/fixtures/cjs-no-dependency-valid-eslint-format.json
+++ b/test/report/fixtures/cjs-no-dependency-valid-eslint-format.json
@@ -1,0 +1,216 @@
+[
+    {
+      "filePath": "node_modules/somemodule/src/somemodule.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> node_modules/somemodule/src/moar-javascript.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> node_modules/somemodule/node_modules/someothermodule/main.js",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 2,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "one_only_one.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> path",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 1,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "one_only_two.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> path",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 1,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "root_one.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> one_only_one.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> one_only_two.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> shared.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> sub/dir.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> fs",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> node_modules/somemodule/src/somemodule.js",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 6,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "shared.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> path",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 1,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "sub/dir.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> sub/depindir.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> path",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 2,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "sub/depindir.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> path",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 1,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "root_two.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> shared.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> somedata.json",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> two_only_one.js",
+          "line": 0,
+          "column": 0
+        },
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> http",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 4,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    },
+    {
+      "filePath": "two_only_one.js",
+      "messages": [
+        {
+          "ruleId": "unnamed",
+          "severity": 1,
+          "message": "-> sub/dir.js",
+          "line": 0,
+          "column": 0
+        }
+      ],
+      "errorCount": 0,
+      "warningCount": 1,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0
+    }
+  ]

--- a/test/report/fixtures/module-errors-eslint-format.json
+++ b/test/report/fixtures/module-errors-eslint-format.json
@@ -1,0 +1,41 @@
+[
+  {
+    "filePath": "src/tmp_lonely.js",
+    "messages": [
+      {
+        "ruleId": "no-orphans",
+        "severity": 2,
+        "message": "",
+        "line": 0,
+        "column": 0
+      }
+    ],
+    "errorCount": 1,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  },
+  {
+    "filePath": "src/tmp_other.js",
+    "messages": [
+      {
+        "ruleId": "not-to-unresolvable",
+        "severity": 2,
+        "message": "-> does-not-exist",
+        "line": 0,
+        "column": 0
+      },
+      {
+        "ruleId": "prefer-lodash-individuals",
+        "severity": 1,
+        "message": "-> node_modules/lodash/lodash.js",
+        "line": 0,
+        "column": 0
+      }
+    ],
+    "errorCount": 1,
+    "warningCount": 1,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0
+  }
+]

--- a/test/report/fixtures/module-errors.json
+++ b/test/report/fixtures/module-errors.json
@@ -1,0 +1,356 @@
+{
+  "modules": [
+    {
+      "source": "src/tmp_lonely.js",
+      "dependencies": [],
+      "orphan": true,
+      "valid": false,
+      "rules": [
+        {
+          "severity": "error",
+          "name": "no-orphans"
+        }
+      ]
+    },
+    {
+      "source": "src/tmp_other.js",
+      "dependencies": [
+        {
+          "resolved": "does-not-exist",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": true,
+          "dependencyTypes": [
+            "unknown"
+          ],
+          "module": "does-not-exist",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "error",
+              "name": "not-to-unresolvable"
+            }
+          ]
+        },
+        {
+          "resolved": "node_modules/lodash/lodash.js",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "npm"
+          ],
+          "license": "MIT",
+          "module": "lodash",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": true,
+          "circular": false,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "prefer-lodash-individuals"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "does-not-exist",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": true,
+      "matchesDoNotFollow": false,
+      "dependencyTypes": [
+        "unknown"
+      ],
+      "dependencies": [],
+      "valid": true
+    },
+    {
+      "source": "node_modules/lodash/lodash.js",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": false,
+      "matchesDoNotFollow": true,
+      "dependencyTypes": [
+        "npm"
+      ],
+      "dependencies": [],
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [
+      {
+        "from": "src/tmp_lonely.js",
+        "to": "src/tmp_lonely.js",
+        "rule": {
+          "severity": "error",
+          "name": "no-orphans"
+        }
+      },
+      {
+        "from": "src/tmp_other.js",
+        "to": "does-not-exist",
+        "rule": {
+          "severity": "error",
+          "name": "not-to-unresolvable"
+        }
+      },
+      {
+        "from": "src/tmp_other.js",
+        "to": "node_modules/lodash/lodash.js",
+        "rule": {
+          "severity": "info",
+          "name": "prefer-lodash-individuals"
+        }
+      }
+    ],
+    "error": 2,
+    "warn": 0,
+    "info": 1,
+    "totalCruised": 4,
+    "optionsUsed": {
+      "args": [
+        "src/tmp_lonely.js",
+        "src/tmp_other.js"
+      ],
+      "combinedDependencies": false,
+      "doNotFollow": {
+        "dependencyTypes": [
+          "npm",
+          "npm-dev",
+          "npm-optional",
+          "npm-peer",
+          "npm-bundled",
+          "npm-no-pkg"
+        ]
+      },
+      "exclude": "fixtures|test/integration",
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": [
+        "amd",
+        "cjs",
+        "es6"
+      ],
+      "outputTo": "-",
+      "outputType": "json",
+      "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/",
+      "preserveSymlinks": false,
+      "rulesFile": ".dependency-cruiser.json",
+      "tsPreCompilationDeps": false
+    },
+    "ruleSetUsed": {
+      "forbidden": [
+        {
+          "name": "cli-to-main-only",
+          "comment": "cli should only depend on the public interface in main",
+          "severity": "error",
+          "from": {
+            "path": "(^src/cli)",
+            "pathNot": "^(src/cli/compileConfig/index\\.js)$"
+          },
+          "to": {
+            "pathNot": "^src/main|^node_modules|^fs$|^path$|$1|^package.json$"
+          }
+        },
+        {
+          "name": "cli-to-main-only-warn",
+          "comment": "cli should only depend on the public interface in main (temp exception)",
+          "severity": "warn",
+          "from": {
+            "path": "^(src/cli/compileConfig/index\\.js)$"
+          },
+          "to": {
+            "pathNot": "^src/(cli|main)|^node_modules|^fs$|^path$|$1|^package.json$"
+          }
+        },
+        {
+          "name": "bin-to-cli-only",
+          "comment": "bin should only depend on cli",
+          "severity": "error",
+          "from": {
+            "path": "(^bin/dependency-cruise)"
+          },
+          "to": {
+            "pathNot": "^src/cli|^node_modules|^package.json$"
+          }
+        },
+        {
+          "name": "restrict-fs-access",
+          "comment": "restrict file access to a few modules only",
+          "severity": "error",
+          "from": {
+            "pathNot": "^src/(extract/parse|extract/resolve|extract/gatherInitialSources\\.js|cli)|^test"
+          },
+          "to": {
+            "path": "^fs$"
+          }
+        },
+        {
+          "name": "no-inter-module-test",
+          "severity": "error",
+          "from": {
+            "path": "(^test/[^\\/]+/)[^\\.]+\\.spec\\.js"
+          },
+          "to": {
+            "path": "^test/[^\\/]+/.+",
+            "pathNot": "utl|$1[^\\.]+\\.json$"
+          }
+        },
+        {
+          "name": "prefer-lodash-individuals",
+          "comment": "Flag dependencies that include lodash as a whole (better use individual lodash packages e.g. 'lodash/get')",
+          "severity": "info",
+          "from": {},
+          "to": {
+            "path": "lodash\\.js"
+          }
+        },
+        {
+          "name": "no-dep-on-test",
+          "severity": "error",
+          "from": {
+            "path": "^(src|bin)"
+          },
+          "to": {
+            "path": "^test|\\.spec\\.js$"
+          }
+        },
+        {
+          "name": "no-external-to-here",
+          "comment": "you never know...",
+          "severity": "info",
+          "from": {
+            "pathNot": "^(src|test|bin)"
+          },
+          "to": {
+            "path": "^(src|test)"
+          }
+        },
+        {
+          "name": "not-to-dev-dep",
+          "severity": "error",
+          "comment": "because an npm i --production will otherwise deliver an unreliably running module",
+          "from": {
+            "path": "^(bin|src)"
+          },
+          "to": {
+            "dependencyTypes": [
+              "npm-dev"
+            ]
+          }
+        },
+        {
+          "name": "optional-deps-used",
+          "severity": "error",
+          "comment": "we don't work with optional dependencies",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "npm-optional"
+            ]
+          }
+        },
+        {
+          "name": "peer-deps-used",
+          "comment": "we don't work with peer dependencies",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "npm-peer"
+            ]
+          }
+        },
+        {
+          "name": "no-unvetted-license",
+          "comment": "Warn in case some dependency uses a license that's not vetted (the licenses might be OK, but your legal department might have 2nd thoughts about them)",
+          "severity": "warn",
+          "from": {},
+          "to": {
+            "licenseNot": "MIT|ISC"
+          }
+        },
+        {
+          "name": "no-orphans",
+          "comment": "Modules without any incoming or outgoing dependencies are might indicate unused code.",
+          "severity": "error",
+          "from": {
+            "orphan": true,
+            "pathNot": "\\.d\\.ts$"
+          },
+          "to": {}
+        },
+        {
+          "name": "no-circular",
+          "comment": "circular dependencies will make you dizzy",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "circular": true
+          }
+        },
+        {
+          "name": "no-deprecated-core",
+          "comment": "These core modules are deprecated - find an alternative.",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "core"
+            ],
+            "path": "^(punycode|domain|constants|sys|_linklist|_stream_wrap)$"
+          }
+        },
+        {
+          "name": "no-duplicate-dep-types",
+          "comment": "including things twice?",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "moreThanOneDependencyType": true
+          }
+        },
+        {
+          "name": "no-non-package-json",
+          "severity": "error",
+          "comment": "because an npm i --production will otherwise deliver an unreliably running module",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "npm-no-pkg",
+              "npm-unknown"
+            ]
+          }
+        },
+        {
+          "name": "not-to-deprecated",
+          "comment": "These modules are deprecated - find an alternative.",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "deprecated"
+            ]
+          }
+        },
+        {
+          "name": "not-to-unresolvable",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "couldNotResolve": true
+          }
+        }
+      ],
+      "allowed": [],
+      "allowedSeverity": "warn"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds a (fairly basic) reporter that emits errors and warnings in an [eslint-json format](https://eslint.org/docs/developer-guide/working-with-custom-formatters#the-results-object). It needs a bit of squeezing as eslint takes one source file at the time and dependency-checks typically cover two of them - so the from will is in the filePath - the to in the _message_ e.g.:

```javascript
[
  {
    "filePath": "src/some-module.js",
    "messages": [
      {
        "ruleId": "prefer-lodash-individuals",
        "severity": 1,
        "message": "-> node_modules/lodash/lodash.js",
        "line": 0,
        "column": 0
      },
      {
        "ruleId": "not-to-unresolvable",
        "severity": 2,
        "message": "-> does-not-exist",
        "line": 0,
        "column": 0
      }
    ],
    "errorCount": 1,
    "warningCount": 1,
    "fixableErrorCount": 0,
    "fixableWarningCount": 0
  }
]
```

Use like this
```sh
depcruise --output-type eslint --config .dependency-cruiser.js bin src test
```

## Motivation and Context
On request - part of resolving #133 (the TeamCity reporter will be in a separate PR). It should also make it easier to use it with custom eslint formatters if you so fancy.

## How Has This Been Tested?
- [x] automated integration test
- [x] automated non-regression

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.