### PR TITLE
bugfix(validate): make group matching more complete

### DIFF
--- a/src/validate/matchDependencyRule.js
+++ b/src/validate/matchDependencyRule.js
@@ -21,7 +21,7 @@ function extractGroups(pRule, pActualPath) {
         let lMatchResult = pActualPath.match(pRule.path);
 
         if (Boolean(lMatchResult) && lMatchResult.length > 1) {
-            lRetval = lMatchResult;
+            lRetval = lMatchResult.filter(pResult => typeof pResult === 'string');
         }
     }
     return lRetval;

--- a/src/validate/matches.js
+++ b/src/validate/matches.js
@@ -10,7 +10,8 @@ function fromPathNot (pRule, pModule){
 
 function _replaceGroupPlaceholders(pString, pExtractedGroups) {
     return pExtractedGroups.reduce(
-        (pAll, pThis, pIndex) => pAll.replace(`$${pIndex}`, pThis),
+        // eslint-disable-next-line security/detect-non-literal-regexp
+        (pAll, pThis, pIndex) => pAll.replace(new RegExp(`\\$${pIndex}`, 'g'), pThis),
         pString
     );
 }
@@ -68,6 +69,7 @@ function toLicenseNot(pRule, pDependency) {
 }
 
 module.exports = {
+    _replaceGroupPlaceholders,
     fromPath,
     fromPathNot,
     toDependencyPath,

--- a/test/validate/matches.spec.js
+++ b/test/validate/matches.spec.js
@@ -1,0 +1,52 @@
+const expect = require('chai').expect;
+const matches = require('../../src/validate/matches');
+
+describe('validate/matches', () => {
+    it('_replaceGroupPlaceholders - leaves re alone if passed empty match result', () => {
+        expect(
+            matches._replaceGroupPlaceholders("$1/aap|noot", [])
+        ).to.equal(
+            "$1/aap|noot"
+        );
+    });
+
+    it('_replaceGroupPlaceholders - leaves re alone if passed groupless match result', () => {
+        expect(
+            matches._replaceGroupPlaceholders("$1/aap|noot", ["houwoei"])
+        ).to.equal(
+            "$1/aap|noot"
+        );
+    });
+
+    it('_replaceGroupPlaceholders - replaces if passed groupless match result and a $0', () => {
+        expect(
+            matches._replaceGroupPlaceholders("$0/aap|noot", ["houwoei"])
+        ).to.equal(
+            "houwoei/aap|noot"
+        );
+    });
+
+    it('_replaceGroupPlaceholders - replaces if passed groupy match result and a $1', () => {
+        expect(
+            matches._replaceGroupPlaceholders("$1/aap|noot", ["whole/result/part", "part"])
+        ).to.equal(
+            "part/aap|noot"
+        );
+    });
+
+    it('_replaceGroupPlaceholders - replaces if passed groupy match result and multiple $1', () => {
+        expect(
+            matches._replaceGroupPlaceholders("$1|$1/[^/]+/|noot", ["whole/result/part", "part"])
+        ).to.equal(
+            "part|part/[^/]+/|noot"
+        );
+    });
+
+    it('_replaceGroupPlaceholders - replaces if passed groupy match result and multiple groups', () => {
+        expect(
+            matches._replaceGroupPlaceholders("$1|$2", ["start/thing/part", "start", "part"])
+        ).to.equal(
+            "start|part"
+        );
+    });
+});


### PR DESCRIPTION
## Description, Motivation and Context
When using group matching expressions, only the first `$` parameter was replaced, which made that a rule like this would not be matched correctly.

```javascript
module.exports = {
  forbidden: [
     {
       from: {
         path: "^src(/.+)/[^/]+$",
       },
       to: {
         pathNot: "src/$1/okidoki|lib/$1",
       }
    }
  ]
}
```

With this PR the second `$1` in the `pathNot` will be heeded correctly as well.

## How Has This Been Tested?
- [x] automated non-regression tests
- [x] additional unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- ~~My change requires a change to the documentation.~~
- ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.