### PR TITLE
bugfix(orphan): also make orphan checks work in 'allowed'

### DIFF
--- a/src/extract/derive/orphan/index.js
+++ b/src/extract/derive/orphan/index.js
@@ -8,18 +8,22 @@ function orphanCheckNecessary(pOptions){
     if (pOptions.validate) {
         return _get(pOptions, 'ruleSet.forbidden', []).some(
             pRule => pRule.from.hasOwnProperty("orphan")
+        ) ||
+        _get(pOptions, 'ruleSet.allowed', []).some(
+            pRule => pRule.from.hasOwnProperty("orphan")
         );
     }
     return false;
 }
-
 
 function addOrphanCheckToGraph(pDependencies){
     return pDependencies.map(
         pNode => Object.assign(
             {},
             pNode,
-            isOrphan(pNode, pDependencies) ? {orphan: true} : {}
+            {
+                orphan: isOrphan(pNode, pDependencies)
+            }
         )
     );
 }

--- a/src/validate/matchModuleRule.js
+++ b/src/validate/matchModuleRule.js
@@ -1,15 +1,20 @@
 const isModuleOnlyRule = require('./isModuleOnlyRule');
 
-function match(pModule){
-    return pRule => (
-        pModule.orphan === true &&
-            pRule.from.orphan === true
+function matchesOrphanRule(pRule, pModule) {
+    return (
+        pRule.from.hasOwnProperty('orphan') &&
+            pModule.orphan === pRule.from.orphan
     ) && (!pRule.from.path ||
                 pModule.source.match(pRule.from.path)
     ) && (!pRule.from.pathNot ||
             !(pModule.source.match(pRule.from.pathNot))
     );
 }
+
+function match(pModule){
+    return pRule => matchesOrphanRule(pRule, pModule);
+}
+
 const isInteresting = pRule => isModuleOnlyRule(pRule);
 
 module.exports = {

--- a/test/extract/derive/orphan/fixtures/twoModule.afterprocessing.json
+++ b/test/extract/derive/orphan/fixtures/twoModule.afterprocessing.json
@@ -1,0 +1,25 @@
+[
+    {
+        "source": "./snok.js",
+        "orphan": false,
+        "dependencies": [
+            {
+                "resolved": "snak.js",
+                "coreModule": false,
+                "followable": true,
+                "couldNotResolve": false,
+                "dependencyTypes": [
+                    "local"
+                ],
+                "module": "./snak.js",
+                "moduleSystem": "cjs",
+                "matchesDoNotFollow": false
+            }
+        ]
+    },
+    {
+        "source": "snak.js",
+        "orphan": false,
+        "dependencies": []
+    }
+]

--- a/test/extract/derive/orphan/index.spec.js
+++ b/test/extract/derive/orphan/index.spec.js
@@ -4,6 +4,7 @@ const orphan = require('../../../../src/extract/derive/orphan');
 const ONE_MODULE_FIXTURE = require('./fixtures/oneModule.json');
 const ONE_MODULE_AFTER_PROCESSING = require('./fixtures/oneModule.afterprocessing.json');
 const TWO_MODULES_FIXTURE = require('./fixtures/twoModule.json');
+const TWO_MODULES_AFTER_PROCESSING = require('./fixtures/twoModule.afterprocessing.json');
 
 
 describe('extract/derive/orphan/index - orphan detection', () => {
@@ -37,8 +38,8 @@ describe('extract/derive/orphan/index - orphan detection', () => {
         );
     });
 
-    it('does _not_ attach the "orphan" boolean to non-orphan modules, not even with the value "false"', () => {
-        expect(orphan(TWO_MODULES_FIXTURE, {forceOrphanCheck: true})).to.deep.equal(TWO_MODULES_FIXTURE);
+    it('does attachs the "orphan" boolean to non-orphan modules with the value "false"', () => {
+        expect(orphan(TWO_MODULES_FIXTURE, {forceOrphanCheck: true})).to.deep.equal(TWO_MODULES_AFTER_PROCESSING);
     });
 
 });


### PR DESCRIPTION
## Description
Also make orphan checks work in 'allowed' and make sure that if you _do_ want orphans somewhere for some reason, you specify that as part of a rule as well now.

## How Has This Been Tested?
- [x] adapted & non-regression automated tests
(despite 100% test coverage there's some additional tests that can be done to prevent regression - those will be added in PR #142, which also refactors the test set up of the validation functions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
