### PR TITLE
ci(gh-actions): set up node modules cache

### DIFF
--- a/.github/workflows/lint-test-workflow-windows-only.yml
+++ b/.github/workflows/lint-test-workflow-windows-only.yml
@@ -1,4 +1,4 @@
-name: linting & test coverage - linux
+name: test coverage - windows only
 
 on:
   push:
@@ -15,12 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version: 
-          - ^8.12
-          - 10.x
           - 12.x
-          - 13.x
         platform:
-          - ubuntu-latest
+          - windows-latest
 
     runs-on: ${{matrix.platform}}
 
@@ -43,14 +40,6 @@ jobs:
         node --version
         npm install
         npm run build
-      shell: bash
-      env:
-        CI: true
-    - name: lint (run on one platform only)
-      run: |
-        node --version
-        npm run lint
-      if: matrix.platform == 'ubuntu-latest' && matrix.node-version == '13.x'
       shell: bash
       env:
         CI: true

--- a/.github/workflows/lint-test-workflow-windows-only.yml
+++ b/.github/workflows/lint-test-workflow-windows-only.yml
@@ -1,4 +1,4 @@
-name: test coverage - windows only
+name: test coverage - windows
 
 on:
   push:

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -35,6 +35,13 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v1
+    - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+        restore-keys: |
+          ${{matrix.node-version}}@${{matrix.platform}}-build-
     - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
## Description
- see title
- also splits off a separate workflow for windows (as they're slow and fail more often - that way they can be re-run independently)

## Motivation and Context
- makes builds faster

## How Has This Been Tested?
By making this PR

## Types of changes
- [x] Other: ci config update

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
