### PR TITLE
fix(test): make the cli/utl/io test run with more certainty

### DIFF
--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -22,6 +22,7 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
         # exclude:
         # - node-version: ^8.12
         #   platform: windows-latest

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  test:
+  check:
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -27,8 +27,6 @@ jobs:
           platform: windows-latest
         - node-version: 10.x
           platform: windows-latest
-        - node-version: 13.x
-          platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -12,7 +12,7 @@ jobs:
   test:
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         node-version: 
           - ^8.12

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -20,7 +20,7 @@ jobs:
           - 12.x
           - 13.x
         platform:
-          # - ubuntu-latest
+          - ubuntu-latest
           - windows-latest
         # exclude:
         # - node-version: ^8.12

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -20,7 +20,7 @@ jobs:
           - 12.x
           - 13.x
         platform:
-          - ubuntu-latest
+          # - ubuntu-latest
           - windows-latest
         # exclude:
         # - node-version: ^8.12

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -22,13 +22,13 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
-        exclude:
-        - node-version: ^8.12
-          platform: windows-latest
-        - node-version: 10.x
-          platform: windows-latest
-        - node-version: 13.x
-          platform: windows-latest
+        # exclude:
+        # - node-version: ^8.12
+        #   platform: windows-latest
+        # - node-version: 10.x
+        #   platform: windows-latest
+        # - node-version: 13.x
+        #   platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -22,7 +22,6 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         # exclude:
         # - node-version: ^8.12
         #   platform: windows-latest

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -22,13 +22,13 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
-        # exclude:
-        # - node-version: ^8.12
-        #   platform: windows-latest
-        # - node-version: 10.x
-        #   platform: windows-latest
-        # - node-version: 13.x
-        #   platform: windows-latest
+        exclude:
+        - node-version: ^8.12
+          platform: windows-latest
+        - node-version: 10.x
+          platform: windows-latest
+        - node-version: 13.x
+          platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -20,13 +20,15 @@ jobs:
           - 12.x
           - 13.x
         platform:
-          - ubuntu-latest
+          # - ubuntu-latest
           - windows-latest
         exclude:
         - node-version: ^8.12
           platform: windows-latest
-        - node-version: 10.x
-          platform: windows-latest
+        # - node-version: 10.x
+        #   platform: windows-latest
+        # - node-version: 13.x
+        #   platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -27,8 +27,8 @@ jobs:
           platform: windows-latest
         - node-version: 10.x
           platform: windows-latest
-        # - node-version: 13.x
-        #   platform: windows-latest
+        - node-version: 13.x
+          platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -27,8 +27,8 @@ jobs:
           platform: windows-latest
         - node-version: 10.x
           platform: windows-latest
-        - node-version: 13.x
-          platform: windows-latest
+        # - node-version: 13.x
+        #   platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -55,7 +55,7 @@ jobs:
       shell: bash
       env:
         CI: true
-    - name: dependency cruise
+    - name: forbidden dependency check
       run: |
         node --version
         npm run depcruise

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -12,7 +12,7 @@ jobs:
   test:
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         node-version: 
           - ^8.12

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -20,15 +20,15 @@ jobs:
           - 12.x
           - 13.x
         platform:
-          # - ubuntu-latest
+          - ubuntu-latest
           - windows-latest
         exclude:
         - node-version: ^8.12
           platform: windows-latest
-        # - node-version: 10.x
-        #   platform: windows-latest
-        # - node-version: 13.x
-        #   platform: windows-latest
+        - node-version: 10.x
+          platform: windows-latest
+        - node-version: 13.x
+          platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 

--- a/.github/workflows/yarn-integration-workflow.yml
+++ b/.github/workflows/yarn-integration-workflow.yml
@@ -26,7 +26,7 @@ jobs:
     - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{matrix.node-version}}
     - name: install
       run: |
         node --version
@@ -34,7 +34,7 @@ jobs:
       shell: bash
       env:
         CI: true
