### PR TITLE
chore(*): enable node 13

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,13 +4,22 @@ cache:
   paths:
     - node_modules
 
-test_async_node_12:
-  image: node:12
+test_async_node_13:
+  image: node:13
   script:
     - npm install
     - npm run lint
     - npm run lint:types
     - npm run depcruise
+    - npm run test:integration
+    - npm run test:cover
+  except:
+    - tags
+
+test_async_node_12:
+  image: node:12
+  script:
+    - npm install
     - npm run test:integration
     - npm run test:cover
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "8"
   - "10"
   - "12"
+  - "13"
 
 before_install:
   - wget https://github.com/sharkdp/hyperfine/releases/download/v1.5.0/hyperfine_1.5.0_amd64.deb
@@ -22,7 +23,8 @@ before_script:
 script:
   - npm run depcruise
   - "npm run test:glob && npm run test:cover"
-  - "if test `node --version | cut -c 2,3` = 12; then npm run lint && npm run test:integration && npm run test:load:short; fi"
+  - "if test `node --version | cut -c 2,3` = 13; then npm run lint && npm run test:integration && npm run test:load:short; fi"
+  - "if test `node --version | cut -c 2,3` = 12; then npm run test:integration; fi"
   - "if test `node --version | cut -c 2,3` = 10; then npm run test:integration; fi"
   - "if test `node --version | cut -c 2,2` = 8; then npm run test:integration; fi"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,11 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 
+# yarn pnp integration test disabled for node 13 because of https://github.com/yarnpkg/yarn/issues/7642
 script:
   - npm run depcruise
   - "npm run test:glob && npm run test:cover"
-  - "if test `node --version | cut -c 2,3` = 13; then npm run lint && npm run test:integration && npm run test:load:short; fi"
+  - "if test `node --version | cut -c 2,3` = 13; then npm run lint && npm run test:load:short; fi"
   - "if test `node --version | cut -c 2,3` = 12; then npm run test:integration; fi"
   - "if test `node --version | cut -c 2,3` = 10; then npm run test:integration; fi"
   - "if test `node --version | cut -c 2,2` = 8; then npm run test:integration; fi"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "13"
+  nodejs_version: "12"
 
 cache:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "12"
+  nodejs_version: "13"
 
 cache:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -111,10 +111,10 @@
     "chalk": "2.4.2",
     "commander": "3.0.2",
     "enhanced-resolve": "4.1.1",
-    "figures": "3.0.0",
+    "figures": "3.1.0",
     "get-stream": "5.1.0",
-    "glob": "7.1.4",
-    "handlebars": "4.4.3",
+    "glob": "7.1.5",
+    "handlebars": "4.4.5",
     "indent-string": "4.0.0",
     "inquirer": "7.0.0",
     "lodash": "4.17.15",
@@ -125,7 +125,7 @@
     "strip-json-comments": "3.0.1",
     "teamcity-service-messages": "0.1.10",
     "tsconfig-paths-webpack-plugin": "3.2.0",
-    "wrap-ansi": "6.0.0"
+    "wrap-ansi": "6.1.0"
   },
   "devDependencies": {
     "chai": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "types/**"
   ],
   "engines": {
-    "node": "^8.10||^10||^12"
+    "node": "^8.10||^10||^12||^13"
   },
   "supportedTranspilers": {
     "coffee-script": ">=1.0.0 <2.0.0",


### PR DESCRIPTION
## Description
Enables node 13 and makes sure it's validated on the ci's (except Appveyor, which doesn't have node 13 yet). Also fixes #207.

## How Has This Been Tested?
- [x] automated non-regression

## Types of changes
- [x] chore 

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [/] My change requires a change to the documentation.
- [/] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
