### PR TITLE
feature(extract|validate): allow rule definitions based on exotic required'ness

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ version: "2"
 checks:
   method-lines:
     config:
-      threshold: 30
+      threshold: 32
 plugins:
   eslint:
     enabled: true

--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -2,6 +2,14 @@
   "extends": "./configs/recommended-strict",
   "forbidden": [
     {
+      "name": "not-to-unresolvable",
+      "from": {},
+      "to": {
+        "couldNotResolve": true,
+        "exoticRequireNot": "^tryRequire$"
+      }
+    },
+    {
       "name": "cli-to-main-only",
       "comment": "This cli module depends on something not in the public interface - which means it either doesn't belong in cli, or the main public interface needs to be expanded.",
       "severity": "error",
@@ -32,7 +40,8 @@
         "path": "(^src/extract/)"
       },
       "to": {
-        "pathNot": "$1|^node_modules|^(path|fs|module|package.json)$|^src/(utl|validate)"
+        "pathNot": "$1|^node_modules|^(path|fs|module|package.json)$|^src/(utl|validate)",
+        "exoticRequireNot": "^tryRequire$"
       }
     },
     {
@@ -93,7 +102,7 @@
       "severity": "error",
       "comment": "In production code do not depend on external ('npm') modules not declared in your package.json's dependencies - otherwise a production only install (i.e. 'npm ci') will break. If this rule triggers on something that's only used during development, adapt the 'from' of the rule in the dependency-cruiser configuration.",
       "from": { "path": "^(bin|src)" },
-      "to": { "dependencyTypes": ["npm-dev"] }
+      "to": { "dependencyTypes": ["npm-dev"], "exoticRequireNot": "^tryRequire$" }
     },
     {
       "name": "optional-deps-used",
@@ -114,7 +123,7 @@
       "comment": "This module uses an external dependency that has license that's not vetted. The license itself might be OK, but bigcorp legal departments might get jittery over anything other than MIT (or ISC).",
       "severity": "error",
       "from": {},
-      "to": { "licenseNot": "MIT|ISC" }
+      "to": { "licenseNot": "MIT|ISC|Apache-2\\.0" }
     },
     {
       "name": "not-unreachable-from-cli",
@@ -149,7 +158,7 @@
     "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/",
 
     /* if true detect dependencies that only exist before typescript-to-javascript compilation */
-    "tsPreCompilationDeps": true
+    "tsPreCompilationDeps": true,
 
     /* if true leave symlinks untouched, otherwise use the realpath */
     // "preserveSymlinks": false,
@@ -179,5 +188,6 @@
     //    "env": {},
     //    "args": {}
     // }
+    "exoticRequireStrings": ["^tryRequire$"]
   }
 }

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -36,6 +36,7 @@
    - [`dependencyTypes`](#dependencytypes)
    - [`dynamic`](#dynamic)
    - [`moreThanOneDependencyType`](#more-than-one-dependencytype-per-dependency-morethanonedependencytype)
+   - [`exoticRequire` and `exoticRequireNot`](#exoticrequire-and-exoticrequirenot)
 4. [The `options`](#the-options)
    - [`doNotFollow`: don't cruise modules adhering to this pattern any further](#donotfollow-dont-cruise-modules-adhering-to-this-pattern-any-further)
    - [`exclude`: exclude dependencies from being cruised](#exclude-exclude-dependencies-from-being-cruised)
@@ -626,7 +627,7 @@ This is a list of dependency types dependency-cruiser currently detects.
 | unknown         | it's unknown what kind of dependency type this is - probably because the module could not be resolved in the first place                                                 | "loodash"                 |
 | undetermined    | the dependency fell through all detection holes. This could happen with amd dependencies - which have a whole jurasic park of ways to define where to resolve modules to | "veloci!./raptor"         |
 
-#### `dynamic`
+### `dynamic`
 
 A boolean that tells you whether the dependency is a dynamic one (i.e.
 it uses the async ES import statement a la `import('othermodule').then(pMod => pMod.doStuff())`).
@@ -662,7 +663,7 @@ You can use this e.g. to restrict the usage of dynamic dependencies:
 }
 ```
 
-#### More than one dependencyType per dependency? `moreThanOneDependencyType`
+### More than one dependencyType per dependency? `moreThanOneDependencyType`
 
 With the flexible character of package.json it's totally possible to specify
 a package more than once - e.g. both in the `peerDependencies` and in the
@@ -686,6 +687,40 @@ When left out it doesn't matter how many dependency types a dependency has.
 
 (If you're more of an 'allowed' user: it matches the 0 and 1 cases when set to
 false).
+
+### `exoticRequire` and `exoticRequireNot`
+
+For exotic requires/ require wrappers you might want to have different
+rules a.c.t. normal requires. E.g.
+
+- When you use a require wrapper to include a dependency that might not be there
+  and handle it elegantly, it's not an error if the module-to-be-there doesn't
+  actually exist - or is e.g. in your optionalDependencies.
+- You might want to ban the use of remapped requires/ require wrappers in certain
+  areas (or altogether).
+
+```json
+{
+  "name": "not-to-optional-deps",
+  "severity": "error",
+  "from": {},
+  "to": {
+    "dependencyTypes": ["npm-optional"],
+    "exoticRequireNot": "^tryRequire$"
+  }
+}
+```
+
+```json
+{
+  "name": "ban-all-exotic-requires",
+  "severity": "error",
+  "from": {},
+  "to": {
+    "exoticRequire": ".+"
+  }
+}
+```
 
 ## The `options`
 
@@ -1110,7 +1145,7 @@ else because of a company wide standard to do so.
 
 In each of these cases you can still infer dependencies with the exoticRequireStrings
 option by adding an exoticRequireStrings array to the options in your
-dependency cruiser config. 
+dependency cruiser config.
 
 E.g.:
 

--- a/oink
+++ b/oink
@@ -1,1 +1,0 @@
-iiiiiii

--- a/oink
+++ b/oink
@@ -1,0 +1,1 @@
+iiiiiii

--- a/src/extract/ast-extractors/extract-commonJS-deps.js
+++ b/src/extract/ast-extractors/extract-commonJS-deps.js
@@ -9,12 +9,16 @@ function pushRequireCallsToDependencies(
   return pNode => {
     ["require"].concat(pExoticRequireStrings).forEach(pName => {
       if (estreeHelpers.isRequireIdentifier(pNode, pName)) {
+        const lExoticRequire =
+          pName === "require" ? {} : { exoticRequire: pName };
+
         if (estreeHelpers.firstArgumentIsAString(pNode.arguments)) {
           pNode.arguments[0].value.split("!").forEach(pString =>
             pDependencies.push({
               moduleName: pString,
               moduleSystem: pModuleSystem,
-              dynamic: false
+              dynamic: false,
+              ...lExoticRequire
             })
           );
         } else if (
@@ -23,7 +27,8 @@ function pushRequireCallsToDependencies(
           pDependencies.push({
             moduleName: pNode.arguments[0].quasis[0].value.cooked,
             moduleSystem: pModuleSystem,
-            dynamic: false
+            dynamic: false,
+            ...lExoticRequire
           });
         }
       }

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -150,7 +150,8 @@ function walk(pResult, pExoticRequireStrings) {
       if (isExoticRequire(pASTNode, pExoticRequireString)) {
         pResult.push({
           moduleName: pASTNode.arguments[0].text,
-          moduleSystem: "cjs"
+          moduleSystem: "cjs",
+          exoticRequire: pExoticRequireString
         });
       }
     });

--- a/src/extract/extract.js
+++ b/src/extract/extract.js
@@ -103,6 +103,9 @@ function addResolutionAttributes(pOptions, pFileName, pResolveOptions) {
       module: pDependency.moduleName,
       moduleSystem: pDependency.moduleSystem,
       dynamic: pDependency.dynamic,
+      ...(pDependency.exoticRequire
+        ? { exoticRequire: pDependency.exoticRequire }
+        : {}),
       followable: lResolved.followable && !lMatchesDoNotFollow,
       matchesDoNotFollow: lMatchesDoNotFollow
     };

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -26,7 +26,8 @@ const SHAREABLE_OPTIONS = [
   "preserveSymlinks",
   "rulesFile",
   "tsPreCompilationDeps",
-  "webpackConfig"
+  "webpackConfig",
+  "exoticRequireStrings"
 ];
 
 /* eslint max-params:0 */

--- a/src/extract/results-schema.json
+++ b/src/extract/results-schema.json
@@ -53,7 +53,7 @@
               "type": "array",
               "description": "A list of rules that describe dependencies that are not allowed. dependency-cruiser will emit a separate error (warning/ informational) messages for each violated rule.",
               "items": {
-                "$ref": "#/definitions/ForiddenRuleType"
+                "$ref": "#/definitions/ForbiddenRuleType"
               }
             },
             "allowed": {
@@ -173,6 +173,10 @@
                   "type": "boolean",
                   "description": "true if this dependency is dynamic, false in all other cases"
                 },
+                "exoticRequire": {
+                  "type": "string",
+                  "description": "If this dependency was defined by a require not named require (as defined in the exoticRequireStrings option): the string that was used"
+                },
                 "matchesDoNotFollow": {
                   "type": "boolean",
                   "description": "'true' if the file name of this module matches the doNotFollow regular expression"
@@ -224,7 +228,7 @@
         }
       }
     },
-    "ForiddenRuleType": {
+    "ForbiddenRuleType": {
       "type": "object",
       "required": ["from", "to"],
       "additionalProperties": false,
@@ -294,6 +298,14 @@
         "dynamic": {
           "type": "boolean",
           "description": "true if this dependency is dynamic, false in all other cases"
+        },
+        "exoticRequire": {
+          "type": "string",
+          "description": "A regular expression to match against any 'exotic' require strings"
+        },
+        "exoticRequireNot": {
+          "type": "string",
+          "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule"
         },
         "moreThanOneDependencyType": {
           "type": "boolean",

--- a/src/main/ruleSet/config-schema.json
+++ b/src/main/ruleSet/config-schema.json
@@ -322,6 +322,14 @@
           "type": "boolean",
           "description": "Whether or not to match when the dependency is a dynamic one."
         },
+        "exoticRequire": {
+          "type": "string",
+          "description": "A regular expression to match against any 'exotic' require strings"
+        },
+        "exoticRequireNot": {
+          "type": "string",
+          "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule"
+        },
         "dependencyTypes": {
           "type": "array",
           "description": "Whether or not to match modules of any of these types (leaving out matches any of them)",

--- a/src/validate/matchDependencyRule.js
+++ b/src/validate/matchDependencyRule.js
@@ -41,6 +41,8 @@ function match(pFrom, pTo) {
         pTo.dependencyTypes.length > 1) &&
       matches.toLicense(pRule, pTo) &&
       matches.toLicenseNot(pRule, pTo) &&
+      matches.toExoticRequire(pRule, pTo) &&
+      matches.toExoticRequireNot(pRule, pTo) &&
       propertyEquals(pTo, pRule, "couldNotResolve") &&
       propertyEquals(pTo, pRule, "circular") &&
       propertyEquals(pTo, pRule, "dynamic")

--- a/src/validate/matches.js
+++ b/src/validate/matches.js
@@ -72,6 +72,22 @@ function toLicenseNot(pRule, pDependency) {
   );
 }
 
+function toExoticRequire(pRule, pDependency) {
+  return (
+    !pRule.to.exoticRequire ||
+    (pDependency.exoticRequire &&
+      pDependency.exoticRequire.match(pRule.to.exoticRequire))
+  );
+}
+
+function toExoticRequireNot(pRule, pDependency) {
+  return (
+    !pRule.to.exoticRequireNot ||
+    (pDependency.exoticRequire &&
+      !pDependency.exoticRequire.match(pRule.to.exoticRequireNot))
+  );
+}
+
 module.exports = {
   _replaceGroupPlaceholders,
   fromPath,
@@ -82,5 +98,7 @@ module.exports = {
   toModulePathNot,
   toDependencyTypes,
   toLicense,
-  toLicenseNot
+  toLicenseNot,
+  toExoticRequire,
+  toExoticRequireNot
 };

--- a/test/cli/fixtures/cjs.dir.filtered.json
+++ b/test/cli/fixtures/cjs.dir.filtered.json
@@ -358,6 +358,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "externalModuleResolutionStrategy": "node_modules"
         }

--- a/test/cli/fixtures/cjs.dir.json
+++ b/test/cli/fixtures/cjs.dir.json
@@ -417,6 +417,7 @@
             "tsPreCompilationDeps": false,
             "preserveSymlinks": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/cli/fixtures/cjs.dir.stdout.json
+++ b/test/cli/fixtures/cjs.dir.stdout.json
@@ -414,6 +414,7 @@
             ],
             "outputType": "json",
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/cli/fixtures/cjs.file.json
+++ b/test/cli/fixtures/cjs.file.json
@@ -306,6 +306,7 @@
             "tsPreCompilationDeps": false,
             "preserveSymlinks": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/cli/fixtures/dynamic-import-nok.json
+++ b/test/cli/fixtures/dynamic-import-nok.json
@@ -45,6 +45,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "externalModuleResolutionStrategy": "node_modules"
         }

--- a/test/cli/fixtures/dynamic-import-ok.json
+++ b/test/cli/fixtures/dynamic-import-ok.json
@@ -45,6 +45,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "externalModuleResolutionStrategy": "node_modules"
         }

--- a/test/cli/fixtures/multiple-in-one-go.json
+++ b/test/cli/fixtures/multiple-in-one-go.json
@@ -153,6 +153,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "externalModuleResolutionStrategy": "node_modules"
         }

--- a/test/cli/fixtures/typescript-path-resolution.json
+++ b/test/cli/fixtures/typescript-path-resolution.json
@@ -65,6 +65,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "webpackConfig": {
                 "fileName": "test/cli/fixtures/typescriptconfig/cli-config-with-path/webpack.config.js"

--- a/test/cli/fixtures/webpack-config-alias-cruiser-config.json
+++ b/test/cli/fixtures/webpack-config-alias-cruiser-config.json
@@ -74,6 +74,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "webpackConfig": {
                 "fileName": "test/cli/fixtures/webpackconfig/aliassy/webpack.regularexport.config.js"

--- a/test/cli/fixtures/webpack-config-alias.json
+++ b/test/cli/fixtures/webpack-config-alias.json
@@ -71,6 +71,7 @@
             "outputType": "json",
             "tsPreCompilationDeps": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "preserveSymlinks": false,
             "webpackConfig": {
                 "fileName": "test/cli/fixtures/webpackconfig/aliassy/webpack.regularexport.config.js"

--- a/test/extract/ast-extractors/extract-amd-deps.spec.js
+++ b/test/extract/ast-extractors/extract-amd-deps.spec.js
@@ -70,12 +70,14 @@ describe("ast-extractors/extract-AMD-deps", () => {
       {
         moduleName: "./one-with-want",
         moduleSystem: "amd",
-        dynamic: false
+        dynamic: false,
+        exoticRequire: "want"
       },
       {
         moduleName: "./two-with-want",
         moduleSystem: "amd",
-        dynamic: false
+        dynamic: false,
+        exoticRequire: "want"
       }
     ]);
   });

--- a/test/extract/ast-extractors/extract-commonjs-deps.spec.js
+++ b/test/extract/ast-extractors/extract-commonjs-deps.spec.js
@@ -41,7 +41,8 @@ describe("ast-extractors/extract-commonJS-deps", () => {
       {
         moduleName: "./static-required-with-need",
         moduleSystem: "cjs",
-        dynamic: false
+        dynamic: false,
+        exoticRequire: "need"
       }
     ]);
   });

--- a/test/extract/ast-extractors/extract-typescript-exotics.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-exotics.spec.js
@@ -21,7 +21,8 @@ describe("ast-extractors/extract-typescript - exotics", () => {
       {
         moduleName: "./required-with-want",
         moduleSystem: "cjs",
-        dynamic: false
+        dynamic: false,
+        exoticRequire: "want"
       }
     ]);
   });
@@ -36,12 +37,14 @@ describe("ast-extractors/extract-typescript - exotics", () => {
       {
         moduleName: "./required-with-want",
         moduleSystem: "cjs",
-        dynamic: false
+        dynamic: false,
+        exoticRequire: "want"
       },
       {
         moduleName: "./required-with-need",
         moduleSystem: "cjs",
-        dynamic: false
+        dynamic: false,
+        exoticRequire: "need"
       }
     ]);
   });

--- a/test/extract/extract.spec.js
+++ b/test/extract/extract.spec.js
@@ -271,4 +271,33 @@ describe("extract/extract - include", () => {
       }
     ]);
   });
+
+  it("annotates the exotic require", () => {
+    const lOptions = normalize({ exoticRequireStrings: ["need"] });
+    const lResolveOptions = normalizeResolveOptions(
+      { bustTheCache: true },
+      lOptions
+    );
+
+    expect(
+      extract(
+        "./test/extract/fixtures/exotic-require/index.js",
+        lOptions,
+        lResolveOptions
+      )
+    ).to.deep.equal([
+      {
+        coreModule: false,
+        couldNotResolve: false,
+        dependencyTypes: ["local"],
+        dynamic: false,
+        followable: true,
+        matchesDoNotFollow: false,
+        module: "./required-with-need",
+        moduleSystem: "cjs",
+        exoticRequire: "need",
+        resolved: "test/extract/fixtures/exotic-require/required-with-need.js"
+      }
+    ]);
+  });
 });

--- a/test/extract/fixtures/cache-busting-first-tree.json
+++ b/test/extract/fixtures/cache-busting-first-tree.json
@@ -103,6 +103,7 @@
   "optionsUsed": {
    "args": "./test/extract/fixtures/cache-busting/index.ts",
    "combinedDependencies": false,
+   "exoticRequireStrings": [],
    "doNotFollow": {
     "dependencyTypes": [
      "npm",

--- a/test/extract/fixtures/cache-busting-second-tree.json
+++ b/test/extract/fixtures/cache-busting-second-tree.json
@@ -144,6 +144,7 @@
   "optionsUsed": {
     "args": "./test/extract/fixtures/cache-busting/index.ts",
    "combinedDependencies": false,
+   "exoticRequireStrings": [],
    "doNotFollow": {
     "dependencyTypes": [
      "npm",

--- a/test/extract/fixtures/exotic-require/index.js
+++ b/test/extract/fixtures/exotic-require/index.js
@@ -1,0 +1,4 @@
+const need = require;
+const requiredWithNeed = need("./required-with-need");
+
+console.log(requiredWithNeed);

--- a/test/extract/fixtures/exotic-require/required-with-need.js
+++ b/test/extract/fixtures/exotic-require/required-with-need.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -137,6 +137,7 @@
     "optionsUsed": {
       "args": "src",
       "combinedDependencies": false,
+      "exoticRequireStrings": [],
       "externalModuleResolutionStrategy": "node_modules",
       "moduleSystems": ["amd", "cjs", "es6"],
       "preserveSymlinks": false,

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -136,6 +136,7 @@
     "optionsUsed": {
       "args": "src",
       "combinedDependencies": false,
+      "exoticRequireStrings": [],
       "externalModuleResolutionStrategy": "node_modules",
       "moduleSystems": ["amd", "cjs", "es6"],
       "preserveSymlinks": false,

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -136,6 +136,7 @@
     "optionsUsed": {
       "args": "src",
       "combinedDependencies": false,
+      "exoticRequireStrings": [],
       "externalModuleResolutionStrategy": "node_modules",
       "moduleSystems": ["amd", "cjs", "es6"],
       "preserveSymlinks": false,

--- a/test/main/fixtures/jsx-as-object.json
+++ b/test/main/fixtures/jsx-as-object.json
@@ -197,6 +197,7 @@
             "tsPreCompilationDeps": false,
             "preserveSymlinks": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -196,6 +196,7 @@
             "tsPreCompilationDeps": false,
             "preserveSymlinks": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/main/fixtures/ts-no-precomp-cjs.json
+++ b/test/main/fixtures/ts-no-precomp-cjs.json
@@ -1,73 +1,66 @@
 {
-    "modules": [
+  "modules": [
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/imported-from-index-but-not-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./also-used",
+          "moduleSystem": "cjs",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts",
+          "valid": true
         },
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts",
-            "valid": true
-        },
-        {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/imported-from-index-but-not-used.ts",
-            "valid": true
-        },
-        {
-            "dependencies": [
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./also-used",
-                    "moduleSystem": "cjs",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-cjs/also-used.ts",
-                    "valid": true
-                },
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./definitely-used",
-                    "moduleSystem": "cjs",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts",
-                    "valid": true
-                }
-            ],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/index.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./definitely-used",
+          "moduleSystem": "cjs",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-off-cjs/definitely-used.ts",
+          "valid": true
         }
-    ],
-    "summary": {
-        "error": 0,
-        "info": 0,
-        "optionsUsed": {
-            "args": "test/main/fixtures/ts-precompilation-deps-off-cjs",
-            "externalModuleResolutionStrategy": "node_modules",
-            "moduleSystems": [
-                "amd",
-                "cjs",
-                "es6"
-            ],
-            "preserveSymlinks": false,
-            "tsPreCompilationDeps": false,
-            "combinedDependencies": false
-        },
-        "totalCruised": 4,
-        "totalDependenciesCruised": 2,
-        "violations": [],
-        "warn": 0
+      ],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-cjs/index.ts",
+      "valid": true
     }
+  ],
+  "summary": {
+    "error": 0,
+    "info": 0,
+    "optionsUsed": {
+      "args": "test/main/fixtures/ts-precompilation-deps-off-cjs",
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": ["amd", "cjs", "es6"],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": false,
+      "combinedDependencies": false,
+      "exoticRequireStrings": []
+    },
+    "totalCruised": 4,
+    "totalDependenciesCruised": 2,
+    "violations": [],
+    "warn": 0
+  }
 }

--- a/test/main/fixtures/ts-no-precomp-es.json
+++ b/test/main/fixtures/ts-no-precomp-es.json
@@ -1,73 +1,66 @@
 {
-    "modules": [
+  "modules": [
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-es/imported-from-index-but-not-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./also-used",
+          "moduleSystem": "cjs",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts",
+          "valid": true
         },
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts",
-            "valid": true
-        },
-        {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-es/imported-from-index-but-not-used.ts",
-            "valid": true
-        },
-        {
-            "dependencies": [
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./also-used",
-                    "moduleSystem": "cjs",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-es/also-used.ts",
-                    "valid": true
-                },
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./definitely-used",
-                    "moduleSystem": "es6",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts",
-                    "valid": true
-                }
-            ],
-            "source": "test/main/fixtures/ts-precompilation-deps-off-es/index.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./definitely-used",
+          "moduleSystem": "es6",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-off-es/definitely-used.ts",
+          "valid": true
         }
-    ],
-    "summary": {
-        "error": 0,
-        "info": 0,
-        "optionsUsed": {
-            "args": "test/main/fixtures/ts-precompilation-deps-off-es",
-            "externalModuleResolutionStrategy": "node_modules",
-            "moduleSystems": [
-                "amd",
-                "cjs",
-                "es6"
-            ],
-            "preserveSymlinks": false,
-            "tsPreCompilationDeps": false,
-            "combinedDependencies": false
-        },
-        "totalCruised": 4,
-        "totalDependenciesCruised": 2,
-        "violations": [],
-        "warn": 0
+      ],
+      "source": "test/main/fixtures/ts-precompilation-deps-off-es/index.ts",
+      "valid": true
     }
+  ],
+  "summary": {
+    "error": 0,
+    "info": 0,
+    "optionsUsed": {
+      "args": "test/main/fixtures/ts-precompilation-deps-off-es",
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": ["amd", "cjs", "es6"],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": false,
+      "combinedDependencies": false,
+      "exoticRequireStrings": []
+    },
+    "totalCruised": 4,
+    "totalDependenciesCruised": 2,
+    "violations": [],
+    "warn": 0
+  }
 }

--- a/test/main/fixtures/ts-precomp-cjs.json
+++ b/test/main/fixtures/ts-precomp-cjs.json
@@ -1,87 +1,78 @@
 {
-    "modules": [
+  "modules": [
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./also-used",
+          "moduleSystem": "cjs",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts",
+          "valid": true
         },
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./definitely-used",
+          "moduleSystem": "es6",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts",
+          "valid": true
         },
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts",
-            "valid": true
-        },
-        {
-            "dependencies": [
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./also-used",
-                    "moduleSystem": "cjs",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/also-used.ts",
-                    "valid": true
-                },
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./definitely-used",
-                    "moduleSystem": "es6",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/definitely-used.ts",
-                    "valid": true
-                },
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./imported-from-index-but-not-used",
-                    "moduleSystem": "es6",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts",
-                    "valid": true
-                }
-            ],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/index.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./imported-from-index-but-not-used",
+          "moduleSystem": "es6",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-on-cjs/imported-from-index-but-not-used.ts",
+          "valid": true
         }
-    ],
-    "summary": {
-        "error": 0,
-        "info": 0,
-        "optionsUsed": {
-            "args": "test/main/fixtures/ts-precompilation-deps-on-cjs",
-            "externalModuleResolutionStrategy": "node_modules",
-            "moduleSystems": [
-                "amd",
-                "cjs",
-                "es6"
-            ],
-            "preserveSymlinks": false,
-            "tsPreCompilationDeps": true,
-            "combinedDependencies": false
-        },
-        "totalCruised": 4,
-        "totalDependenciesCruised": 3,
-        "violations": [],
-        "warn": 0
+      ],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-cjs/index.ts",
+      "valid": true
     }
+  ],
+  "summary": {
+    "error": 0,
+    "info": 0,
+    "optionsUsed": {
+      "args": "test/main/fixtures/ts-precompilation-deps-on-cjs",
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": ["amd", "cjs", "es6"],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": true,
+      "combinedDependencies": false,
+      "exoticRequireStrings": []
+    },
+    "totalCruised": 4,
+    "totalDependenciesCruised": 3,
+    "violations": [],
+    "warn": 0
+  }
 }

--- a/test/main/fixtures/ts-precomp-es.json
+++ b/test/main/fixtures/ts-precomp-es.json
@@ -1,87 +1,78 @@
 {
-    "modules": [
+  "modules": [
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts",
+      "valid": true
+    },
+    {
+      "dependencies": [
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./also-used",
+          "moduleSystem": "cjs",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts",
+          "valid": true
         },
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./definitely-used",
+          "moduleSystem": "es6",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts",
+          "valid": true
         },
         {
-            "dependencies": [],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts",
-            "valid": true
-        },
-        {
-            "dependencies": [
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./also-used",
-                    "moduleSystem": "cjs",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/also-used.ts",
-                    "valid": true
-                },
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./definitely-used",
-                    "moduleSystem": "es6",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/definitely-used.ts",
-                    "valid": true
-                },
-                {
-                    "coreModule": false,
-                    "couldNotResolve": false,
-                    "dependencyTypes": [
-                        "local"
-                    ],
-                    "dynamic": false,
-                    "followable": true,
-                    "matchesDoNotFollow": false,
-                    "module": "./imported-from-index-but-not-used",
-                    "moduleSystem": "es6",
-                    "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts",
-                    "valid": true
-                }
-            ],
-            "source": "test/main/fixtures/ts-precompilation-deps-on-es/index.ts",
-            "valid": true
+          "coreModule": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "dynamic": false,
+          "followable": true,
+          "matchesDoNotFollow": false,
+          "module": "./imported-from-index-but-not-used",
+          "moduleSystem": "es6",
+          "resolved": "test/main/fixtures/ts-precompilation-deps-on-es/imported-from-index-but-not-used.ts",
+          "valid": true
         }
-    ],
-    "summary": {
-        "error": 0,
-        "info": 0,
-        "optionsUsed": {
-            "args": "test/main/fixtures/ts-precompilation-deps-on-es",
-            "externalModuleResolutionStrategy": "node_modules",
-            "moduleSystems": [
-                "amd",
-                "cjs",
-                "es6"
-            ],
-            "preserveSymlinks": false,
-            "tsPreCompilationDeps": true,
-            "combinedDependencies": false
-        },
-        "totalCruised": 4,
-        "totalDependenciesCruised": 3,
-        "violations": [],
-        "warn": 0
+      ],
+      "source": "test/main/fixtures/ts-precompilation-deps-on-es/index.ts",
+      "valid": true
     }
+  ],
+  "summary": {
+    "error": 0,
+    "info": 0,
+    "optionsUsed": {
+      "args": "test/main/fixtures/ts-precompilation-deps-on-es",
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": ["amd", "cjs", "es6"],
+      "preserveSymlinks": false,
+      "tsPreCompilationDeps": true,
+      "combinedDependencies": false,
+      "exoticRequireStrings": []
+    },
+    "totalCruised": 4,
+    "totalDependenciesCruised": 3,
+    "violations": [],
+    "warn": 0
+  }
 }

--- a/test/main/fixtures/ts.json
+++ b/test/main/fixtures/ts.json
@@ -137,6 +137,7 @@
             "tsPreCompilationDeps": false,
             "preserveSymlinks": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/main/fixtures/tsx.json
+++ b/test/main/fixtures/tsx.json
@@ -66,6 +66,7 @@
             "tsPreCompilationDeps": false,
             "preserveSymlinks": false,
             "combinedDependencies": false,
+            "exoticRequireStrings": [],
             "externalModuleResolutionStrategy": "node_modules"
         }
     }

--- a/test/main/fixtures/type-only-module-references/output-no-ts.json
+++ b/test/main/fixtures/type-only-module-references/output-no-ts.json
@@ -15,6 +15,7 @@
     "totalDependenciesCruised": 0,
     "optionsUsed": {
       "combinedDependencies": false,
+      "exoticRequireStrings": [],
       "externalModuleResolutionStrategy": "node_modules",
       "moduleSystems": [
         "amd",

--- a/test/main/fixtures/type-only-module-references/output.json
+++ b/test/main/fixtures/type-only-module-references/output.json
@@ -36,6 +36,7 @@
     "totalDependenciesCruised": 1,
     "optionsUsed": {
       "combinedDependencies": false,
+      "exoticRequireStrings": [],
       "externalModuleResolutionStrategy": "node_modules",
       "moduleSystems": [
         "amd",

--- a/test/validate/fixtures/rules.exotic-require-not.json
+++ b/test/validate/fixtures/rules.exotic-require-not.json
@@ -1,0 +1,9 @@
+{
+  "forbidden": [
+    {
+      "name": "only-use-as-exotic-require",
+      "from": {},
+      "to": { "exoticRequireNot": "^use$" }
+    }
+  ]
+}

--- a/test/validate/fixtures/rules.exotic-require.json
+++ b/test/validate/fixtures/rules.exotic-require.json
@@ -1,0 +1,9 @@
+{
+  "forbidden": [
+    {
+      "name": "no-use-as-exotic-require",
+      "from": {},
+      "to": { "exoticRequire": "^use$" }
+    }
+  ]
+}

--- a/test/validate/index.exoticRequire.spec.js
+++ b/test/validate/index.exoticRequire.spec.js
@@ -1,0 +1,85 @@
+const expect = require("chai").expect;
+const validate = require("../../src/validate");
+const readRuleSet = require("./readruleset.utl");
+
+describe("validate/index - exoticRequire", () => {
+  it("does not flag dependencies that are required with a regular require or import", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.exotic-require.json"),
+        { source: "something" },
+        { resolved: "src/aap/speeltuigen/autoband.ts" }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("does not flag dependencies that are required with an exotic require not in the forbdidden RE", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.exotic-require.json"),
+        { source: "something" },
+        { resolved: "src/aap/speeltuigen/autoband.ts", exoticRequire: "notUse" }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("flags dependencies that are required with a forbidden exotic require", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.exotic-require.json"),
+        { source: "something" },
+        { resolved: "src/aap/speeltuigen/autoband.ts", exoticRequire: "use" }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "no-use-as-exotic-require", severity: "warn" }]
+    });
+  });
+});
+
+describe("validate/index - exoticRequireNot", () => {
+  it("does not flag dependencies that are required with a regular require or import", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.exotic-require-not.json"),
+        { source: "something" },
+        { resolved: "src/aap/speeltuigen/autoband.ts" }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("does not flag dependencies that are required with a sanctioned exotic require", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.exotic-require-not.json"),
+        { source: "something" },
+        {
+          resolved: "src/aap/speeltuigen/autoband.ts",
+          exoticRequire: "use"
+        }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("flags dependencies are required with an unsanctioned exotic require", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.exotic-require-not.json"),
+        { source: "something" },
+        {
+          resolved: "src/aap/speeltuigen/autoband.ts",
+          exoticRequire: "notuse"
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "only-use-as-exotic-require", severity: "warn" }]
+    });
+  });
+});

--- a/test/validate/index.groupmatching.spec.js
+++ b/test/validate/index.groupmatching.spec.js
@@ -1,13 +1,13 @@
 const expect = require("chai").expect;
 const validate = require("../../src/validate");
-const _readRuleSet = require("./readruleset.utl");
+const readRuleSet = require("./readruleset.utl");
 
 describe("validate/index group matching - path group matched in a pathnot", () => {
   it("group-to-pathnot - Disallows dependencies between peer folders", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/noot/pinda.ts" }
       )
@@ -26,7 +26,7 @@ describe("validate/index group matching - path group matched in a pathnot", () =
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/shared/bananas.ts" }
       )
@@ -37,7 +37,7 @@ describe("validate/index group matching - path group matched in a pathnot", () =
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/oerangoetang.ts" }
       )
@@ -48,7 +48,7 @@ describe("validate/index group matching - path group matched in a pathnot", () =
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
       )
@@ -59,7 +59,7 @@ describe("validate/index group matching - path group matched in a pathnot", () =
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/rekwisieten/touw.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
       )
@@ -72,9 +72,7 @@ describe("validate/index group matching - second path group matched in a pathnot
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.group-two-to-pathnot.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/noot/pinda.ts" }
       )
@@ -93,9 +91,7 @@ describe("validate/index group matching - second path group matched in a pathnot
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.group-two-to-pathnot.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/shared/bananas.ts" }
       )
@@ -106,9 +102,7 @@ describe("validate/index group matching - second path group matched in a pathnot
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.group-two-to-pathnot.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/oerangoetang.ts" }
       )
@@ -119,9 +113,7 @@ describe("validate/index group matching - second path group matched in a pathnot
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.group-two-to-pathnot.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
       )
@@ -132,9 +124,7 @@ describe("validate/index group matching - second path group matched in a pathnot
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.group-two-to-pathnot.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/rekwisieten/touw.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
       )

--- a/test/validate/index.license.spec.js
+++ b/test/validate/index.license.spec.js
@@ -1,13 +1,13 @@
 const expect = require("chai").expect;
 const validate = require("../../src/validate");
-const _readRuleSet = require("./readruleset.utl");
+const readRuleSet = require("./readruleset.utl");
 
 describe("validate/index - license", () => {
   it("Skips dependencies that have no license attached", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.license.json"),
+        readRuleSet("./test/validate/fixtures/rules.license.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
       )
@@ -18,7 +18,7 @@ describe("validate/index - license", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.license.json"),
+        readRuleSet("./test/validate/fixtures/rules.license.json"),
         { source: "something" },
         {
           resolved: "src/aap/speeltuigen/autoband.ts",
@@ -32,7 +32,7 @@ describe("validate/index - license", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.license.json"),
+        readRuleSet("./test/validate/fixtures/rules.license.json"),
         { source: "something" },
         {
           resolved: "src/aap/speeltuigen/autoband.ts",
@@ -51,7 +51,7 @@ describe("validate/index - licenseNot", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
+        readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
       )
@@ -62,7 +62,7 @@ describe("validate/index - licenseNot", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
+        readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
         { source: "something" },
         {
           resolved: "src/aap/speeltuigen/autoband.ts",
@@ -76,7 +76,7 @@ describe("validate/index - licenseNot", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
+        readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
         { source: "something" },
         {
           resolved: "src/aap/speeltuigen/autoband.ts",

--- a/test/validate/index.orphans.spec.js
+++ b/test/validate/index.orphans.spec.js
@@ -1,13 +1,13 @@
 const expect = require("chai").expect;
 const validate = require("../../src/validate");
-const _readRuleSet = require("./readruleset.utl");
+const readRuleSet = require("./readruleset.utl");
 
 describe("validate/index - orphans", () => {
   it("Skips modules that have no orphan attribute", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.json"),
         { source: "something" }
       )
     ).to.deep.equal({ valid: true });
@@ -17,7 +17,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.json"),
         { source: "something", orphan: true }
       )
     ).to.deep.equal({
@@ -30,7 +30,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.allowed.json"),
         { source: "something", orphan: true }
       )
     ).to.deep.equal({
@@ -43,7 +43,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.allowed.json"),
         { source: "something", orphan: false }
       )
     ).to.deep.equal({ valid: true });
@@ -53,7 +53,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
         { source: "something", orphan: true }
       )
     ).to.deep.equal({ valid: true });
@@ -63,7 +63,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
         { source: "noorphansallowedhere/blah/something.ts", orphan: true }
       )
     ).to.deep.equal({
@@ -76,7 +76,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.pathnot.json"),
         { source: "orphansallowedhere/something", orphan: true }
       )
     ).to.deep.equal({ valid: true });
@@ -86,7 +86,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.pathnot.json"),
         { source: "blah/something.ts", orphan: true }
       )
     ).to.deep.equal({
@@ -99,7 +99,7 @@ describe("validate/index - orphans", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
+        readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
         { source: "noorphansallowedhere/something.ts", orphan: true },
         {}
       )

--- a/test/validate/index.reachable.spec.js
+++ b/test/validate/index.reachable.spec.js
@@ -1,13 +1,13 @@
 const expect = require("chai").expect;
 const validate = require("../../src/validate");
-const _readRuleSet = require("./readruleset.utl");
+const readRuleSet = require("./readruleset.utl");
 
 describe("validate/index - reachable", () => {
   it("Skips modules that have no reachable attribute", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.json"),
         { source: "something" }
       )
     ).to.deep.equal({ valid: true });
@@ -17,7 +17,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.json"),
         {
           source: "something",
           reachable: [{ asDefinedInRule: "no-unreachable", value: true }]
@@ -30,7 +30,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.json"),
         {
           source: "something",
           reachable: [{ asDefinedInRule: "no-unreachable", value: false }]
@@ -51,7 +51,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.path.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.path.json"),
         {
           source: "something",
           reachable: [{ asDefinedInRule: "no-unreachable", value: false }]
@@ -72,7 +72,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.pathnot.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.pathnot.json"),
         {
           source: "something",
           reachable: [{ asDefinedInRule: "no-unreachable", value: false }]
@@ -85,7 +85,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
         { source: "something" }
       )
     ).to.deep.equal({ valid: true });
@@ -95,7 +95,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
         {
           source: "something",
           reachable: [{ value: true, asDefinedInRule: "not-in-allowed" }]
@@ -108,7 +108,7 @@ describe("validate/index - reachable", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
         {
           source: "something",
           reachable: [{ value: false, asDefinedInRule: "not-in-allowed" }]

--- a/test/validate/index.spec.js
+++ b/test/validate/index.spec.js
@@ -1,13 +1,13 @@
 const expect = require("chai").expect;
 const validate = require("../../src/validate");
-const _readRuleSet = require("./readruleset.utl");
+const readRuleSet = require("./readruleset.utl");
 
 describe("validate/index dependency - generic tests", () => {
   it("is ok with the empty validation", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.empty.json"),
+        readRuleSet("./test/validate/fixtures/rules.empty.json"),
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" }
       )
@@ -18,7 +18,7 @@ describe("validate/index dependency - generic tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.everything-allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.everything-allowed.json"),
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" }
       )
@@ -29,7 +29,7 @@ describe("validate/index dependency - generic tests", () => {
     expect(
       validate.module(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.module-only.empty.allowed.json"
         ),
         { source: "koos koets" }
@@ -41,7 +41,7 @@ describe("validate/index dependency - generic tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.impossible-to-match-allowed.json"
         ),
         { source: "koos koets" },
@@ -57,7 +57,7 @@ describe("validate/index dependency - generic tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.impossible-to-match-error.allowed.json"
         ),
         { source: "koos koets" },
@@ -73,7 +73,7 @@ describe("validate/index dependency - generic tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.nothing-allowed.json"),
+        readRuleSet("./test/validate/fixtures/rules.nothing-allowed.json"),
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" }
       )
@@ -87,7 +87,7 @@ describe("validate/index dependency - generic tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.not-in-allowed-and-a-forbidden.json"
         ),
         { source: "something" },
@@ -110,7 +110,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.node_modules-not-allowed.json"
         ),
         { source: "koos koets" },
@@ -123,7 +123,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.node_modules-not-allowed.json"
         ),
         { source: "koos koets" },
@@ -139,7 +139,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-core.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-core.json"),
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["npm"] }
       )
@@ -150,7 +150,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-core.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-core.json"),
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["core"] }
       )
@@ -164,7 +164,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-core-fs-os.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-core-fs-os.json"),
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["core"] }
       )
@@ -175,7 +175,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-core-fs-os.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-core-fs-os.json"),
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] }
       )
@@ -189,7 +189,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-unresolvable.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-unresolvable.json"),
         { source: "koos koets" },
         { resolved: "diana charitee", couldNotResolve: false }
       )
@@ -200,7 +200,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-unresolvable.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-unresolvable.json"),
         { source: "koos koets" },
         { resolved: "diana charitee", couldNotResolve: true }
       )
@@ -214,9 +214,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.only-to-core.allowed.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.only-to-core.allowed.json"),
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] }
       )
@@ -227,9 +225,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
-          "./test/validate/fixtures/rules.only-to-core.allowed.json"
-        ),
+        readRuleSet("./test/validate/fixtures/rules.only-to-core.allowed.json"),
         { source: "koos koets" },
         { resolved: "ger hekking", dependencyTypes: ["npm"] }
       )
@@ -243,7 +239,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.only-to-core.forbidden.json"
         ),
         { source: "koos koets" },
@@ -256,7 +252,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.only-to-core.forbidden.json"
         ),
         { source: "koos koets" },
@@ -272,7 +268,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
         { source: "./keek/op/de/sub/week.js" },
@@ -285,7 +281,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
         { source: "./doctor/clavan.js" },
@@ -298,7 +294,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
         { source: "./doctor/sub/clavan.js" },
@@ -311,7 +307,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
         { source: "./doctor/clavan.js" },
@@ -327,7 +323,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-not-sub.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-not-sub.json"),
         { source: "./keek/op/de/sub/week.js" },
         { resolved: "./keek/op/de/sub/maand.js", coreModule: false }
       )
@@ -338,7 +334,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-not-sub.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-not-sub.json"),
         { source: "./amber.js" },
         { resolved: "./jade.js", coreModule: false }
       )
@@ -352,7 +348,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-dev-dep.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-dev-dep.json"),
         { source: "src/aap/zus/jet.js" },
         {
           module: "chai",
@@ -375,7 +371,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet("./test/validate/fixtures/rules.not-to-dev-dep.json"),
+        readRuleSet("./test/validate/fixtures/rules.not-to-dev-dep.json"),
         { source: "src/aap/zus/jet.js" },
         {
           module: "jip",
@@ -390,7 +386,7 @@ describe("validate/index - specific tests", () => {
     expect(
       validate.dependency(
         true,
-        _readRuleSet(
+        readRuleSet(
           "./test/validate/fixtures/rules.no-duplicate-dep-types.json"
         ),
         { source: "src/aap/zus/jet.js" },

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -105,6 +105,11 @@ export interface IDependency {
    */
   dynamic: boolean;
   /**
+   * If this dependency was defined by a require not named require (as defined in the
+   * exoticRequireStrings option): the string that was used
+   */
+  exoticRequire?: string;
+  /**
    * Whether or not this is a dependency that can be followed any further. This will be
    * 'false' for for core modules, json, modules that could not be resolved to a file and
    * modules that weren't followed because it matches the doNotFollow expression.

--- a/types/rule-set.d.ts
+++ b/types/rule-set.d.ts
@@ -46,6 +46,14 @@ export interface IToRestriction {
    */
   dynamic?: boolean;
   /**
+   * A regular expression to match against any 'exotic' require strings
+   */
+  exoticRequire?: string;
+  /**
+   * A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule
+   */
+  exoticRequireNot?: string;
+  /**
    * Whether or not to match modules of any of these types (leaving out matches any of them)
    */
   dependencyTypes?: DependencyType[];


### PR DESCRIPTION
## Description

- [x] Adds an 'exoticRequire' attribute to dependencies defined with an exotic require
- [x] Adds the possibility to validate based on that attribute


## Motivation and Context

For exotic requires/ require wrappers you might want to have different rules a.c.t. normal requires. E.g. 
- when you use a require wrapper to include a dependency that might not be there and handle it elegantly, it's not an error if the module-to-be-there doesn't actually exist - or is e.g. in your `optionalDependencies`.
- you might want to ban the use of remapped requires/ require wrappers in certain areas (or altogether)

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] additional automated tests
- [x] dogfooding

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
