### PR TITLE
feature(extract): recognize dynamic imports with template literals (that contain no placeholders)

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -114,7 +114,8 @@ ecmascript) might come later.
 
 ### Q: Does dependency-cruiser detect [dynamic imports](https://github.com/tc39/proposal-dynamic-import)?
 **A**: Yes; in both typescript and javascript - but only with static string arguments
-(see the next question). This should cover most of the use cases for dynamic
+or template expressions that don't contain no placeholders (see the next question).
+This should cover most of the use cases for dynamic
 imports that leverage asynchronous module loading (like [webpack code splitting](https://webpack.js.org/guides/code-splitting/#dynamic-imports)), though.
 
 ### Q: Does dependency-cruiser handle variable or expression requires and imports?
@@ -125,9 +126,7 @@ If you have imports with variables (`require(someVariable)`,
 (`require(funkyBoolean ? 'lodash' : 'underscore'))`
 in your code dependency-cruiser won't be able to determinewhat dependencies
 they're about. For now dependency-cruiser focusses on doing static analysis
-only and doing that well. Dynamic/ runtime analysis is fun, but also a whole
-different ball game.
-
+only and doing that well.
 
 ### Q: Does it work with my monorepo?
 

--- a/src/extract/ast-extractors/estree-utl.js
+++ b/src/extract/ast-extractors/estree-utl.js
@@ -1,0 +1,9 @@
+function isPlaceholderlessTemplateLiteral(pArgument){
+    return pArgument.type === 'TemplateLiteral' &&
+        pArgument.quasis.length === 1 &&
+        pArgument.expressions.length === 0;
+}
+
+module.exports = {
+    isPlaceholderlessTemplateLiteral
+};

--- a/src/extract/ast-extractors/estree-utl.js
+++ b/src/extract/ast-extractors/estree-utl.js
@@ -1,9 +1,27 @@
+function isStringLiteral(pArgument) {
+    return pArgument.type === 'Literal' &&
+        typeof pArgument.value === 'string';
+}
+
+function firstArgumentIsAString(pArgumentsNode) {
+    return Boolean(pArgumentsNode) &&
+        pArgumentsNode[0] &&
+        isStringLiteral(pArgumentsNode[0]);
+}
+
 function isPlaceholderlessTemplateLiteral(pArgument){
     return pArgument.type === 'TemplateLiteral' &&
         pArgument.quasis.length === 1 &&
         pArgument.expressions.length === 0;
 }
 
+function firstArgumentIsATemplateLiteral(pArgumentsNode) {
+    return Boolean(pArgumentsNode) &&
+        pArgumentsNode[0] &&
+        isPlaceholderlessTemplateLiteral(pArgumentsNode[0]);
+}
+
 module.exports = {
-    isPlaceholderlessTemplateLiteral
+    firstArgumentIsAString,
+    firstArgumentIsATemplateLiteral
 };

--- a/src/extract/ast-extractors/extract-ES6-deps.js
+++ b/src/extract/ast-extractors/extract-ES6-deps.js
@@ -1,17 +1,13 @@
 const _get = require('lodash/get');
 const walk = require('./walk');
+const estreeHelpers = require('./estree-utl');
 
 function isImportStatement(pNode) {
     return 'Import' === _get(pNode, 'callee.type');
 }
-function isPlaceholderlessTemplateLiteral(pArgument){
-    return pArgument.type === 'TemplateLiteral' &&
-        pArgument.quasis.length === 1 &&
-        pArgument.expressions.length === 0;
-}
 
 function hasPlaceholderlessTemplateLiteralArgument(pNode) {
-    return _get(pNode, 'arguments', []).some(isPlaceholderlessTemplateLiteral);
+    return estreeHelpers.isPlaceholderlessTemplateLiteral(_get(pNode, 'arguments[0]', {}));
 }
 function isStringLiteral(pArgument) {
     return pArgument.type === 'Literal' &&
@@ -32,7 +28,7 @@ function pushImportNodeValue(pDependencies) {
                 });
             } else if (hasPlaceholderlessTemplateLiteralArgument(pNode)) {
                 pDependencies.push({
-                    moduleName: pNode.arguments.find(isPlaceholderlessTemplateLiteral).quasis[0].value.cooked,
+                    moduleName: pNode.arguments[0].quasis[0].value.cooked,
                     moduleSystem: "es6"
                 });
             }

--- a/src/extract/ast-extractors/extract-ES6-deps.js
+++ b/src/extract/ast-extractors/extract-ES6-deps.js
@@ -7,7 +7,9 @@ function isImportStatement(pNode) {
 }
 
 function hasPlaceholderlessTemplateLiteralArgument(pNode) {
-    return estreeHelpers.isPlaceholderlessTemplateLiteral(_get(pNode, 'arguments[0]', {}));
+    return estreeHelpers.isPlaceholderlessTemplateLiteral(
+        _get(pNode, 'arguments[0]', {})
+    );
 }
 function isStringLiteral(pArgument) {
     return pArgument.type === 'Literal' &&
@@ -15,7 +17,9 @@ function isStringLiteral(pArgument) {
 }
 
 function hasStringArgument(pNode) {
-    return _get(pNode, 'arguments', []).some(isStringLiteral);
+    return isStringLiteral(
+        _get(pNode, 'arguments[0]', {})
+    );
 }
 
 function pushImportNodeValue(pDependencies) {
@@ -23,7 +27,7 @@ function pushImportNodeValue(pDependencies) {
         if (isImportStatement(pNode)) {
             if (hasStringArgument(pNode)) {
                 pDependencies.push({
-                    moduleName: pNode.arguments.find(isStringLiteral).value,
+                    moduleName: pNode.arguments[0].value,
                     moduleSystem: "es6"
                 });
             } else if (hasPlaceholderlessTemplateLiteralArgument(pNode)) {

--- a/src/extract/ast-extractors/extract-ES6-deps.js
+++ b/src/extract/ast-extractors/extract-ES6-deps.js
@@ -6,31 +6,15 @@ function isImportStatement(pNode) {
     return 'Import' === _get(pNode, 'callee.type');
 }
 
-function hasPlaceholderlessTemplateLiteralArgument(pNode) {
-    return estreeHelpers.isPlaceholderlessTemplateLiteral(
-        _get(pNode, 'arguments[0]', {})
-    );
-}
-function isStringLiteral(pArgument) {
-    return pArgument.type === 'Literal' &&
-        typeof pArgument.value === 'string';
-}
-
-function hasStringArgument(pNode) {
-    return isStringLiteral(
-        _get(pNode, 'arguments[0]', {})
-    );
-}
-
 function pushImportNodeValue(pDependencies) {
     return (pNode) => {
         if (isImportStatement(pNode)) {
-            if (hasStringArgument(pNode)) {
+            if (estreeHelpers.firstArgumentIsAString(pNode.arguments)) {
                 pDependencies.push({
                     moduleName: pNode.arguments[0].value,
                     moduleSystem: "es6"
                 });
-            } else if (hasPlaceholderlessTemplateLiteralArgument(pNode)) {
+            } else if (estreeHelpers.firstArgumentIsATemplateLiteral(pNode.arguments)) {
                 pDependencies.push({
                     moduleName: pNode.arguments[0].quasis[0].value.cooked,
                     moduleSystem: "es6"

--- a/src/extract/ast-extractors/extract-commonJS-deps.js
+++ b/src/extract/ast-extractors/extract-commonJS-deps.js
@@ -1,4 +1,5 @@
 const walk = require('./walk');
+const estreeHelpers = require('./estree-utl');
 
 function firstArgumentIsAString(pArgumentsNode) {
     return Boolean(pArgumentsNode) &&
@@ -17,16 +18,10 @@ function isRequireCall(pNode){
         firstArgumentIsAString(pNode.arguments);
 }
 
-function isPlaceholderlessTemplateLiteral(pArgument){
-    return pArgument.type === 'TemplateLiteral' &&
-        pArgument.quasis.length === 1 &&
-        pArgument.expressions.length === 0;
-}
-
 function firstArgumentIsATemplateLiteral(pArgumentsNode) {
     return Boolean(pArgumentsNode) &&
         pArgumentsNode[0] &&
-        isPlaceholderlessTemplateLiteral(pArgumentsNode[0]);
+        estreeHelpers.isPlaceholderlessTemplateLiteral(pArgumentsNode[0]);
 }
 
 function isRequireCallWithTemplateString(pNode){

--- a/src/extract/ast-extractors/extract-commonJS-deps.js
+++ b/src/extract/ast-extractors/extract-commonJS-deps.js
@@ -1,35 +1,23 @@
+const _get = require('lodash/get');
 const walk = require('./walk');
 const estreeHelpers = require('./estree-utl');
 
-function firstArgumentIsAString(pArgumentsNode) {
-    return Boolean(pArgumentsNode) &&
-        pArgumentsNode[0] &&
-        pArgumentsNode[0].value &&
-        typeof pArgumentsNode[0].value === "string";
-}
-
 function isRequireIdentifier(pNode) {
-    return pNode.callee.type === "Identifier" &&
-        pNode.callee.name === "require";
-}
-
-function firstArgumentIsATemplateLiteral(pArgumentsNode) {
-    return Boolean(pArgumentsNode) &&
-        pArgumentsNode[0] &&
-        estreeHelpers.isPlaceholderlessTemplateLiteral(pArgumentsNode[0]);
+    return 'Identifier' === _get(pNode, 'callee.type') &&
+        'require' === _get(pNode, 'callee.name');
 }
 
 function pushRequireCallsToDependencies(pDependencies, pModuleSystem) {
     return (pNode) => {
         if (isRequireIdentifier(pNode)) {
-            if (firstArgumentIsAString(pNode.arguments)) {
+            if (estreeHelpers.firstArgumentIsAString(pNode.arguments)) {
                 pNode.arguments[0].value.split("!").forEach(
                     pString => pDependencies.push({
                         moduleName: pString,
                         moduleSystem: pModuleSystem
                     })
                 );
-            } else if (firstArgumentIsATemplateLiteral(pNode.arguments)) {
+            } else if (estreeHelpers.firstArgumentIsATemplateLiteral(pNode.arguments)) {
                 pDependencies.push({
                     moduleName: pNode.arguments[0].quasis[0].value.cooked,
                     moduleSystem: pModuleSystem

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -100,7 +100,13 @@ function isTypeImport(pASTNode) {
 function firstArgIsAString(pASTNode) {
     const lFirstArgument = pASTNode.arguments[0];
 
-    return lFirstArgument && typescript.SyntaxKind[lFirstArgument.kind] === "StringLiteral";
+    return lFirstArgument &&
+        (
+            // "thing" or 'thing'
+            typescript.SyntaxKind[lFirstArgument.kind] === "StringLiteral" ||
+            // `thing`
+            typescript.SyntaxKind[lFirstArgument.kind] === "FirstTemplateToken"
+        );
 }
 
 /**

--- a/test/extract/ast-extractors/extract-ES6-deps.spec.js
+++ b/test/extract/ast-extractors/extract-ES6-deps.spec.js
@@ -24,10 +24,26 @@ describe("ast-extractors/extract-ES6-deps", () => {
         );
     });
 
-    it("dynamic imports of a template literal doesn't yield an import", () => {
+    it("dynamic imports of a template literal without placeholders yields an import", () => {
         let lDeps = [];
 
         extractES6("import(`./dynamic`).then(pModule => pModule.x);", lDeps);
+        expect(
+            lDeps
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: './dynamic',
+                    moduleSystem: 'es6'
+                }
+            ]
+        );
+    });
+
+    it("dynamic imports of a template literal with placeholders doesn't yield an import", () => {
+        let lDeps = [];
+
+        extractES6("import(`./dynamic/${enhop}`).then(pModule => pModule.x);", lDeps);
         expect(
             lDeps
         ).to.deep.equal(

--- a/test/extract/ast-extractors/extract-commonjs-deps.spec.js
+++ b/test/extract/ast-extractors/extract-commonjs-deps.spec.js
@@ -1,0 +1,68 @@
+const expect     = require('chai').expect;
+const extractcommonJSDeps = require('../../../src/extract/ast-extractors/extract-commonJS-deps');
+const getASTFromSource  = require('../../../src/extract/parse/toJavascriptAST').getASTFromSource;
+
+const extractcommonJS =
+    (pJavaScriptSource, pDependencies) => extractcommonJSDeps(getASTFromSource(pJavaScriptSource, 'js'), pDependencies);
+
+
+describe("ast-extractors/extract-commonJS-deps", () => {
+
+    it("require with in an assignment", () => {
+        let lDeps = [];
+
+        extractcommonJS("const x = require('./static')", lDeps);
+        expect(
+            lDeps
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: './static',
+                    moduleSystem: 'cjs'
+                }
+            ]
+        );
+    });
+
+    it("require with in an assignment - template literal argument", () => {
+        let lDeps = [];
+
+        extractcommonJS("const x = require(`template-literal`)", lDeps);
+        expect(
+            lDeps
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: 'template-literal',
+                    moduleSystem: 'cjs'
+                }
+            ]
+        );
+    });
+
+    it("non-string argument doesn't yield a dependency (number)", () => {
+        let lDeps = [];
+
+        extractcommonJS("require(42);", lDeps);
+        expect(
+            lDeps
+        ).to.deep.equal(
+            []
+        );
+    });
+
+    it("non-string argument doesn't yield a dependency (function call)", () => {
+        let lDeps = [];
+
+        extractcommonJS(`
+            determineWhatToImport = () => 'bla';
+            require(determineWhatToImport());
+        `,
+        lDeps);
+        expect(
+            lDeps
+        ).to.deep.equal(
+            []
+        );
+    });
+});

--- a/test/extract/ast-extractors/extract-typescript-commonjs.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-commonjs.spec.js
@@ -73,6 +73,21 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
         );
     });
 
+    it("extracts regular require with a template string without placeholders", () => {
+        expect(
+            extractTypescript(
+                "const lala = require(`thunderscore`)"
+            )
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: 'thunderscore',
+                    moduleSystem: 'cjs'
+                }
+            ]
+        );
+    });
+
     it("ignores regular require without parameters", () => {
         expect(
             extractTypescript(
@@ -87,6 +102,16 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
         expect(
             extractTypescript(
                 "const lala = require(666)"
+            )
+        ).to.deep.equal(
+            []
+        );
+    });
+
+    it("ignores regular require with a template literal with placeholders", () => {
+        expect(
+            extractTypescript(
+                "const lala = require(`shwoooop/${blabla}`)"
             )
         ).to.deep.equal(
             []

--- a/test/extract/ast-extractors/extract-typescript-dynamic-imports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-dynamic-imports.spec.js
@@ -16,6 +16,28 @@ describe("ast-extractors/extract-typescript - dynamic imports", () => {
         );
     });
 
+    it("correctly detects a dynamic import statement with a template that has no placeholders", () => {
+        expect(
+            extractTypescript("import(`judeljo`).then(judeljo => { judeljo.hochik() }")
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: 'judeljo',
+                    moduleSystem: 'es6'
+                }
+            ]
+        );
+    });
+
+    it("ignores dynamic import statements with a template that has placeholders", () => {
+        expect(
+            extractTypescript("import(`judeljo/${vlap}`).then(judeljo => { judeljo.hochik() }")
+        ).to.deep.equal(
+            []
+        );
+    });
+
+
     it("ignores dynamic import statements with a non-string parameter", () => {
         expect(
             extractTypescript("import(elaborateFunctionCall()).then(judeljo => { judeljo.hochik() }")

--- a/test/extract/ast-extractors/extract-typescript-imports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-imports.spec.js
@@ -68,6 +68,19 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
         );
     });
 
+    it("extracts type imports in const declarations (template literal argument)", () => {
+        expect(
+            extractTypescript("const tiepetjes: import(`./types`).T;")
+        ).to.deep.equal(
+            [
+                {
+                    moduleName: './types',
+                    moduleSystem: 'es6'
+                }
+            ]
+        );
+    });
+
     it("extracts type imports in parameter declarations", () => {
         expect(
             extractTypescript("function f(snort: import('./vypes').T){console.log(snort.bla)}")
@@ -90,6 +103,16 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
                     moduleName: './wypes',
                     moduleSystem: 'es6'
                 }
+            ]
+        );
+    });
+
+    it("leaves type imports with template literals with placeholders alone", () => {
+        expect(
+            // typescript/lib/protocol.d.ts has this thing
+            extractTypescript("const tiepetjes: import(`./types/${lalala()}`).T;")
+        ).to.deep.equal(
+            [
             ]
         );
     });


### PR DESCRIPTION
## Description
Additionally recognizes dynamic imports (and commons requires) that have a placeholder-less template literal as a parameter
```typescript
import(`circular`).then(pBla => circular.makeAngular(8));
const th_ = require(`thunderscore`);
const lala : import(`types`).T;
```

Covers:
- typescript (both `import` statements and `require` calls)
- typescript _type imports_
- javascript (both `import` statements and `require` calls)
- (coffee and live script if they compile down to either of the javascript equivalents) 

## Motivation and Context
Although it might not make a whole lot of sense to use a template literal instead of a regular string, it is legal. In [Angular 8.0's release notes](https://blog.angular.io/version-8-of-angular-smaller-bundles-cli-apis-and-alignment-with-the-ecosystem-af0261112a27) it's used as an example - which will mean it'll trickle down into normal code by copy-paste osmosis.

## Todo


## How Has This Been Tested?
- [x] automated non-regression tests
- [x] unit test
- [x] simple performance non-regression test

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.