### PR TITLE
bugfix(main): align regular and tspath resolution extensions & order

### DIFF
--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -50,6 +50,81 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M145.05,-8C145.05,-8 1858.16,-8 1858.16,-8 1864.16,-8 1870.16,-14 1870.16,-20 1870.16,-20 1870.16,-2090 1870.16,-2090 1870.16,-2096 1864.16,-2102 1858.16,-2102 1858.16,-2102 145.05,-2102 145.05,-2102 139.05,-2102 133.05,-2096 133.05,-2090 133.05,-2090 133.05,-20 133.05,-20 133.05,-14 139.05,-8 145.05,-8"/>
 <text text-anchor="middle" x="1001.6" y="-2090.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">src</text>
 </g>
+<g id="clust3" class="cluster">
+<title>cluster_src/cli</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M153.05,-1793C153.05,-1793 703.07,-1793 703.07,-1793 709.07,-1793 715.07,-1799 715.07,-1805 715.07,-1805 715.07,-2065 715.07,-2065 715.07,-2071 709.07,-2077 703.07,-2077 703.07,-2077 153.05,-2077 153.05,-2077 147.05,-2077 141.05,-2071 141.05,-2065 141.05,-2065 141.05,-1805 141.05,-1805 141.05,-1799 147.05,-1793 153.05,-1793"/>
+<text text-anchor="middle" x="428.06" y="-2065.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
+</g>
+<g id="clust6" class="cluster">
+<title>cluster_src/cli/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M370.47,-1804C370.47,-1804 472.01,-1804 472.01,-1804 478.01,-1804 484.01,-1810 484.01,-1816 484.01,-1816 484.01,-1901 484.01,-1901 484.01,-1907 478.01,-1913 472.01,-1913 472.01,-1913 370.47,-1913 370.47,-1913 364.47,-1913 358.47,-1907 358.47,-1901 358.47,-1901 358.47,-1816 358.47,-1816 358.47,-1810 364.47,-1804 370.47,-1804"/>
+<text text-anchor="middle" x="421.24" y="-1901.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust4" class="cluster">
+<title>cluster_src/cli/compileConfig</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M516.53,-1801C516.53,-1801 695.07,-1801 695.07,-1801 701.07,-1801 707.07,-1807 707.07,-1813 707.07,-1813 707.07,-1869 707.07,-1869 707.07,-1875 701.07,-1881 695.07,-1881 695.07,-1881 516.53,-1881 516.53,-1881 510.53,-1881 504.53,-1875 504.53,-1869 504.53,-1869 504.53,-1813 504.53,-1813 504.53,-1807 510.53,-1801 516.53,-1801"/>
+<text text-anchor="middle" x="605.8" y="-1869.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compileConfig</text>
+</g>
+<g id="clust5" class="cluster">
+<title>cluster_src/cli/initConfig</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M279.45,-1957C279.45,-1957 583.05,-1957 583.05,-1957 589.05,-1957 595.05,-1963 595.05,-1969 595.05,-1969 595.05,-2040 595.05,-2040 595.05,-2046 589.05,-2052 583.05,-2052 583.05,-2052 279.45,-2052 279.45,-2052 273.45,-2052 267.45,-2046 267.45,-2040 267.45,-2040 267.45,-1969 267.45,-1969 267.45,-1963 273.45,-1957 279.45,-1957"/>
+<text text-anchor="middle" x="431.25" y="-2040.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">initConfig</text>
+</g>
+<g id="clust7" class="cluster">
+<title>cluster_src/extract</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M635.56,-677C635.56,-677 1850.16,-677 1850.16,-677 1856.16,-677 1862.16,-683 1862.16,-689 1862.16,-689 1862.16,-1398 1862.16,-1398 1862.16,-1404 1856.16,-1410 1850.16,-1410 1850.16,-1410 635.56,-1410 635.56,-1410 629.56,-1410 623.56,-1404 623.56,-1398 623.56,-1398 623.56,-689 623.56,-689 623.56,-683 629.56,-677 635.56,-677"/>
+<text text-anchor="middle" x="1242.86" y="-1398.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
+</g>
+<g id="clust8" class="cluster">
+<title>cluster_src/extract/ast&#45;extractors</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M879.63,-1057C879.63,-1057 1265.59,-1057 1265.59,-1057 1271.59,-1057 1277.59,-1063 1277.59,-1069 1277.59,-1069 1277.59,-1139 1277.59,-1139 1277.59,-1145 1271.59,-1151 1265.59,-1151 1265.59,-1151 879.63,-1151 879.63,-1151 873.63,-1151 867.63,-1145 867.63,-1139 867.63,-1139 867.63,-1069 867.63,-1069 867.63,-1063 873.63,-1057 879.63,-1057"/>
+<text text-anchor="middle" x="1072.61" y="-1139.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
+</g>
+<g id="clust9" class="cluster">
+<title>cluster_src/extract/derive</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M760.35,-1159C760.35,-1159 974.92,-1159 974.92,-1159 980.92,-1159 986.92,-1165 986.92,-1171 986.92,-1171 986.92,-1349 986.92,-1349 986.92,-1355 980.92,-1361 974.92,-1361 974.92,-1361 760.35,-1361 760.35,-1361 754.35,-1361 748.35,-1355 748.35,-1349 748.35,-1349 748.35,-1171 748.35,-1171 748.35,-1165 754.35,-1159 760.35,-1159"/>
+<text text-anchor="middle" x="867.63" y="-1349.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">derive</text>
+</g>
+<g id="clust10" class="cluster">
+<title>cluster_src/extract/derive/circular</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M768.35,-1285C768.35,-1285 959.66,-1285 959.66,-1285 965.66,-1285 971.66,-1291 971.66,-1297 971.66,-1297 971.66,-1324 971.66,-1324 971.66,-1330 965.66,-1336 959.66,-1336 959.66,-1336 768.35,-1336 768.35,-1336 762.35,-1336 756.35,-1330 756.35,-1324 756.35,-1324 756.35,-1297 756.35,-1297 756.35,-1291 762.35,-1285 768.35,-1285"/>
+<text text-anchor="middle" x="864.01" y="-1324.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">circular</text>
+</g>
+<g id="clust11" class="cluster">
+<title>cluster_src/extract/derive/orphan</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M768.35,-1226C768.35,-1226 960.41,-1226 960.41,-1226 966.41,-1226 972.41,-1232 972.41,-1238 972.41,-1238 972.41,-1265 972.41,-1265 972.41,-1271 966.41,-1277 960.41,-1277 960.41,-1277 768.35,-1277 768.35,-1277 762.35,-1277 756.35,-1271 756.35,-1265 756.35,-1265 756.35,-1238 756.35,-1238 756.35,-1232 762.35,-1226 768.35,-1226"/>
+<text text-anchor="middle" x="864.38" y="-1265.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">orphan</text>
+</g>
+<g id="clust12" class="cluster">
+<title>cluster_src/extract/derive/reachable</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M768.35,-1167C768.35,-1167 966.92,-1167 966.92,-1167 972.92,-1167 978.92,-1173 978.92,-1179 978.92,-1179 978.92,-1206 978.92,-1206 978.92,-1212 972.92,-1218 966.92,-1218 966.92,-1218 768.35,-1218 768.35,-1218 762.35,-1218 756.35,-1212 756.35,-1206 756.35,-1206 756.35,-1179 756.35,-1179 756.35,-1173 762.35,-1167 768.35,-1167"/>
+<text text-anchor="middle" x="867.63" y="-1206.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">reachable</text>
+</g>
+<g id="clust13" class="cluster">
+<title>cluster_src/extract/parse</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M892.63,-949C892.63,-949 974.66,-949 974.66,-949 980.66,-949 986.66,-955 986.66,-961 986.66,-961 986.66,-1017 986.66,-1017 986.66,-1023 980.66,-1029 974.66,-1029 974.66,-1029 892.63,-1029 892.63,-1029 886.63,-1029 880.63,-1023 880.63,-1017 880.63,-1017 880.63,-961 880.63,-961 880.63,-955 886.63,-949 892.63,-949"/>
+<text text-anchor="middle" x="933.65" y="-1017.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">parse</text>
+</g>
+<g id="clust14" class="cluster">
+<title>cluster_src/extract/resolve</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M910.65,-715C910.65,-715 1613.59,-715 1613.59,-715 1619.59,-715 1625.59,-721 1625.59,-727 1625.59,-727 1625.59,-929 1625.59,-929 1625.59,-935 1619.59,-941 1613.59,-941 1613.59,-941 910.65,-941 910.65,-941 904.65,-941 898.65,-935 898.65,-929 898.65,-929 898.65,-727 898.65,-727 898.65,-721 904.65,-715 910.65,-715"/>
+<text text-anchor="middle" x="1262.12" y="-929.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
+</g>
+<g id="clust15" class="cluster">
+<title>cluster_src/extract/resolve/readPackageDeps</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1205.33,-723C1205.33,-723 1449.27,-723 1449.27,-723 1455.27,-723 1461.27,-729 1461.27,-735 1461.27,-735 1461.27,-762 1461.27,-762 1461.27,-768 1455.27,-774 1449.27,-774 1449.27,-774 1205.33,-774 1205.33,-774 1199.33,-774 1193.33,-768 1193.33,-762 1193.33,-762 1193.33,-735 1193.33,-735 1193.33,-729 1199.33,-723 1205.33,-723"/>
+<text text-anchor="middle" x="1327.3" y="-762.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">readPackageDeps</text>
+</g>
+<g id="clust16" class="cluster">
+<title>cluster_src/extract/transpile</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1042.93,-1218C1042.93,-1218 1447.44,-1218 1447.44,-1218 1453.44,-1218 1459.44,-1224 1459.44,-1230 1459.44,-1230 1459.44,-1373 1459.44,-1373 1459.44,-1379 1453.44,-1385 1447.44,-1385 1447.44,-1385 1042.93,-1385 1042.93,-1385 1036.93,-1385 1030.93,-1379 1030.93,-1373 1030.93,-1373 1030.93,-1230 1030.93,-1230 1030.93,-1224 1036.93,-1218 1042.93,-1218"/>
+<text text-anchor="middle" x="1245.18" y="-1373.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
+</g>
+<g id="clust17" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1645.59,-903C1645.59,-903 1842.16,-903 1842.16,-903 1848.16,-903 1854.16,-909 1854.16,-915 1854.16,-915 1854.16,-1029 1854.16,-1029 1854.16,-1035 1848.16,-1041 1842.16,-1041 1842.16,-1041 1645.59,-1041 1645.59,-1041 1639.59,-1041 1633.59,-1035 1633.59,-1029 1633.59,-1029 1633.59,-915 1633.59,-915 1633.59,-909 1639.59,-903 1645.59,-903"/>
+<text text-anchor="middle" x="1743.87" y="-1029.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
 <g id="clust18" class="cluster">
 <title>cluster_src/main</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M516.53,-1530C516.53,-1530 970.92,-1530 970.92,-1530 976.92,-1530 982.92,-1536 982.92,-1542 982.92,-1542 982.92,-1773 982.92,-1773 982.92,-1779 976.92,-1785 970.92,-1785 970.92,-1785 516.53,-1785 516.53,-1785 510.53,-1785 504.53,-1779 504.53,-1773 504.53,-1773 504.53,-1542 504.53,-1542 504.53,-1536 510.53,-1530 516.53,-1530"/>
