### PR TITLE
feature(extract): enable detection of commonjs dependencies not (directly) declared with 'require'

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -262,6 +262,14 @@ _externalModuleResolutionStrategy_ key:
 emits the circular path in the _err_, _err-long_, _err-html_ and
 _teamcity_ reporters.
 
+### Q: I'm using window.require or a require wrapper - how do I make sure dependencies I declared like that are included?
+
+**A**: Add a _exoticRequireStrings_ key in your configuration with the 
+
+```json
+"exoticRequireStrings": ["window.require"]
+```
+
 ## Expanding dependency-cruiser
 
 ### Q: How do I add a new output format?

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -1091,12 +1091,34 @@ the file it investigates:
 
 - monodash/
 - **package.json** _<- look in this one as well; merge it into the one down the tree_
-- packages/  
-   - begindash/  
-   - **package.json** _<- look in this one_  
-   - src/  
-   - index.ts
-  </details>
+- packages/
+  - begindash/
+  - **package.json** _<- look in this one_
+  - src/
+  - index.ts
+    </details>
+
+#### exotic ways to require modules - exoticRequireStrings
+
+In some situations you might not be able to use the `require` function
+directly or at all. E.g. when you're not sure a module is present and
+want to have a fallback ([semver-try-require](https://github.com/sverweij/semnver-try-require)).
+Or because require in your environment is used for something else and
+you needed to redefine require (`const want = require; const whoa = want('whoadash')`).
+Or because you're in AMD and you named the require parameter something
+else because of a company wide standard to do so.
+
+In each of these cases you can still infer dependencies with the exoticRequireStrings
+option by adding an exoticRequireStrings array to the options in your
+dependency cruiser config. 
+
+E.g.:
+
+```json
+"options": {
+  "exoticRequireStrings": ["want", "tryRequire", "window.require"]
+}
+```
 
 ## Configurations in javascript
 

--- a/src/cli/initConfig/config.js.template.hbs
+++ b/src/cli/initConfig/config.js.template.hbs
@@ -302,6 +302,12 @@ module.exports = {
         {{^}}
         // , externalModuleResolutionStrategy: 'node_modules'
         {{/if}}
+        /* List of strings you have in use in addition to cjs/ es6 requires
+           & imports to declare module dependencies. Use this e.g. if you've
+           redeclared require, use a require-wrapper or use window.require as
+           a hack 
+        */
+        // , exoticRequireStrings: []
     }
 };
 // generated: dependency-cruiser@{{version}} on {{date}}

--- a/src/cli/initConfig/config.js.template.js
+++ b/src/cli/initConfig/config.js.template.js
@@ -50,9 +50,9 @@ templates['config.js.template.hbs'] = template({"1":function(container,depth0,he
     + ((stack1 = helpers["if"].call(alias2,(depth0 != null ? depth0.webpackConfig : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.program(15, data, 0),"data":data,"loc":{"start":{"line":283,"column":8},"end":{"line":295,"column":15}}})) != null ? stack1 : "")
     + "\n        /* How to resolve external modules - use \"yarn-pnp\" if you're using yarn's Plug'n'Play.\n           otherwise leave it out (or set to the default, which is 'node_modules')\n        */\n"
     + ((stack1 = helpers["if"].call(alias2,(depth0 != null ? depth0.externalModuleResolutionStrategy : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.program(19, data, 0),"data":data,"loc":{"start":{"line":300,"column":8},"end":{"line":304,"column":15}}})) != null ? stack1 : "")
-    + "    }\n};\n// generated: dependency-cruiser@"
-    + alias5(((helper = (helper = helpers.version || (depth0 != null ? depth0.version : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"version","hash":{},"data":data,"loc":{"start":{"line":307,"column":33},"end":{"line":307,"column":44}}}) : helper)))
+    + "        /* List of strings you have in use in addition to cjs/ es6 requires\n           & imports to declare module dependencies. Use this e.g. if you've\n           redeclared require, use a require-wrapper or use window.require as\n           a hack \n        */\n        // , exoticRequireStrings: []\n    }\n};\n// generated: dependency-cruiser@"
+    + alias5(((helper = (helper = helpers.version || (depth0 != null ? depth0.version : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"version","hash":{},"data":data,"loc":{"start":{"line":313,"column":33},"end":{"line":313,"column":44}}}) : helper)))
     + " on "
-    + alias5(((helper = (helper = helpers.date || (depth0 != null ? depth0.date : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"date","hash":{},"data":data,"loc":{"start":{"line":307,"column":48},"end":{"line":307,"column":56}}}) : helper)))
+    + alias5(((helper = (helper = helpers.date || (depth0 != null ? depth0.date : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"date","hash":{},"data":data,"loc":{"start":{"line":313,"column":48},"end":{"line":313,"column":56}}}) : helper)))
     + "\n";
 },"useData":true});

--- a/src/cli/initConfig/config.json.template.hbs
+++ b/src/cli/initConfig/config.json.template.hbs
@@ -263,6 +263,12 @@
         {{^}}
         // , "externalModuleResolutionStrategy": "node_modules"
         {{/if}}
+        /* List of strings you have in use in addition to cjs/ es6 requires
+           & imports to declare module dependencies. Use this e.g. if you've
+           redeclared require, use a require-wrapper or use window.require as
+           a hack 
+        */
+        // , "exoticRequireStrings": []
     }
 }
 // generated: dependency-cruiser@{{version}} on {{date}}

