### PR TITLE
doc(cli): bring --help output up to date

### DIFF
--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -16,7 +16,7 @@ if (!semver.satisfies(process.versions.node, $package.engines.node)) {
 
 program
     .version($package.version)
-    .description("Validate and visualize dependencies")
+    .description("Validate and visualize dependencies.\nDetails: https://github.com/sverweij/dependency-cruiser")
     .option("-i, --info", `shows what languages and extensions
                               dependency-cruiser supports`)
     .option("-c, --config [file]", `read rules and options from [file]
@@ -31,9 +31,10 @@ program
     .option("-d, --max-depth <n>", `the maximum depth to cruise; 0 <= n <= 99
                               (default: 0, which means 'infinite depth')`)
     .option("-M, --module-systems <items>", `list of module systems (default: amd,cjs,es6)`)
-    .option("-T, --output-type <type>", `output type - html|dot|err|json
+    .option("-T, --output-type <type>", `output type - err|err-long|err-html|dot|json
                               (default: err)`)
-    .option("-P, --prefix <prefix>", "prefix to use for links in the svg reporter")
+    .option("-P, --prefix <prefix>", `prefix to use for links in the dot, err and
+                              err-html reporters`)
     .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
     .option("--ts-pre-compilation-deps", `detect dependencies that only exist before
                               typescript-to-javascript compilation

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -116,7 +116,8 @@ dependency-cruise -x "^node_modules" -T dot src | dot -T svg > dependencygraph.s
 > The `rcdot` reporter is deprecated.    
 > Since version 4.12.0 `rcdot` reporter's
 > coloring has become the default for the `dot` reporter, so `dot` and `rcdot`
-> will yield the same results.
+> will yield the same results. As of version 5.0.0 the rcdot option will be
+> removed.
 
 #### err-html
 Generates an stand alone html report with:


### PR DESCRIPTION
## Motivation and Context
Betterizes comprehensibility of the cli. Also warns about the removal of the _rcdot_ type in 5.0.0 - which has been deprecated a while ago.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.