@@ -124,81 +199,6 @@
 <title>cluster_src/validate</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M910.65,-26C910.65,-26 1273.35,-26 1273.35,-26 1279.35,-26 1285.35,-32 1285.35,-38 1285.35,-38 1285.35,-94 1285.35,-94 1285.35,-100 1279.35,-106 1273.35,-106 1273.35,-106 910.65,-106 910.65,-106 904.65,-106 898.65,-100 898.65,-94 898.65,-94 898.65,-38 898.65,-38 898.65,-32 904.65,-26 910.65,-26"/>
 <text text-anchor="middle" x="1092" y="-94.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">validate</text>
-</g>
-<g id="clust3" class="cluster">
-<title>cluster_src/cli</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M153.05,-1793C153.05,-1793 703.07,-1793 703.07,-1793 709.07,-1793 715.07,-1799 715.07,-1805 715.07,-1805 715.07,-2065 715.07,-2065 715.07,-2071 709.07,-2077 703.07,-2077 703.07,-2077 153.05,-2077 153.05,-2077 147.05,-2077 141.05,-2071 141.05,-2065 141.05,-2065 141.05,-1805 141.05,-1805 141.05,-1799 147.05,-1793 153.05,-1793"/>
-<text text-anchor="middle" x="428.06" y="-2065.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
-</g>
-<g id="clust4" class="cluster">
-<title>cluster_src/cli/compileConfig</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M516.53,-1801C516.53,-1801 695.07,-1801 695.07,-1801 701.07,-1801 707.07,-1807 707.07,-1813 707.07,-1813 707.07,-1869 707.07,-1869 707.07,-1875 701.07,-1881 695.07,-1881 695.07,-1881 516.53,-1881 516.53,-1881 510.53,-1881 504.53,-1875 504.53,-1869 504.53,-1869 504.53,-1813 504.53,-1813 504.53,-1807 510.53,-1801 516.53,-1801"/>
-<text text-anchor="middle" x="605.8" y="-1869.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compileConfig</text>
-</g>
-<g id="clust5" class="cluster">
-<title>cluster_src/cli/initConfig</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M279.45,-1957C279.45,-1957 583.05,-1957 583.05,-1957 589.05,-1957 595.05,-1963 595.05,-1969 595.05,-1969 595.05,-2040 595.05,-2040 595.05,-2046 589.05,-2052 583.05,-2052 583.05,-2052 279.45,-2052 279.45,-2052 273.45,-2052 267.45,-2046 267.45,-2040 267.45,-2040 267.45,-1969 267.45,-1969 267.45,-1963 273.45,-1957 279.45,-1957"/>
-<text text-anchor="middle" x="431.25" y="-2040.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">initConfig</text>
-</g>
-<g id="clust6" class="cluster">
-<title>cluster_src/cli/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M370.47,-1804C370.47,-1804 472.01,-1804 472.01,-1804 478.01,-1804 484.01,-1810 484.01,-1816 484.01,-1816 484.01,-1901 484.01,-1901 484.01,-1907 478.01,-1913 472.01,-1913 472.01,-1913 370.47,-1913 370.47,-1913 364.47,-1913 358.47,-1907 358.47,-1901 358.47,-1901 358.47,-1816 358.47,-1816 358.47,-1810 364.47,-1804 370.47,-1804"/>
-<text text-anchor="middle" x="421.24" y="-1901.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust7" class="cluster">
-<title>cluster_src/extract</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M635.56,-677C635.56,-677 1850.16,-677 1850.16,-677 1856.16,-677 1862.16,-683 1862.16,-689 1862.16,-689 1862.16,-1398 1862.16,-1398 1862.16,-1404 1856.16,-1410 1850.16,-1410 1850.16,-1410 635.56,-1410 635.56,-1410 629.56,-1410 623.56,-1404 623.56,-1398 623.56,-1398 623.56,-689 623.56,-689 623.56,-683 629.56,-677 635.56,-677"/>
-<text text-anchor="middle" x="1242.86" y="-1398.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
-</g>
-<g id="clust16" class="cluster">
-<title>cluster_src/extract/transpile</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1042.93,-1218C1042.93,-1218 1447.44,-1218 1447.44,-1218 1453.44,-1218 1459.44,-1224 1459.44,-1230 1459.44,-1230 1459.44,-1373 1459.44,-1373 1459.44,-1379 1453.44,-1385 1447.44,-1385 1447.44,-1385 1042.93,-1385 1042.93,-1385 1036.93,-1385 1030.93,-1379 1030.93,-1373 1030.93,-1373 1030.93,-1230 1030.93,-1230 1030.93,-1224 1036.93,-1218 1042.93,-1218"/>
-<text text-anchor="middle" x="1245.18" y="-1373.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
-</g>
-<g id="clust17" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1645.59,-903C1645.59,-903 1842.16,-903 1842.16,-903 1848.16,-903 1854.16,-909 1854.16,-915 1854.16,-915 1854.16,-1029 1854.16,-1029 1854.16,-1035 1848.16,-1041 1842.16,-1041 1842.16,-1041 1645.59,-1041 1645.59,-1041 1639.59,-1041 1633.59,-1035 1633.59,-1029 1633.59,-1029 1633.59,-915 1633.59,-915 1633.59,-909 1639.59,-903 1645.59,-903"/>
-<text text-anchor="middle" x="1743.87" y="-1029.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust8" class="cluster">
-<title>cluster_src/extract/ast&#45;extractors</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M879.63,-1057C879.63,-1057 1265.59,-1057 1265.59,-1057 1271.59,-1057 1277.59,-1063 1277.59,-1069 1277.59,-1069 1277.59,-1139 1277.59,-1139 1277.59,-1145 1271.59,-1151 1265.59,-1151 1265.59,-1151 879.63,-1151 879.63,-1151 873.63,-1151 867.63,-1145 867.63,-1139 867.63,-1139 867.63,-1069 867.63,-1069 867.63,-1063 873.63,-1057 879.63,-1057"/>
-<text text-anchor="middle" x="1072.61" y="-1139.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
-</g>
-<g id="clust13" class="cluster">
-<title>cluster_src/extract/parse</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M892.63,-949C892.63,-949 974.66,-949 974.66,-949 980.66,-949 986.66,-955 986.66,-961 986.66,-961 986.66,-1017 986.66,-1017 986.66,-1023 980.66,-1029 974.66,-1029 974.66,-1029 892.63,-1029 892.63,-1029 886.63,-1029 880.63,-1023 880.63,-1017 880.63,-1017 880.63,-961 880.63,-961 880.63,-955 886.63,-949 892.63,-949"/>
-<text text-anchor="middle" x="933.65" y="-1017.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">parse</text>
-</g>
-<g id="clust9" class="cluster">
-<title>cluster_src/extract/derive</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M760.35,-1159C760.35,-1159 974.92,-1159 974.92,-1159 980.92,-1159 986.92,-1165 986.92,-1171 986.92,-1171 986.92,-1349 986.92,-1349 986.92,-1355 980.92,-1361 974.92,-1361 974.92,-1361 760.35,-1361 760.35,-1361 754.35,-1361 748.35,-1355 748.35,-1349 748.35,-1349 748.35,-1171 748.35,-1171 748.35,-1165 754.35,-1159 760.35,-1159"/>
-<text text-anchor="middle" x="867.63" y="-1349.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">derive</text>
-</g>
-<g id="clust11" class="cluster">
-<title>cluster_src/extract/derive/orphan</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M768.35,-1285C768.35,-1285 960.41,-1285 960.41,-1285 966.41,-1285 972.41,-1291 972.41,-1297 972.41,-1297 972.41,-1324 972.41,-1324 972.41,-1330 966.41,-1336 960.41,-1336 960.41,-1336 768.35,-1336 768.35,-1336 762.35,-1336 756.35,-1330 756.35,-1324 756.35,-1324 756.35,-1297 756.35,-1297 756.35,-1291 762.35,-1285 768.35,-1285"/>
-<text text-anchor="middle" x="864.38" y="-1324.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">orphan</text>
-</g>
-<g id="clust12" class="cluster">
-<title>cluster_src/extract/derive/reachable</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M768.35,-1167C768.35,-1167 966.92,-1167 966.92,-1167 972.92,-1167 978.92,-1173 978.92,-1179 978.92,-1179 978.92,-1206 978.92,-1206 978.92,-1212 972.92,-1218 966.92,-1218 966.92,-1218 768.35,-1218 768.35,-1218 762.35,-1218 756.35,-1212 756.35,-1206 756.35,-1206 756.35,-1179 756.35,-1179 756.35,-1173 762.35,-1167 768.35,-1167"/>
-<text text-anchor="middle" x="867.63" y="-1206.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">reachable</text>
-</g>
-<g id="clust10" class="cluster">
-<title>cluster_src/extract/derive/circular</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M768.35,-1226C768.35,-1226 959.66,-1226 959.66,-1226 965.66,-1226 971.66,-1232 971.66,-1238 971.66,-1238 971.66,-1265 971.66,-1265 971.66,-1271 965.66,-1277 959.66,-1277 959.66,-1277 768.35,-1277 768.35,-1277 762.35,-1277 756.35,-1271 756.35,-1265 756.35,-1265 756.35,-1238 756.35,-1238 756.35,-1232 762.35,-1226 768.35,-1226"/>
-<text text-anchor="middle" x="864.01" y="-1265.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">circular</text>
-</g>
-<g id="clust14" class="cluster">
-<title>cluster_src/extract/resolve</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M910.65,-715C910.65,-715 1613.59,-715 1613.59,-715 1619.59,-715 1625.59,-721 1625.59,-727 1625.59,-727 1625.59,-929 1625.59,-929 1625.59,-935 1619.59,-941 1613.59,-941 1613.59,-941 910.65,-941 910.65,-941 904.65,-941 898.65,-935 898.65,-929 898.65,-929 898.65,-727 898.65,-727 898.65,-721 904.65,-715 910.65,-715"/>
-<text text-anchor="middle" x="1262.12" y="-929.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
-</g>
-<g id="clust15" class="cluster">
-<title>cluster_src/extract/resolve/readPackageDeps</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1205.33,-723C1205.33,-723 1449.27,-723 1449.27,-723 1455.27,-723 1461.27,-729 1461.27,-735 1461.27,-735 1461.27,-762 1461.27,-762 1461.27,-768 1455.27,-774 1449.27,-774 1449.27,-774 1205.33,-774 1205.33,-774 1199.33,-774 1193.33,-768 1193.33,-762 1193.33,-762 1193.33,-735 1193.33,-735 1193.33,-729 1199.33,-723 1205.33,-723"/>
-<text text-anchor="middle" x="1327.3" y="-762.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">readPackageDeps</text>
 </g>
 <!-- bin/depcruise&#45;fmt.js -->
 <g id="node1" class="node">
