### PR TITLE
bugfix(resolve): also resolve modules that only occur in node_modules/@types

### DIFF
--- a/src/main/resolveOptions/normalize.js
+++ b/src/main/resolveOptions/normalize.js
@@ -6,51 +6,50 @@ const TsConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const transpileMeta       = require('../../extract/transpile/meta');
 
 const CACHE_DURATION = 4000;
+const DEFAULT_RESOLVE_OPTIONS = {
+    // for later: check semantics of enhanced-resolve symlinks and
+    // node's preserveSymlinks. They seem to be
+    // symlink === !preserveSynlinks - but using it that way
+    // breaks backwards compatibility
+    //
+    // Someday we'll rely on this and remove the code that manually
+    // does this in extract/resolve/index.js
+    symlinks: false,
+    // if a webpack config overrides extensions, there's probably
+    // good cause. The scannableExtensions are an educated guess
+    // anyway, that works well in most circumstances.
+    // Note that if extract/transpile/index gets an unknown extension
+    // passed, it'll fall back to the javascript parser
+    extensions: transpileMeta.scannableExtensions,
+    // for typescript projects that import stuff that's only in
+    // node_modules/@types we need:
+    // - the inclusion of .d.ts to the extensions (see above)
+    // - an explicit inclusion of node_modules/@types to the spots
+    //   to look for modules (in addition to "node_modules" which
+    //   is the default for enhanced-resolve)
+    modules: ["node_modules", "node_modules/@types"]
+};
+
+const NON_OVERRIDABLE_RESOLVE_OPTIONS = {
+    // This should cover most of the bases of dependency-cruiser's
+    // uses. Not overridable for now because for other
+    // file systems it's not sure we can use sync system calls
+    // Also: passing a non-cached filesystem makes performance
+    // worse.
+    fileSystem: new enhancedResolve.CachedInputFileSystem(
+        new enhancedResolve.NodeJsInputFileSystem(),
+        CACHE_DURATION
+    ),
+    // our code depends on sync behavior, so having this
+    // overriden is not an option
+    useSyncFileSystemCalls: true
+};
 
 function pushPlugin(pPlugins, pPluginToPush) {
     return (pPlugins || []).concat(pPluginToPush);
 }
 
 function compileResolveOptions(pResolveOptions, pTSConfig){
-    let DEFAULT_RESOLVE_OPTIONS = {
-        // for later: check semantics of enhanced-resolve symlinks and
-        // node's preserveSymlinks. They seem to be
-        // symlink === !preserveSynlinks - but using it that way
-        // breaks backwards compatibility
-        //
-        // Someday we'll rely on this and remove the code that manually
-        // does this in extract/resolve/index.js
-        symlinks: false,
-        // if a webpack config overrides extensions, there's probably
-        // good cause. The scannableExtensions are an educated guess
-        // anyway, that works well in most circumstances.
-        // Note that if extract/transpile/index gets an unknown extension
-        // passed, it'll fall back to the javascript parser
-        extensions: transpileMeta.scannableExtensions,
-        // for typescript projects that import stuff that's only in
-        // node_modules/@types we need:
-        // - the inclusion of .d.ts to the extensions (see above)
-        // - an explicit inclusion of node_modules/@types to the spots
-        //   to look for modules (in addition to "node_modules" which
-        //   is the default for enhanced-resolve)
-        modules: ["node_modules", "node_modules/@types"]
-    };
-
-    const NON_OVERRIDABLE_RESOLVE_OPTIONS = {
-        // This should cover most of the bases of dependency-cruiser's
-        // uses. Not overridable for now because for other
-        // file systems it's not sure we can use sync system calls
-        // Also: passing a non-cached filesystem makes performance
-        // worse.
-        fileSystem: new enhancedResolve.CachedInputFileSystem(
-            new enhancedResolve.NodeJsInputFileSystem(),
-            CACHE_DURATION
-        ),
-        // our code depends on sync behavior, so having this
-        // overriden is not an option
-        useSyncFileSystemCalls: true
-    };
-
     let lResolveOptions = {};
 
     // TsConfigPathsPlugin requires a baseUrl to be present in the
@@ -74,6 +73,7 @@ function compileResolveOptions(pResolveOptions, pTSConfig){
     }
 
     return Object.assign(
+        {},
         DEFAULT_RESOLVE_OPTIONS,
         lResolveOptions,
         pResolveOptions,

--- a/src/main/resolveOptions/normalize.js
+++ b/src/main/resolveOptions/normalize.js
@@ -26,7 +26,14 @@ function compileResolveOptions(pResolveOptions, pTSConfig){
         // anyway, that works well in most circumstances.
         // Note that if extract/transpile/index gets an unknown extension
         // passed, it'll fall back to the javascript parser
-        extensions: transpileMeta.scannableExtensions
+        extensions: transpileMeta.scannableExtensions,
+        // for typescript projects that import stuff that's only in
+        // node_modules/@types we need:
+        // - the inclusion of .d.ts to the extensions (see above)
+        // - an explicit inclusion of node_modules/@types to the spots
+        //   to look for modules (in addition to "node_modules" which
+        //   is the default for enhanced-resolve)
+        modules: ["node_modules", "node_modules/@types"]
     };
 
     const NON_OVERRIDABLE_RESOLVE_OPTIONS = {

--- a/test/main/fixtures/type-only-module-references/node_modules/@types/graphql/package.json
+++ b/test/main/fixtures/type-only-module-references/node_modules/@types/graphql/package.json
@@ -1,0 +1,130 @@
+{
+  "_from": "@types/graphql",
+  "_id": "@types/graphql@14.2.1",
+  "_inBundle": false,
+  "_integrity": "sha512-81YjgyCz+kYDXkPuk1j4+jCgFjM4DubzrI88tvpWOQp5eILa0A/KvtGAbXONPhD6vRa3neiFb/ES1IDQ82n5Rw==",
+  "_location": "/@types/graphql",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "@types/graphql",
+    "name": "@types/graphql",
+    "escapedName": "@types%2fgraphql",
+    "scope": "@types",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#DEV:/",
+    "#USER"
+  ],
+  "_resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.1.tgz",
+  "_shasum": "02027ff799aa4dc5aa88ff2eed4058d29e7eb491",
+  "_spec": "@types/graphql",
+  "_where": "/Users/sander/prg/js/learn/dependency-cruiser-issue-mysterious-type-not-found",
+  "bugs": {
+    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "TonyYang",
+      "url": "https://github.com/TonyPythoneer"
+    },
+    {
+      "name": "Caleb Meredith",
+      "url": "https://github.com/calebmer"
+    },
+    {
+      "name": "Dominic Watson",
+      "url": "https://github.com/intellix"
+    },
+    {
+      "name": "Firede",
+      "url": "https://github.com/firede"
+    },
+    {
+      "name": "Kepennar",
+      "url": "https://github.com/kepennar"
+    },
+    {
+      "name": "Mikhail Novikov",
+      "url": "https://github.com/freiksenet"
+    },
+    {
+      "name": "Ivan Goncharov",
+      "url": "https://github.com/IvanGoncharov"
+    },
+    {
+      "name": "Hagai Cohen",
+      "url": "https://github.com/DxCx"
+    },
+    {
+      "name": "Ricardo Portugal",
+      "url": "https://github.com/rportugal"
+    },
+    {
+      "name": "Tim Griesser",
+      "url": "https://github.com/tgriesser"
+    },
+    {
+      "name": "Dylan Stewart",
+      "url": "https://github.com/dyst5422"
+    },
+    {
+      "name": "Alessio Dionisi",
+      "url": "https://github.com/adnsio"
+    },
+    {
+      "name": "Divyendu Singh",
+      "url": "https://github.com/divyenduz"
+    },
+    {
+      "name": "Brad Zacher",
+      "url": "https://github.com/bradzacher"
+    },
+    {
+      "name": "Curtis Layne",
+      "url": "https://github.com/clayne11"
+    },
+    {
+      "name": "Jonathan Cardoso",
+      "url": "https://github.com/JCMais"
+    },
+    {
+      "name": "Pavel Lang",
+      "url": "https://github.com/langpavel"
+    },
+    {
+      "name": "Mark Caudill",
+      "url": "https://github.com/mc0"
+    },
+    {
+      "name": "Martijn Walraven",
+      "url": "https://github.com/martijnwalraven"
+    },
+    {
+      "name": "Jed Mao",
+      "url": "https://github.com/jedmao"
+    }
+  ],
+  "dependencies": {},
+  "deprecated": false,
+  "description": "TypeScript definitions for graphql",
+  "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped#readme",
+  "license": "MIT",
+  "main": "",
+  "name": "@types/graphql",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+    "directory": "types/graphql"
+  },
+  "scripts": {},
+  "typeScriptVersion": "2.6",
+  "types": "index",
+  "typesPublisherContentHash": "3fcff77949b4eacdd93d8727d06246dc3d589f8b8ed47e32a7cff05437c484f1",
+  "version": "14.2.1"
+}

