### PR TITLE
feature(extract): recognize composite exotic requires (e.g. window.require)

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -188,6 +188,6 @@
     //    "env": {},
     //    "args": {}
     // }
-    "exoticRequireStrings": ["^tryRequire$"]
+    "exoticRequireStrings": ["tryRequire"]
   }
 }

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -264,10 +264,11 @@ _teamcity_ reporters.
 
 ### Q: I'm using window.require or a require wrapper - how do I make sure dependencies I declared like that are included?
 
-**A**: Add a _exoticRequireStrings_ key in your configuration with the 
+**A**: From version 5.4.0 or higher you can add an _exoticRequireStrings_ key in
+your configuration with the wrapper(s) and/ or redefinitions of require:
 
 ```json
-"exoticRequireStrings": ["window.require"]
+"exoticRequireStrings": ["window.require", "need", "tryRequire"]
 ```
 
 ## Expanding dependency-cruiser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "5.3.2",
+  "version": "5.4.0-beta-0",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/extract/ast-extractors/estree-helpers.js
+++ b/src/extract/ast-extractors/estree-helpers.js
@@ -28,11 +28,30 @@ function firstArgumentIsATemplateLiteral(pArgumentsNode) {
   );
 }
 
-function isRequireIdentifier(pNode, pName) {
+function isMemberCallExpression(pNode, pObjectName, pPropertyName) {
+  return (
+    pNode.type === "CallExpression" &&
+    pNode.callee.type === "MemberExpression" &&
+    pNode.callee.object.type === "Identifier" &&
+    pNode.callee.object.name === pObjectName &&
+    pNode.callee.property.type === "Identifier" &&
+    pNode.callee.property.name === pPropertyName
+  );
+}
+
+function isCalleeIdentifier(pNode, pName) {
   return (
     "Identifier" === _get(pNode, "callee.type") &&
     pName === _get(pNode, "callee.name")
   );
+}
+
+function isRequireOfSomeSort(pNode, pName) {
+  const lRequireStringElements = pName.split(".");
+
+  return lRequireStringElements.length > 1
+    ? isMemberCallExpression(pNode, ...lRequireStringElements)
+    : isCalleeIdentifier(pNode, pName);
 }
 
 function isLikelyAMDDefineOrRequire(pNode) {
@@ -57,7 +76,9 @@ module.exports = {
   firstArgumentIsATemplateLiteral,
   isStringLiteral,
   isPlaceholderlessTemplateLiteral,
-  isRequireIdentifier,
+  isMemberCallExpression,
+  isCalleeIdentifier,
+  isRequireOfSomeSort,
   isLikelyAMDDefineOrRequire,
   isLikelyAMDDefine
 };

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -105,13 +105,39 @@ function isRequireCallExpression(pASTNode) {
   );
 }
 
-function isExoticRequire(pASTNode, pString) {
+function isSingleExoticRequire(pASTNode, pString) {
   return (
     typescript.SyntaxKind[pASTNode.kind] === "CallExpression" &&
     pASTNode.expression &&
     pASTNode.expression.text === pString &&
     firstArgIsAString(pASTNode)
   );
+}
+
+/* eslint complexity:0 */
+function isCompositeExoticRequire(pASTNode, pObjectName, pPropertyName) {
+  return (
+    typescript.SyntaxKind[pASTNode.kind] === "CallExpression" &&
+    pASTNode.expression &&
+    typescript.SyntaxKind[pASTNode.expression.kind] ===
+      "PropertyAccessExpression" &&
+    pASTNode.expression.expression &&
+    typescript.SyntaxKind[pASTNode.expression.expression.kind] ===
+      "Identifier" &&
+    pASTNode.expression.expression.escapedText === pObjectName &&
+    pASTNode.expression.name &&
+    typescript.SyntaxKind[pASTNode.expression.name.kind] === "Identifier" &&
+    pASTNode.expression.name.escapedText === pPropertyName &&
+    firstArgIsAString(pASTNode)
+  );
+}
+
+function isExoticRequire(pASTNode, pString) {
+  const lRequireStringElements = pString.split(".");
+
+  return lRequireStringElements.length > 1
+    ? isCompositeExoticRequire(pASTNode, ...lRequireStringElements)
+    : isSingleExoticRequire(pASTNode, pString);
 }
 
 function isDynamicImportExpression(pASTNode) {

--- a/test/extract/ast-extractors/extract-commonjs-deps.spec.js
+++ b/test/extract/ast-extractors/extract-commonjs-deps.spec.js
@@ -47,6 +47,24 @@ describe("ast-extractors/extract-commonJS-deps", () => {
     ]);
   });
 
+  it("use an exotic combined require and specify it as exoticRequireString", () => {
+    let lDeps = [];
+
+    extractcommonJS(
+      "const x = window.require('./static-required-with-need')",
+      lDeps,
+      ["window.require"]
+    );
+    expect(lDeps).to.deep.equal([
+      {
+        moduleName: "./static-required-with-need",
+        moduleSystem: "cjs",
+        dynamic: false,
+        exoticRequire: "window.require"
+      }
+    ]);
+  });
+
   it("use an exotic require and don't specify it as exoticRequireString", () => {
     let lDeps = [];
 

--- a/test/extract/ast-extractors/extract-typescript-exotics.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-exotics.spec.js
@@ -27,6 +27,22 @@ describe("ast-extractors/extract-typescript - exotics", () => {
     ]);
   });
 
+  it("detects dependencies declared with member expression passed as exoticRequireStrings", () => {
+    expect(
+      extractTypescript(
+        "const yo = window.require('./required-with-window-require')",
+        ["window.require"]
+      )
+    ).to.deep.equal([
+      {
+        moduleName: "./required-with-window-require",
+        moduleSystem: "cjs",
+        dynamic: false,
+        exoticRequire: "window.require"
+      }
+    ]);
+  });
+
   it("detects dependencies declared with multiple function names passed as exoticRequireStrings", () => {
     expect(
       extractTypescript(


### PR DESCRIPTION
## Description

- Same as #216, but for composite requires (one level deep) like `window.require`


## Todo

- [x] javascript
- [x] typescript

## Motivation and Context

- fixes #206

## How Has This Been Tested?

- [x] additional unit tests
- [x] automated non-regression tests


## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