@@ -1144,8 +1144,8 @@
 <g id="node39" class="node">
 <title>src/extract/derive/circular/getCycle.js</title>
 <g id="a_node39"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/circular/getCycle.js" xlink:title="getCycle.js">
-<path fill="#ccffcc" stroke="black" d="M958,-1251.5C958,-1251.5 909.3,-1251.5 909.3,-1251.5 906.47,-1251.5 903.63,-1248.67 903.63,-1245.83 903.63,-1245.83 903.63,-1240.17 903.63,-1240.17 903.63,-1237.33 906.47,-1234.5 909.3,-1234.5 909.3,-1234.5 958,-1234.5 958,-1234.5 960.83,-1234.5 963.67,-1237.33 963.67,-1240.17 963.67,-1240.17 963.67,-1245.83 963.67,-1245.83 963.67,-1248.67 960.83,-1251.5 958,-1251.5"/>
-<text text-anchor="middle" x="933.65" y="-1240.3" font-family="Helvetica,sans-Serif" font-size="9.00">getCycle.js</text>
+<path fill="#ccffcc" stroke="black" d="M958,-1310.5C958,-1310.5 909.3,-1310.5 909.3,-1310.5 906.47,-1310.5 903.63,-1307.67 903.63,-1304.83 903.63,-1304.83 903.63,-1299.17 903.63,-1299.17 903.63,-1296.33 906.47,-1293.5 909.3,-1293.5 909.3,-1293.5 958,-1293.5 958,-1293.5 960.83,-1293.5 963.67,-1296.33 963.67,-1299.17 963.67,-1299.17 963.67,-1304.83 963.67,-1304.83 963.67,-1307.67 960.83,-1310.5 958,-1310.5"/>
+<text text-anchor="middle" x="933.65" y="-1299.3" font-family="Helvetica,sans-Serif" font-size="9.00">getCycle.js</text>
 </a>
 </g>
 </g>
