### PR TITLE
feature(report): err, teamcity: only emit the module name once for module-only rule violations

### DIFF
--- a/src/report/err.js
+++ b/src/report/err.js
@@ -8,8 +8,11 @@ const SEVERITY2CHALK = {
 };
 
 function formatError(pErr) {
-    return `${SEVERITY2CHALK[pErr.rule.severity](pErr.rule.severity)} ${pErr.rule.name}: ` +
-           `${chalk.bold(pErr.from)} ${figures.arrowRight} ${chalk.bold(pErr.to)}` +
+    const lModuleNames = pErr.from === pErr.to
+        ? chalk.bold(pErr.from)
+        : `${chalk.bold(pErr.from)} ${figures.arrowRight} ${chalk.bold(pErr.to)}`;
+
+    return `${SEVERITY2CHALK[pErr.rule.severity](pErr.rule.severity)} ${pErr.rule.name}: ${lModuleNames}` +
            `${pErr.additionalInformation ? `\n  ${pErr.additionalInformation}` : ""}`;
 }
 

--- a/src/report/teamcity.js
+++ b/src/report/teamcity.js
@@ -50,7 +50,7 @@ function reportViolatedRules(pRuleSetUsed, pViolations) {
 }
 
 function bakeViolationMessage(pViolation) {
-    return `${pViolation.from} -> ${pViolation.to}`;
+    return pViolation.from === pViolation.to ? pViolation.from : `${pViolation.from} -> ${pViolation.to}`;
 }
 function reportViolations(pViolations) {
     return pViolations.map(pViolation =>

--- a/test/report/err.spec.js
+++ b/test/report/err.spec.js
@@ -1,4 +1,5 @@
 const expect     = require('chai').expect;
+const chalk      = require('chalk');
 const render     = require('../../src/report/err');
 const okdeps     = require('./fixtures/everything-fine.json');
 const deps       = require('./fixtures/cjs-no-dependency-valid.json');
@@ -7,6 +8,14 @@ const erradds    = require('./fixtures/err-with-additional-information.json');
 const orphanerrs = require('./fixtures/orphan-deps.json');
 
 describe("report/err", () => {
+    let chalkEnabled = chalk.enabled;
+
+    before("disable chalk coloring", () => {
+        chalk.enabled = false;
+    });
+    after("put chalk enabled back to its original value", () => {
+        chalk.enabled = chalkEnabled;
+    });
     it("says everything fine", () => {
         expect(render(okdeps)).to.contain('no dependency violations found');
     });
@@ -14,7 +23,7 @@ describe("report/err", () => {
         const lResult = render(deps);
 
         expect(lResult).to.contain(
-            '\u001b[31merror\u001b[39m no-leesplank: \u001b[1maap\u001b[22m → \u001b[1mnoot\u001b[22m\n'
+            'error no-leesplank: aap → noot\n'
         );
         expect(lResult).to.contain('2 dependency violations (2 errors, 0 warnings)');
     });
@@ -24,7 +33,7 @@ describe("report/err", () => {
     it("renders module only violations as module only", () => {
         const lResult = render(orphanerrs);
 
-        expect(lResult).to.contain('\u001b[31merror\u001b[39m no-orphans: \u001b[1mremi.js\u001b[22m\n');
+        expect(lResult).to.contain('error no-orphans: remi.js\n');
         expect(lResult).to.contain('1 dependency violations (1 errors, 0 warnings)');
     });
     it("renders addtional information", () => {

--- a/test/report/err.spec.js
+++ b/test/report/err.spec.js
@@ -1,19 +1,31 @@
-const expect   = require('chai').expect;
-const render   = require('../../src/report/err');
-const okdeps   = require('./fixtures/everything-fine.json');
-const deps     = require('./fixtures/cjs-no-dependency-valid.json');
-const warndeps = require('./fixtures/err-only-warnings.json');
-const erradds  = require('./fixtures/err-with-additional-information.json');
+const expect     = require('chai').expect;
+const render     = require('../../src/report/err');
+const okdeps     = require('./fixtures/everything-fine.json');
+const deps       = require('./fixtures/cjs-no-dependency-valid.json');
+const warndeps   = require('./fixtures/err-only-warnings.json');
+const erradds    = require('./fixtures/err-with-additional-information.json');
+const orphanerrs = require('./fixtures/orphan-deps.json');
 
 describe("report/err", () => {
     it("says everything fine", () => {
         expect(render(okdeps)).to.contain('no dependency violations found');
     });
     it("renders a bunch of errors", () => {
-        expect(render(deps)).to.contain('2 dependency violations (2 errors, 0 warnings)');
+        const lResult = render(deps);
+
+        expect(lResult).to.contain(
+            '\u001b[31merror\u001b[39m no-leesplank: \u001b[1maap\u001b[22m → \u001b[1mnoot\u001b[22m\n'
+        );
+        expect(lResult).to.contain('2 dependency violations (2 errors, 0 warnings)');
     });
     it("renders a bunch of warnings", () => {
         expect(render(warndeps)).to.contain('1 dependency violations (0 errors, 1 warnings)');
+    });
+    it("renders module only violations as module only", () => {
+        const lResult = render(orphanerrs);
+
+        expect(lResult).to.contain('\u001b[31merror\u001b[39m no-orphans: \u001b[1mremi.js\u001b[22m\n');
+        expect(lResult).to.contain('1 dependency violations (1 errors, 0 warnings)');
     });
     it("renders addtional information", () => {
         const lResult = render(erradds);

--- a/test/report/fixtures/one-violation.json
+++ b/test/report/fixtures/one-violation.json
@@ -91,6 +91,14 @@
                     "severity": "info",
                     "name": "everything-is-a-violation"
                 }
+            },
+            {
+                "from": "src/main/options/validate.js",
+                "to": "node_modules/safe-regex/index.js",
+                "rule": {
+                    "severity": "info",
+                    "name": "everything-is-a-violation"
+                }
             }
         ],
         "error": 0,

--- a/test/report/fixtures/teamcity/module-errors-teamcity-format.txt
+++ b/test/report/fixtures/teamcity/module-errors-teamcity-format.txt
@@ -6,5 +6,5 @@
 ##teamcity[inspection typeId='not-to-unresolvable' message='src/index.js -> ./medontexist.json' file='src/index.js' SEVERITY='ERROR']
 ##teamcity[inspection typeId='not-to-dev-dep' message='src/index.js -> node_modules/dependency-cruiser/src/main/index.js' file='src/index.js' SEVERITY='ERROR']
 ##teamcity[inspection typeId='not-to-dev-dep' message='src/index.js -> node_modules/eslint/lib/api.js' file='src/index.js' SEVERITY='ERROR']
-##teamcity[inspection typeId='no-orphans' message='src/orphan.js -> src/orphan.js' file='src/orphan.js' SEVERITY='ERROR']
+##teamcity[inspection typeId='no-orphans' message='src/orphan.js' file='src/orphan.js' SEVERITY='ERROR']
 ##teamcity[inspection typeId='not-in-allowed' message='src/index.js -> ./medontexist.json' file='src/index.js' SEVERITY='WARNING']


### PR DESCRIPTION
## Motivation and Context
- Enhances readability in said reporters.
- Conceptually closer to the nature of the violation

E.g. in the _err_ reporter observe the no-orphans violation:
Before:
```
  warn cli-to-main-only-warn: src/cli/compileConfig/index.js → src/extract/resolve/resolve.js
  error no-orphans: src/tmp_orphan.js → src/tmp_orphan.js

✖ 2 dependency violations (1 errors, 1 warnings). 201 modules cruised.
```
After:
```
  warn cli-to-main-only-warn: src/cli/compileConfig/index.js → src/extract/resolve/resolve.js
  error no-orphans: src/tmp_orphan.js

✖ 2 dependency violations (1 errors, 1 warnings). 201 modules cruised.
```

## How Has This Been Tested?
- [x] automated non-regression tests
- [x] additional automated tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~My change requires a change to the documentation.~~
- ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.