### PR TITLE
bugfix(doc): to.dynamic is a boolean

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -640,7 +640,7 @@ You can use this e.g. to restrict the usage of dynamic dependencies:
       "name": "no-non-dynamic-dependencies",
       "severity": "error",
       "from": {},
-      "to": { "dynamic": "true" }
+      "to": { "dynamic": true }
     }
   ]
 }
@@ -656,7 +656,7 @@ You can use this e.g. to restrict the usage of dynamic dependencies:
       "comment": "only dynamically depend on 'otherside' modules",
       "severity": "error",
       "from": {},
-      "to": { "path": "@theotherside/", "dynamic": "false" }
+      "to": { "path": "@theotherside/", "dynamic": false }
     }
   ]
 }


### PR DESCRIPTION
## Description
`to.dynamic` should be a boolean.

## Motivation and Context
The [rules reference documentation](doc/rules-reference.md ) is not in line with the [schema definition](https://github.com/sverweij/dependency-cruiser/blob/53853d3edd5c1fc0fa91f5c888198123fd6b000c/src/schema/configuration.schema.json#L164).

## How Has This Been Tested?
1) Create `.dependency-cruiser.json`
    ```javascript
    {
    "forbidden": [
        {
        "name": "no-non-dynamic-dependencies",
        "severity": "error",
        "from": {},
        "to": { "dynamic": "true" }
        }
    ]
    }
    ```
2) Run `depcruise --validate .dependency-cruiser.json src`
3) Results in an error:
    ```
    ERROR: The rules file is not valid: data.forbidden[0].to.dynamic should be boolean, data.forbidden[0].to 
    should NOT have additional properties, data.forbidden[0] should match exactly one schema in oneOf.
    ```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
