### PR TITLE
refactor(extract): use acorn instead of acorn-dynamic-import for detecting dynamic imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   },
   "dependencies": {
     "acorn": "7.0.0",
-    "acorn-dynamic-import": "4.0.0",
     "acorn-loose": "7.0.0",
     "acorn-walk": "7.0.0",
     "ajv": "6.10.2",

--- a/src/extract/ast-extractors/estree-helpers.js
+++ b/src/extract/ast-extractors/estree-helpers.js
@@ -35,10 +35,6 @@ function isRequireIdentifier(pNode) {
   );
 }
 
-function isImportStatement(pNode) {
-  return "Import" === _get(pNode, "callee.type");
-}
-
 function isLikelyAMDDefineOrRequire(pNode) {
   return (
     pNode.expression.type === "CallExpression" &&
@@ -59,8 +55,9 @@ function isLikelyAMDDefine(pNode) {
 module.exports = {
   firstArgumentIsAString,
   firstArgumentIsATemplateLiteral,
+  isStringLiteral,
+  isPlaceholderlessTemplateLiteral,
   isRequireIdentifier,
-  isImportStatement,
   isLikelyAMDDefineOrRequire,
   isLikelyAMDDefine
 };

--- a/src/extract/ast-extractors/extract-AMD-deps.js
+++ b/src/extract/ast-extractors/extract-AMD-deps.js
@@ -1,4 +1,4 @@
-const walk = require("./walk");
+const walk = require("acorn-walk");
 const extractCommonJSDependencies = require("./extract-commonJS-deps");
 const estreeHelpers = require("./estree-helpers");
 

--- a/src/extract/ast-extractors/extract-commonJS-deps.js
+++ b/src/extract/ast-extractors/extract-commonJS-deps.js
@@ -1,4 +1,4 @@
-const walk = require("./walk");
+const walk = require("acorn-walk");
 const estreeHelpers = require("./estree-helpers");
 
 function pushRequireCallsToDependencies(pDependencies, pModuleSystem) {

--- a/src/extract/ast-extractors/walk.js
+++ b/src/extract/ast-extractors/walk.js
@@ -1,4 +1,0 @@
-const walk = require("acorn-walk");
-const inject = require("acorn-dynamic-import/lib/walk").default;
-
-module.exports = inject(walk);

--- a/src/extract/parse/toJavascriptAST.js
+++ b/src/extract/parse/toJavascriptAST.js
@@ -1,18 +1,27 @@
 const fs = require("fs");
 const acorn = require("acorn");
 const acornLoose = require("acorn-loose");
-const acornDynamicImport = require("acorn-dynamic-import");
 const _memoize = require("lodash/memoize");
 const transpile = require("../transpile");
 const getExtension = require("../utl/getExtension");
-
-const acornExtended = acorn.Parser.extend(acornDynamicImport.default);
 
 function getASTFromSource(pSource, pExtension, pTSConfig) {
   const lJavaScriptSource = transpile(pExtension, pSource, pTSConfig);
 
   try {
-    return acornExtended.parse(lJavaScriptSource, { sourceType: "module" });
+    // console.log(
+    //   JSON.stringify(
+    //     acorn.parse(lJavaScriptSource, { sourceType: "module", ecmaVersion: 11 }),
+    //     null,
+    //     "  "
+    //   )
+    // );
+    // ecmaVersion 11 necessary for acorn to understand dynamic imports
+    // default ecmaVersion for acorn 7 is still 10.
+    return acorn.parse(lJavaScriptSource, {
+      sourceType: "module",
+      ecmaVersion: 11
+    });
   } catch (e) {
     return acornLoose.parse(lJavaScriptSource, { sourceType: "module" });
   }


### PR DESCRIPTION
## Description
see title

## Motivation and Context
... as acorn started supporting that in version 7.0.0 (as per https://github.com/acornjs/acorn/pull/844), so it's not necessary anymore to use a plugin for this. Moreover, the plugin expects acorn ^6 as a peer, and as we're using 7 npm complains about it on install, which looks daft.

## How Has This Been Tested?
- [x] automated non-regression tests

## Types of changes
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
