### PR TITLE
Added types for ICruiseResult Interface and also changed the function…

### DIFF
--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -406,13 +406,451 @@ export interface ICruiseOptions {
    */
   forceOrphanCheck?: boolean;
 }
+export interface ICruiseResult {
+  /**
+   * A list of modules, with for each module the modules it depends upon
+   */
+  modules: Module[];
+  /**
+   * Data summarizing the found dependencies
+   */
+  summary: Summary;
+}
+
+export interface Module {
+  /**
+   * Whether or not this is a node.js core module
+   */
+  coreModule?: boolean;
+  /**
+   * 'true' if dependency-cruiser could not resolve the module name in the source code to a
+   * file name or core module. 'false' in all other cases.
+   */
+  couldNotResolve?: boolean;
+  dependencies:     Dependency[];
+  /**
+   * the type of inclusion - local, core, unknown (= we honestly don't know), undetermined (=
+   * we didn't bother determining it) or one of the npm dependencies defined in a package.jsom
+   * ('npm' for 'depenencies', 'npm-dev', 'npm-optional', 'npm-peer', 'npm-no-pkg' for
+   * development, optional, peer dependencies and dependencies in node_modules but not in
+   * package.json respectively)
+   */
+  dependencyTypes?: DependencyType[];
+  /**
+   * Whether or not this is a dependency that can be followed any further. This will be
+   * 'false' for for core modules, json, modules that could not be resolved to a file and
+   * modules that weren't followed because it matches the doNotFollow expression.
+   */
+  followable?: boolean;
+  /**
+   * the license, if known (usually known for modules pulled from npm, not for local ones)
+   */
+  license?: string;
+  /**
+   * 'true' if the file name of this module matches the doNotFollow regular expression
+   */
+  matchesDoNotFollow?: boolean;
+  /**
+   * 'true' if this module does not have dependencies, and no module has it as a dependency
+   */
+  orphan?: boolean;
+  /**
+   * An array of objects that tell whether this module is 'reachable', and according to rule
+   * in which this reachability was defined
+   */
+  reachable?: ReachableType[];
+  /**
+   * an array of rules violated by this module - left out if the module is valid
+   */
+  rules?: RuleSummaryType[];
+  /**
+   * The (resolved) file name of the module, e.g. 'src/main/index.js'
+   */
+  source: string;
+  /**
+   * 'true' if this module violated a rule; 'false' in all other cases. The violated rule will
+   * be in the 'rule' object at the same level.
+   */
+  valid: boolean;
+}
+
+export interface Dependency {
+  /**
+   * 'true' if following this dependency will ultimately return to the source, false in all
+   * other cases
+   */
+  circular?: boolean;
+  /**
+   * Whether or not this is a node.js core module - deprecated in favor of dependencyType ===
+   * core
+   */
+  coreModule: boolean;
+  /**
+   * 'true' if dependency-cruiser could not resulve the module name in the source code to a
+   * file name or core module. 'false' in all other cases.
+   */
+  couldNotResolve: boolean;
+  /**
+   * If following this dependency will ultimately return to the source (circular === true),
+   * this attribute will contain an (ordered) array of module names that shows (one of the)
+   * circular path(s)
+   */
+  cycle?: string[];
+  /**
+   * the type of inclusion - local, core, unknown (= we honestly don't know), undetermined (=
+   * we didn't bother determining it) or one of the npm dependencies defined in a package.jsom
+   * ('npm' for 'depenencies', 'npm-dev', 'npm-optional', 'npm-peer', 'npm-no-pkg' for
+   * development, optional, peer dependencies and dependencies in node_modules but not in
+   * package.json respectively)
+   */
+  dependencyTypes: DependencyType[];
+  /**
+   * true if this dependency is dynamic, false in all other cases
+   */
+  dynamic: boolean;
+  /**
+   * Whether or not this is a dependency that can be followed any further. This will be
+   * 'false' for for core modules, json, modules that could not be resolved to a file and
+   * modules that weren't followed because it matches the doNotFollow expression.
+   */
+  followable: boolean;
+  /**
+   * the license, if known (usually known for modules pulled from npm, not for local ones)
+   */
+  license?: string;
+  /**
+   * 'true' if the file name of this module matches the doNotFollow regular expression
+   */
+  matchesDoNotFollow?: boolean;
+  /**
+   * The name of the module as it appeared in the source code, e.g. './main'
+   */
+  module:       string;
+  moduleSystem: ModuleSystemType;
+  /**
+   * The (resolved) file name of the module, e.g. 'src/main//index.js'
+   */
+  resolved: string;
+  /**
+   * an array of rules violated by this dependency - left out if the dependency is valid
+   */
+  rules?: RuleSummaryType[];
+  /**
+   * 'true' if this dependency violated a rule; 'false' in all other cases. The violated rule
+   * will be in the 'rule' object at the same level.
+   */
+  valid: boolean;
+}
+
+/**
+* If there was a rule violation (valid === false), this object contains the name of the
+* rule and severity of violating it.
+*/
+export interface RuleSummaryType {
+  /**
+   * The (short, eslint style) name of the violated rule. Typically something like
+   * 'no-core-punycode' or 'no-outside-deps'.
+   */
+  name:     string;
+  severity: SeverityType;
+}
+
+/**
+* How severe a violation of a rule is. The 'error' severity will make some reporters return
+* a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated:
+* use that. The absence of the 'ignore' severity here is by design; ignored rules don't
+* show up in the output.
+*
+* Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
+*/
+
+export interface ReachableType {
+  /**
+   * The name of the rule where the reachability was defined
+   */
+  asDefinedInRule: string;
+  /**
+   * 'true' if this module is reachable from any of the modules matched by the from part of a
+   * reachability-rule in 'asDefinedInRule', 'false' if not.
+   */
+  value: boolean;
+}
+
+/**
+* Data summarizing the found dependencies
+*/
+export interface Summary {
+  /**
+   * the number of errors in the dependencies
+   */
+  error: number;
+  /**
+   * the number of informational level notices in the dependencies
+   */
+  info:        number;
+  optionsUsed: OptionsType;
+  /**
+   * rules used in the cruise
+   */
+  ruleSetUsed?: RuleSetUsed;
+  /**
+   * the number of modules cruised
+   */
+  totalCruised: number;
+  /**
+   * the number of dependencies cruised
+   */
+  totalDependenciesCruised?: number;
+  /**
+   * A list of violations found in the dependencies. The dependencies themselves also contain
+   * this information, this summary is here for convenience.
+   */
+  violations: ViolationType[];
+  /**
+   * the number of warnings in the dependencies
+   */
+  warn: number;
+}
+
+/**
+* the (command line) options used to generate the dependency-tree
+*/
+export interface OptionsType {
+  /**
+   * arguments passed on the command line
+   */
+  args?:                 string;
+  combinedDependencies?: boolean;
+  /**
+   * Criteria for modules to include, but not to follow further
+   */
+  doNotFollow?: DoNotFollow;
+  /**
+   * Criteria for dependencies to exclude
+   */
+  exclude?: Exclude;
+  /**
+   * What external module resolution strategy to use. Defaults to 'node_modules'
+   */
+  externalModuleResolutionStrategy?: ExternalModuleResolutionStrategyType;
+  /**
+   * a regular expression for modules to cruise; anything outside it will be skipped
+   */
+  includeOnly?: string;
+  /**
+   * The maximum cruise depth specified. 0 means no maximum specified
+   */
+  maxDepth?:      number;
+  moduleSystems?: ModuleSystemType[];
+  /**
+   * File the output was written to ('-' for stdout)
+   */
+  outputTo?:         string;
+  outputType?:       OutputType;
+  prefix?:           string;
+  preserveSymlinks?: boolean;
+  /**
+   * The rules file used to validate the dependencies (if any)
+   */
+  rulesFile?:            string;
+  tsConfig?:             TsConfig;
+  tsPreCompilationDeps?: boolean;
+  /**
+   * The webpack configuration options used for the cruise
+   */
+  webpackConfig?: WebpackConfig;
+}
+
+/**
+* Criteria for modules to include, but not to follow further
+*/
+export interface DoNotFollow {
+  /**
+   * an array of dependency types to include, but not follow further
+   */
+  dependencyTypes?: DependencyType[];
+  /**
+   * a regular expression for modules to include, but not follow further
+   */
+  path?: string;
+}
+
+/**
+* Criteria for dependencies to exclude
+*/
+export interface Exclude {
+  /**
+   * a boolean indicating whether or not to exclude dynamic dependencies
+   */
+  dynamic?: boolean;
+  /**
+   * a regular expression for modules to exclude from being cruised
+   */
+  path?: string;
+}
+
+export interface TsConfig {
+  fileName?: string;
+}
+
+/**
+* The webpack configuration options used for the cruise
+*/
+export interface WebpackConfig {
+  /**
+   * The arguments used
+   */
+  arguments?: { [key: string]: any };
+  /**
+   * The 'env' parameters passed
+   */
+  env?: Env;
+  /**
+   * The name of the webpack configuration file used
+   */
+  fileName?: string;
+}
+
+/**
+* The 'env' parameters passed
+*/
+export type Env = { [key: string]: any } | string;
+
+/**
+* rules used in the cruise
+*/
+export interface RuleSetUsed {
+  /**
+   * A list of rules that describe dependencies that are allowed. dependency-cruiser will emit
+   * the warning message 'not-in-allowed' for each dependency that does not at least meet one
+   * of them.
+   */
+  allowed?: RuleType[];
+  /**
+   * Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
+   */
+  allowedSeverity?: SeverityType;
+  /**
+   * A list of rules that describe dependencies that are not allowed. dependency-cruiser will
+   * emit a separate error (warning/ informational) messages for each violated rule.
+   */
+  forbidden?: ForiddenRuleType[];
+}
+
+export interface RuleType {
+  comment?: string;
+  from:     FromRestrictionType;
+  to:       ToRestrictionType;
+}
+
+/**
+* Criteria an end of a dependency should match to be caught by this rule. Leave it empty if
+* you want any module to be matched.
+*/
+export interface FromRestrictionType {
+  /**
+   * Whether or not to match when the module is an orphan (= has no incoming or outgoing
+   * dependencies). When this property it is part of a rule, dependency-cruiser will ignore
+   * the 'to' part.
+   */
+  orphan?: boolean;
+  /**
+   * A regular expression an end of a dependency should match to be catched by this rule.
+   */
+  path?: string;
+  /**
+   * A regular expression an end of a dependency should NOT match to be catched by this rule.
+   */
+  pathNot?: string;
+}
+
+/**
+* Criteria the 'to' end of a dependency should match to be caught by this rule. Leave it
+* empty if you want any module to be matched.
+*/
+export interface ToRestrictionType {
+  /**
+   * Whether or not to match when following to the to will ultimately end up in the from.
+   */
+  circular?: boolean;
+  /**
+   * Whether or not to match modules dependency-cruiser could not resolve (and probably aren't
+   * on disk). For this one too: leave out if you don't care either way.
+   */
+  couldNotResolve?: boolean;
+  /**
+   * Whether or not to match modules of any of these types (leaving out matches any of them)
+   */
+  dependencyTypes?: DependencyType[];
+  /**
+   * true if this dependency is dynamic, false in all other cases
+   */
+  dynamic?: boolean;
+  /**
+   * Whether or not to match modules that were released under one of the mentioned licenses.
+   * E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible
+   * with the GPL) use "GPL"
+   */
+  license?: string;
+  /**
+   * Whether or not to match modules that were NOT released under one of the mentioned
+   * licenses. E.g. to flag everyting non MIT use "MIT" here
+   */
+  licenseNot?: string;
+  /**
+   * If true matches dependencies with more than one dependency type (e.g. defined in _both_
+   * npm and npm-dev)
+   */
+  moreThanOneDependencyType?: boolean;
+  /**
+   * A regular expression an end of a dependency should match to be catched by this rule.
+   */
+  path?: string;
+  /**
+   * A regular expression an end of a dependency should NOT match to be catched by this rule.
+   */
+  pathNot?: string;
+  /**
+   * Whether or not to match modules that aren't reachable from the from part of the rule.
+   * NOTE & TODO: should be separate rule type that ensures there's only one, and that has
+   * only path and pathNot in the to part
+   */
+  reachable?: boolean;
+}
+
+export interface ForiddenRuleType {
+  /**
+   * You can use this field to document why the rule is there.
+   */
+  comment?: string;
+  from:     FromRestrictionType;
+  /**
+   * A short name for the rule - will appear in reporters to enable customers to quickly
+   * identify a violated rule. Try to keep them short, eslint style. E.g. 'not-to-core' for a
+   * rule forbidding dependencies on core modules, or 'not-to-unresolvable' for one that
+   * prevents dependencies on modules that probably don't exist.
+   */
+  name?:     string;
+  severity?: SeverityType;
+  to:        ToRestrictionType;
+}
+
+export interface ViolationType {
+  /**
+   * The circular path if the violation was about circularity
+   */
+  cycle?: string[];
+  from:   string;
+  rule:   RuleSummaryType;
+  to:     string;
+}
 
 export interface IReporterOutput {
   /**
    * The output proper of the reporter. For most reporters this will be
    * a string.
    */
-  output: any;
+  output: ICruiseResult | string;
   /**
    * The exit code - reporters can return a non-zero value when they find
    * errors here. api consumers (like a cli) can use this to return a
@@ -441,7 +879,7 @@ export interface IReporterOutput {
  *                        [here](../src/cli/flattenTypeScriptConfig.js))
  */
 export function cruise(
-  pFileDirArray: string[],
+  pFileDirArray: ICruiseResult[],
   pOptions?: ICruiseOptions,
   pResolveOptions?: any,
   pTSConfig?: any

--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -410,14 +410,14 @@ export interface ICruiseResult {
   /**
    * A list of modules, with for each module the modules it depends upon
    */
-  modules: Module[];
+  modules: IModule[];
   /**
    * Data summarizing the found dependencies
    */
-  summary: Summary;
+  summary: ISummary;
 }
 
-export interface Module {
+export interface IModule {
   /**
    * Whether or not this is a node.js core module
    */
@@ -427,7 +427,7 @@ export interface Module {
    * file name or core module. 'false' in all other cases.
    */
   couldNotResolve?: boolean;
-  dependencies:     Dependency[];
+  dependencies: IDependency[];
   /**
    * the type of inclusion - local, core, unknown (= we honestly don't know), undetermined (=
    * we didn't bother determining it) or one of the npm dependencies defined in a package.jsom
@@ -458,11 +458,11 @@ export interface Module {
    * An array of objects that tell whether this module is 'reachable', and according to rule
    * in which this reachability was defined
    */
-  reachable?: ReachableType[];
+  reachable?: IReachableType[];
   /**
    * an array of rules violated by this module - left out if the module is valid
    */
-  rules?: RuleSummaryType[];
+  rules?: IRuleSummaryType[];
   /**
    * The (resolved) file name of the module, e.g. 'src/main/index.js'
    */
@@ -474,7 +474,7 @@ export interface Module {
   valid: boolean;
 }
 
-export interface Dependency {
+export interface IDependency {
   /**
    * 'true' if following this dependency will ultimately return to the source, false in all
    * other cases
@@ -525,7 +525,7 @@ export interface Dependency {
   /**
    * The name of the module as it appeared in the source code, e.g. './main'
    */
-  module:       string;
+  module: string;
   moduleSystem: ModuleSystemType;
   /**
    * The (resolved) file name of the module, e.g. 'src/main//index.js'
@@ -534,7 +534,7 @@ export interface Dependency {
   /**
    * an array of rules violated by this dependency - left out if the dependency is valid
    */
-  rules?: RuleSummaryType[];
+  rules?: IRuleSummaryType[];
   /**
    * 'true' if this dependency violated a rule; 'false' in all other cases. The violated rule
    * will be in the 'rule' object at the same level.
@@ -543,28 +543,28 @@ export interface Dependency {
 }
 
 /**
-* If there was a rule violation (valid === false), this object contains the name of the
-* rule and severity of violating it.
-*/
-export interface RuleSummaryType {
+ * If there was a rule violation (valid === false), this object contains the name of the
+ * rule and severity of violating it.
+ */
+export interface IRuleSummaryType {
   /**
    * The (short, eslint style) name of the violated rule. Typically something like
    * 'no-core-punycode' or 'no-outside-deps'.
    */
-  name:     string;
+  name: string;
   severity: SeverityType;
 }
 
 /**
-* How severe a violation of a rule is. The 'error' severity will make some reporters return
-* a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated:
-* use that. The absence of the 'ignore' severity here is by design; ignored rules don't
-* show up in the output.
-*
-* Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
-*/
+ * How severe a violation of a rule is. The 'error' severity will make some reporters return
+ * a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated:
+ * use that. The absence of the 'ignore' severity here is by design; ignored rules don't
+ * show up in the output.
+ *
+ * Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
+ */
 
-export interface ReachableType {
+export interface IReachableType {
   /**
    * The name of the rule where the reachability was defined
    */
@@ -577,9 +577,9 @@ export interface ReachableType {
 }
 
 /**
-* Data summarizing the found dependencies
-*/
-export interface Summary {
+ * Data summarizing the found dependencies
+ */
+export interface ISummary {
   /**
    * the number of errors in the dependencies
    */
@@ -587,12 +587,12 @@ export interface Summary {
   /**
    * the number of informational level notices in the dependencies
    */
-  info:        number;
-  optionsUsed: OptionsType;
+  info: number;
+  optionsUsed: IOptionsType;
   /**
    * rules used in the cruise
    */
-  ruleSetUsed?: RuleSetUsed;
+  ruleSetUsed?: IRuleSetUsed;
   /**
    * the number of modules cruised
    */
@@ -605,7 +605,7 @@ export interface Summary {
    * A list of violations found in the dependencies. The dependencies themselves also contain
    * this information, this summary is here for convenience.
    */
-  violations: ViolationType[];
+  violations: IViolationType[];
   /**
    * the number of warnings in the dependencies
    */
@@ -613,22 +613,22 @@ export interface Summary {
 }
 
 /**
-* the (command line) options used to generate the dependency-tree
-*/
-export interface OptionsType {
+ * the (command line) options used to generate the dependency-tree
+ */
+export interface IOptionsType {
   /**
    * arguments passed on the command line
    */
-  args?:                 string;
+  args?: string;
   combinedDependencies?: boolean;
   /**
    * Criteria for modules to include, but not to follow further
    */
-  doNotFollow?: DoNotFollow;
+  doNotFollow?: IDoNotFollow;
   /**
    * Criteria for dependencies to exclude
    */
-  exclude?: Exclude;
+  exclude?: IExclude;
   /**
    * What external module resolution strategy to use. Defaults to 'node_modules'
    */
@@ -640,31 +640,31 @@ export interface OptionsType {
   /**
    * The maximum cruise depth specified. 0 means no maximum specified
    */
-  maxDepth?:      number;
+  maxDepth?: number;
   moduleSystems?: ModuleSystemType[];
   /**
    * File the output was written to ('-' for stdout)
    */
-  outputTo?:         string;
-  outputType?:       OutputType;
-  prefix?:           string;
+  outputTo?: string;
+  outputType?: OutputType;
+  prefix?: string;
   preserveSymlinks?: boolean;
   /**
    * The rules file used to validate the dependencies (if any)
    */
-  rulesFile?:            string;
-  tsConfig?:             TsConfig;
+  rulesFile?: string;
+  tsConfig?: ITsConfig;
   tsPreCompilationDeps?: boolean;
   /**
    * The webpack configuration options used for the cruise
    */
-  webpackConfig?: WebpackConfig;
+  webpackConfig?: IWebpackConfig;
 }
 
 /**
-* Criteria for modules to include, but not to follow further
-*/
-export interface DoNotFollow {
+ * Criteria for modules to include, but not to follow further
+ */
+export interface IDoNotFollow {
   /**
    * an array of dependency types to include, but not follow further
    */
@@ -676,9 +676,9 @@ export interface DoNotFollow {
 }
 
 /**
-* Criteria for dependencies to exclude
-*/
-export interface Exclude {
+ * Criteria for dependencies to exclude
+ */
+export interface IExclude {
   /**
    * a boolean indicating whether or not to exclude dynamic dependencies
    */
@@ -689,14 +689,14 @@ export interface Exclude {
   path?: string;
 }
 
-export interface TsConfig {
+export interface ITsConfig {
   fileName?: string;
 }
 
 /**
-* The webpack configuration options used for the cruise
-*/
-export interface WebpackConfig {
+ * The webpack configuration options used for the cruise
+ */
+export interface IWebpackConfig {
   /**
    * The arguments used
    */
@@ -712,20 +712,20 @@ export interface WebpackConfig {
 }
 
 /**
-* The 'env' parameters passed
-*/
+ * The 'env' parameters passed
+ */
 export type Env = { [key: string]: any } | string;
 
 /**
-* rules used in the cruise
-*/
-export interface RuleSetUsed {
+ * rules used in the cruise
+ */
+export interface IRuleSetUsed {
   /**
    * A list of rules that describe dependencies that are allowed. dependency-cruiser will emit
    * the warning message 'not-in-allowed' for each dependency that does not at least meet one
    * of them.
    */
-  allowed?: RuleType[];
+  allowed?: IRuleType[];
   /**
    * Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
    */
@@ -734,20 +734,20 @@ export interface RuleSetUsed {
    * A list of rules that describe dependencies that are not allowed. dependency-cruiser will
    * emit a separate error (warning/ informational) messages for each violated rule.
    */
-  forbidden?: ForiddenRuleType[];
+  forbidden?: IForiddenRuleType[];
 }
 
-export interface RuleType {
+export interface IRuleType {
   comment?: string;
-  from:     FromRestrictionType;
-  to:       ToRestrictionType;
+  from: IFromRestrictionType;
+  to: IToRestrictionType;
 }
 
 /**
-* Criteria an end of a dependency should match to be caught by this rule. Leave it empty if
-* you want any module to be matched.
-*/
-export interface FromRestrictionType {
+ * Criteria an end of a dependency should match to be caught by this rule. Leave it empty if
+ * you want any module to be matched.
+ */
+export interface IFromRestrictionType {
   /**
    * Whether or not to match when the module is an orphan (= has no incoming or outgoing
    * dependencies). When this property it is part of a rule, dependency-cruiser will ignore
@@ -765,10 +765,10 @@ export interface FromRestrictionType {
 }
 
 /**
-* Criteria the 'to' end of a dependency should match to be caught by this rule. Leave it
-* empty if you want any module to be matched.
-*/
-export interface ToRestrictionType {
+ * Criteria the 'to' end of a dependency should match to be caught by this rule. Leave it
+ * empty if you want any module to be matched.
+ */
+export interface IToRestrictionType {
   /**
    * Whether or not to match when following to the to will ultimately end up in the from.
    */
@@ -818,31 +818,31 @@ export interface ToRestrictionType {
   reachable?: boolean;
 }
 
-export interface ForiddenRuleType {
+export interface IForiddenRuleType {
   /**
    * You can use this field to document why the rule is there.
    */
   comment?: string;
-  from:     FromRestrictionType;
+  from: IFromRestrictionType;
   /**
    * A short name for the rule - will appear in reporters to enable customers to quickly
    * identify a violated rule. Try to keep them short, eslint style. E.g. 'not-to-core' for a
    * rule forbidding dependencies on core modules, or 'not-to-unresolvable' for one that
    * prevents dependencies on modules that probably don't exist.
    */
-  name?:     string;
+  name?: string;
   severity?: SeverityType;
-  to:        ToRestrictionType;
+  to: IToRestrictionType;
 }
 
-export interface ViolationType {
+export interface IViolationType {
   /**
    * The circular path if the violation was about circularity
    */
   cycle?: string[];
-  from:   string;
-  rule:   RuleSummaryType;
-  to:     string;
+  from: string;
+  rule: IRuleSummaryType;
+  to: string;
 }
 
 export interface IReporterOutput {


### PR DESCRIPTION
… params type to the same and also for IReporterOutput

<!--- Provide a general summary of your changes in the Title above -->

> Plan to do something drastic?  
> Leave an [issue](https://github.com/sverweij/dependency-cruiser/issues/new) with a
> summary of the changes you propose + some context on why you'd want to
> do that.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
