### PR TITLE
refactor(report): remove the 'rcdot' alias for the dot reporter

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -112,13 +112,6 @@ dependency-cruise -x "^node_modules" -T dot src | dot -T svg > dependencygraph.s
 > modules on folder level. It works fine, but its output is a tad more ugly
 > than I'd like so there'll be tweaks to spruce it up in the future.
 
-> ##### rcdot
-> The `rcdot` reporter is deprecated.    
-> Since version 4.12.0 `rcdot` reporter's
-> coloring has become the default for the `dot` reporter, so `dot` and `rcdot`
-> will yield the same results. As of version 5.0.0 the rcdot option will be
-> removed.
-
 #### err-html
 Generates an stand alone html report with:
 - a summary with files & dependencies cruised and the number of errors and warnings found

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -66,7 +66,7 @@ function wrapInDependencyList(pExtractResult, pReporterOutput, pOutputType) {
  *                (default: 0, which means 'infinite depth')
  *  moduleSystems: an array of module systems to use for following dependencies;
  *                defaults to ["es6", "cjs", "amd"]
- *  outputType  : one of "json", "html", "dot", "rcdot", "csv" or "err". When left
+ *  outputType  : one of "json", "html", "dot", "csv" or "err". When left
  *                out the function will return a javascript object as dependencies
  *  preserveSymlinks: if true does not resolve symlinks, defaults to false
  * }

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -2,7 +2,7 @@ const _get      = require('lodash/get');
 const safeRegex = require('../../utl/safe-regex');
 
 const MODULE_SYSTEM_LIST_RE  = /^((cjs|amd|es6|tsd)(,|$))+$/gi;
-const OUTPUT_TYPES_RE        = /^(html|dot|rcdot|ddot|csv|err|json|teamcity|err-html|err-long)$/g;
+const OUTPUT_TYPES_RE        = /^(html|dot|ddot|csv|err|json|teamcity|err-html|err-long)$/g;
 const VALID_DEPTH_RE         = /^[0-9]{1,2}$/g;
 
 function validateSystems(pModuleSystems) {

--- a/src/report/index.js
+++ b/src/report/index.js
@@ -12,7 +12,6 @@ const TYPE2REPORTER      = {
     "json"     : reportJson,
     "html"     : reportHtml,
     "dot"      : reportDot,
-    "rcdot"    : reportDot,
     "ddot"     : reportDDot,
     "csv"      : reportCsv,
     "err"      : reportErr,


### PR DESCRIPTION
## Description, Motivation and Context
- See title (BREAKING CHANGE)
- The rcdot alias was deprecated for a few minor versions already because it was superfluous

## How Has This Been Tested?
- [x] automated non-regression tests

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