@@ -1153,23 +1153,23 @@
 <g id="node40" class="node">
 <title>src/extract/derive/circular/index.js</title>
 <g id="a_node40"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/circular/index.js" xlink:title="index.js">
-<path fill="#ccffcc" stroke="black" d="M812.69,-1251.5C812.69,-1251.5 770.02,-1251.5 770.02,-1251.5 767.19,-1251.5 764.35,-1248.67 764.35,-1245.83 764.35,-1245.83 764.35,-1240.17 764.35,-1240.17 764.35,-1237.33 767.19,-1234.5 770.02,-1234.5 770.02,-1234.5 812.69,-1234.5 812.69,-1234.5 815.52,-1234.5 818.35,-1237.33 818.35,-1240.17 818.35,-1240.17 818.35,-1245.83 818.35,-1245.83 818.35,-1248.67 815.52,-1251.5 812.69,-1251.5"/>
-<text text-anchor="middle" x="791.35" y="-1240.3" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
+<path fill="#ccffcc" stroke="black" d="M812.69,-1310.5C812.69,-1310.5 770.02,-1310.5 770.02,-1310.5 767.19,-1310.5 764.35,-1307.67 764.35,-1304.83 764.35,-1304.83 764.35,-1299.17 764.35,-1299.17 764.35,-1296.33 767.19,-1293.5 770.02,-1293.5 770.02,-1293.5 812.69,-1293.5 812.69,-1293.5 815.52,-1293.5 818.35,-1296.33 818.35,-1299.17 818.35,-1299.17 818.35,-1304.83 818.35,-1304.83 818.35,-1307.67 815.52,-1310.5 812.69,-1310.5"/>
+<text text-anchor="middle" x="791.35" y="-1299.3" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/derive/circular/index.js&#45;&gt;src/extract/derive/circular/getCycle.js -->
 <g id="edge45" class="edge">
 <title>src/extract/derive/circular/index.js&#45;&gt;src/extract/derive/circular/getCycle.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818.45,-1243C818.45,-1243 897.45,-1243 897.45,-1243"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="897.45,-1245.1 903.45,-1243 897.45,-1240.9 897.45,-1245.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818.45,-1302C818.45,-1302 897.45,-1302 897.45,-1302"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="897.45,-1304.1 903.45,-1302 897.45,-1299.9 897.45,-1304.1"/>
 </g>
 <!-- src/extract/derive/orphan/index.js -->
 <g id="node41" class="node">
 <title>src/extract/derive/orphan/index.js</title>
 <g id="a_node41"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/orphan/index.js" xlink:title="index.js">
