### PR TITLE
bugfix(doc): correct link to defaultTheme.json

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -1225,7 +1225,7 @@ The criteria are evaluated top to bottom:
 - Criteria in the configuration file take precedence over the default ones.
 
 For an extensive example you can have a look at the default theme dependency-cruiser
-ships with - [defaultTheme.json](../src/report/dot/common/defaultTheme.json).
+ships with - [defaultTheme.json](../src/report/dot/defaultTheme.json).
 
 ##### Some examples
 


### PR DESCRIPTION
## Description
Path should be ../src/report/dot/defaultTheme.json (wihtout unexisting folder **common**)

## How Has This Been Tested?
Full link to file is https://github.com/sverweij/dependency-cruiser/blob/develop/src/report/dot/defaultTheme.json

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
