### PR TITLE
bugfix(resolve): use resolve.isCore instead of core functionality for the same

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "lodash": "4.17.14",
     "pnp-webpack-plugin": "1.5.0",
     "regexp-tree": "0.1.11",
+    "resolve": "1.11.1",
     "semver": "6.2.0",
     "semver-try-require": "2.0.7",
     "strip-json-comments": "3.0.1",

--- a/src/extract/resolve/isCore.js
+++ b/src/extract/resolve/isCore.js
@@ -1,3 +1,5 @@
-const builtinModules = require('module').builtinModules;
+// const builtinModules = require('module').builtinModules;
+const resolve = require('resolve');
 
-module.exports = (pModuleName) => builtinModules.some(pBuiltinModule => pBuiltinModule === pModuleName);
+module.exports = resolve.isCore;
+// module.exports = (pModuleName) => builtinModules.some(pBuiltinModule => pBuiltinModule === pModuleName);

--- a/test/extract/resolve/isCore.spec.js
+++ b/test/extract/resolve/isCore.spec.js
@@ -1,21 +1,22 @@
+/* eslint-disable no-unused-expressions */
 const expect = require('chai').expect;
 const isCore = require('../../../src/extract/resolve/isCore');
 
 describe("extract/resolve/isCore", () => {
     it("returns false when passed nothing", () => {
-        expect(isCore()).to.equal(false);
+        expect(isCore()).to.be.undefined;
     });
 
     it("returns false when passed null", () => {
-        expect(isCore(null)).to.equal(false);
+        expect(isCore(null)).to.be.undefined;
     });
 
     it("returns false when passed a local module", () => {
-        expect(isCore("./path")).to.equal(false);
+        expect(isCore("./path")).to.be.undefined;
     });
 
     it("returns false when passed a non core module", () => {
-        expect(isCore("flowdash")).to.equal(false);
+        expect(isCore("flowdash")).to.be.undefined;
     });
 
     it("returns true when passed a core module", () => {


### PR DESCRIPTION
use resolve.isCore instead of core functionality to detect the whether a module is core as some (still) supported node versions (elder 8 and 6 - newer 8 and 6 _do_ have it!) donot have this functionality in the `module` module - as discovered in #167.

Reverts #170 that started to use the `module` module for this functionality

## How Has This Been Tested?
- [x] unit tests
- [x] automated non-regression tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
