### PR TITLE
build(npm): only support node versions supported by Node.js

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,6 +13,9 @@ plugins:
       # compat is not a codeclimeate supported eslint plugin
       compat/compat:
         enabled: false
+      # fairly fresh mocha rule, not supported by codeclimate yet
+      mocha/no-async-describe:
+        enabled: false
       # indent rules on codeclimate seem to be different from
       # the local ones - probably because cc uses an older version
       # of eslint

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,7 +6,7 @@ checks:
 plugins:
   eslint:
     enabled: true
-    channel: "eslint-4"
+    channel: "eslint-5"
     config: 
       config: .eslintrc.json
     checks:
@@ -20,7 +20,7 @@ plugins:
       # the local ones - probably because cc uses an older version
       # of eslint
       indent:
-        enabled: false
+        enabled: true
 exclude_patterns:
   - ".github/"
   - "configs/"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
         "import"
     ],
     "parserOptions": {
-        "ecmaVersion": 6,
+        "ecmaVersion": 2018,
         "sourceType": "module",
         "ecmaFeatures": {
             "jsx": false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -270,6 +270,7 @@
         "mocha/no-top-level-hooks": "error",// disallow top-level hooks
         "mocha/valid-suite-description": "error",// match suite descriptions against a pre-configured regular expression
         "mocha/valid-test-description": "off", // match test descriptions against a pre-configured regular expression
+        "mocha/no-async-describe": "error",
 
         // node
         "node/exports-style": ["error", "module.exports"],

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,15 +34,6 @@ test_async_node_8:
   except:
    - tags
 
-test_async_node_6:
-  image: node:6
-  script:
-   - npm install
-   - npm run test:cover
-  except:
-   - tags
-   - master
-
 # publish:
 #  image: node:latest
 #  script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "11"
+  nodejs_version: "12"
 
 cache:
   - node_modules

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -6,7 +6,8 @@ const processCLI = require("../src/cli");
 const $package   = require("../package.json");
 
 const VERSION_ERR = `\nERROR: your node version (${process.versions.node}) is not supported. dependency-cruiser
-       follows the node.js release cycle and runs on node versions ${$package.engines.node}
+       follows the node.js release cycle and runs on these node versions:
+       ${$package.engines.node}
        See https://nodejs.org/en/about/releases/ for details.
 
 `;

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -5,10 +5,16 @@ const semver     = require("semver");
 const processCLI = require("../src/cli");
 const $package   = require("../package.json");
 
+const VERSION_ERR = `\nERROR: your node version (${process.versions.node}) is not supported. dependency-cruiser
+       follows the node.js release cycle and runs on node versions ${$package.engines.node}
+       See https://nodejs.org/en/about/releases/ for details.
+
+`;
+
 /* istanbul ignore if  */
 if (!semver.satisfies(process.versions.node, $package.engines.node)) {
-    process.stderr.write(`\nERROR: your node version (${process.versions.node}) is not recent enough.\n`);
-    process.stderr.write(`       dependency-cruiser needs a version of node ${$package.engines.node}\n\n`);
+
+    process.stderr.write(VERSION_ERR);
 
     /* eslint no-process-exit: 0 */
     process.exit(1);

--- a/configs/recommended-strict.js
+++ b/configs/recommended-strict.js
@@ -1,14 +1,11 @@
 const recommended = require('./recommended');
 
-module.exports = Object.assign(
-    {},
-    recommended,
-    {
-        forbidden: recommended.forbidden.map(
-            pRule => {
-                pRule.severity = "error";
-                return pRule;
-            }
-        )
-    }
-);
+module.exports = {
+    ...recommended,
+    forbidden: recommended.forbidden.map(
+        pRule => {
+            pRule.severity = "error";
+            return pRule;
+        }
+    )
+};

--- a/configs/recommended-warn-only.js
+++ b/configs/recommended-warn-only.js
@@ -1,14 +1,11 @@
 const recommended = require('./recommended');
 
-module.exports = Object.assign(
-    {},
-    recommended,
-    {
-        forbidden: recommended.forbidden.map(
-            pRule => {
-                pRule.severity = "warn";
-                return pRule;
-            }
-        )
-    }
-);
+module.exports = {
+    ...recommended,
+    forbidden: recommended.forbidden.map(
+        pRule => {
+            pRule.severity = "warn";
+            return pRule;
+        }
+    )
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "5.0.0-beta-0",
+  "version": "5.0.0-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/package.json
+++ b/package.json
@@ -93,38 +93,6 @@
     "upem:update": "npm outdated --json | upem",
     "version": "npm-run-all build depcruise:graph:doc scm:stage"
   },
-  "upem": {
-    "donotup": [
-      {
-        "package": "eslint",
-        "because": "eslint 5.16 is the last still running under node 6"
-      },
-      {
-        "package": "eslint-plugin-node",
-        "because": "eslint-plugin-node 8.0.1 is the last still running under node 6"
-      },
-      {
-        "package": "indent-string",
-        "because": "indent-string >= 4 dropped node 6 support, while dependency-cruiser still supports node 6"
-      },
-      {
-        "package": "semver-try-require",
-        "because": "semver-try-require 2.0.7 is the last version still supporting node 6"
-      },
-      {
-        "package": "symlink-dir",
-        "because": "symlink-dir >= 3 doesn't work on node < 8 - while dependency-cruiser still supports node 6"
-      },
-      {
-        "package": "upem",
-        "because": "upem 2.1.1 is the last one still running under node 6"
-      },
-      {
-        "package": "wrap-ansi",
-        "because": "wrap-ansi >= 6 dropped node 6 support, while dependency-cruiser still supports node 6"
-      }
-    ]
-  },
   "dependencies": {
     "acorn": "6.2.0",
     "acorn-dynamic-import": "4.0.0",
@@ -137,27 +105,27 @@
     "figures": "3.0.0",
     "glob": "7.1.4",
     "handlebars": "4.1.2",
-    "indent-string": "3.2.0",
+    "indent-string": "4.0.0",
     "inquirer": "6.5.0",
     "lodash": "4.17.14",
     "pnp-webpack-plugin": "1.5.0",
     "regexp-tree": "0.1.11",
     "resolve": "1.11.1",
     "semver": "6.2.0",
-    "semver-try-require": "2.0.7",
+    "semver-try-require": "3.0.0",
     "strip-json-comments": "3.0.1",
     "teamcity-service-messages": "0.1.10",
     "tsconfig-paths-webpack-plugin": "3.2.0",
-    "wrap-ansi": "5.1.0"
+    "wrap-ansi": "6.0.0"
   },
   "devDependencies": {
     "chai": "4.2.0",
     "chai-json-schema": "1.5.1",
     "coffeescript": "2.4.1",
-    "eslint": "5.16.0",
+    "eslint": "6.0.1",
     "eslint-plugin-import": "2.18.0",
     "eslint-plugin-mocha": "5.3.0",
-    "eslint-plugin-node": "8.0.1",
+    "eslint-plugin-node": "9.1.0",
     "eslint-plugin-security": "1.4.0",
     "intercept-stdout": "0.1.2",
     "mocha": "6.1.4",
@@ -165,10 +133,10 @@
     "npm-run-all": "4.1.5",
     "nyc": "14.1.1",
     "shx": "0.3.2",
-    "symlink-dir": "2.0.2",
+    "symlink-dir": "3.1.0",
     "tslint": "5.18.0",
     "typescript": "3.5.3",
-    "upem": "2.1.1",
+    "upem": "3.0.0",
     "yarn": "1.17.3"
   },
   "repository": {
@@ -212,7 +180,7 @@
     "types/**"
   ],
   "engines": {
-    "node": ">=6"
+    "node": "^8||^10||^12"
   },
   "supportedTranspilers": {
     "coffee-script": ">=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "coffeescript": "2.4.1",
     "eslint": "6.0.1",
     "eslint-plugin-import": "2.18.0",
-    "eslint-plugin-mocha": "5.3.0",
+    "eslint-plugin-mocha": "6.0.0",
     "eslint-plugin-node": "9.1.0",
     "eslint-plugin-security": "1.4.0",
     "intercept-stdout": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "4.27.2",
+  "version": "5.0.0-beta-0",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "lodash": "4.17.14",
     "pnp-webpack-plugin": "1.5.0",
     "regexp-tree": "0.1.11",
-    "resolve": "1.11.1",
     "semver": "6.2.0",
     "semver-try-require": "3.0.0",
     "strip-json-comments": "3.0.1",
@@ -180,7 +179,7 @@
     "types/**"
   ],
   "engines": {
-    "node": "^8||^10||^12"
+    "node": "^8.10||^10||^12"
   },
   "supportedTranspilers": {
     "coffee-script": ">=1.0.0 <2.0.0",

--- a/src/cli/compileConfig/mergeConfigs.js
+++ b/src/cli/compileConfig/mergeConfigs.js
@@ -7,10 +7,10 @@ function extendNamedRule(pExtendedRule, pForbiddenArrayBase) {
     return pForbiddenArrayBase
         .filter(pBaseRule => pBaseRule.name === pExtendedRule.name)
         .reduce(
-            (pAll, pBaseRule) => Object.assign(
-                pBaseRule,
-                pAll
-            ),
+            (pAll, pBaseRule) => ({
+                ...pBaseRule,
+                ...pAll
+            }),
             pExtendedRule
         );
 }
@@ -87,7 +87,7 @@ function mergeAllowed(pAllowedArrayExtended, pAllowedArrayBase){
 
 function mergeOptions(pOptionsExtended, pOptionsBase) {
     // TODO: make implementation less naive (?)
-    return Object.assign({}, pOptionsBase, pOptionsExtended);
+    return {...pOptionsBase, ...pOptionsExtended};
 }
 
 /**

--- a/src/cli/initConfig/createConfigFile.js
+++ b/src/cli/initConfig/createConfigFile.js
@@ -40,15 +40,13 @@ function writeTheThing (pFileName, pConfig) {
 }
 
 function normalizeInitOptions(pInitOptions){
-    let lRetval = Object.assign(
-        {
-            version: $package.version,
-            date: (new Date()).toJSON(),
-            configFormat: ".json",
-            configType: "self-contained"
-        },
-        pInitOptions
-    );
+    let lRetval = {
+        version: $package.version,
+        date: (new Date()).toJSON(),
+        configFormat: ".json",
+        configType: "self-contained",
+        ...pInitOptions
+    };
 
     if (lRetval.configType === "preset" && !lRetval.preset) {
         lRetval.preset = "dependency-cruiser/configs/recommended-warn-only";

--- a/src/cli/normalizeOptions.js
+++ b/src/cli/normalizeOptions.js
@@ -93,13 +93,11 @@ function validateAndNormalizeRulesFileName (pValidate) {
  * @return {object}          [description]
  */
 module.exports = (pOptions) => {
-    pOptions = Object.assign(
-        {
-            outputTo: defaults.OUTPUT_TO,
-            outputType: defaults.OUTPUT_TYPE
-        },
-        pOptions
-    );
+    pOptions = {
+        outputTo: defaults.OUTPUT_TO,
+        outputType: defaults.OUTPUT_TYPE,
+        ...pOptions
+    };
 
     if (pOptions.hasOwnProperty("moduleSystems")) {
         pOptions.moduleSystems = pOptions.moduleSystems.split(",").map(pString => pString.trim());

--- a/src/extract/addValidations.js
+++ b/src/extract/addValidations.js
@@ -1,28 +1,26 @@
 const validate = require('../validate');
 
 function addDependencyValidation (pDependency, pValidate, pRuleSet, pModule) {
-    return Object.assign(
-        {},
-        pDependency,
-        validate.dependency(
+    return {
+        ...pDependency,
+        ...validate.dependency(
             pValidate,
             pRuleSet,
             pModule,
             pDependency
         )
-    );
+    };
 }
 
 function addModuleValidation(pModule, pValidate, pRuleSet) {
-    return Object.assign(
-        {},
-        pModule,
-        validate.module(
+    return {
+        ...pModule,
+        ...validate.module(
             pValidate,
             pRuleSet,
             pModule
         )
-    );
+    };
 }
 
 /**
@@ -38,10 +36,9 @@ function addModuleValidation(pModule, pValidate, pRuleSet) {
  *                                part of
  */
 module.exports = (pModules, pValidate, pRuleSet) => pModules.map(
-    pModule => Object.assign(
-        {},
-        addModuleValidation(pModule, pValidate, pRuleSet),
+    pModule => (
         {
+            ...addModuleValidation(pModule, pValidate, pRuleSet),
             dependencies: pModule.dependencies.map(
                 pDependency => addDependencyValidation(pDependency, pValidate, pRuleSet, pModule)
             )

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -170,7 +170,7 @@ module.exports = (pTypeScriptAST) =>
             .concat(extractImportEquals(pTypeScriptAST))
             .concat(extractTrippleSlashDirectives(pTypeScriptAST))
             .concat(extractNestedDependencies(pTypeScriptAST))
-            .map(pModule => Object.assign({dynamic: false}, pModule))
+            .map(pModule => ({dynamic: false, ...pModule}))
         : [];
 
 

--- a/src/extract/derive/circular/index.js
+++ b/src/extract/derive/circular/index.js
@@ -14,13 +14,10 @@ function circularityDetectionNecessary(pOptions) {
 }
 
 function addCircularityCheckToDependency (pToDep, pGraph, pFrom) {
-    return Object.assign(
-        {},
-        pToDep,
-        {
-            circular: dependencyEndsUpAtFrom(pGraph, pFrom, pToDep.resolved)
-        }
-    );
+    return {
+        ...pToDep,
+        circular: dependencyEndsUpAtFrom(pGraph, pFrom, pToDep.resolved)
+    };
 }
 
 /**
@@ -35,10 +32,9 @@ function addCircularityCheckToDependency (pToDep, pGraph, pFrom) {
  */
 function addCircularityCheckToGraph (pModules) {
     return pModules.map(
-        pModule => Object.assign(
-            {},
-            pModule,
+        pModule => (
             {
+                ...pModule,
                 dependencies: pModule.dependencies.map(
                     pToDep => addCircularityCheckToDependency(pToDep, pModules, pModule.source)
                 )

--- a/src/extract/derive/orphan/index.js
+++ b/src/extract/derive/orphan/index.js
@@ -18,10 +18,9 @@ function orphanCheckNecessary(pOptions){
 
 function addOrphanCheckToGraph(pDependencies){
     return pDependencies.map(
-        pNode => Object.assign(
-            {},
-            pNode,
+        pNode => (
             {
+                ...pNode,
                 orphan: isOrphan(pNode, pDependencies)
             }
         )

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -78,16 +78,14 @@ function addResolutionAttributes(pOptions, pFileName, pResolveOptions) {
         );
         const lMatchesDoNotFollow = matchesDoNotFollow(lResolved, pOptions.doNotFollow);
 
-        return Object.assign(
-            lResolved,
-            {
-                module: pDependency.moduleName,
-                moduleSystem: pDependency.moduleSystem,
-                dynamic: pDependency.dynamic,
-                followable: lResolved.followable && !lMatchesDoNotFollow,
-                matchesDoNotFollow: lMatchesDoNotFollow
-            }
-        );
+        return {
+            ...lResolved,
+            module: pDependency.moduleName,
+            moduleSystem: pDependency.moduleSystem,
+            dynamic: pDependency.dynamic,
+            followable: lResolved.followable && !lMatchesDoNotFollow,
+            matchesDoNotFollow: lMatchesDoNotFollow
+        };
     };
 }
 

--- a/src/extract/gatherInitialSources.js
+++ b/src/extract/gatherInitialSources.js
@@ -54,7 +54,7 @@ function gatherScannableFilesFromDir (pDirName, pOptions) {
  *                               files to be gathered.
  */
 module.exports = (pFileDirArray, pOptions) => {
-    const lOptions = Object.assign({baseDir: process.cwd()}, pOptions);
+    const lOptions = {baseDir: process.cwd(), ...pOptions};
 
     return pFileDirArray
         .reduce(

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -118,12 +118,10 @@ function makeOptionsPresentable(pOptions) {
 
 function summarizeOptions(pFileDirArray, pOptions) {
     return {
-        optionsUsed: Object.assign(
-            makeOptionsPresentable(pOptions),
-            {
-                args: pFileDirArray.map(pathToPosix).join(" ")
-            }
-        )
+        optionsUsed: {
+            ...makeOptionsPresentable(pOptions),
+            args: pFileDirArray.map(pathToPosix).join(" ")
+        }
     };
 }
 
@@ -141,15 +139,12 @@ function addRuleSetUsed(pOptions) {
 
 function filterExcludedDependencies(pModule, pExclude) {
     // no need to do the 'path' thing as that was addressed in extractFileDirArray already
-    return Object.assign(
-        {},
-        pModule,
-        {
-            dependencies: pModule.dependencies.filter(
-                pDependency => !pExclude.hasOwnProperty('dynamic') || (pExclude.dynamic !== pDependency.dynamic)
-            )
-        }
-    );
+    return {
+        ...pModule,
+        dependencies: pModule.dependencies.filter(
+            pDependency => !pExclude.hasOwnProperty('dynamic') || (pExclude.dynamic !== pDependency.dynamic)
+        )
+    };
 }
 
 module.exports = (pFileDirArray, pOptions, pResolveOptions, pTSConfig) => {

--- a/src/extract/resolve/isCore.js
+++ b/src/extract/resolve/isCore.js
@@ -1,5 +1,3 @@
-// const builtinModules = require('module').builtinModules;
-const resolve = require('resolve');
+const builtinModules = require('module').builtinModules;
 
-module.exports = resolve.isCore;
-// module.exports = (pModuleName) => builtinModules.some(pBuiltinModule => pBuiltinModule === pModuleName);
+module.exports = (pModuleName) => builtinModules.some(pBuiltinModule => pBuiltinModule === pModuleName);

--- a/src/extract/resolve/readPackageDeps/mergePackages.js
+++ b/src/extract/resolve/readPackageDeps/mergePackages.js
@@ -13,11 +13,10 @@ function normalizePackageKeys(pPackage) {
 }
 
 function mergeDependencyKey(pClosestDependencyKey, pFurtherDependencyKey) {
-    return Object.assign(
-        {},
-        pFurtherDependencyKey,
-        pClosestDependencyKey
-    );
+    return {
+        ...pFurtherDependencyKey,
+        ...pClosestDependencyKey
+    };
 }
 
 function mergeDependencyArray(pClosestDependencyKey, pFurtherDependencyKey) {

--- a/src/extract/resolve/resolve-AMD.js
+++ b/src/extract/resolve/resolve-AMD.js
@@ -37,21 +37,19 @@ module.exports = (pModuleName, pBaseDir, pFileDir, pResolveOptions) => {
         couldNotResolve: !Boolean(isCore(pModuleName)) && !fileExists(lProbablePath)
     };
 
-    return Object.assign(
-        lRetval,
-        // we might want to use resolve options instead of {} here
-        resolveHelpers.addLicenseAttribute(pModuleName, pBaseDir, {}),
-        {
-            dependencyTypes: determineDependencyTypes(
-                lRetval,
-                pModuleName,
-                readPackageDeps(pFileDir, pBaseDir, pResolveOptions.combinedDependencies),
-                pFileDir,
-                pResolveOptions,
-                pBaseDir
-            )
-        }
-    );
+    // we might want to use resolve options instead of {} here
+    return {
+        ...lRetval,
+        ...(resolveHelpers.addLicenseAttribute(pModuleName, pBaseDir, {})),
+        dependencyTypes: determineDependencyTypes(
+            lRetval,
+            pModuleName,
+            readPackageDeps(pFileDir, pBaseDir, pResolveOptions.combinedDependencies),
+            pFileDir,
+            pResolveOptions,
+            pBaseDir
+        )
+    };
 };
 
 module.exports.clearCache = () => {

--- a/src/extract/resolve/resolve-commonJS.js
+++ b/src/extract/resolve/resolve-commonJS.js
@@ -34,29 +34,25 @@ function addResolutionAttributes(pBaseDir, pModuleName, pFileDir, pResolveOption
  */
 module.exports = (pModuleName, pBaseDir, pFileDir, pResolveOptions) => {
 
-    let lRetval = Object.assign(
-        {
-            resolved        : pModuleName,
-            coreModule      : false,
-            followable      : false,
-            couldNotResolve : false,
-            dependencyTypes : ["undetermined"]
-        },
-        addResolutionAttributes(pBaseDir, pModuleName, pFileDir, pResolveOptions)
-    );
+    let lRetval = {
+        resolved        : pModuleName,
+        coreModule      : false,
+        followable      : false,
+        couldNotResolve : false,
+        dependencyTypes : ["undetermined"],
+        ...addResolutionAttributes(pBaseDir, pModuleName, pFileDir, pResolveOptions)
+    };
 
-    return Object.assign(
-        lRetval,
-        resolveHelpers.addLicenseAttribute(pModuleName, pBaseDir, pResolveOptions),
-        {
-            dependencyTypes: determineDependencyTypes(
-                lRetval,
-                pModuleName,
-                readPackageDeps(pFileDir, pBaseDir, pResolveOptions.combinedDependencies),
-                pFileDir,
-                pResolveOptions,
-                pBaseDir
-            )
-        }
-    );
+    return {
+        ...lRetval,
+        ...(resolveHelpers.addLicenseAttribute(pModuleName, pBaseDir, pResolveOptions)),
+        dependencyTypes: determineDependencyTypes(
+            lRetval,
+            pModuleName,
+            readPackageDeps(pFileDir, pBaseDir, pResolveOptions.combinedDependencies),
+            pFileDir,
+            pResolveOptions,
+            pBaseDir
+        )
+    };
 };

--- a/src/extract/resolve/resolve.js
+++ b/src/extract/resolve/resolve.js
@@ -8,16 +8,11 @@ function init(pResolveOptions, pCachingContext) {
     if (!gInitialized[pCachingContext] || pResolveOptions.bustTheCache) {
         // assuming the cached file system here
         pResolveOptions.fileSystem.purge();
-        gResolver = enhancedResolve.ResolverFactory.createResolver(
-            Object.assign(
-                {},
-                pResolveOptions,
-                {
-                    // we're doing that ourselves for now
-                    symlinks: false
-                }
-            )
-        );
+        gResolver = enhancedResolve.ResolverFactory.createResolver({
+            ...pResolveOptions,
+            // we're doing that ourselves for now
+            symlinks: false
+        });
         /* eslint security/detect-object-injection:0 */
         gInitialized[pCachingContext] = true;
     }

--- a/src/extract/summarize.js
+++ b/src/extract/summarize.js
@@ -76,14 +76,10 @@ module.exports = (pModules) => {
         .concat(extractModuleViolations(pModules))
         .sort(order.violations);
 
-    return Object.assign(
-        {
-            violations : lViolations
-        },
-        extractMetaData(lViolations),
-        {
-            totalCruised: pModules.length,
-            totalDependenciesCruised: pModules.reduce((pAll, pModule) => pAll + pModule.dependencies.length, 0)
-        }
-    );
+    return {
+        violations : lViolations,
+        ...extractMetaData(lViolations),
+        totalCruised: pModules.length,
+        totalDependenciesCruised: pModules.reduce((pAll, pModule) => pAll + pModule.dependencies.length, 0)
+    };
 };

--- a/src/extract/transpile/typeScriptWrap.js
+++ b/src/extract/transpile/typeScriptWrap.js
@@ -12,11 +12,11 @@ function getCompilerOptions(pTsx, pTSConfig = {}) {
         lCompilerOptions.jsx = "react";
     }
 
-    return Object.assign(
-        {"target": "es2015"},
-        lCompilerOptions,
-        _get(pTSConfig, "options", {})
-    );
+    return {
+        "target": "es2015",
+        ...lCompilerOptions,
+        ..._get(pTSConfig, "options", {})
+    };
 }
 
 module.exports = (pTsx) => ({
@@ -24,13 +24,9 @@ module.exports = (pTsx) => ({
 
     transpile: (pSource, pTSConfig) => typescript.transpileModule(
         pSource,
-        Object.assign(
-            {},
-            pTSConfig,
-            {
-                compilerOptions: getCompilerOptions(pTsx, pTSConfig)
-            }
-        )
-
+        {
+            ...pTSConfig,
+            compilerOptions: getCompilerOptions(pTsx, pTSConfig)
+        }
     ).outputText
 });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -27,13 +27,10 @@ function wrapInDependencyList(pExtractResult, pReporterOutput, pOutputType) {
     let lRetval = pExtractResult;
 
     if (pOutputType) {
-        lRetval = Object.assign(
-            {},
-            pExtractResult,
-            {
-                modules: pReporterOutput
-            }
-        );
+        lRetval = {
+            ...pExtractResult,
+            modules: pReporterOutput
+        };
     }
     return lRetval;
 }

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -16,13 +16,11 @@ function normalizeFilterOption(pFilterOption) {
 }
 
 module.exports = pOptions => {
-    let lRetval = Object.assign(
-        {
-            baseDir: process.cwd()
-        },
-        defaults,
-        pOptions
-    );
+    let lRetval = {
+        baseDir: process.cwd(),
+        ...defaults,
+        ...pOptions
+    };
 
     lRetval.maxDepth = parseInt(lRetval.maxDepth, 10);
     lRetval.moduleSystems = uniq(lRetval.moduleSystems.sort());

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -73,7 +73,7 @@ function validate(pOptions) {
         if (_get(pOptions, 'ruleSet.options')) {
             lRetval = validate(pOptions.ruleSet.options);
         }
-        return Object.assign(lRetval, pOptions);
+        return {...lRetval, ...pOptions};
     }
     return lRetval;
 }

--- a/src/main/resolveOptions/normalize.js
+++ b/src/main/resolveOptions/normalize.js
@@ -72,37 +72,34 @@ function compileResolveOptions(pResolveOptions, pTSConfig){
         );
     }
 
-    return Object.assign(
-        {},
-        DEFAULT_RESOLVE_OPTIONS,
-        lResolveOptions,
-        pResolveOptions,
-        NON_OVERRIDABLE_RESOLVE_OPTIONS
-    );
+    return {
+        ...DEFAULT_RESOLVE_OPTIONS,
+        ...lResolveOptions,
+        ...pResolveOptions,
+        ...NON_OVERRIDABLE_RESOLVE_OPTIONS
+    };
 }
 
 module.exports = (pResolveOptions, pOptions, pTSConfig) => compileResolveOptions(
-    Object.assign(
-        {
+    {
 
-            /*
-                for later: check semantics of enhanced-resolve symlinks and
-                node's preserveSymlinks. They seem to be
-                symlink === !preserveSymlinks - but using it that way
-                breaks backwards compatibility
-            */
-            symlinks: pOptions.preserveSymlinks,
-            tsConfig: _get(pOptions, "ruleSet.options.tsConfig.fileName", null),
+        /*
+            for later: check semantics of enhanced-resolve symlinks and
+            node's preserveSymlinks. They seem to be
+            symlink === !preserveSymlinks - but using it that way
+            breaks backwards compatibility
+        */
+        symlinks: pOptions.preserveSymlinks,
+        tsConfig: _get(pOptions, "ruleSet.options.tsConfig.fileName", null),
 
-            /* squirel the externalModuleResolutionStrategy and combinedDependencies
-               thing into the resolve options
-                - they're not for enhanced resolve, but they are for what we consider
-                resolve options ...
-            */
-            externalModuleResolutionStrategy: pOptions.externalModuleResolutionStrategy,
-            combinedDependencies: pOptions.combinedDependencies
-        },
-        pResolveOptions || {}
-    ),
+        /* squirel the externalModuleResolutionStrategy and combinedDependencies
+            thing into the resolve options
+            - they're not for enhanced resolve, but they are for what we consider
+            resolve options ...
+        */
+        externalModuleResolutionStrategy: pOptions.externalModuleResolutionStrategy,
+        combinedDependencies: pOptions.combinedDependencies,
+        ...(pResolveOptions || {})
+    },
     pTSConfig || {}
 );

--- a/src/main/ruleSet/normalize.js
+++ b/src/main/ruleSet/normalize.js
@@ -13,13 +13,11 @@ function normalizeName(pRule) {
 }
 
 function normalizeRule(pRule) {
-    return Object.assign(
-        pRule,
-        {
-            severity : normalizeSeverity(pRule.severity),
-            name     : normalizeName(pRule.name)
-        }
-    );
+    return {
+        ...pRule,
+        severity : normalizeSeverity(pRule.severity),
+        name     : normalizeName(pRule.name)
+    };
 }
 
 /**

--- a/src/report/dot/common/coloring.js
+++ b/src/report/dot/common/coloring.js
@@ -40,10 +40,10 @@ function determineModuleColors(pModule, pColoringScheme) {
 
         lInvalidColoring = {color: lColor, fontcolor: lColor};
     }
-    return Object.assign(
-        _get(lColoringScheme.find(pSchemeEntry => moduleMatchesCriteria(pSchemeEntry, pModule)), 'colors', {}),
-        lInvalidColoring
-    );
+    return {
+        ..._get(lColoringScheme.find(pSchemeEntry => moduleMatchesCriteria(pSchemeEntry, pModule)), 'colors', {}),
+        ...lInvalidColoring
+    };
 }
 
 function determineDependencyColor(pDependency) {
@@ -53,11 +53,10 @@ function determineDependencyColor(pDependency) {
         lColorAddition.color = severity2Color(pDependency.rule.severity);
     }
 
-    return Object.assign(
-        {},
-        pDependency,
-        lColorAddition
-    );
+    return {
+        ...pDependency,
+        ...lColorAddition
+    };
 }
 
 module.exports = {

--- a/src/report/dot/common/folderify.js
+++ b/src/report/dot/common/folderify.js
@@ -21,9 +21,8 @@ module.exports = (pModule) => {
 
     lAdditions.label = path.basename(pModule.source);
 
-    return Object.assign(
-        {},
-        pModule,
-        lAdditions
-    );
+    return {
+        ...pModule,
+        ...lAdditions
+    };
 };

--- a/src/report/dot/folderLevel/consolidateModuleDependencies.js
+++ b/src/report/dot/folderLevel/consolidateModuleDependencies.js
@@ -4,16 +4,13 @@ const _reject = require('lodash/reject');
 const _uniqBy = require('lodash/uniqBy');
 
 function mergeDependency(pLeftDependency, pRightDependency) {
-    return Object.assign(
-        {},
-        pLeftDependency,
-        pRightDependency,
-        {
-            dependendencyTypes: _uniqBy(pLeftDependency.dependendencyTypes.concat(pRightDependency.dependendencyTypes)),
-            rules: pLeftDependency.rules.concat(_get(pRightDependency, 'rules', [])),
-            valid: pLeftDependency.valid && pRightDependency.valid
-        }
-    );
+    return {
+        ...pLeftDependency,
+        ...pRightDependency,
+        dependendencyTypes: _uniqBy(pLeftDependency.dependendencyTypes.concat(pRightDependency.dependendencyTypes)),
+        rules: pLeftDependency.rules.concat(_get(pRightDependency, 'rules', [])),
+        valid: pLeftDependency.valid && pRightDependency.valid
+    };
 }
 
 function mergeDependencies(pResolvedName, pDependencies){
@@ -43,9 +40,9 @@ function consolidateDependencies(pDependencies) {
     return lRetval;
 }
 
-module.exports = (pModule) =>
-    Object.assign(
-        {},
-        pModule,
-        {dependencies: consolidateDependencies(pModule.dependencies)}
-    );
+module.exports = (pModule) => (
+    {
+        ...pModule,
+        dependencies: consolidateDependencies(pModule.dependencies)
+    }
+);

--- a/src/report/dot/folderLevel/consolidateModules.js
+++ b/src/report/dot/folderLevel/consolidateModules.js
@@ -2,16 +2,13 @@ const _clone  = require('lodash/clone');
 const _reject = require('lodash/reject');
 
 function mergeModule(pLeftModule, pRightModule) {
-    return Object.assign(
-        {},
-        pLeftModule,
-        pRightModule,
-        {
-            dependencies: pLeftModule.dependencies
-                .concat(pRightModule.dependencies),
-            valid: pLeftModule.valid && pRightModule.valid
-        }
-    );
+    return {
+        ...pLeftModule,
+        ...pRightModule,
+        dependencies: pLeftModule.dependencies
+            .concat(pRightModule.dependencies),
+        valid: pLeftModule.valid && pRightModule.valid
+    };
 }
 
 function mergeModules(pSourceString, pModules){

--- a/src/report/dot/folderLevel/index.js
+++ b/src/report/dot/folderLevel/index.js
@@ -10,50 +10,38 @@ const consolidateModuleDependencies = require("./consolidateModuleDependencies")
 require("./ddot.template");
 
 function colorize(pModule) {
-    return Object.assign(
-        {},
-        pModule,
-        {
-            dependencies: pModule.dependencies.map(coloring.determineDependencyColor)
-        }
-    );
+    return {
+        ...pModule,
+        dependencies: pModule.dependencies.map(coloring.determineDependencyColor)
+    };
 }
 function extractRelevantTransgressions(pModule){
-    return Object.assign(
-        {},
-        (pModule.rules ? Object.assign({}, pModule, {rule: pModule.rules[0]}) : pModule),
-        {
-            dependencies: pModule.dependencies.map(
-                pDependency =>
-                    Object.assign(
-                        {},
-                        pDependency,
-                        {
-                            rule: pDependency.rules[0]
-                        }
-                    )
+    return {
+        ...(pModule.rules ? {...pModule, rule: pModule.rules[0]} : pModule),
+        dependencies: pModule.dependencies.map(
+            pDependency => (
+                {
+                    ...pDependency,
+                    rule: pDependency.rules[0]
+                }
             )
-        }
-    );
+        )
+    };
 }
 
 function shortendep (pDep) {
-    return Object.assign(
-        {},
-        pDep,
-        {
-            resolved: path.dirname(pDep.resolved)
-        }
-    );
+    return {
+        ...pDep,
+        resolved: path.dirname(pDep.resolved)
+    };
 }
 
 function squashToDir (pModules) {
     return pModules
-        .map(pModule =>
-            Object.assign(
-                {},
-                pModule,
+        .map(
+            pModule => (
                 {
+                    ...pModule,
                     source: path.dirname(pModule.source),
                     dependencies: pModule.dependencies.map(shortendep)
                 }

--- a/src/report/dot/moduleLevel/index.js
+++ b/src/report/dot/moduleLevel/index.js
@@ -9,35 +9,28 @@ const compareOnSource = require("../common/compareOnSource");
 require("./dot.template");
 
 function colorize(pColoringScheme) {
-    return pModule => Object.assign(
-        {},
-        pModule,
+    return pModule => (
         {
-            dependencies: pModule.dependencies.map(coloring.determineDependencyColor)
-        },
-        coloring.determineModuleColors(pModule, pColoringScheme)
+            ...pModule,
+            dependencies: pModule.dependencies.map(coloring.determineDependencyColor),
+            ...coloring.determineModuleColors(pModule, pColoringScheme)
+        }
     );
 }
 
 function extractFirstTransgression(pModule){
-    return Object.assign(
-        {},
-        (pModule.rules ? Object.assign({}, pModule, {rule: pModule.rules[0]}) : pModule),
-        {
-            dependencies: pModule.dependencies.map(
-                pDependency =>
-                    pDependency.rules
-                        ? Object.assign(
-                            {},
-                            pDependency,
-                            {
-                                rule: pDependency.rules[0]
-                            }
-                        )
-                        : pDependency
-            )
-        }
-    );
+    return {
+        ...(pModule.rules ? {...pModule, rule: pModule.rules[0]} : pModule),
+        dependencies: pModule.dependencies.map(
+            pDependency =>
+                pDependency.rules
+                    ? {
+                        ...pDependency,
+                        rule: pDependency.rules[0]
+                    }
+                    : pDependency
+        )
+    };
 }
 
 /**

--- a/src/report/err-html/index.js
+++ b/src/report/err-html/index.js
@@ -38,13 +38,11 @@ function aggregateViolations(pViolations, pRuleSetUsed) {
  */
 module.exports = pResults => Handlebars.templates['err-html.template.hbs'](
     {
-        summary: Object.assign(
-            formatSummaryForReport(pResults.summary),
-            {
-                agggregateViolations: aggregateViolations(
-                    pResults.summary.violations, pResults.summary.ruleSetUsed
-                )
-            }
-        )
+        summary: {
+            ...formatSummaryForReport(pResults.summary),
+            agggregateViolations: aggregateViolations(
+                pResults.summary.violations, pResults.summary.ruleSetUsed
+            )
+        }
     }
 );

--- a/src/report/err-html/utl.js
+++ b/src/report/err-html/utl.js
@@ -20,34 +20,27 @@ function mergeCountIntoRule(pRule, pViolationCounts) {
         ? pViolationCounts[pRule.name]
         : 0;
 
-    return Object.assign(
-        {},
-        pRule,
-        {
-            count: lCount,
-            unviolated: lCount <= 0
-        }
-    );
+    return {
+        ...pRule,
+        count: lCount,
+        unviolated: lCount <= 0
+    };
 }
 
 function formatSummaryForReport(pSummary) {
-    return Object.assign(
-        {},
-        pSummary,
-        {
-            depcruiseVersion: `dependency-cruiser@${version}`,
-            runDate: (new Date()).toISOString(),
-            violations: (pSummary.violations || []).map(
-                pViolation => Object.assign(
-                    {},
-                    pViolation,
-                    {
-                        to: pViolation.from === pViolation.to ? "" : pViolation.to
-                    }
-                )
+    return {
+        ...pSummary,
+        depcruiseVersion: `dependency-cruiser@${version}`,
+        runDate: (new Date()).toISOString(),
+        violations: (pSummary.violations || []).map(
+            pViolation => (
+                {
+                    ...pViolation,
+                    to: pViolation.from === pViolation.to ? "" : pViolation.to
+                }
             )
-        }
-    );
+        )
+    };
 }
 
 module.exports = {

--- a/src/report/err/err.js
+++ b/src/report/err/err.js
@@ -46,14 +46,10 @@ function formatSummary(pSummary) {
 
 function addExplanation(pRuleSet, pLong) {
     return pLong
-        ? (pViolation) =>
-            Object.assign(
-                {},
-                pViolation,
-                {
-                    comment: _get(findRuleByName(pRuleSet, pViolation.rule.name), 'comment', '-')
-                }
-            )
+        ? (pViolation) => ({
+            ...pViolation,
+            comment: _get(findRuleByName(pRuleSet, pViolation.rule.name), 'comment', '-')
+        })
         : pViolation => pViolation;
 }
 

--- a/src/report/html/index.js
+++ b/src/report/html/index.js
@@ -5,19 +5,17 @@ const dependencyToIncidenceTransformer = require("../utl/dependencyToIncidenceTr
 require("./html.template");
 
 function addShowTitle(pDependencyEntry) {
-    return Object.assign(
-        pDependencyEntry,
-        {
-            incidences: pDependencyEntry.incidences.map(pIncidence =>
-                Object.assign(
-                    pIncidence,
-                    {
-                        hasRelation: pIncidence.incidence !== "false"
-                    }
-                )
+    return {
+        ...pDependencyEntry,
+        incidences: pDependencyEntry.incidences.map(
+            pIncidence => (
+                {
+                    ...pIncidence,
+                    hasRelation: pIncidence.incidence !== "false"
+                }
             )
-        }
-    );
+        )
+    };
 }
 
 /**

--- a/src/report/utl/dependencyToIncidenceTransformer.js
+++ b/src/report/utl/dependencyToIncidenceTransformer.js
@@ -30,20 +30,19 @@ function determineIncidenceType(pFromListEntry) {
 }
 
 function addIncidences(pFromList) {
-    return (pDependency) =>
-        Object.assign(
-            pDependency,
-            {
-                incidences: pFromList.map(pFromListEntry =>
-                    Object.assign(
-                        {
-                            to: pFromListEntry.source
-                        },
-                        determineIncidenceType(pFromListEntry)(pDependency)
-                    )
+    return (pDependency) => (
+        {
+            ...pDependency,
+            incidences: pFromList.map(
+                pFromListEntry => (
+                    {
+                        to: pFromListEntry.source,
+                        ...(determineIncidenceType(pFromListEntry)(pDependency))
+                    }
                 )
-            }
-        );
+            )
+        }
+    );
 }
 
 module.exports =

--- a/test/extract/resolve/isCore.spec.js
+++ b/test/extract/resolve/isCore.spec.js
@@ -4,19 +4,19 @@ const isCore = require('../../../src/extract/resolve/isCore');
 
 describe("extract/resolve/isCore", () => {
     it("returns false when passed nothing", () => {
-        expect(isCore()).to.be.undefined;
+        expect(isCore()).to.equal(false);
     });
 
     it("returns false when passed null", () => {
-        expect(isCore(null)).to.be.undefined;
+        expect(isCore(null)).to.equal(false);
     });
 
     it("returns false when passed a local module", () => {
-        expect(isCore("./path")).to.be.undefined;
+        expect(isCore("./path")).to.equal(false);
     });
 
     it("returns false when passed a non core module", () => {
-        expect(isCore("flowdash")).to.be.undefined;
+        expect(isCore("flowdash")).to.equal(false);
     });
 
     it("returns true when passed a core module", () => {


### PR DESCRIPTION
## Description
- de-support node 6, 7, < 8.10, 9 and 11 (BREAKING)
- adapt the de-support error message to reflect this
- kick node 6 from all ci integration build matrices
- replace Object.assigns with object spread where this improves legibility
- :arrow_up: external dependencies frozen on their last node 6 version to their latest && greatest:
indent-string, semver-try-require, wrap-ansi, eslint, eslint-plugin-node, symlink-dir, upem

## Motivation and Context
- nodejs.org still supports version 8, 10 and 12 - and dependency-cruiser will follow that. 
- In addition to this, according to nodes download stats 7, 9 and 11 ([source](https://nodejs.org/metrics/)) of the last three months these versions are not used much either:
<img width="956" alt="Screenshot 2019-07-16 at 22 36 01" src="https://user-images.githubusercontent.com/4822597/61328883-47e12980-a81c-11e9-804f-96cb163c99ec.png">

- the minimum requirement of node 8.10 is mainly to make sure we can use a builtin for determining what a core module is instead of having to rely on an external module. My assumption is that if you're still on node 8, you use _latest_ anyway, so I expect this to impact nobody.
- Many external dependencies dependency-cruiser depends upon don't support node 6 anymore, so supporting node 6 would become problematic in the near future.

## How Has This Been Tested?
- [x] automated non-regression tests

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.