-<path fill="#ccffcc" stroke="black" d="M812.69,-1310.5C812.69,-1310.5 770.02,-1310.5 770.02,-1310.5 767.19,-1310.5 764.35,-1307.67 764.35,-1304.83 764.35,-1304.83 764.35,-1299.17 764.35,-1299.17 764.35,-1296.33 767.19,-1293.5 770.02,-1293.5 770.02,-1293.5 812.69,-1293.5 812.69,-1293.5 815.52,-1293.5 818.35,-1296.33 818.35,-1299.17 818.35,-1299.17 818.35,-1304.83 818.35,-1304.83 818.35,-1307.67 815.52,-1310.5 812.69,-1310.5"/>
-<text text-anchor="middle" x="791.35" y="-1299.3" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
+<path fill="#ccffcc" stroke="black" d="M812.69,-1251.5C812.69,-1251.5 770.02,-1251.5 770.02,-1251.5 767.19,-1251.5 764.35,-1248.67 764.35,-1245.83 764.35,-1245.83 764.35,-1240.17 764.35,-1240.17 764.35,-1237.33 767.19,-1234.5 770.02,-1234.5 770.02,-1234.5 812.69,-1234.5 812.69,-1234.5 815.52,-1234.5 818.35,-1237.33 818.35,-1240.17 818.35,-1240.17 818.35,-1245.83 818.35,-1245.83 818.35,-1248.67 815.52,-1251.5 812.69,-1251.5"/>
+<text text-anchor="middle" x="791.35" y="-1240.3" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
 </a>
 </g>
 </g>
