### PR TITLE
add .d.ts to allow for custom tsconfig resolving

### DIFF
--- a/src/main/resolveOptions/normalize.js
+++ b/src/main/resolveOptions/normalize.js
@@ -61,7 +61,17 @@ function compileResolveOptions(pResolveOptions, pTSConfig) {
   if (pResolveOptions.tsConfig && _has(pTSConfig, "options.baseUrl")) {
     lResolveOptions.plugins = pushPlugin(
       lResolveOptions.plugins,
-      new TsConfigPathsPlugin({ configFile: pResolveOptions.tsConfig, extensions: [".ts", ".tsx", ".d.ts"] })
+      new TsConfigPathsPlugin({
+        configFile: pResolveOptions.tsConfig,
+        // different from the typescript compiler, tsConfigPathsPlugin
+        // only has .ts and .tsx as default extension to scan given
+        // an import/ require/ export argument.
+        // Added .js, .jsx and .d.ts before .ts and .tsx to mirror
+        // the typescript compiler's behavior
+        // Should probably be fixed upstream, but put in here until
+        // that happens.
+        extensions: [".js", ".json", ".jsx", ".d.ts", ".ts", ".tsx"]
+      })
     );
   }
 

--- a/src/main/resolveOptions/normalize.js
+++ b/src/main/resolveOptions/normalize.js
@@ -61,7 +61,7 @@ function compileResolveOptions(pResolveOptions, pTSConfig) {
   if (pResolveOptions.tsConfig && _has(pTSConfig, "options.baseUrl")) {
     lResolveOptions.plugins = pushPlugin(
       lResolveOptions.plugins,
-      new TsConfigPathsPlugin({ configFile: pResolveOptions.tsConfig })
+      new TsConfigPathsPlugin({ configFile: pResolveOptions.tsConfig, extensions: [".ts", ".tsx", ".d.ts"] })
     );
   }
 

--- a/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.d.ts
+++ b/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.d.ts
@@ -1,0 +1,1 @@
+export const sly = "and the family stone";

--- a/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.ts
+++ b/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.ts
@@ -1,0 +1,1 @@
+export const sly = 'and the family stone';

--- a/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/js-before-ts.js
+++ b/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/js-before-ts.js
@@ -1,0 +1,1 @@
+export const version = "4.8.1";

--- a/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/js-before-ts.ts
+++ b/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/src/aliassed/js-before-ts.ts
@@ -1,0 +1,1 @@
+export const version = "4.8.1";

--- a/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/tsconfig.json
+++ b/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/tsconfig.json
@@ -1,61 +1,18 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                       /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "target": "ES2015",
+    "module": "commonjs",
+    "outDir": "./dist",
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "strict": true,
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
-    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./src",
+    "paths": {
       "things/*": ["./aliassed/*"],
-    },        
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "esModuleInterop": true
   }
 }

--- a/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/tsconfig.json
+++ b/test/extract/resolve/fixtures/ts-config-with-path-correct-resolution-prio/tsconfig.json
@@ -1,0 +1,61 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "things/*": ["./aliassed/*"],
+    },        
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/test/extract/resolve/fixtures/ts-config-with-path/tsconfig.json
+++ b/test/extract/resolve/fixtures/ts-config-with-path/tsconfig.json
@@ -1,63 +1,20 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                       /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "target": "ES2015",
+    "module": "commonjs",
+    "outDir": "./dist",
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "strict": true,
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
-    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./src",
+    "paths": {
       "*": ["./typos/*"],
       "gewoon/*": ["./common/*"],
       "shared": ["./shared"]
-    },        
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "esModuleInterop": true
   }
 }

--- a/test/extract/resolve/index.spec.js
+++ b/test/extract/resolve/index.spec.js
@@ -11,6 +11,13 @@ const TSCONFIG = path.join(
   "tsconfig.json"
 );
 const PARSED_TSCONFIG = parseTSConfig(TSCONFIG);
+const TSCONFIG_RESOLUTIONS = path.join(
+  __dirname,
+  "fixtures",
+  "ts-config-with-path-correct-resolution-prio",
+  "tsconfig.json"
+);
+const PARSED_TSCONFIG_RESOLUTIONS = parseTSConfig(TSCONFIG);
 
 describe("extract/resolve/index", () => {
   it("resolves a local dependency to a file on disk", () => {
@@ -291,6 +298,70 @@ describe("extract/resolve/index", () => {
       dependencyTypes: ["aliased"],
       followable: true,
       resolved: "ts-config-with-path/src/typos/daddayaddaya.ts"
+    });
+  });
+
+  it("for aliasses resolves in the same fashion as the typescript compiler - dts-vs-ts", () => {
+    expect(
+      resolve(
+        {
+          module: "things/dts-before-ts",
+          moduleSystem: "es6"
+        },
+        path.join(__dirname, "fixtures"),
+        path.join(
+          __dirname,
+          "fixtures",
+          "ts-config-with-path-correct-resolution-prio"
+        ),
+        normalizeResolveOptions(
+          {
+            tsConfig: TSCONFIG_RESOLUTIONS,
+            bustTheCache: true
+          },
+          {},
+          PARSED_TSCONFIG_RESOLUTIONS
+        )
+      )
+    ).to.deep.equal({
+      coreModule: false,
+      couldNotResolve: false,
+      dependencyTypes: ["aliased"],
+      followable: true,
+      resolved:
+        "ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.d.ts"
+    });
+  });
+
+  it("for aliasses resolves in the same fashion as the typescript compiler - js-vs-ts", () => {
+    expect(
+      resolve(
+        {
+          module: "things/js-before-ts",
+          moduleSystem: "es6"
+        },
+        path.join(__dirname, "fixtures"),
+        path.join(
+          __dirname,
+          "fixtures",
+          "ts-config-with-path-correct-resolution-prio"
+        ),
+        normalizeResolveOptions(
+          {
+            tsConfig: TSCONFIG_RESOLUTIONS,
+            bustTheCache: true
+          },
+          {},
+          PARSED_TSCONFIG_RESOLUTIONS
+        )
+      )
+    ).to.deep.equal({
+      coreModule: false,
+      couldNotResolve: false,
+      dependencyTypes: ["aliased"],
+      followable: true,
+      resolved:
+        "ts-config-with-path-correct-resolution-prio/src/aliassed/js-before-ts.js"
     });
   });
 


### PR DESCRIPTION
In one of our projects we use `.d.ts` files which are not generated to limit the possibility in the file. Most of them are model files

> Plan to do something drastic?  
> Leave an [issue](https://github.com/sverweij/dependency-cruiser/issues/new) with a
> summary of the changes you propose + some context on why you'd want to
> do that.

## Description
Just add `.d.ts` the default is to only have `.ts` and `.tsx`. Unsure if this is the correct place though.

## Motivation and Context
In one of our projects we use `.d.ts` files which are not generated to limit the possibility in the file. Most of them are model files

## How Has This Been Tested?
Tested locally on the project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [ ] The code I've added is my own original work.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