--- a/src/cli/initConfig/config.json.template.js
+++ b/src/cli/initConfig/config.json.template.js
@@ -50,9 +50,9 @@ templates['config.json.template.hbs'] = template({"1":function(container,depth0,
     + ((stack1 = helpers["if"].call(alias2,(depth0 != null ? depth0.webpackConfig : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.program(15, data, 0),"data":data,"loc":{"start":{"line":244,"column":8},"end":{"line":256,"column":15}}})) != null ? stack1 : "")
     + "\n        /* How to resolve external modules - use \"yarn-pnp\" if you're using yarn's Plug'n'Play.\n           otherwise leave it out (or set to the default, which is 'node_modules')\n        */\n"
     + ((stack1 = helpers["if"].call(alias2,(depth0 != null ? depth0.externalModuleResolutionStrategy : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.program(19, data, 0),"data":data,"loc":{"start":{"line":261,"column":8},"end":{"line":265,"column":15}}})) != null ? stack1 : "")
-    + "    }\n}\n// generated: dependency-cruiser@"
-    + alias5(((helper = (helper = helpers.version || (depth0 != null ? depth0.version : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"version","hash":{},"data":data,"loc":{"start":{"line":268,"column":33},"end":{"line":268,"column":44}}}) : helper)))
+    + "        /* List of strings you have in use in addition to cjs/ es6 requires\n           & imports to declare module dependencies. Use this e.g. if you've\n           redeclared require, use a require-wrapper or use window.require as\n           a hack \n        */\n        // , \"exoticRequireStrings\": []\n    }\n}\n// generated: dependency-cruiser@"
+    + alias5(((helper = (helper = helpers.version || (depth0 != null ? depth0.version : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"version","hash":{},"data":data,"loc":{"start":{"line":274,"column":33},"end":{"line":274,"column":44}}}) : helper)))
     + " on "
-    + alias5(((helper = (helper = helpers.date || (depth0 != null ? depth0.date : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"date","hash":{},"data":data,"loc":{"start":{"line":268,"column":48},"end":{"line":268,"column":56}}}) : helper)))
+    + alias5(((helper = (helper = helpers.date || (depth0 != null ? depth0.date : depth0)) != null ? helper : alias3),(typeof helper === alias4 ? helper.call(alias2,{"name":"date","hash":{},"data":data,"loc":{"start":{"line":274,"column":48},"end":{"line":274,"column":56}}}) : helper)))
     + "\n";
 },"useData":true});

--- a/src/extract/ast-extractors/estree-helpers.js
+++ b/src/extract/ast-extractors/estree-helpers.js
@@ -28,10 +28,10 @@ function firstArgumentIsATemplateLiteral(pArgumentsNode) {
   );
 }
 
-function isRequireIdentifier(pNode) {
+function isRequireIdentifier(pNode, pName) {
   return (
     "Identifier" === _get(pNode, "callee.type") &&
-    "require" === _get(pNode, "callee.name")
+    pName === _get(pNode, "callee.name")
   );
 }
 

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -13,7 +13,8 @@ const toTypescriptAST = require("./parse/toTypescriptAST");
 function extractFromTypeScriptAST(pDependencies, pOptions, pFileName) {
   return pDependencies.concat(
     extractTypeScriptDeps(
-      toTypescriptAST.getASTCached(path.join(pOptions.baseDir, pFileName))
+      toTypescriptAST.getASTCached(path.join(pOptions.baseDir, pFileName)),
+      pOptions.exoticRequireStrings
     )
   );
 }

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -39,13 +39,18 @@ function extractFromJavaScriptAST(
   );
 
   if (pOptions.moduleSystems.indexOf("cjs") > -1) {
-    extractCommonJSDeps(lAST, pDependencies);
+    extractCommonJSDeps(
+      lAST,
+      pDependencies,
+      "cjs",
+      pOptions.exoticRequireStrings
+    );
   }
   if (pOptions.moduleSystems.indexOf("es6") > -1) {
     extractES6Deps(lAST, pDependencies);
   }
   if (pOptions.moduleSystems.indexOf("amd") > -1) {
-    extractAMDDeps(lAST, pDependencies);
+    extractAMDDeps(lAST, pDependencies, pOptions.exoticRequireStrings);
   }
 }
 