@@ -1177,16 +1177,16 @@
 <g id="node42" class="node">
 <title>src/extract/derive/orphan/isOrphan.js</title>
 <g id="a_node42"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/derive/orphan/isOrphan.js" xlink:title="isOrphan.js">
-<path fill="#ccffcc" stroke="black" d="M958.5,-1310.5C958.5,-1310.5 908.8,-1310.5 908.8,-1310.5 905.96,-1310.5 903.13,-1307.67 903.13,-1304.83 903.13,-1304.83 903.13,-1299.17 903.13,-1299.17 903.13,-1296.33 905.96,-1293.5 908.8,-1293.5 908.8,-1293.5 958.5,-1293.5 958.5,-1293.5 961.34,-1293.5 964.17,-1296.33 964.17,-1299.17 964.17,-1299.17 964.17,-1304.83 964.17,-1304.83 964.17,-1307.67 961.34,-1310.5 958.5,-1310.5"/>
-<text text-anchor="middle" x="933.65" y="-1299.3" font-family="Helvetica,sans-Serif" font-size="9.00">isOrphan.js</text>
+<path fill="#ccffcc" stroke="black" d="M958.5,-1251.5C958.5,-1251.5 908.8,-1251.5 908.8,-1251.5 905.96,-1251.5 903.13,-1248.67 903.13,-1245.83 903.13,-1245.83 903.13,-1240.17 903.13,-1240.17 903.13,-1237.33 905.96,-1234.5 908.8,-1234.5 908.8,-1234.5 958.5,-1234.5 958.5,-1234.5 961.34,-1234.5 964.17,-1237.33 964.17,-1240.17 964.17,-1240.17 964.17,-1245.83 964.17,-1245.83 964.17,-1248.67 961.34,-1251.5 958.5,-1251.5"/>
+<text text-anchor="middle" x="933.65" y="-1240.3" font-family="Helvetica,sans-Serif" font-size="9.00">isOrphan.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/derive/orphan/index.js&#45;&gt;src/extract/derive/orphan/isOrphan.js -->
 <g id="edge46" class="edge">
 <title>src/extract/derive/orphan/index.js&#45;&gt;src/extract/derive/orphan/isOrphan.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818.45,-1302C818.45,-1302 896.95,-1302 896.95,-1302"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="896.95,-1304.1 902.95,-1302 896.95,-1299.9 896.95,-1304.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818.45,-1243C818.45,-1243 896.95,-1243 896.95,-1243"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="896.95,-1245.1 902.95,-1243 896.95,-1240.9 896.95,-1245.1"/>
 </g>
 <!-- src/extract/derive/reachable/index.js -->
 <g id="node43" class="node">
