### PR TITLE
refactor(extract): only use individual lodash functions

### DIFF
--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -1,5 +1,7 @@
-const _               = require('lodash');
 const _get            = require('lodash/get');
+const _uniqBy         = require('lodash/uniqBy');
+const _spread         = require('lodash/spread');
+const _concat         = require('lodash/concat');
 const pathToPosix     = require('./utl/pathToPosix');
 const extract         = require('./extract');
 const deriveCirculars = require('./derive/circular');
@@ -37,7 +39,7 @@ function extractRecursive (pFileName, pOptions, pVisited, pDepth, pResolveOption
 function extractFileDirArray(pFileDirArray, pOptions, pResolveOptions, pTSConfig) {
     let lVisited = new Set();
 
-    return _.spread(_.concat)(
+    return _spread(_concat)(
         gather(pFileDirArray, pOptions)
             .reduce((pDependencies, pFilename) => {
                 if (!lVisited.has(pFilename)){
@@ -153,11 +155,10 @@ function filterExcludedDependencies(pModule, pExclude) {
 module.exports = (pFileDirArray, pOptions, pResolveOptions, pTSConfig) => {
     clearCaches();
 
-    let lModules = _(
-        extractFileDirArray(pFileDirArray, pOptions, pResolveOptions, pTSConfig).reduce(complete, [])
-    ).uniqBy(pModule => pModule.source)
-        .map(pModule => filterExcludedDependencies(pModule, pOptions.exclude))
-        .value();
+    let lModules = _uniqBy(
+        extractFileDirArray(pFileDirArray, pOptions, pResolveOptions, pTSConfig).reduce(complete, []),
+        pModule => pModule.source
+    ).map(pModule => filterExcludedDependencies(pModule, pOptions.exclude));
 
     lModules = deriveCirculars(lModules, pOptions);
     lModules = deriveOrphans(lModules, pOptions);

--- a/src/extract/parse/toTypescriptAST.js
+++ b/src/extract/parse/toTypescriptAST.js
@@ -1,6 +1,6 @@
 const fs         = require('fs');
-const tryRequire = require("semver-try-require");
-const _memoize   = require("lodash/memoize");
+const tryRequire = require('semver-try-require');
+const _memoize   = require('lodash/memoize');
 const typescript = tryRequire(
     "typescript",
     require("../../../package.json").supportedTranspilers.typescript

--- a/test/extract/fixtures/es6.json
+++ b/test/extract/fixtures/es6.json
@@ -34,12 +34,12 @@
                 "couldNotResolve": false
             },
             {
-                "module": "lodash",
-                "resolved": "node_modules/lodash/lodash.js",
+                "module": "eslint",
+                "resolved": "node_modules/eslint/lib/api.js",
                 "moduleSystem": "es6",
                 "coreModule": false,
                 "dependencyTypes": [
-                    "npm"
+                    "npm-dev"
                 ],
                 "dynamic": false,
                 "license": "MIT",

--- a/test/extract/fixtures/es6/imports-and-exports.js
+++ b/test/extract/fixtures/es6/imports-and-exports.js
@@ -1,7 +1,8 @@
 import {parse} from "acorn";
 import * as tea from "chai";
 export * from "mocha";
-export {_} from "lodash";
+export {Linter} from "eslint";
 import "os";
+
 
 export const version = "1.0.0";


### PR DESCRIPTION
## Description
replaces the two spots that still imported lodash wholesale (for chaining) with imports of lodash individual functions.

## Motivation and Context
- More clear what's used
- Easier to reduce download size (we're not using everything in lodash).

That last one doesn't materialise, though, because it's used as a transient dependency (by inquirer)

## How Has This Been Tested?
- [x] automated non-regression tests

## Types of changes
- [x] Refactoring (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
