### PR TITLE
ci(codeclimate): up eslint version to use over there

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,21 +6,13 @@ checks:
 plugins:
   eslint:
     enabled: true
-    channel: "eslint-5"
+    channel: "eslint-6"
     config:
       config: .eslintrc.json
     checks:
       # compat is not a codeclimeate supported eslint plugin
       compat/compat:
         enabled: false
-      # fairly fresh mocha rule, not supported by codeclimate yet
-      mocha/no-async-describe:
-        enabled: false
-      # indent rules on codeclimate seem to be different from
-      # the local ones - probably because cc uses an older version
-      # of eslint
-      indent:
-        enabled: true
 exclude_patterns:
   - ".github/"
   - "configs/"


### PR DESCRIPTION
## Description, Motivation and Context
We're using newer versions of plugins locally - so cc starts complaining it can't find some of the newer rules. Upping to aslint 6 should fix that.

## How Has This Been Tested?
- [ ] green ci


## Types of changes
- [x] chore

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