@@ -1446,20 +1446,20 @@
 <!-- src/extract/index.js&#45;&gt;src/extract/clearCaches.js -->
 <g id="edge60" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/clearCaches.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M685.78,-1210.17C715.58,-1210.17 759.16,-1210.17 759.16,-1210.17 759.16,-1210.17 759.16,-922.72 759.16,-922.72"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="761.26,-922.72 759.16,-916.72 757.06,-922.72 761.26,-922.72"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M685.78,-1208.75C715.58,-1208.75 759.16,-1208.75 759.16,-1208.75 759.16,-1208.75 759.16,-922.68 759.16,-922.68"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="761.26,-922.68 759.16,-916.68 757.06,-922.68 761.26,-922.68"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/derive/circular/index.js -->
 <g id="edge61" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/derive/circular/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M668.16,-1221.52C668.16,-1230.39 668.16,-1243 668.16,-1243 668.16,-1243 758.32,-1243 758.32,-1243"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="758.32,-1245.1 764.32,-1243 758.32,-1240.9 758.32,-1245.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M659.16,-1221.53C659.16,-1243.81 659.16,-1302 659.16,-1302 659.16,-1302 758.28,-1302 758.28,-1302"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="758.28,-1304.1 764.28,-1302 758.28,-1299.9 758.28,-1304.1"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/derive/orphan/index.js -->
 <g id="edge62" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/derive/orphan/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M650.16,-1221.53C650.16,-1243.81 650.16,-1302 650.16,-1302 650.16,-1302 758.13,-1302 758.13,-1302"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="758.13,-1304.1 764.13,-1302 758.13,-1299.9 758.13,-1304.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M685.6,-1217.25C724.63,-1217.25 792.16,-1217.25 792.16,-1217.25 792.16,-1217.25 792.16,-1228.28 792.16,-1228.28"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="790.06,-1228.28 792.16,-1234.28 794.26,-1228.28 790.06,-1228.28"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/derive/reachable/index.js -->
 <g id="edge63" class="edge">
@@ -1476,8 +1476,8 @@
 <!-- src/extract/index.js&#45;&gt;src/extract/gatherInitialSources.js -->
 <g id="edge65" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/gatherInitialSources.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M685.66,-1215.83C770.79,-1215.83 1027.16,-1215.83 1027.16,-1215.83 1027.16,-1215.83 1027.16,-1201.81 1027.16,-1201.81"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1029.26,-1201.81 1027.16,-1195.81 1025.06,-1201.81 1029.26,-1201.81"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M685.66,-1213C770.79,-1213 1027.16,-1213 1027.16,-1213 1027.16,-1213 1027.16,-1201.51 1027.16,-1201.51"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1029.26,-1201.51 1027.16,-1195.51 1025.06,-1201.51 1029.26,-1201.51"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/utl/pathToPosix.js -->
 <g id="edge67" class="edge">