--- a/src/extract/results-schema.json
+++ b/src/extract/results-schema.json
@@ -517,6 +517,13 @@
           "type": "string",
           "description": "What external module resolution strategy to use. Defaults to 'node_modules'",
           "enum": ["node_modules", "yarn-pnp"]
+        },
+        "exoticRequireStrings": {
+          "type": "array",
+          "description": "List of strings you have in use in addition to cjs/ es6 requires & imports to declare module dependencies. Use this e.g. if you've redeclared require (`const want = require`), use a require-wrapper (like semver-try-require) or use window.require as a hack to workaround something",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/src/main/options/defaults.json
+++ b/src/main/options/defaults.json
@@ -5,5 +5,6 @@
   "tsPreCompilationDeps": false,
   "preserveSymlinks": false,
   "combinedDependencies": false,
-  "externalModuleResolutionStrategy": "node_modules"
+  "externalModuleResolutionStrategy": "node_modules",
+  "exoticRequireStrings": []
 }

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -26,6 +26,7 @@ module.exports = pOptions => {
   lRetval.moduleSystems = uniq(lRetval.moduleSystems.sort());
   lRetval.doNotFollow = normalizeFilterOption(lRetval.doNotFollow);
   lRetval.exclude = normalizeFilterOption(lRetval.exclude);
+  lRetval.exoticRequireStrings = uniq(lRetval.exoticRequireStrings.sort());
 
   return lRetval;
 };

--- a/src/main/ruleSet/config-schema.json
+++ b/src/main/ruleSet/config-schema.json
@@ -165,6 +165,13 @@
               "description": "Arguments to pass if your config file returns a function. E.g. {mode: 'production'} if you want to use webpack 4's 'mode' feature"
             }
           }
+        },
+        "exoticRequireStrings": {
+          "type": "array",
+          "description": "List of strings you have in use in addition to cjs/ es6 requires & imports to declare module dependencies. Use this e.g. if you've redeclared require (`const want = require`), use a require-wrapper (like semver-try-require) or use window.require as a hack to workaround something",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/test/extract/ast-extractors/extract-amd-deps.spec.js
+++ b/test/extract/ast-extractors/extract-amd-deps.spec.js
@@ -1,0 +1,82 @@
+const expect = require("chai").expect;
+const extractAMDDeps = require("../../../src/extract/ast-extractors/extract-AMD-deps");
+const getASTFromSource = require("../../../src/extract/parse/toJavascriptAST")
+  .getASTFromSource;
+
+const extractAMD = (
+  pJavaScriptSource,
+  pDependencies,
+  pExoticRequireStrings = []
+) =>
+  extractAMDDeps(
+    getASTFromSource(pJavaScriptSource, "js"),
+    pDependencies,
+    pExoticRequireStrings
+  );
+
+describe("ast-extractors/extract-AMD-deps", () => {
+  it("amd define", () => {
+    let lDeps = [];
+
+    extractAMD(
+      `define(["./root_one", "./root_two"], function(root_one){ /* do stuff */ });`,
+      lDeps
+    );
+    expect(lDeps).to.deep.equal([
+      {
+        moduleName: "./root_one",
+        moduleSystem: "amd",
+        dynamic: false
+      },
+      {
+        moduleName: "./root_two",
+        moduleSystem: "amd",
+        dynamic: false
+      }
+    ]);
+  });
+
+  it("amd require wrapper", () => {
+    let lDeps = [];
+    const lInput = `define(function(require, exports, module){
+      var one = require('./one-with-require'),
+          two = require('./two-with-require');
+  });`;
+
+    extractAMD(lInput, lDeps);
+    expect(lDeps).to.deep.equal([
+      {
+        moduleName: "./one-with-require",
+        moduleSystem: "amd",
+        dynamic: false
+      },
+      {
+        moduleName: "./two-with-require",
+        moduleSystem: "amd",
+        dynamic: false
+      }
+    ]);
+  });
+
+  it("amd require wrapper with the require parameter named something else", () => {
+    let lDeps = [];
+    const lInput = `define(function(want, exports, module){
+      var one = want('./one-with-want'),
+          two = want('./two-with-want');
+  });`;
+
+    extractAMD(lInput, lDeps, ["want"]);
+    expect(lDeps).to.deep.equal([
+      {
+        moduleName: "./one-with-want",
+        moduleSystem: "amd",
+        dynamic: false
+      },
+      {
+        moduleName: "./two-with-want",
+        moduleSystem: "amd",
+        dynamic: false
+      }
+    ]);
+  });
+});

--- a/test/extract/ast-extractors/extract-typescript-exotics.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-exotics.spec.js
@@ -1,0 +1,48 @@
+const expect = require("chai").expect;
+const extractTypescript = require("./extract-typescript.utl");
+
+describe("ast-extractors/extract-typescript - exotics", () => {
+  it("doesn't detects 'exotic' dependencies when no exoticRequireStrings were passed", () => {
+    expect(
+      extractTypescript(
+        "const want = require; const yo = want('./required-with-want');",
+        []
+      )
+    ).to.deep.equal([]);
+  });
+
+  it("detects dependencies declared with one function names passed as exoticRequireStrings", () => {
+    expect(
+      extractTypescript(
+        "const want = need = require; const yo = want('./required-with-want'); const nope = need('./required-with-need');",
+        ["want"]
+      )
+    ).to.deep.equal([
+      {
+        moduleName: "./required-with-want",
+        moduleSystem: "cjs",
+        dynamic: false
+      }
+    ]);
+  });
+
+  it("detects dependencies declared with multiple function names passed as exoticRequireStrings", () => {
+    expect(
+      extractTypescript(
+        "const want = need = require; const yo = want('./required-with-want'); const nope = need('./required-with-need');",
+        ["want", "need"]
+      )
+    ).to.deep.equal([
+      {
+        moduleName: "./required-with-want",
+        moduleSystem: "cjs",
+        dynamic: false
+      },
+      {
+        moduleName: "./required-with-need",
+        moduleSystem: "cjs",
+        dynamic: false
+      }
+    ]);
+  });
+});

--- a/test/extract/ast-extractors/extract-typescript-others.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-others.spec.js
@@ -15,7 +15,8 @@ describe("ast-extractors/extract-typescript - others", () => {
             path.join(__dirname, "typescript2.8-union-types-ast.json"),
             "utf8"
           )
-        )
+        ),
+        []
       )
     ).to.deep.equal([]);
   });

