### PR TITLE
refactor(cli): extracts the platform check into a separate function

### DIFF
--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -2,7 +2,7 @@
 const validateNodeEnv = require("../src/cli/validateNodeEnv");
 
 try {
-    validateNodeEnv(process.versions.node);
+    validateNodeEnv();
 
     // importing things only after the validateNodeEnv check so we can show an understandable
     // error. Otherwise, on unsupported platforms we would show a stack trace, which is

--- a/bin/dependency-cruise
+++ b/bin/dependency-cruise
@@ -1,65 +1,60 @@
 #!/usr/bin/env node
+const validateNodeEnv = require("../src/cli/validateNodeEnv");
 
-const program    = require("commander");
-const semver     = require("semver");
-const processCLI = require("../src/cli");
-const $package   = require("../package.json");
+try {
+    validateNodeEnv(process.versions.node);
 
-const VERSION_ERR = `\nERROR: your node version (${process.versions.node}) is not supported. dependency-cruiser
-       follows the node.js release cycle and runs on these node versions:
-       ${$package.engines.node}
-       See https://nodejs.org/en/about/releases/ for details.
+    // importing things only after the validateNodeEnv check so we can show an understandable
+    // error. Otherwise, on unsupported platforms we would show a stack trace, which is
+    // not so nice
+    /* eslint-disable global-require */
+    const program  = require("commander");
+    const $package = require("../package.json");
+    const cli      = require("../src/cli");
 
-`;
-
-/* istanbul ignore if  */
-if (!semver.satisfies(process.versions.node, $package.engines.node)) {
-
-    process.stderr.write(VERSION_ERR);
-
-    /* eslint no-process-exit: 0 */
-    process.exit(1);
-}
-
-program
-    .version($package.version)
-    .description("Validate and visualize dependencies.\nDetails: https://github.com/sverweij/dependency-cruiser")
-    .option("-i, --info", `shows what languages and extensions
+    program
+        .version($package.version)
+        .description("Validate and visualize dependencies.\nDetails: https://github.com/sverweij/dependency-cruiser")
+        .option("-i, --info", `shows what languages and extensions
                               dependency-cruiser supports`)
-    .option("-c, --config [file]", `read rules and options from [file]
+        .option("-c, --config [file]", `read rules and options from [file]
                               (default: .dependency-cruiser.json)`)
-    .option("-v, --validate [file]", `alias for --config`)
-    .option("-f, --output-to <file>", `file to write output to; - for stdout
+        .option("-v, --validate [file]", `alias for --config`)
+        .option("-f, --output-to <file>", `file to write output to; - for stdout
                              `, "-")
-    .option("-X, --do-not-follow <regex>", `include modules matching the regex,
+        .option("-X, --do-not-follow <regex>", `include modules matching the regex,
                               but don't follow them any further`)
-    .option("-x, --exclude <regex>", "exclude all modules matching the regex")
-    .option("--include-only <regex>",     "only include modules matching the regex")
-    .option("-d, --max-depth <n>", `the maximum depth to cruise; 0 <= n <= 99
+        .option("-x, --exclude <regex>", "exclude all modules matching the regex")
+        .option("--include-only <regex>",     "only include modules matching the regex")
+        .option("-d, --max-depth <n>", `the maximum depth to cruise; 0 <= n <= 99
                               (default: 0, which means 'infinite depth')`)
-    .option("-M, --module-systems <items>", `list of module systems (default: amd,cjs,es6)`)
-    .option("-T, --output-type <type>", `output type - err|err-long|err-html|dot|json
+        .option("-M, --module-systems <items>", `list of module systems (default: amd,cjs,es6)`)
+        .option("-T, --output-type <type>", `output type - err|err-long|err-html|dot|json
                               (default: err)`)
-    .option("-P, --prefix <prefix>", `prefix to use for links in the dot, err and
+        .option("-P, --prefix <prefix>", `prefix to use for links in the dot, err and
                               err-html reporters`)
-    .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
-    .option("--ts-pre-compilation-deps", `detect dependencies that only exist before
+        .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
+        .option("--ts-pre-compilation-deps", `detect dependencies that only exist before
                               typescript-to-javascript compilation
                               (off by default)`)
-    .option("--ts-config [file]", `use a typescript configuration ('project')
+        .option("--ts-config [file]", `use a typescript configuration ('project')
                               (default: tsconfig.json)`)
-    .option("--webpack-config [file]", `use a webpack configuration
+        .option("--webpack-config [file]", `use a webpack configuration
                               (default: webpack.config.js)`)
-    .option("--init [oneshot]", `write a .dependency-cruiser config with basic
+        .option("--init [oneshot]", `write a .dependency-cruiser config with basic
                               validations to the current folder.`)
-    .arguments("<files-or-directories>")
-    .parse(process.argv);
+        .arguments("<files-or-directories>")
+        .parse(process.argv);
 
-if (Boolean(program.args[0]) || program.info || program.init) {
-    process.exitCode = processCLI(
-        program.args,
-        program
-    );
-} else {
-    program.help();
+    if (Boolean(program.args[0]) || program.info || program.init) {
+        process.exitCode = cli(
+            program.args,
+            program
+        );
+    } else {
+        program.help();
+    }
+} catch (e) {
+    process.stderr.write(e.message);
+    process.exitCode = 1;
 }

--- a/src/cli/validateNodeEnv.js
+++ b/src/cli/validateNodeEnv.js
@@ -1,0 +1,15 @@
+const semver   = require("semver");
+const $package = require("../../package.json");
+
+module.exports = function validateNodeEnv(pNodeVersion) {
+    const VERSION_ERR = `\nERROR: This node version (${pNodeVersion}) is not supported. dependency-cruiser
+       follows the node.js release cycle and runs on these node versions:
+       ${$package.engines.node}
+       See https://nodejs.org/en/about/releases/ for details.
+
+`;
+
+    if (!semver.satisfies(pNodeVersion, $package.engines.node)) {
+        throw new Error(VERSION_ERR);
+    }
+};

--- a/src/cli/validateNodeEnv.js
+++ b/src/cli/validateNodeEnv.js
@@ -5,7 +5,7 @@ module.exports = function validateNodeEnv(pNodeVersion) {
     // not using default parameter here because the check should run
     // run on node 4 as well
     const lNodeVersion = pNodeVersion || process.versions.node;
-    const VERSION_ERR = `\nERROR: This node version (${lNodeVersion}) is not supported. dependency-cruiser
+    const VERSION_ERR = `\nERROR: Your node version (${lNodeVersion}) is not supported. dependency-cruiser
        follows the node.js release cycle and runs on these node versions:
        ${$package.engines.node}
        See https://nodejs.org/en/about/releases/ for details.

--- a/src/cli/validateNodeEnv.js
+++ b/src/cli/validateNodeEnv.js
@@ -2,14 +2,17 @@ const semver   = require("semver");
 const $package = require("../../package.json");
 
 module.exports = function validateNodeEnv(pNodeVersion) {
-    const VERSION_ERR = `\nERROR: This node version (${pNodeVersion}) is not supported. dependency-cruiser
+    // not using default parameter here because the check should run
+    // run on node 4 as well
+    const lNodeVersion = pNodeVersion || process.versions.node;
+    const VERSION_ERR = `\nERROR: This node version (${lNodeVersion}) is not supported. dependency-cruiser
        follows the node.js release cycle and runs on these node versions:
        ${$package.engines.node}
        See https://nodejs.org/en/about/releases/ for details.
 
 `;
 
-    if (!semver.satisfies(pNodeVersion, $package.engines.node)) {
+    if (!semver.satisfies(lNodeVersion, $package.engines.node)) {
         throw new Error(VERSION_ERR);
     }
 };

--- a/test/cli/valideNodeEnv.spec.js
+++ b/test/cli/valideNodeEnv.spec.js
@@ -2,20 +2,31 @@ const expect        = require("chai").expect;
 const validateNodeEnv = require("../../src/cli/validateNodeEnv");
 
 describe("cli/validateNodeEnv", () => {
-    it("throws when no node version is passed", () => {
-        expect(() => validateNodeEnv()).to.throw();
-    });
 
-    it("throws when an empty node version is passed", () => {
-        expect(() => validateNodeEnv("")).to.throw();
-    });
-
-    it("doesn't throw when an older and unsupported node version is passed", () => {
+    it("throws when an older and unsupported node version is passed", () => {
         expect(() => validateNodeEnv("6.0.0")).to.throw();
     });
 
-    it("doesn't throw when a newer but unsupported node version is passed", () => {
+    it("throws when a newer but unsupported node version is passed", () => {
         expect(() => validateNodeEnv("9.0.0")).to.throw();
+    });
+
+    it("doesn't throw when an empty node version is passed (assuming test is run on a supported platform)", () => {
+        expect(() => validateNodeEnv("")).to.not.throw();
+    });
+
+    it("doesn't throw when a null node version is passed (assuming test is run on a supported platform)", () => {
+        // eslint-disable-next-line no-undefined
+        expect(() => validateNodeEnv(null)).to.not.throw();
+    });
+
+    it("doesn't throw when an undefined node version is passed (assuming test is run on a supported platform)", () => {
+        // eslint-disable-next-line no-undefined
+        expect(() => validateNodeEnv(undefined)).to.not.throw();
+    });
+
+    it("doesn't throw when no node version is passed (assuming this test is run on a supported platform ...)", () => {
+        expect(() => validateNodeEnv()).to.not.throw();
     });
 
     it("doesn't throw when a supported node version is passed", () => {

--- a/test/cli/valideNodeEnv.spec.js
+++ b/test/cli/valideNodeEnv.spec.js
@@ -1,0 +1,24 @@
+const expect        = require("chai").expect;
+const validateNodeEnv = require("../../src/cli/validateNodeEnv");
+
+describe("cli/validateNodeEnv", () => {
+    it("throws when no node version is passed", () => {
+        expect(() => validateNodeEnv()).to.throw();
+    });
+
+    it("throws when an empty node version is passed", () => {
+        expect(() => validateNodeEnv("")).to.throw();
+    });
+
+    it("doesn't throw when an older and unsupported node version is passed", () => {
+        expect(() => validateNodeEnv("6.0.0")).to.throw();
+    });
+
+    it("doesn't throw when a newer but unsupported node version is passed", () => {
+        expect(() => validateNodeEnv("9.0.0")).to.throw();
+    });
+
+    it("doesn't throw when a supported node version is passed", () => {
+        expect(() => validateNodeEnv("12.0.0")).to.not.throw();
+    });
+});


### PR DESCRIPTION
## Description, Motivation and Context
extracts the platform check into a separate function so it can be re-used and unit tested. Also makes sure the cli emits a neat warning message on node 4 and 6 and doesn't show a stack trace because one of dc's dependencies uses an unsupported feature.

## How Has This Been Tested?
- [x] additional unit test
- [x] automated non-regression tests

## Types of changes
- [x] Refactoring (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.