@@ -2067,8 +2067,8 @@
 <!-- src/validate/matchDependencyRule.js&#45;&gt;src/validate/isModuleOnlyRule.js -->
 <g id="edge152" class="edge">
 <title>src/validate/matchDependencyRule.js&#45;&gt;src/validate/isModuleOnlyRule.js</title>
-<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1120.16,-63.46C1120.16,-54.9 1120.16,-43 1120.16,-43 1120.16,-43 1173.31,-43 1173.31,-43"/>
-<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1173.31,-45.1 1179.31,-43 1173.31,-40.9 1173.31,-45.1"/>
+<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1120.16,-63.34C1120.16,-56.21 1120.16,-47.25 1120.16,-47.25 1120.16,-47.25 1173.31,-47.25 1173.31,-47.25"/>
+<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1173.31,-49.35 1179.31,-47.25 1173.31,-45.15 1173.31,-49.35"/>
 </g>
 <!-- src/validate/matches.js -->
 <g id="node107" class="node">
@@ -2094,7 +2094,7 @@
 <!-- src/validate/matchModuleRule.js&#45;&gt;src/validate/matches.js -->
 <g id="edge155" class="edge">
 <title>src/validate/matchModuleRule.js&#45;&gt;src/validate/matches.js</title>
-<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1114.51,-47.25C1127.57,-47.25 1138.16,-47.25 1138.16,-47.25 1138.16,-47.25 1138.16,-69.17 1138.16,-69.17 1138.16,-69.17 1192.8,-69.17 1192.8,-69.17"/>
+<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1114.51,-43C1127.57,-43 1138.16,-43 1138.16,-43 1138.16,-43 1138.16,-69.17 1138.16,-69.17 1138.16,-69.17 1192.8,-69.17 1192.8,-69.17"/>
 <polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1192.8,-71.27 1198.8,-69.17 1192.8,-67.07 1192.8,-71.27"/>
 </g>
 <!-- src/validate/matches.js&#45;&gt;src/utl/arrayUtil.js -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "6.3.0",
+  "version": "7.0.0-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/extract/resolve/isFollowable.js
+++ b/src/extract/resolve/isFollowable.js
@@ -18,6 +18,7 @@ function initFollowableExtensions(pResolveOptions) {
   // will result in false positives.
   const KNOWN_UNFOLLOWABLES = [
     ".json",
+    ".node",
     ".css",
     ".sass",
     ".scss",

--- a/src/main/resolveOptions/normalize.js
+++ b/src/main/resolveOptions/normalize.js
@@ -63,14 +63,12 @@ function compileResolveOptions(pResolveOptions, pTSConfig) {
       lResolveOptions.plugins,
       new TsConfigPathsPlugin({
         configFile: pResolveOptions.tsConfig,
-        // different from the typescript compiler, tsConfigPathsPlugin
-        // only has .ts and .tsx as default extension to scan given
-        // an import/ require/ export argument.
-        // Added .js, .jsx and .d.ts before .ts and .tsx to mirror
-        // the typescript compiler's behavior
-        // Should probably be fixed upstream, but put in here until
-        // that happens.
-        extensions: [".js", ".json", ".jsx", ".d.ts", ".ts", ".tsx"]
+        // TsConfigPathsPlugin doesn't (can't) read enhanced-resolve's
+        // list of extensions, and the default it uses for extensions
+        // so we do it ourselves - either with the extensions passed
+        // or with the supported ones.
+        extensions:
+          pResolveOptions.extensions || DEFAULT_RESOLVE_OPTIONS.extensions
       })
     );
   }

--- a/test/extract/resolve/index.spec.js
+++ b/test/extract/resolve/index.spec.js
@@ -329,7 +329,7 @@ describe("extract/resolve/index", () => {
       dependencyTypes: ["aliased"],
       followable: true,
       resolved:
-        "ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.d.ts"
+        "ts-config-with-path-correct-resolution-prio/src/aliassed/dts-before-ts.ts"
     });
   });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Use the same `extensions` array as passed to `enhanced-resolve` for the ts config alias/ path plugin (instead of a hard-coded list).

## Motivation and Context
Using the extensions passed to the webpack config/ the extensions dc supports with current settings makes for more flexibility (just pass it once in the webpack config) and consistency (dc will _exactly_ the same resolution extensions whether the dependency is included directly or via an aliasing mechanism).

This expands upon #243.

## How Has This Been Tested?
- [x] automated non-regression tests


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:
  - My change doesn't require a change to the documentation, or ...
  - it does and I have updated it

- [x] ⚖️
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).