-    - name: run check
+    - name: forbidden dependency checks in a yarn pnp environment
       run: |
         node --version
         npm run test:integration

--- a/test/cli/compileConfig/index.spec.js
+++ b/test/cli/compileConfig/index.spec.js
@@ -86,8 +86,10 @@ describe("cli/compileConfig", () => {
       "../fixtures/extends/circular-two.js"
     )} -> ${path.join(__dirname, "../fixtures/extends/circular-one.js")}.`;
 
-    expect(() =>
-      compileConfig(path.join(__dirname, "../fixtures/extends/circular-one.js"))
-    ).to.throw(lMessageOutTake);
+    expect(() => {
+      compileConfig(
+        path.join(__dirname, "../fixtures/extends/circular-one.js")
+      );
+    }).to.throw(lMessageOutTake);
   });
 });

--- a/test/cli/getResolveConfig.spec.js
+++ b/test/cli/getResolveConfig.spec.js
@@ -8,15 +8,17 @@ describe("cli/ getResolveConfig", () => {
   });
 
   it("throws when a non-existing config file is passed", () => {
-    expect(() => getResolveConfig("config-does-not-exist")).to.throw();
+    expect(() => {
+      getResolveConfig("config-does-not-exist");
+    }).to.throw();
   });
 
   it("throws when a config file is passed that does not contain valid javascript", () => {
-    expect(() =>
+    expect(() => {
       getResolveConfig(
         path.join(__dirname, "./fixtures/webpackconfig/invalid.config.js")
-      )
-    ).to.throw();
+      );
+    }).to.throw();
   });
 
   it("returns an empty object when a config file is passed without a 'resolve' section", () => {

--- a/test/cli/parseTSConfig.spec.js
+++ b/test/cli/parseTSConfig.spec.js
@@ -7,22 +7,26 @@ const DIRNAME = pathToPosix(__dirname);
 
 describe("cli/parseTSConfig - flatten typescript config - simple config scenarios", () => {
   it("throws when no config file name is passed", () => {
-    expect(() => parseTSConfig()).to.throw();
+    expect(() => {
+      parseTSConfig();
+    }).to.throw();
   });
 
   it("throws when a non-existing config file is passed", () => {
-    expect(() => parseTSConfig("config-does-not-exist")).to.throw();
+    expect(() => {
+      parseTSConfig("config-does-not-exist");
+    }).to.throw();
   });
 
   it("throws when a config file is passed that does not contain valid json", () => {
-    expect(() =>
+    expect(() => {
       parseTSConfig(
         path.join(
           __dirname,
           "./fixtures/typescriptconfig/tsconfig.invalid.json"
         )
-      )
-    ).to.throw();
+      );
+    }).to.throw();
   });
 
   it("returns an empty object when an empty config file is passed", () => {
@@ -77,25 +81,25 @@ describe("cli/parseTSConfig - flatten typescript config - simple config scenario
 
 describe("cli/parseTSConfig - flatten typescript config - 'extend' config scenarios", () => {
   it("throws when a config file is passed that contains a extends to a non-existing file", () => {
-    expect(() =>
+    expect(() => {
       parseTSConfig(
         path.join(
           __dirname,
           "./fixtures/typescriptconfig/tsconfig.extendsnonexisting.json"
         )
-      )
-    ).to.throw();
+      );
+    }).to.throw();
   });
 
   it("throws when a config file is passed that has a circular reference", () => {
-    expect(() =>
+    expect(() => {
       parseTSConfig(
         path.join(
           __dirname,
           "./fixtures/typescriptconfig/tsconfig.circular.json"
         )
-      )
-    ).to.throw(
+      );
+    }).to.throw(
       "error TS18000: Circularity detected while resolving configuration"
     );
   });

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -15,11 +15,16 @@ const OUTFILE = path.join(
 
 const removeDammit = pFileName => {
   try {
+    process.stdout.write(`|>|>|>|> unlinkin ${pFileName} starting\n`);
     fs.unlinkSync(pFileName);
+    process.stdout.write(`|>|>|>|> unlinkin ${pFileName} done\n`);
   } catch (e) {
     // probably files didn't exist in the first place
     // so ignore the exception
     process.stdout.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
+  } finally {
+    // hard ignore as well
+    process.stdout.write(`|>|>|>|> finally!\n`);
   }
 };
 
@@ -33,9 +38,9 @@ describe("cli/utl/io", () => {
   });
 
   after("tear down", () => {
-    process.stdout.write(`|>|>|> tear down - start`);
+    process.stdout.write(`|>|>|> tear down - start\n`);
     removeDammit(OUTFILE);
-    process.stdout.write(`|>|>|> tear down - done dee dee done`);
+    process.stdout.write(`|>|>|> tear down - done dee dee done\n`);
   });
 
   it("getInStream('-') is a readable stream", () => {

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -19,6 +19,7 @@ const removeDammit = pFileName => {
   } catch (e) {
     // probably files didn't exist in the first place
     // so ignore the exception
+    process.stderr.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
   }
 };
 
@@ -28,7 +29,9 @@ describe("cli/utl/io", () => {
     fs.writeFileSync(OUTFILE, "{}", "utf8");
   });
 
-  after("tear down", () => removeDammit(OUTFILE));
+  after("tear down", () => {
+    removeDammit(OUTFILE);
+  });
 
   it("getInStream('-') is a readable stream", () => {
     expect(getInStream("-") instanceof stream.Readable).to.be.true;

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -41,15 +41,6 @@ describe("cli/utl/io", () => {
     process.stdout.write(`|>|>|> tear down - done dee dee done\n`);
   });
 
-  it("getInStream('-') is a readable stream", () => {
-    expect(getInStream("-") instanceof stream.Readable).to.be.true;
-  });
-  it("getInStream('-') yields stdin", () => {
-    expect(getInStream("-")).to.equal(process.stdin);
-  });
-  it("getInStream('-') does not yield a file stream", () => {
-    expect(getInStream("-") instanceof fs.ReadStream).to.be.false;
-  });
   it("getInStream(OUTFILE) yields a readable stream", () => {
     expect(getInStream(OUTFILE) instanceof stream.Readable).to.be.true;
   });
@@ -58,5 +49,14 @@ describe("cli/utl/io", () => {
   });
   it("getInStream(OUTFILE) does not yields stdin", () => {
     expect(getInStream(OUTFILE)).to.not.equal(process.stdin);
+  });
+  it("getInStream('-') is a readable stream", () => {
+    expect(getInStream("-") instanceof stream.Readable).to.be.true;
+  });
+  it("getInStream('-') yields stdin", () => {
+    expect(getInStream("-")).to.equal(process.stdin);
+  });
+  it("getInStream('-') does not yield a file stream", () => {
+    expect(getInStream("-") instanceof fs.ReadStream).to.be.false;
   });
 });

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -30,9 +30,7 @@ const removeDammit = pFileName => {
 
 describe("cli/utl/io", () => {
   before("set up", () => {
-    process.stdout.write(`|>|>|> set up\n`);
-    removeDammit(OUTFILE);
-    process.stdout.write(`|>|>|> set up - removed\n`);
+    process.stdout.write(`|>|>|> set up - started\n`);
     fs.writeFileSync(OUTFILE, "{}", "utf8");
     process.stdout.write(`|>|>|> set up - written\n`);
   });

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -5,30 +5,30 @@ const stream = require("stream");
 const expect = require("chai").expect;
 const getInStream = require("../../../src/cli/utl/io").getInStream;
 
-const OUTFILE = path.join(
-  __dirname,
-  "output",
-  `tmp_hello_${Math.random()
-    .toString()
-    .substr("0.".length)}.json`
-);
-
-const removeDammit = pFileName => {
-  try {
-    process.stdout.write(`|>|>|>|> unlinkin ${pFileName} starting\n`);
-    fs.unlinkSync(pFileName);
-    process.stdout.write(`|>|>|>|> unlinkin ${pFileName} done\n`);
-  } catch (e) {
-    // probably files didn't exist in the first place
-    // so ignore the exception
-    process.stdout.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
-  } finally {
-    // explicitly ignore finally as well
-    process.stdout.write(`|>|>|>|> finally!\n`);
-  }
-};
-
 describe("cli/utl/io", () => {
+  const OUTFILE = path.join(
+    __dirname,
+    "output",
+    `tmp_hello_${Math.random()
+      .toString()
+      .substr("0.".length)}.json`
+  );
+
+  function removeDammit(pFileName) {
+    try {
+      process.stdout.write(`|>|>|>|> unlinkin ${pFileName} starting\n`);
+      fs.unlinkSync(pFileName);
+      process.stdout.write(`|>|>|>|> unlinkin ${pFileName} done\n`);
+    } catch (e) {
+      // probably files didn't exist in the first place
+      // so ignore the exception
+      process.stdout.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
+    } finally {
+      // explicitly ignore finally as well
+      process.stdout.write(`|>|>|>|> finally!\n`);
+    }
+  }
+
   before("set up", () => {
     process.stdout.write(`|>|>|> set up - started\n`);
     fs.writeFileSync(OUTFILE, "{}", "utf8");

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -23,7 +23,7 @@ const removeDammit = pFileName => {
     // so ignore the exception
     process.stdout.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
   } finally {
-    // hard ignore as well
+    // explicitly ignore finally as well
     process.stdout.write(`|>|>|>|> finally!\n`);
   }
 };

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -25,11 +25,11 @@ const removeDammit = pFileName => {
 
 describe("cli/utl/io", () => {
   before("set up", () => {
-    process.stdout.write(`|>|>|> set up`);
+    process.stdout.write(`|>|>|> set up\n`);
     removeDammit(OUTFILE);
-    process.stdout.write(`|>|>|> set up - removed`);
+    process.stdout.write(`|>|>|> set up - removed\n`);
     fs.writeFileSync(OUTFILE, "{}", "utf8");
-    process.stdout.write(`|>|>|> set up - written`);
+    process.stdout.write(`|>|>|> set up - written\n`);
   });
 
   after("tear down", () => {

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -19,18 +19,23 @@ const removeDammit = pFileName => {
   } catch (e) {
     // probably files didn't exist in the first place
     // so ignore the exception
-    process.stderr.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
+    process.stdout.write(`|>|>|>|> could not unlink ${pFileName} - ${e}\n`);
   }
 };
 
 describe("cli/utl/io", () => {
   before("set up", () => {
+    process.stdout.write(`|>|>|> set up`);
     removeDammit(OUTFILE);
+    process.stdout.write(`|>|>|> set up - removed`);
     fs.writeFileSync(OUTFILE, "{}", "utf8");
+    process.stdout.write(`|>|>|> set up - written`);
   });
 
   after("tear down", () => {
+    process.stdout.write(`|>|>|> tear down - start`);
     removeDammit(OUTFILE);
+    process.stdout.write(`|>|>|> tear down - done dee dee done`);
   });
 
   it("getInStream('-') is a readable stream", () => {

--- a/test/cli/utl/validateFileExistence.spec.js
+++ b/test/cli/utl/validateFileExistence.spec.js
@@ -3,12 +3,16 @@ const validateFileExistence = require("../../../src/cli/utl/validateFileExistenc
 
 describe("cli/utl/validateFileExistence", () => {
   it("throws when the file or dir passed does not exists", () => {
-    expect(() => validateFileExistence("file-or-dir-does-not-exist")).to.throw(
+    expect(() => {
+      validateFileExistence("file-or-dir-does-not-exist");
+    }).to.throw(
       "Can't open 'file-or-dir-does-not-exist' for reading. Does it exist?"
     );
   });
 
   it("passes when the file or dir passed exists", () => {
-    expect(() => validateFileExistence("package.json")).to.not.throw();
+    expect(() => {
+      validateFileExistence("package.json");
+    }).to.not.throw();
   });
 });

--- a/test/cli/valideNodeEnv.spec.js
+++ b/test/cli/valideNodeEnv.spec.js
@@ -3,32 +3,45 @@ const validateNodeEnv = require("../../src/cli/validateNodeEnv");
 
 describe("cli/validateNodeEnv", () => {
   it("throws when an older and unsupported node version is passed", () => {
-    expect(() => validateNodeEnv("6.0.0")).to.throw();
+    expect(() => {
+      validateNodeEnv("6.0.0");
+    }).to.throw();
   });
 
   it("throws when a newer but unsupported node version is passed", () => {
-    expect(() => validateNodeEnv("9.0.0")).to.throw();
+    expect(() => {
+      validateNodeEnv("9.0.0");
+    }).to.throw();
   });
 
   it("doesn't throw when an empty node version is passed (assuming test is run on a supported platform)", () => {
-    expect(() => validateNodeEnv("")).to.not.throw();
+    expect(() => {
+      validateNodeEnv("");
+    }).to.not.throw();
   });
 
   it("doesn't throw when a null node version is passed (assuming test is run on a supported platform)", () => {
-    // eslint-disable-next-line no-undefined
-    expect(() => validateNodeEnv(null)).to.not.throw();
+    expect(() => {
+      validateNodeEnv(null);
+    }).to.not.throw();
   });
 
   it("doesn't throw when an undefined node version is passed (assuming test is run on a supported platform)", () => {
-    // eslint-disable-next-line no-undefined
-    expect(() => validateNodeEnv(undefined)).to.not.throw();
+    expect(() => {
+      // eslint-disable-next-line no-undefined
+      validateNodeEnv(undefined);
+    }).to.not.throw();
   });
 
   it("doesn't throw when no node version is passed (assuming this test is run on a supported platform ...)", () => {
-    expect(() => validateNodeEnv()).to.not.throw();
+    expect(() => {
+      validateNodeEnv();
+    }).to.not.throw();
   });
 
   it("doesn't throw when a supported node version is passed", () => {
-    expect(() => validateNodeEnv("12.0.0")).to.not.throw();
+    expect(() => {
+      validateNodeEnv("12.0.0");
+    }).to.not.throw();
   });
 });

--- a/test/extract/extract.spec.js
+++ b/test/extract/extract.spec.js
@@ -137,7 +137,9 @@ describe("extract/extract - Error scenarios - ", () => {
     );
   });
   it("Raises an exception on non-existing files", () => {
-    expect(() => extract("non-existing-file.md", normalize({}), {})).to.throw(
+    expect(() => {
+      extract("non-existing-file.md", normalize({}), {});
+    }).to.throw(
       "Extracting dependencies ran afoul of...\n\n  ENOENT: no such file or directory, open "
     );
   });

--- a/test/extract/resolve/isRelativeModuleName.spec.js
+++ b/test/extract/resolve/isRelativeModuleName.spec.js
@@ -3,15 +3,15 @@ const isRelativeModuleName = require("../../../src/extract/resolve/isRelativeMod
 
 describe("extract/resolve/isRelativeModuleName", () => {
   it("throws an error when passed nothing", () => {
-    expect(() => isRelativeModuleName()).to.throw(
-      "Cannot read property 'startsWith' of undefined"
-    );
+    expect(() => {
+      isRelativeModuleName();
+    }).to.throw("Cannot read property 'startsWith' of undefined");
   });
 
   it("throws an error when passed null", () => {
-    expect(() => isRelativeModuleName(null)).to.throw(
-      "Cannot read property 'startsWith' of null"
-    );
+    expect(() => {
+      isRelativeModuleName(null);
+    }).to.throw("Cannot read property 'startsWith' of null");
   });
 
   it("returns false when passed an empty string", () => {

--- a/test/extract/resolve/readPackageDeps/index.spec.js
+++ b/test/extract/resolve/readPackageDeps/index.spec.js
@@ -137,17 +137,17 @@ describe("extract/resolve/readPackageDeps - combined dependencies strategy", () 
     process.chdir(
       "test/extract/resolve/readPackageDeps/fixtures/amok-prevention-non-exist"
     );
-    expect(() =>
-      readPackageDeps(process.cwd(), "bullocks-or-non-valid-basedir", true)
-    ).to.throw(/Unusal baseDir passed to package reading function/);
+    expect(() => {
+      readPackageDeps(process.cwd(), "bullocks-or-non-valid-basedir", true);
+    }).to.throw(/Unusal baseDir passed to package reading function/);
   });
 
   it("passing a basedir that weirdly ends in '/' doesn't make combining dependencies loop eternaly", () => {
     process.chdir(
       "test/extract/resolve/readPackageDeps/fixtures/amok-prevention-bogus-sub"
     );
-    expect(() =>
-      readPackageDeps(process.cwd(), `${path.dirname(process.cwd())}/`, true)
-    ).to.throw(/Unusal baseDir passed to package reading function/);
+    expect(() => {
+      readPackageDeps(process.cwd(), `${path.dirname(process.cwd())}/`, true);
+    }).to.throw(/Unusal baseDir passed to package reading function/);
   });
 });

--- a/test/main/main.format.spec.js
+++ b/test/main/main.format.spec.js
@@ -18,21 +18,21 @@ const MINIMAL_RESULT = {
 
 describe("main.format - format", () => {
   it("barfs when it gets an invalid output type", () => {
-    expect(() => main.format({}, "not-a-valid-reporter")).to.throw(
-      "'not-a-valid-reporter' is not a valid output type."
-    );
+    expect(() => {
+      main.format({}, "not-a-valid-reporter");
+    }).to.throw("'not-a-valid-reporter' is not a valid output type.");
   });
 
   it("barfs when it gets a result passed that is invalid json", () => {
-    expect(() => main.format("that is no json")).to.throw(
-      "The supplied dependency-cruiser result is not valid:"
-    );
+    expect(() => {
+      main.format("that is no json");
+    }).to.throw("The supplied dependency-cruiser result is not valid:");
   });
 
   it("barfs when it gets a result passed that doesn't comply to the result schema", () => {
-    expect(() =>
-      main.format({ valid: "JSON", not: "schema compliant though" })
-    ).to.throw(
+    expect(() => {
+      main.format({ valid: "JSON", not: "schema compliant though" });
+    }).to.throw(
       "The supplied dependency-cruiser result is not valid: data should NOT have additional properties"
     );
   });

--- a/test/main/options/validate.spec.js
+++ b/test/main/options/validate.spec.js
@@ -3,101 +3,121 @@ const validateOptions = require("../../../src/main/options/validate");
 
 describe("main/options/validate", () => {
   it("throws when a invalid module system is passed ", () => {
-    expect(() =>
-      validateOptions({ moduleSystems: ["notavalidmodulesystem"] })
-    ).to.throw("Invalid module system list: 'notavalidmodulesystem'\n");
+    expect(() => {
+      validateOptions({ moduleSystems: ["notavalidmodulesystem"] });
+    }).to.throw("Invalid module system list: 'notavalidmodulesystem'\n");
   });
 
   it("passes when a valid module system is passed", () => {
-    expect(() => validateOptions({ moduleSystems: ["cjs"] })).to.not.throw();
+    expect(() => {
+      validateOptions({ moduleSystems: ["cjs"] });
+    }).to.not.throw();
   });
 
   it("throws when a invalid output type is passed ", () => {
-    expect(() =>
-      validateOptions({ outputType: "notAValidOutputType" })
-    ).to.throw("'notAValidOutputType' is not a valid output type.\n");
+    expect(() => {
+      validateOptions({ outputType: "notAValidOutputType" });
+    }).to.throw("'notAValidOutputType' is not a valid output type.\n");
   });
 
   it("passes when a valid output type is passed", () => {
-    expect(() => validateOptions({ outputType: "err" })).to.not.throw();
+    expect(() => {
+      validateOptions({ outputType: "err" });
+    }).to.not.throw();
   });
 
   it("throws when a non-integer is passed as maxDepth", () => {
-    expect(() => validateOptions({ maxDepth: "not an integer" })).to.throw(
+    expect(() => {
+      validateOptions({ maxDepth: "not an integer" });
+    }).to.throw(
       "'not an integer' is not a valid depth - use an integer between 0 and 99"
     );
   });
 
   it("throws when > 99 is passed as maxDepth (string)", () => {
-    expect(() => validateOptions({ maxDepth: "101" })).to.throw(
-      "'101' is not a valid depth - use an integer between 0 and 99"
-    );
+    expect(() => {
+      validateOptions({ maxDepth: "101" });
+    }).to.throw("'101' is not a valid depth - use an integer between 0 and 99");
   });
 
   it("throws when > 99 is passed as maxDepth (number)", () => {
-    expect(() => validateOptions({ maxDepth: 101 })).to.throw(
-      "'101' is not a valid depth - use an integer between 0 and 99"
-    );
+    expect(() => {
+      validateOptions({ maxDepth: 101 });
+    }).to.throw("'101' is not a valid depth - use an integer between 0 and 99");
   });
 
   it("throws when < 0 is passed as maxDepth (string)", () => {
-    expect(() => validateOptions({ maxDepth: "-1" })).to.throw(
-      "'-1' is not a valid depth - use an integer between 0 and 99"
-    );
+    expect(() => {
+      validateOptions({ maxDepth: "-1" });
+    }).to.throw("'-1' is not a valid depth - use an integer between 0 and 99");
   });
 
   it("throws when < 0 is passed as maxDepth (number)", () => {
-    expect(() => validateOptions({ maxDepth: -1 })).to.throw(
-      "'-1' is not a valid depth - use an integer between 0 and 99"
-    );
+    expect(() => {
+      validateOptions({ maxDepth: -1 });
+    }).to.throw("'-1' is not a valid depth - use an integer between 0 and 99");
   });
 
   it("passes when a valid depth is passed as maxDepth (string)", () => {
-    expect(() => validateOptions({ maxDepth: "42" })).to.not.throw();
+    expect(() => {
+      validateOptions({ maxDepth: "42" });
+    }).to.not.throw();
   });
 
   it("passes when a valid depth is passed as maxDepth (number)", () => {
-    expect(() => validateOptions({ maxDepth: 42 })).to.not.throw();
+    expect(() => {
+      validateOptions({ maxDepth: 42 });
+    }).to.not.throw();
   });
 
   it("throws when --exclude is passed an unsafe regex", () => {
-    expect(() => validateOptions({ exclude: "([A-Za-z]+)*" })).to.throw(
+    expect(() => {
+      validateOptions({ exclude: "([A-Za-z]+)*" });
+    }).to.throw(
       "The pattern '([A-Za-z]+)*' will probably run very slowly - cowardly refusing to run.\n"
     );
   });
 
   it("throws when exclude.path is passed an unsafe regex", () => {
-    expect(() => validateOptions({ exclude: "([A-Za-z]+)*" })).to.throw(
+    expect(() => {
+      validateOptions({ exclude: "([A-Za-z]+)*" });
+    }).to.throw(
       "The pattern '([A-Za-z]+)*' will probably run very slowly - cowardly refusing to run.\n"
     );
   });
 
   it("throws when exclude.pathNot is passed an unsafe regex", () => {
-    expect(() => validateOptions({ exclude: "([A-Za-z]+)*" })).to.throw(
+    expect(() => {
+      validateOptions({ exclude: "([A-Za-z]+)*" });
+    }).to.throw(
       "The pattern '([A-Za-z]+)*' will probably run very slowly - cowardly refusing to run.\n"
     );
   });
 
   it("throws when doNotFollow.pathNot is passed an unsafe regex", () => {
-    expect(() => validateOptions({ doNotFollow: "([A-Za-z]+)*" })).to.throw(
+    expect(() => {
+      validateOptions({ doNotFollow: "([A-Za-z]+)*" });
+    }).to.throw(
       "The pattern '([A-Za-z]+)*' will probably run very slowly - cowardly refusing to run.\n"
     );
   });
 
   it("passes when --exclude is passed a safe regex", () => {
-    expect(() => validateOptions({ exclude: "([A-Za-z]+)" })).to.not.throw();
+    expect(() => {
+      validateOptions({ exclude: "([A-Za-z]+)" });
+    }).to.not.throw();
   });
 
   it("passes when --validate is passed a safe regex in ruleSet.exclude", () => {
-    expect(() =>
-      validateOptions({ ruleSet: { options: { exclude: "([A-Za-z]+)" } } })
-    ).to.not.throw();
+    expect(() => {
+      validateOptions({ ruleSet: { options: { exclude: "([A-Za-z]+)" } } });
+    }).to.not.throw();
   });
 
   it("throws when --validate is passed an unsafe regex in ruleSet.exclude", () => {
-    expect(() =>
-      validateOptions({ ruleSet: { options: { exclude: "(.*)+" } } })
-    ).to.throw(
+    expect(() => {
+      validateOptions({ ruleSet: { options: { exclude: "(.*)+" } } });
+    }).to.throw(
       "The pattern '(.*)+' will probably run very slowly - cowardly refusing to run.\n"
     );
   });

--- a/test/main/ruleSet/validate.spec.js
+++ b/test/main/ruleSet/validate.spec.js
@@ -3,9 +3,9 @@ const expect = require("chai").expect;
 const validate = require("../../../src/main/ruleSet/validate");
 
 function shouldBarfWithMessage(pRulesFile, pMessage) {
-  expect(() =>
-    validate(JSON.parse(fs.readFileSync(pRulesFile, "utf8")))
-  ).to.throw(pMessage);
+  expect(() => {
+    validate(JSON.parse(fs.readFileSync(pRulesFile, "utf8")));
+  }).to.throw(pMessage);
 }
 
 function shouldBeOK(pRulesFile) {


### PR DESCRIPTION
## Motivation and Context
Once in a while the test borks because there's something afoot with a temp file that's created half way. The tests themselves are successful, but something gets thrown and mocha gets in a tizzy declaring one of the tests failed and hence the suite.

Research so far:
- cli/utl/io creates a temp file in its set up and throws it away in its tear down
- to make sure the file doesn't exist yet, in the set up it's first deleted - with a try/catch to muffle any protests
- in some cases an exception related to this is thrown during the tests - popping up in random places where chai is doing a .to.throw or .to.not.throw - failing random tests

Done:
> Although they might address other imperfections in the test code, 
> some of these are probably waving a dead chicken against the problem at hand.

- added a `finally` to aforementioned try/catch
- removed the file deletion before creation (apparently the exception that generates isn't sufficiently muffled by the catch (and the finally added in this PR)).
- all .to.throw and .to.not.throw tests now use a function expression that doesn't return anything (`() => {doStuff();}` instead of `() => doStuff()`) - which is marginally more correct.
- move the OUTFILE and the removeDammit function within the scope of the describe.

## How Has This Been Tested?
With this PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Results
Definitely made some improvements in this PR - but couldn't pinpoint the solution, though. Merging anyway as the improvements add value, and I don't want to spend more time on it right now.