### PR TITLE
fixed npm audit vulnerability by updating handlebars to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "figures": "3.0.0",
     "get-stream": "5.1.0",
     "glob": "7.1.4",
-    "handlebars": "4.1.2",
+    "handlebars": "^4.3.0",
     "indent-string": "4.0.0",
     "inquirer": "7.0.0",
     "lodash": "4.17.15",


### PR DESCRIPTION
It uses caret to allow clients to use newer versions.

Fixes #189.