--- a/test/extract/ast-extractors/extract-typescript.utl.js
+++ b/test/extract/ast-extractors/extract-typescript.utl.js
@@ -2,5 +2,8 @@ const extractTypescript = require("../../../src/extract/ast-extractors/extract-t
 const getASTFromSource = require("../../../src/extract/parse/toTypescriptAST")
   .getASTFromSource;
 
-module.exports = pTypesScriptSource =>
-  extractTypescript(getASTFromSource(pTypesScriptSource));
+module.exports = (pTypesScriptSource, pExoticRequireStrings = []) =>
+  extractTypescript(
+    getASTFromSource(pTypesScriptSource),
+    pExoticRequireStrings
+  );

--- a/types/cruise-options.d.ts
+++ b/types/cruise-options.d.ts
@@ -116,6 +116,15 @@ export interface ICruiseOptions {
    * Defaults to `false`.
    */
   combinedDependencies?: boolean;
+  /*
+   * List of strings you have in use in addition to cjs/ es6 requires
+   * & imports to declare module dependencies. Use this e.g. if you've
+   * redeclared require (`const want = require`), use a require-wrapper
+   * (like semver-try-require) or use window.require as a hack
+   *
+   * Defaults to `[]`
+   */
+  exoticRequireStrings?: string[];
   /**
    * (API only) when set to `true` forces the extraction module to
    * detect circular dependencies even when there is no rule in the rule


### PR DESCRIPTION
## Description

- Adds an `exoticRequireStrings` option to the dependency-cruiser config, that takes zero or more alternative strings dependency-cruiser should treat like a function that requires other modules (see the added rules documentation for details).
  - Added (commented) to the init templates
  - Document in the rules reference and the FAQ
  - Works for all supported languages
- Currently limited to single functions (`need('exodash')`, not yet nested ones (`window.require('elektrodash'`)

## Todo

- [/] make it possible to define rules on exotic require strings (either forbidding or allowing things based on the require string used) => separate PR
- [/] implement in the typescript extraction for composites ('window.require') => separate PR
- [/] implement in the javscript extraction for composites ('window.require') => separate PR


## Motivation and Context

- first step on the way to address #206
- also addresses some similar use cases (hopefully in the decline) where it's necessary to override or wrap the `require` function but where you still want or need to infer dependencies.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] new unit tests

## Types of changes

- [x] New feature (non-breaking change which adds functionality)


## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
