### PR TITLE
bugfix(resolve): in edge cases correctly determine relativeness as well

### DIFF
--- a/src/extract/resolve/determineDependencyTypes.js
+++ b/src/extract/resolve/determineDependencyTypes.js
@@ -1,6 +1,7 @@
-const path            = require('path');
-const isCore          = require('./isCore');
-const localNpmHelpers = require('./localNpmHelpers');
+const path                 = require('path');
+const isCore               = require('./isCore');
+const isRelativeModuleName = require('./isRelativeModuleName');
+const localNpmHelpers      = require('./localNpmHelpers');
 
 const npm2depType = {
     "dependencies"         : "npm",
@@ -91,16 +92,12 @@ function isModule(pDependency, pModules = ["node_modules"], pBaseDir = ".") {
     );
 }
 
-function isLocal(pModuleName) {
-    return pModuleName.startsWith(".");
-}
-
 function isAliased(pModuleName, pAliasObject) {
     return Object.keys(pAliasObject || {}).some(pAliasLHS => pModuleName.startsWith(pAliasLHS));
 }
 
 function isLikelyTSAliased(pModuleName, pResolved, pTsConfig) {
-    return pTsConfig && !isLocal(pModuleName) && pResolved && !pResolved.includes("node_modules");
+    return pTsConfig && !isRelativeModuleName(pModuleName) && pResolved && !pResolved.includes("node_modules");
 }
 
 function isAliassy(pModuleName, pDependency, pResolveOptions){
@@ -134,7 +131,7 @@ module.exports = (pDependency, pModuleName, pPackageDeps, pFileDir, pResolveOpti
         // attribute in favor of this one and determining it here will make
         // live easier in the future
         lRetval = ["core"];
-    } else if (isLocal(pModuleName)) {
+    } else if (isRelativeModuleName(pModuleName)) {
         lRetval = ["local"];
     } else if (isModule(pDependency, pResolveOptions.modules, pBaseDir)) {
         lRetval = determineModuleDependencyTypes(

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -1,10 +1,9 @@
-const fs               = require('fs');
-const path             = require('path');
-const pathToPosix      = require('../utl/pathToPosix');
-const resolveAMD       = require('./resolve-AMD');
-const resolveCommonJS  = require('./resolve-commonJS');
-
-const isRelativeModuleName = pString => pString.startsWith(".");
+const fs                   = require('fs');
+const path                 = require('path');
+const pathToPosix          = require('../utl/pathToPosix');
+const isRelativeModuleName = require('./isRelativeModuleName');
+const resolveAMD           = require('./resolve-AMD');
+const resolveCommonJS      = require('./resolve-commonJS');
 
 function resolveModule(pDependency, pBaseDir, pFileDir, pResolveOptions) {
     let lRetval = null;

--- a/src/extract/resolve/isRelativeModuleName.js
+++ b/src/extract/resolve/isRelativeModuleName.js
@@ -1,0 +1,5 @@
+module.exports = pString =>
+    pString.startsWith("./") ||
+    pString.startsWith("../") ||
+    pString === "." ||
+    pString === "..";

--- a/src/extract/resolve/localNpmHelpers.js
+++ b/src/extract/resolve/localNpmHelpers.js
@@ -1,9 +1,9 @@
-const fs       = require('fs');
-const path     = require('path');
-const _memoize = require('lodash/memoize');
-const resolve  = require('./resolve');
+const fs                   = require('fs');
+const path                 = require('path');
+const _memoize             = require('lodash/memoize');
+const resolve              = require('./resolve');
+const isRelativeModuleName = require('./isRelativeModuleName');
 
-const isLocal     = (pModule) => pModule.startsWith('.');
 const isScoped    = (pModule) => pModule.startsWith('@');
 
 /**
@@ -34,7 +34,7 @@ const isScoped    = (pModule) => pModule.startsWith('@');
  * @return {string}         the module name root
  */
 function getPackageRoot (pModule) {
-    if (!Boolean(pModule) || isLocal(pModule)) {
+    if (!Boolean(pModule) || isRelativeModuleName(pModule)) {
         return pModule;
     }
 

--- a/test/extract/resolve/isRelativeModuleName.spec.js
+++ b/test/extract/resolve/isRelativeModuleName.spec.js
@@ -1,0 +1,50 @@
+const expect = require('chai').expect;
+const isRelativeModuleName = require('../../../src/extract/resolve/isRelativeModuleName');
+
+describe("extract/resolve/isRelativeModuleName", () => {
+    it("throws an error when passed nothing", () => {
+        try {
+            isRelativeModuleName();
+            expect('not here').to.equal('here, though');
+        } catch (e) {
+            expect(e.message).to.contain("Cannot read property 'startsWith' of undefined");
+        }
+    });
+
+    it("throws an error when passed null", () => {
+        try {
+            isRelativeModuleName();
+            expect('not here').to.equal('here, though');
+        } catch (e) {
+            expect(e.message).to.contain("Cannot read property 'startsWith' of undefined");
+        }
+    });
+
+    it("returns false when passed an empty string", () => {
+        expect(isRelativeModuleName("")).to.equal(false);
+    });
+
+    it("returns false when passed an external module", () => {
+        expect(isRelativeModuleName("externaldash")).to.equal(false);
+    });
+
+    it("returns false when passed an external module name that starts with a dot", () => {
+        expect(isRelativeModuleName(".external-starts-with-a-dot")).to.equal(false);
+    });
+
+    it("returns true when passed a local module in the same folder", () => {
+        expect(isRelativeModuleName("./path")).to.equal(true);
+    });
+
+    it("returns true when passed a local module in a sub folder", () => {
+        expect(isRelativeModuleName("../../halikidee")).to.equal(true);
+    });
+
+    it("returns true when passed the current folder", () => {
+        expect(isRelativeModuleName(".")).to.equal(true);
+    });
+
+    it("returns true when passed the parent folder", () => {
+        expect(isRelativeModuleName("..")).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Description
- sort `.thing.js` into the external module bin instead of the local one
- centralises the function that determines this

## Motivation and Context
`./hello` is local, but `.hello` is not, despite starting with a dot. It requires `./.hello` to make it that. The resolver now correctly identifies them.

It's an edge case (npm discourages the use of package names starting with a .), but it should be handled correctly. 

## How Has This Been Tested?
- [x] additional unit tests
- [x] automated non-regression tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.