### PR TITLE
bugfix(options): correctly process maxDepth specified in configs

### DIFF
--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -33,7 +33,7 @@ function validateOutputType(pOutputType) {
 }
 
 function validateMaxDepth(pDepth) {
-    if (Boolean(pDepth) && !(pDepth.match(VALID_DEPTH_RE))) {
+    if (Boolean(pDepth) && !(pDepth.toString().match(VALID_DEPTH_RE))) {
         throw Error(
             `'${pDepth}' is not a valid depth - use an integer between 0 and 99`
         );

--- a/test/main/options/validate.spec.js
+++ b/test/main/options/validate.spec.js
@@ -54,7 +54,7 @@ describe("main/options/validate", () => {
         }
     });
 
-    it("throws when > 99 is passed as maxDepth", () => {
+    it("throws when > 99 is passed as maxDepth (string)", () => {
         try {
             validateOptions({"maxDepth": "101"});
             expect("not to be here").to.equal("still here, though");
@@ -65,7 +65,18 @@ describe("main/options/validate", () => {
         }
     });
 
-    it("throws when < 0 is passed as maxDepth", () => {
+    it("throws when > 99 is passed as maxDepth (number)", () => {
+        try {
+            validateOptions({"maxDepth": 101});
+            expect("not to be here").to.equal("still here, though");
+        } catch (e) {
+            expect(e.toString()).to.deep.equal(
+                "Error: '101' is not a valid depth - use an integer between 0 and 99"
+            );
+        }
+    });
+
+    it("throws when < 0 is passed as maxDepth (string)", () => {
         try {
             validateOptions({"maxDepth": "-1"});
             expect("not to be here").to.equal("still here, though");
@@ -76,9 +87,29 @@ describe("main/options/validate", () => {
         }
     });
 
-    it("passes when a valid depth is passed as maxDepth", () => {
+    it("throws when < 0 is passed as maxDepth (number)", () => {
+        try {
+            validateOptions({"maxDepth": -1});
+            expect("not to be here").to.equal("still here, though");
+        } catch (e) {
+            expect(e.toString()).to.deep.equal(
+                "Error: '-1' is not a valid depth - use an integer between 0 and 99"
+            );
+        }
+    });
+
+    it("passes when a valid depth is passed as maxDepth (string)", () => {
         try {
             validateOptions({"maxDepth": "42"});
+            expect("to be here without throws happening").to.equal("to be here without throws happening");
+        } catch (e) {
+            expect("not to be here").to.equal(`still here, though: ${e}`);
+        }
+    });
+
+    it("passes when a valid depth is passed as maxDepth (number)", () => {
+        try {
+            validateOptions({"maxDepth": 42});
             expect("to be here without throws happening").to.equal("to be here without throws happening");
         } catch (e) {
             expect("not to be here").to.equal(`still here, though: ${e}`);


### PR DESCRIPTION
## Description
- The maxDepth option is a number, but was processed as a string (because --max-depth is a string), giving errors. 

## Motivation and Context
Due to this bug maxDepth in a config didn't work at all.

## How Has This Been Tested?
- [x] additional unit tests
- [x] automated non-regression tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.