--- a/test/main/fixtures/type-only-module-references/node_modules/@types/graphql/tsutils/Maybe.d.ts
+++ b/test/main/fixtures/type-only-module-references/node_modules/@types/graphql/tsutils/Maybe.d.ts
@@ -1,0 +1,4 @@
+// Conveniently represents flow's "Maybe" type https://flow.org/en/docs/types/maybe/
+type Maybe<T> = null | undefined | T;
+
+export default Maybe;

--- a/test/main/fixtures/type-only-module-references/output-no-ts.json
+++ b/test/main/fixtures/type-only-module-references/output-no-ts.json
@@ -1,0 +1,29 @@
+{
+  "modules": [
+    {
+      "source": "src/use-maybe.ts",
+      "dependencies": [],
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [],
+    "error": 0,
+    "warn": 0,
+    "info": 0,
+    "totalCruised": 1,
+    "totalDependenciesCruised": 0,
+    "optionsUsed": {
+      "combinedDependencies": false,
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": [
+        "amd",
+        "cjs",
+        "es6"
+      ],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": false,
+      "args": "src"
+    }
+  }
+}

--- a/test/main/fixtures/type-only-module-references/output.json
+++ b/test/main/fixtures/type-only-module-references/output.json
@@ -1,0 +1,50 @@
+{
+  "modules": [
+    {
+      "source": "src/use-maybe.ts",
+      "dependencies": [
+        {
+          "resolved": "node_modules/@types/graphql/tsutils/Maybe.d.ts",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "npm-no-pkg"
+          ],
+          "license": "MIT",
+          "module": "graphql/tsutils/Maybe",
+          "moduleSystem": "es6",
+          "dynamic": false,
+          "matchesDoNotFollow": false,
+          "valid": true
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "node_modules/@types/graphql/tsutils/Maybe.d.ts",
+      "dependencies": [],
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [],
+    "error": 0,
+    "warn": 0,
+    "info": 0,
+    "totalCruised": 2,
+    "totalDependenciesCruised": 1,
+    "optionsUsed": {
+      "combinedDependencies": false,
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": [
+        "amd",
+        "cjs",
+        "es6"
+      ],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": true,
+      "args": "src"
+    }
+  }
+}

--- a/test/main/fixtures/type-only-module-references/src/use-maybe.ts
+++ b/test/main/fixtures/type-only-module-references/src/use-maybe.ts
@@ -1,0 +1,16 @@
+import Maybe from 'graphql/tsutils/Maybe';
+
+interface SearchStation {
+  code: Maybe<string>;
+  cityCode: Maybe<string>;
+  airportName: Maybe<string>;
+  cityName: Maybe<string>;
+  country: Maybe<string>;
+  display: Maybe<string>;
+  isCity: Maybe<boolean>;
+}
+
+
+export function searchFlight(pFrom: SearchStation, pTo: SearchStation) {
+    return 'abra ca dabra';
+}

--- a/test/main/main.type-only-module-references.spec.js
+++ b/test/main/main.type-only-module-references.spec.js
@@ -1,0 +1,53 @@
+const chai       = require('chai');
+const main       = require("../../src/main");
+const depSchema  = require('../../src/extract/results-schema.json');
+const output      = require('./fixtures/type-only-module-references/output.json');
+const outputNoTS  = require('./fixtures/type-only-module-references/output-no-ts.json');
+
+
+const expect     = chai.expect;
+
+chai.use(require('chai-json-schema'));
+
+const gWorkingDir = process.cwd();
+
+describe('main - type only module references', () => {
+    beforeEach("reset current wd", () => {
+        process.chdir(gWorkingDir);
+    });
+
+    afterEach("reset current wd", () => {
+        process.chdir(gWorkingDir);
+    });
+
+    it("finds something that's only in node_modules/@types", () => {
+        process.chdir('test/main/fixtures/type-only-module-references');
+
+        const lResult = main.cruise(
+            ["src"],
+            {
+                tsPreCompilationDeps: true
+            },
+            {bustTheCache:true}
+        );
+
+        expect(lResult).to.deep.equal(output);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+
+    it("don't find it when not looking for pre-compilation deps", () => {
+        process.chdir('test/main/fixtures/type-only-module-references');
+
+        const lResult = main.cruise(
+            ["src"],
+            {
+                tsPreCompilationDeps: false
+            },
+            {bustTheCache:true}
+        );
+
+        expect(lResult).to.deep.equal(outputNoTS);
+        expect(lResult).to.be.jsonSchema(depSchema);
+    });
+
+});

--- a/test/main/resolveOptions/normalize.spec.js
+++ b/test/main/resolveOptions/normalize.spec.js
@@ -4,7 +4,7 @@ const normalizeOptions        = require('../../../src/main/options/normalize');
 const normalizeResolveOptions = require('../../../src/main/resolveOptions/normalize');
 
 describe("main/resolveOptions/normalize", () => {
-    const DEFAULT_NO_OF_RESOLVE_OPTIONS = 7;
+    const DEFAULT_NO_OF_RESOLVE_OPTIONS = 8;
     const TEST_TSCONFIG = path.join(__dirname, "..", "fixtures", "tsconfig.test.json");
     const TSCONFIG_CONTENTS = {};
     const TSCONFIG_CONTENTS_WITH_BASEURL = {options:{baseUrl:""}};


### PR DESCRIPTION
## Description
- adds node_modules/@types as a spot to look for external modules

## Motivation and Context
- In typescript projects you sometimes use stuff that _only_ occurs in a node_modules/@types - e.g. the `graphql/tsutils/Maybe` type definition.
We want dependency-cruiser to find these as well when cruising for ts-pre-compilation dependencies.

## How Has This Been Tested?
- [x] additional automated test
- [x] automated non-regression tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.