### PR TITLE
feature(extract): more actionable default violation ordering

### DIFF
--- a/src/extract/results-schema.json
+++ b/src/extract/results-schema.json
@@ -33,6 +33,10 @@
                     "type": "number",
                     "description": "the number of modules cruised"
                 },
+                "totalDependenciesCruised": {
+                    "type": "number",
+                    "description": "the number of dependencies cruised"
+                },
                 "ruleSetUsed": {
                     "type":"object",
                     "additionalProperties": false,

--- a/src/extract/summarize.js
+++ b/src/extract/summarize.js
@@ -83,7 +83,8 @@ module.exports = (pModules) => {
         },
         extractMetaData(lViolations),
         {
-            totalCruised: pModules.length
+            totalCruised: pModules.length,
+            totalDependenciesCruised: pModules.reduce((pAll, pCurrent) => pAll + pCurrent.dependencies.length, 0)
         }
     );
 };

--- a/src/extract/summarize.js
+++ b/src/extract/summarize.js
@@ -1,6 +1,5 @@
 const _flattenDeep = require('lodash/flattenDeep');
-
-const dependencySortFn = (left, right) => `${left.from}|${left.to}` > `${right.from}|${right.to}` ? 1 : -1;
+const order = require('./utl/order');
 
 function cutNonTransgressions(pSourceEntry) {
     return {
@@ -75,7 +74,7 @@ function extractModuleViolations(pModules){
 module.exports = (pModules) => {
     const lViolations = extractDependencyViolations(pModules)
         .concat(extractModuleViolations(pModules))
-        .sort(dependencySortFn);
+        .sort(order.violations);
 
     return Object.assign(
         {
@@ -84,7 +83,7 @@ module.exports = (pModules) => {
         extractMetaData(lViolations),
         {
             totalCruised: pModules.length,
-            totalDependenciesCruised: pModules.reduce((pAll, pCurrent) => pAll + pCurrent.dependencies.length, 0)
+            totalDependenciesCruised: pModules.reduce((pAll, pModule) => pAll + pModule.dependencies.length, 0)
         }
     );
 };

--- a/src/extract/utl/order.js
+++ b/src/extract/utl/order.js
@@ -1,0 +1,27 @@
+function severity2number(pSeverity) {
+    const SEVERITY2NUMBER = {
+        error: 1,
+        warn: 2,
+        info: 3,
+        ignore: 4
+    };
+
+    // eslint-disable-next-line security/detect-object-injection
+    return SEVERITY2NUMBER[pSeverity] || -1;
+}
+
+function severities(pFirstSeverity, pSecondSeverity) {
+    return Math.sign(severity2number(pFirstSeverity) - severity2number(pSecondSeverity));
+}
+
+function violations(pFirstViolation, pSecondViolation) {
+    return severities(pFirstViolation.rule.severity, pSecondViolation.rule.severity) ||
+        pFirstViolation.rule.name.localeCompare(pSecondViolation.rule.name) ||
+        pFirstViolation.from.localeCompare(pSecondViolation.from) ||
+        pFirstViolation.to.localeCompare(pSecondViolation.to);
+}
+
+module.exports = {
+    severities,
+    violations
+};

--- a/test/cli/fixtures/cjs.dir.filtered.json
+++ b/test/cli/fixtures/cjs.dir.filtered.json
@@ -343,6 +343,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 12,
+        "totalDependenciesCruised": 16,
         "optionsUsed": {
             "args": "test/cli/fixtures/cjs",
             "outputTo": "test/cli/output/cjs.dir.filtered.json",

--- a/test/cli/fixtures/cjs.dir.json
+++ b/test/cli/fixtures/cjs.dir.json
@@ -404,6 +404,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 15,
+        "totalDependenciesCruised": 19,
         "optionsUsed": {
             "args": "test/cli/fixtures/cjs",
             "outputTo": "test/cli/output/cjs.dir.json",

--- a/test/cli/fixtures/cjs.dir.stdout.json
+++ b/test/cli/fixtures/cjs.dir.stdout.json
@@ -404,6 +404,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 15,
+        "totalDependenciesCruised": 19,
         "optionsUsed": {
             "outputTo": "-",
             "moduleSystems": [

--- a/test/cli/fixtures/cjs.file.json
+++ b/test/cli/fixtures/cjs.file.json
@@ -293,6 +293,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 11,
+        "totalDependenciesCruised": 14,
         "optionsUsed": {
             "args": "test/cli/fixtures/cjs/root_one.js",
             "outputTo": "test/cli/output/cjs.file.json",

--- a/test/cli/fixtures/dynamic-import-nok.json
+++ b/test/cli/fixtures/dynamic-import-nok.json
@@ -32,6 +32,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 2,
+        "totalDependenciesCruised": 1,
         "ruleSetUsed": {},
         "optionsUsed": {
             "args": "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/import_dynamically2.ts",

--- a/test/cli/fixtures/dynamic-import-ok.json
+++ b/test/cli/fixtures/dynamic-import-ok.json
@@ -32,6 +32,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 2,
+        "totalDependenciesCruised": 1,
         "ruleSetUsed": {},
         "optionsUsed": {
             "args": "test/cli/fixtures/typescriptconfig/cli-dynamic-imports/import_dynamically.ts",

--- a/test/cli/fixtures/multiple-in-one-go.json
+++ b/test/cli/fixtures/multiple-in-one-go.json
@@ -141,6 +141,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 7,
+        "totalDependenciesCruised": 5,
         "optionsUsed": {
             "args": "test/cli/fixtures/cjs/sub test/cli/fixtures/duplicate-subs/sub/more-in-sub.js test/cli/fixtures/unresolvable-in-sub",
             "outputTo": "test/cli/output/multiple-in-one-go.json",

--- a/test/cli/fixtures/typescript-path-resolution.json
+++ b/test/cli/fixtures/typescript-path-resolution.json
@@ -52,6 +52,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 3,
+        "totalDependenciesCruised": 2,
         "ruleSetUsed": {},
         "optionsUsed": {
             "args": "test/cli/fixtures/typescriptconfig/cli-config-with-path/src",

--- a/test/cli/fixtures/webpack-config-alias-cruiser-config.json
+++ b/test/cli/fixtures/webpack-config-alias-cruiser-config.json
@@ -58,6 +58,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 3,
+        "totalDependenciesCruised": 2,
         "ruleSetUsed": {
             "forbidden": []
         },

--- a/test/cli/fixtures/webpack-config-alias.json
+++ b/test/cli/fixtures/webpack-config-alias.json
@@ -58,6 +58,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 3,
+        "totalDependenciesCruised": 2,
         "ruleSetUsed": {},
         "optionsUsed": {
             "args": "test/cli/fixtures/webpackconfig/aliassy/src",

--- a/test/extract/fixtures/cache-busting-first-tree.json
+++ b/test/extract/fixtures/cache-busting-first-tree.json
@@ -99,6 +99,7 @@
   "warn": 0,
   "info": 0,
   "totalCruised": 4,
+  "totalDependenciesCruised": 3,
   "optionsUsed": {
    "args": "./test/extract/fixtures/cache-busting/index.ts",
    "combinedDependencies": false,

--- a/test/extract/fixtures/cache-busting-second-tree.json
+++ b/test/extract/fixtures/cache-busting-second-tree.json
@@ -140,6 +140,7 @@
   "warn": 0,
   "info": 0,
   "totalCruised": 5,
+  "totalDependenciesCruised": 4,
   "optionsUsed": {
     "args": "./test/extract/fixtures/cache-busting/index.ts",
    "combinedDependencies": false,

--- a/test/extract/summarize.spec.js
+++ b/test/extract/summarize.spec.js
@@ -14,6 +14,7 @@ describe('extract/summarize - summarize extraction', () => {
             info: 0,
             warn: 0,
             error: 0,
+            totalDependenciesCruised: 0,
             totalCruised: 0
         });
     });
@@ -32,6 +33,7 @@ describe('extract/summarize - summarize extraction', () => {
             info: 0,
             warn: 0,
             error: 0,
+            totalDependenciesCruised: 0,
             totalCruised: 1
         });
     });
@@ -61,6 +63,7 @@ describe('extract/summarize - summarize extraction', () => {
             info: 0,
             warn: 1,
             error: 0,
+            totalDependenciesCruised: 0,
             totalCruised: 1
         });
     });
@@ -103,6 +106,7 @@ describe('extract/summarize - summarize extraction', () => {
             info: 0,
             warn: 0,
             error: 0,
+            totalDependenciesCruised: 1,
             totalCruised: 2
         });
     });
@@ -168,6 +172,7 @@ describe('extract/summarize - summarize extraction', () => {
             info: 1,
             warn: 0,
             error: 1,
+            totalDependenciesCruised: 1,
             totalCruised: 2
         });
     });

--- a/test/extract/utl/order.severities.spec.js
+++ b/test/extract/utl/order.severities.spec.js
@@ -1,0 +1,29 @@
+const expect = require('chai').expect;
+const order  = require('../../../src/extract/utl/order');
+
+
+describe("extract/utl/order - severities", () => {
+    it("returns 0 for identical severities", () => {
+        expect(order.severities("warn", "warn")).to.equal(0);
+    });
+
+    it("returns 0 for identical severities - even unknown ones", () => {
+        expect(order.severities("unknown", "unknown")).to.equal(0);
+    });
+
+    it("returns -1 when comparing an unknown severity with a known one", () => {
+        expect(order.severities("unknown", "error")).to.equal(-1);
+    });
+
+    it("returns 1 when comparing a known severity with an unknown one", () => {
+        expect(order.severities("info", "unknown")).to.equal(1);
+    });
+
+    it("returns 1 when comparing a less severe severity with a more severe one", () => {
+        expect(order.severities("info", "error")).to.equal(1);
+    });
+
+    it("returns -1 when comparing a more severe severity with a less severe one", () => {
+        expect(order.severities("error", "info")).to.equal(-1);
+    });
+});

--- a/test/extract/utl/order.violations.spec.js
+++ b/test/extract/utl/order.violations.spec.js
@@ -1,0 +1,74 @@
+const expect = require('chai').expect;
+const order  = require('../../../src/extract/utl/order');
+
+
+describe("extract/utl/order - violations", () => {
+    const lViolation = {
+        from: "from",
+        to: "to",
+        rule: {
+            name: "cool-rule",
+            severity: "error"
+        }
+    };
+
+    const lLessSevereViolation = {
+        from: "from",
+        to: "to",
+        rule: {
+            name: "cool-rule",
+            severity: "info"
+        }
+    };
+
+    const lLaterNameViolation = {
+        from: "from",
+        to: "to",
+        rule: {
+            name: "drool-rule",
+            severity: "error"
+        }
+    };
+
+    const lLaterToViolation = {
+        from: "from",
+        to: "tox",
+        rule: {
+            name: "cool-rule",
+            severity: "error"
+        }
+    };
+
+    const lLaterFromViolation = {
+        from: "fromx",
+        to: "to",
+        rule: {
+            name: "cool-rule",
+            severity: "error"
+        }
+    };
+
+    it("returns 0 for identical violations", () => {
+        expect(order.violations(lViolation, lViolation)).to.equal(0);
+    });
+
+    it("returns -1 when severity > the one compared against", () => {
+        expect(order.violations(lViolation, lLessSevereViolation)).to.equal(-1);
+    });
+
+    it("returns 1 when severity < the one compared against", () => {
+        expect(order.violations(lLessSevereViolation, lViolation)).to.equal(1);
+    });
+
+    it("returns -1 when rule name < the one compared against", () => {
+        expect(order.violations(lViolation, lLaterNameViolation)).to.equal(-1);
+    });
+
+    it("returns -1 when rule 'from' < the one compared against", () => {
+        expect(order.violations(lViolation, lLaterFromViolation)).to.equal(-1);
+    });
+
+    it("returns -1 when rule 'to' < the one compared against", () => {
+        expect(order.violations(lViolation, lLaterToViolation)).to.equal(-1);
+    });
+});

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -113,6 +113,7 @@
     "warn": 1,
     "info": 2,
     "totalCruised": 3,
+    "totalDependenciesCruised": 3,
     "optionsUsed": {
       "args": "src",
       "combinedDependencies": false,

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -85,14 +85,6 @@
   "summary": {
     "violations": [
       {
-        "from": "src/circular.js",
-        "to": "src/index.js",
-        "rule": {
-          "severity": "info",
-          "name": "no-circular"
-        }
-      },
-      {
         "from": "src/dynamic-to-circular.js",
         "to": "src/circular.js",
         "rule": {
@@ -100,6 +92,15 @@
           "name": "no-dynamic"
         }
       },
+      {
+        "from": "src/circular.js",
+        "to": "src/index.js",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
+        }
+      },
+
       {
         "from": "src/index.js",
         "to": "src/dynamic-to-circular.js",

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -113,6 +113,7 @@
     "warn": 1,
     "info": 2,
     "totalCruised": 3,
+    "totalDependenciesCruised": 3,
     "optionsUsed": {
       "args": "src",
       "combinedDependencies": false,

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -85,19 +85,19 @@
   "summary": {
     "violations": [
       {
-        "from": "src/circular.ts",
-        "to": "src/index.ts",
-        "rule": {
-          "severity": "info",
-          "name": "no-circular"
-        }
-      },
-      {
         "from": "src/dynamic-to-circular.ts",
         "to": "src/circular.ts",
         "rule": {
           "severity": "warn",
           "name": "no-dynamic"
+        }
+      },
+      {
+        "from": "src/circular.ts",
+        "to": "src/index.ts",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
         }
       },
       {

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -113,6 +113,7 @@
     "warn": 1,
     "info": 2,
     "totalCruised": 3,
+    "totalDependenciesCruised": 3,
     "optionsUsed": {
       "args": "src",
       "combinedDependencies": false,

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -85,19 +85,19 @@
   "summary": {
     "violations": [
       {
-        "from": "src/circular.ts",
-        "to": "src/index.ts",
-        "rule": {
-          "severity": "info",
-          "name": "no-circular"
-        }
-      },
-      {
         "from": "src/dynamic-to-circular.ts",
         "to": "src/circular.ts",
         "rule": {
           "severity": "warn",
           "name": "no-dynamic"
+        }
+      },
+      {
+        "from": "src/circular.ts",
+        "to": "src/index.ts",
+        "rule": {
+          "severity": "info",
+          "name": "no-circular"
         }
       },
       {

--- a/test/main/fixtures/jsx-as-object.json
+++ b/test/main/fixtures/jsx-as-object.json
@@ -189,6 +189,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 8,
+        "totalDependenciesCruised": 7,
         "ruleSetUsed": {},
         "optionsUsed": {
             "args": "test/main/fixtures/jsx",

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -189,6 +189,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 8,
+        "totalDependenciesCruised": 7,
         "optionsUsed": {
             "args": "test/main/fixtures/jsx",
             "moduleSystems": ["amd", "cjs", "es6"],

--- a/test/main/fixtures/ts-no-precomp-cjs.json
+++ b/test/main/fixtures/ts-no-precomp-cjs.json
@@ -66,6 +66,7 @@
             "combinedDependencies": false
         },
         "totalCruised": 4,
+        "totalDependenciesCruised": 2,
         "violations": [],
         "warn": 0
     }

--- a/test/main/fixtures/ts-no-precomp-es.json
+++ b/test/main/fixtures/ts-no-precomp-es.json
@@ -66,6 +66,7 @@
             "combinedDependencies": false
         },
         "totalCruised": 4,
+        "totalDependenciesCruised": 2,
         "violations": [],
         "warn": 0
     }

--- a/test/main/fixtures/ts-precomp-cjs.json
+++ b/test/main/fixtures/ts-precomp-cjs.json
@@ -80,6 +80,7 @@
             "combinedDependencies": false
         },
         "totalCruised": 4,
+        "totalDependenciesCruised": 3,
         "violations": [],
         "warn": 0
     }

--- a/test/main/fixtures/ts-precomp-es.json
+++ b/test/main/fixtures/ts-precomp-es.json
@@ -80,6 +80,7 @@
             "combinedDependencies": false
         },
         "totalCruised": 4,
+        "totalDependenciesCruised": 3,
         "violations": [],
         "warn": 0
     }

--- a/test/main/fixtures/ts.json
+++ b/test/main/fixtures/ts.json
@@ -130,6 +130,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 6,
+        "totalDependenciesCruised": 6,
         "optionsUsed":{
             "args": "test/main/fixtures/ts",
             "moduleSystems": ["amd", "cjs", "es6"],

--- a/test/main/fixtures/tsx.json
+++ b/test/main/fixtures/tsx.json
@@ -59,6 +59,7 @@
         "warn": 0,
         "info": 0,
         "totalCruised": 3,
+        "totalDependenciesCruised": 2,
         "optionsUsed": {
             "args": "test/main/fixtures/tsx",
             "moduleSystems": ["amd", "cjs", "es6"],


### PR DESCRIPTION
## Description
- Emits violations in order of severity, rule name, from, to - instead of just looking to the from and too.
- Also adds a 'dependenciesCruised' attribute - so you can see how many were cruised.

## Motivation and Context
This makes reports that focus on errors easier to read & act upon. Especially on projects with thousands of modules & dependencies, the number of violations might be so big that a sort order makes a world of a difference. 

Currently affects the `err` reporter - but in the upcoming html err reporter it will be more useful even.

## How Has This Been Tested?
- [x] additional unit tests
- [x] automated non-regression tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.