### PR TITLE
feature(extract|validate): add the 'dynamic' attribute to distinguish dynamic dependencies in rules

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -610,7 +610,7 @@ You can use this e.g. to restrict the usage of dynamic dependencies:
 {
     "forbidden":[
         {
-            "name": "no-non-dynamic-dependencies",
+            "name": "only-dyn-deps-to-otherside",
             "comment": "only dynamically depend on 'otherside' modules",
             "severity": "error",
             "from": {},

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -33,6 +33,7 @@
     - [`circular`](#circular)
     - [`license` and `licenseNot`](#license-and-licensenot)
     - [`dependencyTypes`](#dependencytypes)
+    - [`dynamic`](#dynamic)
     - [`moreThanOneDependencyType`](#more-than-one-dependencytype-per-dependency-morethanonedependencytype)
 4. [The `options`](#the-options)
     - [`doNotFollow`: don't cruise modules adhering to this pattern any further](#donotfollow-dont-cruise-modules-adhering-to-this-pattern-any-further)
@@ -583,6 +584,37 @@ This is a list of dependency types dependency-cruiser currently detects.
  aliased         | it's a module that's linked through an aliased (webpack)| "~/hello.ts"
  unknown         | it's unknown what kind of dependency type this is - probably because the module could not be resolved in the first place | "loodash"
  undetermined    | the dependency fell through all detection holes. This could happen with amd dependencies - which have a whole jurasic park of ways to define where to resolve modules to | "veloci!./raptor"
+
+
+#### `dynamic`
+A boolean that tells you whether the dependency is a dynamic one (i.e. 
+it uses the async ES import statement a la `import('othermodule').then(pMod => pMod.doStuff())`).
+
+You can use this e.g. to restrict the usage of dynamic dependencies:
+
+```json
+"forbidden":[
+    {
+        "name": "no-non-dynamic-dependencies",
+        "severity": "error",
+        "from": {},
+        "to": { "dynamic": "true" }
+    }
+]
+```
+
+... or to enforce the use of dynamic dependencies for certain dependencies
+```json
+"forbidden":[
+    {
+        "name": "no-non-dynamic-dependencies",
+        "comment": "only dynamically depend on 'otherside' modules",
+        "severity": "error",
+        "from": {},
+        "to": { "path": "@theotherside/", dynamic": "false" }
+    }
+]
+```
 
 #### More than one dependencyType per dependency? `moreThanOneDependencyType`
 With the flexible character of package.json it's totally possible to specify

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -593,27 +593,31 @@ it uses the async ES import statement a la `import('othermodule').then(pMod => p
 You can use this e.g. to restrict the usage of dynamic dependencies:
 
 ```json
-"forbidden":[
-    {
-        "name": "no-non-dynamic-dependencies",
-        "severity": "error",
-        "from": {},
-        "to": { "dynamic": "true" }
-    }
-]
+{
+    "forbidden":[
+        {
+            "name": "no-non-dynamic-dependencies",
+            "severity": "error",
+            "from": {},
+            "to": { "dynamic": "true" }
+        }
+    ]
+}
 ```
 
 ... or to enforce the use of dynamic dependencies for certain dependencies
 ```json
-"forbidden":[
-    {
-        "name": "no-non-dynamic-dependencies",
-        "comment": "only dynamically depend on 'otherside' modules",
-        "severity": "error",
-        "from": {},
-        "to": { "path": "@theotherside/", dynamic": "false" }
-    }
-]
+{
+    "forbidden":[
+        {
+            "name": "no-non-dynamic-dependencies",
+            "comment": "only dynamically depend on 'otherside' modules",
+            "severity": "error",
+            "from": {},
+            "to": { "path": "@theotherside/", "dynamic": "false" }
+        }
+    ]
+}
 ```
 
 #### More than one dependencyType per dependency? `moreThanOneDependencyType`

--- a/src/extract/ast-extractors/extract-AMD-deps.js
+++ b/src/extract/ast-extractors/extract-AMD-deps.js
@@ -12,7 +12,8 @@ function extractRegularAMDDependencies(pNode, pDependencies) {
                 if (Boolean(el.value) && typeof el.value === "string") {
                     el.value.split('!').forEach(pString => pDependencies.push({
                         moduleName: pString,
-                        moduleSystem: "amd"
+                        moduleSystem: "amd",
+                        dynamic: false
                     }));
                 }
             }));

--- a/src/extract/ast-extractors/extract-ES6-deps.js
+++ b/src/extract/ast-extractors/extract-ES6-deps.js
@@ -12,12 +12,14 @@ function pushImportNodeValue(pDependencies) {
             if (estreeHelpers.firstArgumentIsAString(pNode.arguments)) {
                 pDependencies.push({
                     moduleName: pNode.arguments[0].value,
-                    moduleSystem: "es6"
+                    moduleSystem: "es6",
+                    dynamic: true
                 });
             } else if (estreeHelpers.firstArgumentIsATemplateLiteral(pNode.arguments)) {
                 pDependencies.push({
                     moduleName: pNode.arguments[0].quasis[0].value.cooked,
-                    moduleSystem: "es6"
+                    moduleSystem: "es6",
+                    dynamic: true
                 });
             }
 
@@ -30,7 +32,8 @@ module.exports = (pAST, pDependencies) => {
         if (pNode.source && pNode.source.value){
             pDependencies.push({
                 moduleName: pNode.source.value,
-                moduleSystem: "es6"
+                moduleSystem: "es6",
+                dynamic: false
             });
         }
     }

--- a/src/extract/ast-extractors/extract-commonJS-deps.js
+++ b/src/extract/ast-extractors/extract-commonJS-deps.js
@@ -14,13 +14,15 @@ function pushRequireCallsToDependencies(pDependencies, pModuleSystem) {
                 pNode.arguments[0].value.split("!").forEach(
                     pString => pDependencies.push({
                         moduleName: pString,
-                        moduleSystem: pModuleSystem
+                        moduleSystem: pModuleSystem,
+                        dynamic: false
                     })
                 );
             } else if (estreeHelpers.firstArgumentIsATemplateLiteral(pNode.arguments)) {
                 pDependencies.push({
                     moduleName: pNode.arguments[0].quasis[0].value.cooked,
-                    moduleSystem: pModuleSystem
+                    moduleSystem: pModuleSystem,
+                    dynamic: false
                 });
             }
         }

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -134,7 +134,8 @@ function extractNestedDependencies(pAST) {
         if (isDynamicImportExpression(pASTNode) && firstArgIsAString(pASTNode)) {
             lResult.push({
                 moduleName: pASTNode.arguments[0].text,
-                moduleSystem: 'es6'
+                moduleSystem: 'es6',
+                dynamic: true
             });
         }
         // const atype: import('./types').T
@@ -157,7 +158,7 @@ function extractNestedDependencies(pAST) {
 /**
  * returns all dependencies in the (top level) AST
  *
- * @type {(pTypeScriptAST: import("typescript").Node) => {moduleName: string, moduleSystem: string}[]}
+ * @type {(pTypeScriptAST: import("typescript").Node) => {moduleName: string, moduleSystem: string, dynamic: boolean}[]}
  */
 module.exports = (pTypeScriptAST) =>
     Boolean(typescript)
@@ -165,6 +166,7 @@ module.exports = (pTypeScriptAST) =>
             .concat(extractImportEquals(pTypeScriptAST))
             .concat(extractTrippleSlashDirectives(pTypeScriptAST))
             .concat(extractNestedDependencies(pTypeScriptAST))
+            .map(pModule => Object.assign({dynamic: false}, pModule))
         : [];
 
 

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -82,6 +82,7 @@ function addResolutionAttributes(pOptions, pFileName, pResolveOptions) {
             {
                 module: pDependency.moduleName,
                 moduleSystem: pDependency.moduleSystem,
+                dynamic: pDependency.dynamic,
                 followable: lResolved.followable && !lMatchesDoNotFollow,
                 matchesDoNotFollow: lMatchesDoNotFollow
             }

--- a/src/extract/results-schema.json
+++ b/src/extract/results-schema.json
@@ -275,6 +275,10 @@
                     "description": "Whether or not to match modules of any of these types (leaving out matches any of them)",
                     "items": { "$ref": "#/definitions/DependencyType" }
                 },
+                "dynamic": {
+                    "type": "boolean",
+                    "description": "true if this dependency is dynamic, false in all other cases"
+                },
                 "moreThanOneDependencyType": {
                     "type": "boolean",
                     "description": "If true matches dependencies with more than one dependency type (e.g. defined in _both_ npm and npm-dev)"

--- a/src/extract/results-schema.json
+++ b/src/extract/results-schema.json
@@ -128,7 +128,8 @@
                                 "followable",
                                 "couldNotResolve",
                                 "moduleSystem",
-                                "valid"
+                                "valid",
+                                "dynamic"
                             ],
                             "additionalProperties": false,
                             "properties": {
@@ -156,6 +157,10 @@
                                 "followable": {
                                     "type": "boolean",
                                     "description": "Whether or not this is a dependency that can be followed any further. This will be 'false' for for core modules, json, modules that could not be resolved to a file and modules that weren't followed because it matches the doNotFollow expression."
+                                },
+                                "dynamic": {
+                                    "type": "boolean",
+                                    "description": "true if this dependency is dynamic, false in all other cases"
                                 },
                                 "matchesDoNotFollow": {
                                     "type": "boolean",

--- a/src/main/ruleSet/config-schema.json
+++ b/src/main/ruleSet/config-schema.json
@@ -291,6 +291,10 @@
                     "type": "boolean",
                     "description": "Whether or not to match when following to the to will ultimately end up in the from."
                 },
+                "dynamic": {
+                    "type": "boolean",
+                    "description": "Whether or not to match when the dependency is a dynamic one."
+                },
                 "dependencyTypes": {
                     "type": "array",
                     "description": "Whether or not to match modules of any of these types (leaving out matches any of them)",

--- a/src/validate/matchDependencyRule.js
+++ b/src/validate/matchDependencyRule.js
@@ -47,7 +47,8 @@ function match(pFrom, pTo) {
             matches.toLicense(pRule, pTo) &&
             matches.toLicenseNot(pRule, pTo) &&
             propertyEquals(pTo, pRule, "couldNotResolve") &&
-            propertyEquals(pTo, pRule, "circular");
+            propertyEquals(pTo, pRule, "circular") &&
+            propertyEquals(pTo, pRule, "dynamic");
     };
 }
 const isInteresting = pRule => !isModuleOnlyRule(pRule);

--- a/src/validate/matches.js
+++ b/src/validate/matches.js
@@ -1,6 +1,6 @@
 const intersects = require('../utl/arrayUtil').intersects;
 
-function _fromPath(pRule, pModule) {
+function fromPath(pRule, pModule) {
     return (!pRule.from.path || pModule.source.match(pRule.from.path));
 }
 
@@ -68,7 +68,7 @@ function toLicenseNot(pRule, pDependency) {
 }
 
 module.exports = {
-    fromPath: _fromPath,
+    fromPath,
     fromPathNot,
     toDependencyPath,
     toModulePath,

--- a/test/cli/fixtures/cjs.dir.filtered.json
+++ b/test/cli/fixtures/cjs.dir.filtered.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -43,6 +44,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -63,6 +65,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -77,6 +80,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_two",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -91,6 +95,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -105,6 +110,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -119,6 +125,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "fs",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -151,6 +158,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -171,6 +179,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./depindir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -185,6 +194,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -205,6 +215,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -225,6 +236,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -239,6 +251,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./somedata.json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -253,6 +266,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./two_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -267,6 +281,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "http",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -311,6 +326,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/cjs.dir.json
+++ b/test/cli/fixtures/cjs.dir.json
@@ -21,6 +21,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./moar-javascript",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -35,6 +36,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "someothermodule",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -55,6 +57,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -87,6 +90,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -107,6 +111,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -121,6 +126,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_two",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -135,6 +141,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -149,6 +156,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -163,6 +171,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "fs",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -177,6 +186,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "somemodule",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -209,6 +219,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -229,6 +240,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./depindir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -243,6 +255,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -263,6 +276,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -283,6 +297,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -297,6 +312,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./somedata.json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -311,6 +327,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./two_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -325,6 +342,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "http",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -369,6 +387,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/cjs.dir.stdout.json
+++ b/test/cli/fixtures/cjs.dir.stdout.json
@@ -22,6 +22,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./moar-javascript",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -36,6 +37,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "someothermodule",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -56,6 +58,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -88,6 +91,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -108,6 +112,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -122,6 +127,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_two",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -136,6 +142,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -150,6 +157,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -164,6 +172,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "fs",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -178,6 +187,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "somemodule",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -210,6 +220,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -230,6 +241,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./depindir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -244,6 +256,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -264,6 +277,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -284,6 +298,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -298,6 +313,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./somedata.json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -312,6 +328,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./two_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -326,6 +343,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "http",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -370,6 +388,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/cjs.file.json
+++ b/test/cli/fixtures/cjs.file.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_one",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -25,6 +26,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./one_only_two",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -39,6 +41,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -53,6 +56,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/dir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -67,6 +71,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "fs",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -81,6 +86,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "somemodule",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -113,6 +119,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -145,6 +152,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -165,6 +173,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -185,6 +194,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./depindir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -199,6 +209,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -219,6 +230,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -239,6 +251,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./moar-javascript",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -253,6 +266,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "someothermodule",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/dynamic-import-nok.json
+++ b/test/cli/fixtures/dynamic-import-nok.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": true,
                     "module": "./import_this",
                     "moduleSystem": "es6",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/dynamic-import-ok.json
+++ b/test/cli/fixtures/dynamic-import-ok.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./import_this",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/multiple-in-one-go.json
+++ b/test/cli/fixtures/multiple-in-one-go.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -43,6 +44,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./depindir",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -57,6 +59,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -82,6 +85,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "./not-at-home",
                     "moduleSystem": "es6",
                     "matchesDoNotFollow": false,
@@ -96,6 +100,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "./this/path/does/not/exist",
                     "moduleSystem": "es6",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/typescript-path-resolution.json
+++ b/test/cli/fixtures/typescript-path-resolution.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "aliased"
                     ],
+                    "dynamic": false,
                     "module": "shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -35,6 +36,7 @@
                     "dependencyTypes": [
                         "aliased"
                     ],
+                    "dynamic": false,
                     "module": "shared",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/webpack-config-alias-cruiser-config.json
+++ b/test/cli/fixtures/webpack-config-alias-cruiser-config.json
@@ -16,6 +16,7 @@
                     "dependencyTypes": [
                         "aliased"
                     ],
+                    "dynamic": false,
                     "module": "configSpullenAlias",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -29,6 +30,7 @@
                     "dependencyTypes": [
                         "aliased"
                     ],
+                    "dynamic": false,
                     "module": "configSpullenAlias/someconfig.json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/cli/fixtures/webpack-config-alias.json
+++ b/test/cli/fixtures/webpack-config-alias.json
@@ -16,6 +16,7 @@
                     "dependencyTypes": [
                         "aliased"
                     ],
+                    "dynamic": false,
                     "module": "configSpullenAlias",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -29,6 +30,7 @@
                     "dependencyTypes": [
                         "aliased"
                     ],
+                    "dynamic": false,
                     "module": "configSpullenAlias/someconfig.json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/extract/ast-extractors/extract-ES6-deps.spec.js
+++ b/test/extract/ast-extractors/extract-ES6-deps.spec.js
@@ -18,7 +18,8 @@ describe("ast-extractors/extract-ES6-deps", () => {
             [
                 {
                     moduleName: './dynamic',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: true
                 }
             ]
         );
@@ -34,7 +35,8 @@ describe("ast-extractors/extract-ES6-deps", () => {
             [
                 {
                     moduleName: './dynamic',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: true
                 }
             ]
         );
@@ -64,7 +66,8 @@ describe("ast-extractors/extract-ES6-deps", () => {
             [
                 {
                     moduleName: 'http',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: true
                 }
             ]
         );

--- a/test/extract/ast-extractors/extract-commonjs-deps.spec.js
+++ b/test/extract/ast-extractors/extract-commonjs-deps.spec.js
@@ -18,7 +18,8 @@ describe("ast-extractors/extract-commonJS-deps", () => {
             [
                 {
                     moduleName: './static',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 }
             ]
         );
@@ -34,7 +35,8 @@ describe("ast-extractors/extract-commonJS-deps", () => {
             [
                 {
                     moduleName: 'template-literal',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 }
             ]
         );

--- a/test/extract/ast-extractors/extract-typescript-commonjs.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-commonjs.spec.js
@@ -10,7 +10,8 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
             [
                 {
                     moduleName: './thing-that-uses-export-equals',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 }
             ]
         );
@@ -27,15 +28,18 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
             [
                 {
                     moduleName: 'legit-one',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 },
                 {
                     moduleName: 'legit-two',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 },
                 {
                     moduleName: 'legit-three',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 }
             ]
         );
@@ -60,15 +64,18 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
         ).to.deep.equal(
             [{
                 moduleName: 'midash',
-                moduleSystem: 'cjs'
+                moduleSystem: 'cjs',
+                dynamic: false
             },
             {
                 moduleName: 'slodash',
-                moduleSystem: 'cjs'
+                moduleSystem: 'cjs',
+                dynamic: false
             },
             {
                 moduleName: 'hidash',
-                moduleSystem: 'cjs'
+                moduleSystem: 'cjs',
+                dynamic: false
             }]
         );
     });
@@ -82,7 +89,8 @@ describe("ast-extractors/extract-typescript - regular commonjs require", () => {
             [
                 {
                     moduleName: 'thunderscore',
-                    moduleSystem: 'cjs'
+                    moduleSystem: 'cjs',
+                    dynamic: false
                 }
             ]
         );

--- a/test/extract/ast-extractors/extract-typescript-dynamic-imports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-dynamic-imports.spec.js
@@ -10,7 +10,8 @@ describe("ast-extractors/extract-typescript - dynamic imports", () => {
             [
                 {
                     moduleName: 'judeljo',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: true
                 }
             ]
         );
@@ -23,7 +24,8 @@ describe("ast-extractors/extract-typescript - dynamic imports", () => {
             [
                 {
                     moduleName: 'judeljo',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: true
                 }
             ]
         );

--- a/test/extract/ast-extractors/extract-typescript-exports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-exports.spec.js
@@ -10,7 +10,8 @@ describe("ast-extractors/extract-typescript - re-exports", () => {
             [
                 {
                     moduleName: './ts-thing',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -23,7 +24,8 @@ describe("ast-extractors/extract-typescript - re-exports", () => {
             [
                 {
                     moduleName: './ts-thing',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );

--- a/test/extract/ast-extractors/extract-typescript-imports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-imports.spec.js
@@ -10,7 +10,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './import-for-side-effects',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -23,7 +24,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './ts-thing',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -36,7 +38,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './ts-thing',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -49,7 +52,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './ts-thing',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -62,7 +66,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './types',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -75,7 +80,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './types',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -88,7 +94,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './vypes',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );
@@ -101,7 +108,8 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
             [
                 {
                     moduleName: './wypes',
-                    moduleSystem: 'es6'
+                    moduleSystem: 'es6',
+                    dynamic: false
                 }
             ]
         );

--- a/test/extract/ast-extractors/extract-typescript-triple-slash-directives.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-triple-slash-directives.spec.js
@@ -10,7 +10,8 @@ describe("ast-extractors/extract-typescript - triple slash directives", () => {
             [
                 {
                     moduleName: './ts-thing',
-                    moduleSystem: 'tsd'
+                    moduleSystem: 'tsd',
+                    dynamic: false
                 }
             ]
         );
@@ -23,7 +24,8 @@ describe("ast-extractors/extract-typescript - triple slash directives", () => {
             [
                 {
                     moduleName: './ts-thing-types',
-                    moduleSystem: 'tsd'
+                    moduleSystem: 'tsd',
+                    dynamic: false
                 }
             ]
         );
@@ -36,7 +38,8 @@ describe("ast-extractors/extract-typescript - triple slash directives", () => {
             [
                 {
                     moduleName: './ts-thing-types',
-                    moduleSystem: 'tsd'
+                    moduleSystem: 'tsd',
+                    dynamic: false
                 }
             ]
         );

--- a/test/extract/extract.spec.js
+++ b/test/extract/extract.spec.js
@@ -78,7 +78,7 @@ describe('extract/extract - CommonJS - with bangs', () => {
 
 describe('extract/extract - ES6 - ', () => es6Fixtures.forEach(runFixture));
 describe('extract/extract - AMD - ', () => amdFixtures.forEach(runFixture));
-describe('AMD - with bangs', () => {
+describe('extract/extract - AMD - with bangs', () => {
 
     it('splits bang!./blabla into bang and ./blabla - regular requirejs', () => {
         const lOptions = normalize({moduleSystems: ["amd"]});
@@ -201,6 +201,7 @@ describe('extract/extract - include', () => {
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./bla",
@@ -229,6 +230,7 @@ describe('extract/extract - include', () => {
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "../di",
@@ -241,6 +243,7 @@ describe('extract/extract - include', () => {
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./bla",

--- a/test/extract/fixtures/amd-bang-CJSWrapper.json
+++ b/test/extract/fixtures/amd-bang-CJSWrapper.json
@@ -5,6 +5,7 @@
         "dependencyTypes": [
             "local"
         ],
+        "dynamic": false,
         "followable": true,
         "matchesDoNotFollow": false,
         "couldNotResolve": false,
@@ -17,6 +18,7 @@
         "dependencyTypes": [
             "local"
         ],
+        "dynamic": false,
         "followable": true,
         "matchesDoNotFollow": false,
         "couldNotResolve": false,
@@ -29,6 +31,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,
@@ -41,6 +44,7 @@
         "dependencyTypes": [
             "local"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": false,
@@ -53,6 +57,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,

--- a/test/extract/fixtures/amd-bang-requirejs.json
+++ b/test/extract/fixtures/amd-bang-requirejs.json
@@ -5,6 +5,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,
@@ -17,6 +18,7 @@
         "dependencyTypes": [
             "local"
         ],
+        "dynamic": false,
         "followable": true,
         "matchesDoNotFollow": false,
         "couldNotResolve": false,
@@ -29,6 +31,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,
@@ -41,6 +44,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,
@@ -53,6 +57,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,
@@ -65,6 +70,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,
@@ -77,6 +83,7 @@
         "dependencyTypes": [
             "core"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": false,
@@ -89,6 +96,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "matchesDoNotFollow": false,
         "couldNotResolve": true,

--- a/test/extract/fixtures/amd-recursive.json
+++ b/test/extract/fixtures/amd-recursive.json
@@ -16,6 +16,7 @@
                         "dependencyTypes": [
                             "unknown"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": true,
@@ -29,6 +30,7 @@
                         "dependencyTypes": [
                             "unknown"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": true,
@@ -42,6 +44,7 @@
                         "dependencyTypes": [
                             "undetermined"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,

--- a/test/extract/fixtures/amd.json
+++ b/test/extract/fixtures/amd.json
@@ -13,6 +13,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -25,6 +26,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -45,6 +47,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -57,6 +60,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -77,6 +81,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -89,6 +94,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -101,6 +107,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -122,6 +129,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -134,6 +142,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -154,6 +163,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -166,6 +176,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -178,6 +189,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -190,6 +202,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -210,6 +223,7 @@
                 "dependencyTypes": [
                     "unknown"
                 ],
+                "dynamic": false,
                 "license": "MIT",
                 "followable": false,
                 "matchesDoNotFollow": false,
@@ -223,6 +237,7 @@
                 "dependencyTypes": [
                     "unknown"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": true
@@ -235,6 +250,7 @@
                 "dependencyTypes": [
                     "undetermined"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -262,6 +278,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -283,6 +300,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -303,6 +321,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -324,6 +343,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false

--- a/test/extract/fixtures/bundled-dependencies.json
+++ b/test/extract/fixtures/bundled-dependencies.json
@@ -21,6 +21,7 @@
                         "dependencyTypes": [
                             "npm"
                         ],
+                        "dynamic": false,
                         "license": "MIT",
                         "module": "idontgetbundled",
                         "moduleSystem": "cjs",
@@ -36,6 +37,7 @@
                             "npm",
                             "npm-bundled"
                         ],
+                        "dynamic": false,
                         "license": "MIT",
                         "module": "igetbundled",
                         "moduleSystem": "cjs",

--- a/test/extract/fixtures/cache-busting-first-tree.json
+++ b/test/extract/fixtures/cache-busting-first-tree.json
@@ -11,6 +11,7 @@
      "dependencyTypes": [
       "local"
      ],
+     "dynamic": false,
      "module": "./local",
      "moduleSystem": "cjs",
      "matchesDoNotFollow": false,
@@ -24,6 +25,7 @@
      "dependencyTypes": [
       "npm"
      ],
+     "dynamic": false,
      "module": "different-in-other-tree",
      "moduleSystem": "es6",
      "matchesDoNotFollow": true,
@@ -37,6 +39,7 @@
      "dependencyTypes": [
       "core"
      ],
+     "dynamic": false,
      "module": "path",
      "moduleSystem": "es6",
      "matchesDoNotFollow": false,

--- a/test/extract/fixtures/cache-busting-second-tree.json
+++ b/test/extract/fixtures/cache-busting-second-tree.json
@@ -11,6 +11,7 @@
      "dependencyTypes": [
       "local"
      ],
+     "dynamic": false,
      "module": "./local",
      "moduleSystem": "cjs",
      "matchesDoNotFollow": false,
@@ -24,6 +25,7 @@
      "dependencyTypes": [
       "npm"
      ],
+     "dynamic": false,
      "module": "different-in-other-tree",
      "moduleSystem": "es6",
      "matchesDoNotFollow": true,
@@ -37,6 +39,7 @@
      "dependencyTypes": [
       "core"
      ],
+     "dynamic": false,
      "module": "fs",
      "moduleSystem": "es6",
      "matchesDoNotFollow": false,
@@ -86,6 +89,7 @@
      "dependencyTypes": [
       "core"
      ],
+     "dynamic": false,
      "module": "http",
      "moduleSystem": "es6",
      "matchesDoNotFollow": false,

--- a/test/extract/fixtures/cjs-bang.json
+++ b/test/extract/fixtures/cjs-bang.json
@@ -5,6 +5,7 @@
         "dependencyTypes": [
             "local"
         ],
+        "dynamic": false,
         "followable": true,
         "matchesDoNotFollow": false,
         "couldNotResolve": false,
@@ -17,6 +18,7 @@
         "dependencyTypes": [
             "unknown"
         ],
+        "dynamic": false,
         "followable": false,
         "couldNotResolve": true,
         "matchesDoNotFollow": false,

--- a/test/extract/fixtures/cjs-recursive.json
+++ b/test/extract/fixtures/cjs-recursive.json
@@ -29,6 +29,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -42,6 +43,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -55,6 +57,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -68,6 +71,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -111,6 +115,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -142,6 +147,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -161,6 +167,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -174,6 +181,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -193,6 +201,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -223,6 +232,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -236,6 +246,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -249,10 +260,12 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
-                        "valid": true                    },
+                        "valid": true
+                    },
                     {
                         "module": "./sub/dir",
                         "resolved": "test/extract/fixtures/cjs/sub/dir.js",
@@ -261,6 +274,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -274,6 +288,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -305,6 +320,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -336,6 +352,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -355,6 +372,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -374,6 +392,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -387,6 +406,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -406,6 +426,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -444,6 +465,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -458,6 +480,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -487,6 +510,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -522,6 +546,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -542,6 +567,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -562,6 +588,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -582,6 +609,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,

--- a/test/extract/fixtures/cjs.json
+++ b/test/extract/fixtures/cjs.json
@@ -15,6 +15,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -27,6 +28,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -39,6 +41,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -51,6 +54,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -63,6 +67,7 @@
                 "dependencyTypes": [
                     "npm"
                 ],
+                "dynamic": false,
                 "license": "MIT",
                 "followable": true,
                 "matchesDoNotFollow": false,
@@ -76,6 +81,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -103,6 +109,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -115,6 +122,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -135,6 +143,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -155,6 +164,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -175,6 +185,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -202,6 +213,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -222,6 +234,7 @@
                 "dependencyTypes": [
                     "npm-no-pkg"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -242,6 +255,7 @@
                 "dependencyTypes": [
                     "unknown"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": true
@@ -254,6 +268,7 @@
                 "dependencyTypes": [
                     "unknown"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": true
@@ -274,6 +289,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -295,6 +311,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -316,6 +333,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -336,6 +354,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -358,6 +377,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false

--- a/test/extract/fixtures/coffee-recursive.json
+++ b/test/extract/fixtures/coffee-recursive.json
@@ -14,6 +14,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -27,6 +28,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -41,6 +43,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "couldNotResolve": false,
                         "module": "./sub/kaching",
@@ -53,6 +56,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -66,6 +70,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -102,6 +107,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,

--- a/test/extract/fixtures/coffee.json
+++ b/test/extract/fixtures/coffee.json
@@ -13,6 +13,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -25,6 +26,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -37,6 +39,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -49,6 +52,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -61,6 +65,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false

--- a/test/extract/fixtures/deprecated-node-module.json
+++ b/test/extract/fixtures/deprecated-node-module.json
@@ -19,6 +19,7 @@
                             "npm-no-pkg",
                             "deprecated"
                         ],
+                        "dynamic": false,
                         "module": "deprecated-at-the-start-for-test-purposes",
                         "moduleSystem": "cjs",
                         "valid": true                    }
@@ -37,6 +38,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "module": "./package.json",
                         "moduleSystem": "cjs",
                         "valid": true

--- a/test/extract/fixtures/donotfollow-dependency-types.json
+++ b/test/extract/fixtures/donotfollow-dependency-types.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./dofollowstuffinhere",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -24,6 +25,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./donotfollowonceinthisfolder",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -37,6 +39,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./donotfollowonceinthisfolder/meta",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -50,6 +53,7 @@
                     "dependencyTypes": [
                         "npm"
                     ],
+                    "dynamic": false,
                     "module": "in-package-json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -63,6 +67,7 @@
                     "dependencyTypes": [
                         "npm-no-pkg"
                     ],
+                    "dynamic": false,
                     "module": "not-in-package-json",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": true,
@@ -94,6 +99,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "../donotfollowonceinthisfolder/meta",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -107,6 +113,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./callfromlocal",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -126,6 +133,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./notcalledfromoutside",
                     "moduleSystem": "es6",
                     "matchesDoNotFollow": false,
@@ -155,6 +163,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "../dofollowstuffinhere",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -168,6 +177,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./notcalledfromoutside",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/extract/fixtures/donotfollow.json
+++ b/test/extract/fixtures/donotfollow.json
@@ -11,6 +11,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./dofollowstuffinhere",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,
@@ -24,6 +25,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./donotfollowonceinthisfolder",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": true,
@@ -37,6 +39,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./donotfollowonceinthisfolder/meta",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": true,
@@ -80,6 +83,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "../donotfollowonceinthisfolder/meta",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": true,
@@ -93,6 +97,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./callfromlocal",
                     "moduleSystem": "cjs",
                     "matchesDoNotFollow": false,

--- a/test/extract/fixtures/es6.json
+++ b/test/extract/fixtures/es6.json
@@ -13,6 +13,7 @@
                 "dependencyTypes": [
                     "npm"
                 ],
+                "dynamic": false,
                 "license": "MIT",
                 "followable": true,
                 "matchesDoNotFollow": false,
@@ -26,6 +27,7 @@
                 "dependencyTypes": [
                     "npm-dev"
                 ],
+                "dynamic": false,
                 "license": "MIT",
                 "followable": true,
                 "matchesDoNotFollow": false,
@@ -39,6 +41,7 @@
                 "dependencyTypes": [
                     "npm"
                 ],
+                "dynamic": false,
                 "license": "MIT",
                 "followable": true,
                 "matchesDoNotFollow": false,
@@ -52,6 +55,7 @@
                 "dependencyTypes": [
                     "npm-dev"
                 ],
+                "dynamic": false,
                 "license": "MIT",
                 "followable": true,
                 "matchesDoNotFollow": false,
@@ -65,6 +69,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false

--- a/test/extract/fixtures/maxDepth0.json
+++ b/test/extract/fixtures/maxDepth0.json
@@ -12,6 +12,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -25,6 +26,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -38,6 +40,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/oneDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -51,6 +54,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "os",
                     "moduleSystem": "es6",
                     "valid": true
@@ -87,6 +91,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -100,6 +105,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./twoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -119,6 +125,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/threeDeepInSub",
                     "moduleSystem": "cjs",
                     "valid": true
@@ -138,6 +145,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "os",
                     "moduleSystem": "cjs",
                     "valid": true
@@ -157,6 +165,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./twoDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -176,6 +185,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./threeDeepInSub",
                     "moduleSystem": "cjs",
                     "valid": true

--- a/test/extract/fixtures/maxDepth1.json
+++ b/test/extract/fixtures/maxDepth1.json
@@ -12,6 +12,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -25,6 +26,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -38,6 +40,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/oneDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -51,6 +54,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "os",
                     "moduleSystem": "es6",
                     "valid": true

--- a/test/extract/fixtures/maxDepth2.json
+++ b/test/extract/fixtures/maxDepth2.json
@@ -12,6 +12,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -25,6 +26,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -38,6 +40,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/oneDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -51,6 +54,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "os",
                     "moduleSystem": "es6",
                     "valid": true
@@ -87,6 +91,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -100,6 +105,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./twoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -124,6 +130,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./twoDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true

--- a/test/extract/fixtures/maxDepth4.json
+++ b/test/extract/fixtures/maxDepth4.json
@@ -12,6 +12,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -25,6 +26,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -38,6 +40,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/oneDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -51,6 +54,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "os",
                     "moduleSystem": "es6",
                     "valid": true
@@ -87,6 +91,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./oneAndTwoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -100,6 +105,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./twoDeep",
                     "moduleSystem": "es6",
                     "valid": true
@@ -119,6 +125,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/threeDeepInSub",
                     "moduleSystem": "cjs",
                     "valid": true
@@ -138,6 +145,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "os",
                     "moduleSystem": "cjs",
                     "valid": true
@@ -157,6 +165,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./twoDeepInSub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -176,6 +185,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./threeDeepInSub",
                     "moduleSystem": "cjs",
                     "valid": true

--- a/test/extract/fixtures/ts-recursive.json
+++ b/test/extract/fixtures/ts-recursive.json
@@ -18,6 +18,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -32,6 +33,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -46,6 +48,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -60,6 +63,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -74,6 +78,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -88,6 +93,7 @@
                         "dependencyTypes": [
                             "core"
                         ],
+                        "dynamic": false,
                         "followable": false,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -137,6 +143,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -179,6 +186,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -199,6 +207,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,
@@ -232,6 +241,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "module": "./b",
                         "moduleSystem": "es6",
                         "matchesDoNotFollow": false,
@@ -245,6 +255,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "module": "./c",
                         "moduleSystem": "es6",
                         "matchesDoNotFollow": false,
@@ -264,6 +275,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "module": "./c",
                         "moduleSystem": "es6",
                         "matchesDoNotFollow": false,
@@ -297,6 +309,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "followable": true,
                         "matchesDoNotFollow": false,
                         "couldNotResolve": false,

--- a/test/extract/fixtures/ts.json
+++ b/test/extract/fixtures/ts.json
@@ -13,6 +13,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -25,6 +26,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -37,6 +39,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -49,6 +52,7 @@
                 "dependencyTypes": [
                     "local"
                 ],
+                "dynamic": false,
                 "followable": true,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -61,6 +65,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false
@@ -73,6 +78,7 @@
                 "dependencyTypes": [
                     "core"
                 ],
+                "dynamic": false,
                 "followable": false,
                 "matchesDoNotFollow": false,
                 "couldNotResolve": false

--- a/test/extract/fixtures/vue.json
+++ b/test/extract/fixtures/vue.json
@@ -16,6 +16,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "module": "./App.vue",
                         "moduleSystem": "es6",
                         "matchesDoNotFollow": false,
@@ -29,6 +30,7 @@
                         "dependencyTypes": [
                             "unknown"
                         ],
+                        "dynamic": false,
                         "module": "vue",
                         "moduleSystem": "es6",
                         "matchesDoNotFollow": false,
@@ -60,6 +62,7 @@
                         "dependencyTypes": [
                             "local"
                         ],
+                        "dynamic": false,
                         "module": "./components/HelloWorld.vue",
                         "moduleSystem": "es6",
                         "matchesDoNotFollow": false,

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -1,0 +1,149 @@
+{
+  "modules": [
+    {
+      "source": "src/circular.js",
+      "dependencies": [
+        {
+          "resolved": "src/index.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./index",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "no-circular"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "src/index.js",
+      "dependencies": [
+        {
+          "resolved": "src/dynamic-to-circular.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./dynamic-to-circular",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "no-circular"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "src/dynamic-to-circular.js",
+      "dependencies": [
+        {
+          "resolved": "src/circular.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./circular",
+          "moduleSystem": "es6",
+          "dynamic": true,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "warn",
+              "name": "no-dynamic"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [
+      {
+        "from": "src/circular.js",
+        "to": "src/index.js",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      },
+      {
+        "from": "src/dynamic-to-circular.js",
+        "to": "src/circular.js",
+        "rule": {
+          "severity": "warn",
+          "name": "no-dynamic"
+        }
+      },
+      {
+        "from": "src/index.js",
+        "to": "src/dynamic-to-circular.js",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      }
+    ],
+    "error": 0,
+    "warn": 1,
+    "info": 2,
+    "totalCruised": 3,
+    "optionsUsed": {
+      "combinedDependencies": false,
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": [
+        "amd",
+        "cjs",
+        "es6"
+      ],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": false
+    },
+    "ruleSetUsed": {
+      "forbidden": [
+        {
+          "name": "no-circular",
+          "severity": "info",
+          "from": {},
+          "to": {
+            "dynamic": false,
+            "circular": true
+          }
+        },
+        {
+          "name": "no-dynamic",
+          "severity": "warn",
+          "from": {},
+          "to": {
+            "dynamic": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/main/fixtures/dynamic-imports/es/src/circular.js
+++ b/test/main/fixtures/dynamic-imports/es/src/circular.js
@@ -1,0 +1,3 @@
+import * as index from './index';
+
+export const fun() => console.log(index.value);

--- a/test/main/fixtures/dynamic-imports/es/src/dynamic-to-circular.js
+++ b/test/main/fixtures/dynamic-imports/es/src/dynamic-to-circular.js
@@ -1,0 +1,1 @@
+import('./circular').then(pModule => pModule.fun())

--- a/test/main/fixtures/dynamic-imports/es/src/index.js
+++ b/test/main/fixtures/dynamic-imports/es/src/index.js
@@ -1,0 +1,4 @@
+import { fun } from "./dynamic-to-circular";
+
+fun();
+export const value = 3.14

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -1,0 +1,149 @@
+{
+  "modules": [
+    {
+      "source": "src/circular.ts",
+      "dependencies": [
+        {
+          "resolved": "src/index.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./index",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "no-circular"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "src/index.ts",
+      "dependencies": [
+        {
+          "resolved": "src/dynamic-to-circular.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./dynamic-to-circular",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "no-circular"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "src/dynamic-to-circular.ts",
+      "dependencies": [
+        {
+          "resolved": "src/circular.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./circular",
+          "moduleSystem": "es6",
+          "dynamic": true,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "warn",
+              "name": "no-dynamic"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [
+      {
+        "from": "src/circular.ts",
+        "to": "src/index.ts",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      },
+      {
+        "from": "src/dynamic-to-circular.ts",
+        "to": "src/circular.ts",
+        "rule": {
+          "severity": "warn",
+          "name": "no-dynamic"
+        }
+      },
+      {
+        "from": "src/index.ts",
+        "to": "src/dynamic-to-circular.ts",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      }
+    ],
+    "error": 0,
+    "warn": 1,
+    "info": 2,
+    "totalCruised": 3,
+    "optionsUsed": {
+      "combinedDependencies": false,
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": [
+        "amd",
+        "cjs",
+        "es6"
+      ],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": true
+    },
+    "ruleSetUsed": {
+      "forbidden": [
+        {
+          "name": "no-circular",
+          "severity": "info",
+          "from": {},
+          "to": {
+            "dynamic": false,
+            "circular": true
+          }
+        },
+        {
+          "name": "no-dynamic",
+          "severity": "warn",
+          "from": {},
+          "to": {
+            "dynamic": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -1,0 +1,149 @@
+{
+  "modules": [
+    {
+      "source": "src/circular.ts",
+      "dependencies": [
+        {
+          "resolved": "src/index.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./index",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "no-circular"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "src/index.ts",
+      "dependencies": [
+        {
+          "resolved": "src/dynamic-to-circular.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./dynamic-to-circular",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "info",
+              "name": "no-circular"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "src/dynamic-to-circular.ts",
+      "dependencies": [
+        {
+          "resolved": "src/circular.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "module": "./circular",
+          "moduleSystem": "es6",
+          "dynamic": true,
+          "matchesDoNotFollow": false,
+          "circular": true,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "warn",
+              "name": "no-dynamic"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [
+      {
+        "from": "src/circular.ts",
+        "to": "src/index.ts",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      },
+      {
+        "from": "src/dynamic-to-circular.ts",
+        "to": "src/circular.ts",
+        "rule": {
+          "severity": "warn",
+          "name": "no-dynamic"
+        }
+      },
+      {
+        "from": "src/index.ts",
+        "to": "src/dynamic-to-circular.ts",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      }
+    ],
+    "error": 0,
+    "warn": 1,
+    "info": 2,
+    "totalCruised": 3,
+    "optionsUsed": {
+      "combinedDependencies": false,
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": [
+        "amd",
+        "cjs",
+        "es6"
+      ],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": false
+    },
+    "ruleSetUsed": {
+      "forbidden": [
+        {
+          "name": "no-circular",
+          "severity": "info",
+          "from": {},
+          "to": {
+            "dynamic": false,
+            "circular": true
+          }
+        },
+        {
+          "name": "no-dynamic",
+          "severity": "warn",
+          "from": {},
+          "to": {
+            "dynamic": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/main/fixtures/dynamic-imports/typescript/src/circular.ts
+++ b/test/main/fixtures/dynamic-imports/typescript/src/circular.ts
@@ -1,0 +1,3 @@
+import * as index from './index';
+
+export const fun() => console.log(index.value);

--- a/test/main/fixtures/dynamic-imports/typescript/src/dynamic-to-circular.ts
+++ b/test/main/fixtures/dynamic-imports/typescript/src/dynamic-to-circular.ts
@@ -1,0 +1,1 @@
+import('./circular').then(pModule => pModule.fun())

--- a/test/main/fixtures/dynamic-imports/typescript/src/index.ts
+++ b/test/main/fixtures/dynamic-imports/typescript/src/index.ts
@@ -1,0 +1,4 @@
+import { fun } from "./dynamic-to-circular";
+
+fun();
+export const value = 3.14

--- a/test/main/fixtures/jsx-as-object.json
+++ b/test/main/fixtures/jsx-as-object.json
@@ -13,6 +13,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./jsx",
                     "moduleSystem": "cjs",
                     "valid": true
@@ -32,6 +33,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "components/pay-method-choice",
                     "moduleSystem": "es6",
                     "valid": true
@@ -45,6 +47,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "components/product-detail",
                     "moduleSystem": "es6",
                     "valid": true
@@ -58,6 +61,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "products",
                     "moduleSystem": "es6",
                     "valid": true
@@ -71,6 +75,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "react",
                     "moduleSystem": "es6",
                     "valid": true
@@ -84,6 +89,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "tracking",
                     "moduleSystem": "es6",
                     "valid": true
@@ -97,6 +103,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "utils",
                     "moduleSystem": "es6",
                     "valid": true

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -13,6 +13,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./jsx",
                     "moduleSystem": "cjs",
                     "valid": true
@@ -32,6 +33,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "components/pay-method-choice",
                     "moduleSystem": "es6",
                     "valid": true
@@ -45,6 +47,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "components/product-detail",
                     "moduleSystem": "es6",
                     "valid": true
@@ -58,6 +61,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "products",
                     "moduleSystem": "es6",
                     "valid": true
@@ -71,6 +75,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "react",
                     "moduleSystem": "es6",
                     "valid": true
@@ -84,6 +89,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "tracking",
                     "moduleSystem": "es6",
                     "valid": true
@@ -97,6 +103,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "utils",
                     "moduleSystem": "es6",
                     "valid": true

--- a/test/main/fixtures/ts-no-precomp-cjs.json
+++ b/test/main/fixtures/ts-no-precomp-cjs.json
@@ -23,6 +23,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./also-used",
@@ -36,6 +37,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./definitely-used",

--- a/test/main/fixtures/ts-no-precomp-es.json
+++ b/test/main/fixtures/ts-no-precomp-es.json
@@ -23,6 +23,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./also-used",
@@ -36,6 +37,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./definitely-used",

--- a/test/main/fixtures/ts-precomp-cjs.json
+++ b/test/main/fixtures/ts-precomp-cjs.json
@@ -23,6 +23,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./also-used",
@@ -36,6 +37,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./definitely-used",
@@ -49,6 +51,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./imported-from-index-but-not-used",

--- a/test/main/fixtures/ts-precomp-es.json
+++ b/test/main/fixtures/ts-precomp-es.json
@@ -23,6 +23,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./also-used",
@@ -36,6 +37,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./definitely-used",
@@ -49,6 +51,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "followable": true,
                     "matchesDoNotFollow": false,
                     "module": "./imported-from-index-but-not-used",

--- a/test/main/fixtures/ts.json
+++ b/test/main/fixtures/ts.json
@@ -13,6 +13,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./javascriptThing",
                     "moduleSystem": "es6",
                     "valid": true
@@ -26,6 +27,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub",
                     "moduleSystem": "es6",
                     "valid": true
@@ -39,6 +41,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/kaching",
                     "moduleSystem": "es6",
                     "valid": true
@@ -52,6 +55,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/willBeReExported",
                     "moduleSystem": "es6",
                     "valid": true
@@ -65,6 +69,7 @@
                     "dependencyTypes": [
                         "core"
                     ],
+                    "dynamic": false,
                     "module": "path",
                     "moduleSystem": "es6",
                     "valid": true
@@ -101,6 +106,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./willBeReExported",
                     "moduleSystem": "es6",
                     "valid": true

--- a/test/main/fixtures/tsx.json
+++ b/test/main/fixtures/tsx.json
@@ -13,6 +13,7 @@
                     "dependencyTypes": [
                         "local"
                     ],
+                    "dynamic": false,
                     "module": "./sub/render",
                     "moduleSystem": "es6",
                     "valid": true
@@ -32,6 +33,7 @@
                     "dependencyTypes": [
                         "unknown"
                     ],
+                    "dynamic": false,
                     "module": "react-dom",
                     "moduleSystem": "es6",
                     "valid": true

--- a/test/main/main.dynamic-imports.spec.js
+++ b/test/main/main.dynamic-imports.spec.js
@@ -1,0 +1,134 @@
+const chai       = require('chai');
+const main       = require("../../src/main");
+const depSchema  = require('../../src/extract/results-schema.json');
+const esOut      = require('./fixtures/dynamic-imports/es/output.json');
+const tsOut      = require('./fixtures/dynamic-imports/typescript/output.json');
+const tsOutpre   = require('./fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json');
+
+const expect     = chai.expect;
+
+chai.use(require('chai-json-schema'));
+
+const gWorkingDir = process.cwd();
+
+describe('main - dynamic imports', () => {
+    beforeEach("reset current wd", () => {
+        process.chdir(gWorkingDir);
+    });
+
+    afterEach("reset current wd", () => {
+        process.chdir(gWorkingDir);
+    });
+
+    it("detects dynamic dependencies in es", () => {
+        process.chdir('test/main/fixtures/dynamic-imports/es');
+        const lResult = main.cruise(
+            ["src"],
+            {
+                ruleSet: {
+                    forbidden: [
+                        {
+                            name: 'no-circular',
+                            severity: 'info',
+                            from: {
+                            },
+                            to: {
+                                dynamic: false,
+                                circular: true
+                            }
+                        },
+                        {
+                            name: 'no-dynamic',
+                            severity: 'warn',
+                            from: {
+                            },
+                            to: {
+                                dynamic: true
+                            }
+                        }
+                    ]
+                },
+                validate: true
+            },
+            {bustTheCache:true}
+        );
+
+        expect(lResult).to.deep.equal(esOut);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+
+    it("detects dynamic dependencies in typescript", () => {
+        process.chdir('test/main/fixtures/dynamic-imports/typescript');
+        const lResult = main.cruise(
+            ["src"],
+            {
+                ruleSet: {
+                    forbidden: [
+                        {
+                            name: 'no-circular',
+                            severity: 'info',
+                            from: {
+                            },
+                            to: {
+                                dynamic: false,
+                                circular: true
+                            }
+                        },
+                        {
+                            name: 'no-dynamic',
+                            severity: 'warn',
+                            from: {
+                            },
+                            to: {
+                                dynamic: true
+                            }
+                        }
+                    ]
+                },
+                validate: true
+            },
+            {bustTheCache:true}
+        );
+
+        expect(lResult).to.deep.equal(tsOut);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+
+    it("detects dynamic dependencies in typescript when using tsPreCompilationDeps", () => {
+        process.chdir('test/main/fixtures/dynamic-imports/typescript');
+        const lResult = main.cruise(
+            ["src"],
+            {
+                ruleSet: {
+                    forbidden: [
+                        {
+                            name: 'no-circular',
+                            severity: 'info',
+                            from: {
+                            },
+                            to: {
+                                dynamic: false,
+                                circular: true
+                            }
+                        },
+                        {
+                            name: 'no-dynamic',
+                            severity: 'warn',
+                            from: {
+                            },
+                            to: {
+                                dynamic: true
+                            }
+                        }
+                    ]
+                },
+                validate: true,
+                tsPreCompilationDeps: true
+            },
+            {bustTheCache:true}
+        );
+
+        expect(lResult).to.deep.equal(tsOutpre);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+});

--- a/test/main/main.spec.js
+++ b/test/main/main.spec.js
@@ -5,10 +5,6 @@ const tsFixture  = require('./fixtures/ts.json');
 const tsxFixture = require('./fixtures/tsx.json');
 const jsxFixture = require('./fixtures/jsx.json');
 const jsxAsObjectFixture = require('./fixtures/jsx-as-object.json');
-const tsPreCompFixtureCJS = require('./fixtures/ts-precomp-cjs.json');
-const tsPreCompFixtureES = require('./fixtures/ts-precomp-es.json');
-const tsNoPrecompFixtureCJS = require('./fixtures/ts-no-precomp-cjs.json');
-const tsNoPrecompFixtureES = require('./fixtures/ts-no-precomp-es.json');
 
 const expect     = chai.expect;
 
@@ -51,88 +47,5 @@ describe("main", () => {
         expect(lResult).to.deep.equal(jsxAsObjectFixture);
         expect(lResult).to.be.jsonSchema(depSchema);
     });
-    it("ts-pre-compilation-deps: on, target CJS", () => {
-        const lResult = main.cruise(
-            ["test/main/fixtures/ts-precompilation-deps-on-cjs"],
-            {
-                tsConfig: {
-                    fileName: "test/main/fixtures/tsconfig.targetcjs.json"
-                },
-                tsPreCompilationDeps: true
-            },
-            {bustTheCache:true},
-            {
-                "options": {
-                    "baseUrl": ".",
-                    "module": "commonjs"
-                }
-            }
-        );
-
-        expect(lResult).to.deep.equal(tsPreCompFixtureCJS);
-        expect(lResult).to.be.jsonSchema(depSchema);
-    });
-    it("ts-pre-compilation-deps: on, target ES", () => {
-        const lResult = main.cruise(
-            ["test/main/fixtures/ts-precompilation-deps-on-es"],
-            {
-                tsConfig: {
-                    fileName: "test/main/fixtures/tsconfig.targetes.json"
-                },
-                tsPreCompilationDeps: true
-            },
-            {bustTheCache:true},
-            {
-                "options": {
-                    "baseUrl": ".",
-                    "module": "es6"
-                }
-            }
-        );
-
-        expect(lResult).to.deep.equal(tsPreCompFixtureES);
-        expect(lResult).to.be.jsonSchema(depSchema);
-    });
-    it("ts-pre-compilation-deps: off, target CJS", () => {
-        const lResult = main.cruise(
-            ["test/main/fixtures/ts-precompilation-deps-off-cjs"],
-            {
-                tsConfig: {
-                    fileName: "test/main/fixtures/tsconfig.targetcjs.json"
-                },
-                tsPreCompilationDeps: false
-            },
-            {bustTheCache:true},
-            {
-                "options": {
-                    "baseUrl": ".",
-                    "module": "commonjs"
-                }
-            }
-        );
-
-        expect(lResult).to.deep.equal(tsNoPrecompFixtureCJS);
-        expect(lResult).to.be.jsonSchema(depSchema);
-    });
-    it("ts-pre-compilation-deps: off, target ES", () => {
-        const lResult = main.cruise(
-            ["test/main/fixtures/ts-precompilation-deps-off-es"],
-            {
-                tsConfig: {
-                    fileName: "test/main/fixtures/tsconfig.targetes.json"
-                },
-                tsPreCompilationDeps: false
-            },
-            {bustTheCache:true},
-            {
-                "options": {
-                    "baseUrl": ".",
-                    "module": "es6"
-                }
-            }
-        );
-
-        expect(lResult).to.deep.equal(tsNoPrecompFixtureES);
-        expect(lResult).to.be.jsonSchema(depSchema);
-    });
 });
+

--- a/test/main/main.ts-pre-compilation-deps.spec.js
+++ b/test/main/main.ts-pre-compilation-deps.spec.js
@@ -1,0 +1,98 @@
+const chai       = require('chai');
+const main       = require("../../src/main");
+const depSchema  = require('../../src/extract/results-schema.json');
+const tsPreCompFixtureCJS   = require('./fixtures/ts-precomp-cjs.json');
+const tsPreCompFixtureES    = require('./fixtures/ts-precomp-es.json');
+const tsNoPrecompFixtureCJS = require('./fixtures/ts-no-precomp-cjs.json');
+const tsNoPrecompFixtureES  = require('./fixtures/ts-no-precomp-es.json');
+
+const expect     = chai.expect;
+
+chai.use(require('chai-json-schema'));
+
+describe('main - tsPreCompilationDeps', () => {
+    it("ts-pre-compilation-deps: on, target CJS", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-on-cjs"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetcjs.json"
+                },
+                tsPreCompilationDeps: true
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "commonjs"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsPreCompFixtureCJS);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: on, target ES", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-on-es"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetes.json"
+                },
+                tsPreCompilationDeps: true
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "es6"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsPreCompFixtureES);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: off, target CJS", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-off-cjs"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetcjs.json"
+                },
+                tsPreCompilationDeps: false
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "commonjs"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsNoPrecompFixtureCJS);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+    it("ts-pre-compilation-deps: off, target ES", () => {
+        const lResult = main.cruise(
+            ["test/main/fixtures/ts-precompilation-deps-off-es"],
+            {
+                tsConfig: {
+                    fileName: "test/main/fixtures/tsconfig.targetes.json"
+                },
+                tsPreCompilationDeps: false
+            },
+            {bustTheCache:true},
+            {
+                "options": {
+                    "baseUrl": ".",
+                    "module": "es6"
+                }
+            }
+        );
+
+        expect(lResult).to.deep.equal(tsNoPrecompFixtureES);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+});


### PR DESCRIPTION
## Description
- Adds the 'dynamic' attribute to the internal data model, that equals _true_ if the dependency is dynamic, and _false_ in all other cases
- Enables validating against a dependency being either true or false

Sample rule snippet to make sure modules in `@theotherside` get depended on with dynamic imports only:
```json
{
    "forbidden":[
        {
            "name": "only-dyn-deps-to-otherside",
            "comment": "only dynamically depend on 'otherside' modules",
            "severity": "error",
            "from": {},
            "to": { "path": "@theotherside/", "dynamic": "false" }
        }
    ]
}
```

Or to prevent the usage of dynamic imports (note: this isn't 100% water tight - needs [this back log item](https://github.com/sverweij/dependency-cruiser/projects/1#card-21113518) to be resolved)
```javascript
{
  forbidden: [
    {
      name: "no-dyn-deps",
      from: {
      },
      to {
        dynamic: true
      }
  ]
}
```

## Motivation and Context
addresses #141 (partly)

## How Has This Been Tested?
- [x] (adapted) automated non-regression tests
- [x] new automated tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.