### PR TITLE
feature(report): err-html: click on rule = navigate to details

### DIFF
--- a/src/report/err-html/err-html.template.hbs
+++ b/src/report/err-html/err-html.template.hbs
@@ -1,201 +1,244 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <title>dependency-cruiser - results</title>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-        <style type="text/css">
-            body{
-                font-family:sans-serif;
-                margin:0 auto;
-                max-width:90%;
-                line-height:1.6;
-                font-size:14px;
-                color:#444;
-                padding:0 10px;
-                background-color:#fff;
-            }
-            footer{
-                color: gray;
-                margin-top: 1.4em;
-                border-top: solid 1px currentColor
-            }
-            a {
-                text-decoration: none
-            }
-            a.noiseless {
-                color: currentColor
-            }
-            h1,h2,h3{
-                line-height:1.2
-            }
-            table {
-                border-collapse: collapse;
-                width: 100%;
-            }
-            th, td {
-                text-align: left;
-                padding: 4px;
-            }
-            tbody tr:nth-child(odd){
-                background-color: rgba(128,128,128,0.2);
-            }
-            .error {
-                color: red;
-            }
-            .warn {
-                color: orange;
-            }
-            .info {
-                color: blue;
-            }
-            .ok {
-                color: limegreen;
-            }
-            td.nowrap {
-                white-space: nowrap
-            }
-            svg{
-                fill:currentColor
-            }
-            #show-unviolated {
-                display: block
-                
-            }
-            #hide-unviolated {
-                display: none
-            }
-            #show-all-the-rules:target #show-unviolated{
-                display: none
-            }
-            #show-all-the-rules:target #hide-unviolated{
-                display: block
-            }
-            tr.unviolated {
-                display: none
-            }
-            #show-all-the-rules:target tr.unviolated {
-                display: table-row;
-                color: gray;
-            }
-            .p__svg--inline{
-                vertical-align: top;
-                width: 1.2em;
-                height: 1.2em
-            }
-            .controls {
-                background-color: #fff;
-                vertical-align: bottom;
-                text-align: center
-            }
-            .controls:hover {
-                opacity: 1;
-            }
-            .controls a {
-                text-decoration: none;
-                color: gray;
-            }
-            .controls a:hover {
-                text-decoration: underline;
-                color: blue;
-            }
-            .extra {
-                color: gray;
-            }
-        </style>
-        <style type="text/css" media="print">
-            th, td {
-                border: 1px solid #444;
-            }
-            .controls {
-                display: none
-            }
-        </style>
-    </head>
-    <body id="show-all-the-rules">
-        <h1>Forbidden dependency check - results</h1>
-        <h2><svg class="p__svg--inline" viewBox="0 0 14 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0v2h3.6l.9-1.8.9 5.4L9 8.5l1.6 1.5H14V8h-2.5z"></path></svg> Summary</h2>
-        <p>
-            <div style="float:left;padding-right:20px">
-                <strong>{{summary.totalCruised}}</strong> modules
-            </div>
-            <div style="float:left;padding-right:20px">
-                <strong>{{summary.totalDependenciesCruised}}</strong> dependencies
-            </div>
-            <div style="float:left;padding-right:20px">
-                <strong>{{summary.error}}</strong> errors
-            </div>
-            <div style="float:left;padding-right:20px">
-                <strong>{{summary.warn}}</strong> warnings
-            </div>
-            <div style="float:left;padding-right:20px">
-                <strong>{{summary.info}}</strong> informational
-            </div>
-            &nbsp;
-        </p>
-        <table>
-            <tbody>
-                <thead>
-                    <tr>
-                        <th></th>
-                        <th>severity</th>
-                        <th>rule</th>
-                        <th>#&nbsp;violations</th>
-                        <th>explanation</th>
-                    </tr>
-                </thead>
-                {{#summary.agggregateViolations}}
-                <tr {{#if unviolated}}class="unviolated"{{/if}}>
-                    <td>{{#if unviolated}}<span class="ok">&check;</span>{{else}}<span class="{{severity}}">&cross;</span>{{/if}}</td>
-                    <td class={{#if unviolated}}"{{ok}}"{{else}}"{{severity}}"{{/if}}>{{severity}}</td>
-                    <td class="nowrap"><a id="{{name}}" class="noiseless">{{name}}</a></td>
-                    <td><strong>{{count}}</strong></td>
-                    <td>{{comment}}</td>
-                </tr>
-                {{/summary.agggregateViolations}}
-                <tr>
-                    <td colspan="5" class="controls">
-                        <div id="show-unviolated">
-                            &downarrow; <a href="#show-all-the-rules">also show unviolated rules</a>
-                        </div>
-                        <div id="hide-unviolated">
-                            &uparrow; <a href="">hide unviolated rules</a>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
 
-        {{#if summary.violations}}
-        <h2><svg class="p__svg--inline" viewBox="0 0 12 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"></path></svg> All violations</h2>
-        <table>
+<head>
+    <title>dependency-cruiser - results</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style type="text/css">
+        body {
+            font-family: sans-serif;
+            margin: 0 auto;
+            max-width: 90%;
+            line-height: 1.6;
+            font-size: 14px;
+            color: #444;
+            padding: 0 10px;
+            background-color: #fff;
+        }
+
+        footer {
+            color: gray;
+            margin-top: 1.4em;
+            border-top: solid 1px currentColor
+        }
+
+        a {
+            text-decoration: none
+        }
+
+        a.noiseless {
+            color: currentColor
+        }
+
+        h1,
+        h2,
+        h3 {
+            line-height: 1.2
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th,
+        td {
+            text-align: left;
+            padding: 4px;
+        }
+
+        tbody tr:nth-child(odd) {
+            background-color: rgba(128, 128, 128, 0.2);
+        }
+
+        .error {
+            color: red;
+        }
+
+        .warn {
+            color: orange;
+        }
+
+        .info {
+            color: blue;
+        }
+
+        .ok {
+            color: limegreen;
+        }
+
+        td.nowrap {
+            white-space: nowrap
+        }
+
+        svg {
+            fill: currentColor
+        }
+
+        #show-unviolated {
+            display: block
+        }
+
+        #hide-unviolated {
+            display: none
+        }
+
+        #show-all-the-rules:target #show-unviolated {
+            display: none
+        }
+
+        #show-all-the-rules:target #hide-unviolated {
+            display: block
+        }
+
+        tr.unviolated {
+            display: none
+        }
+
+        #show-all-the-rules:target tr.unviolated {
+            display: table-row;
+            color: gray;
+        }
+
+        .p__svg--inline {
+            vertical-align: top;
+            width: 1.2em;
+            height: 1.2em
+        }
+
+        .controls {
+            background-color: #fff;
+            vertical-align: bottom;
+            text-align: center
+        }
+
+        .controls:hover {
+            opacity: 1;
+        }
+
+        .controls a {
+            text-decoration: none;
+            color: gray;
+        }
+
+        .controls a:hover {
+            text-decoration: underline;
+            color: blue;
+        }
+
+        .extra {
+            color: gray;
+        }
+    </style>
+    <style type="text/css" media="print">
+        th,
+        td {
+            border: 1px solid #444;
+        }
+
+        .controls {
+            display: none
+        }
+    </style>
+</head>
+
+<body id="show-all-the-rules">
+    <h1>Forbidden dependency check - results</h1>
+    <h2><svg class="p__svg--inline" viewBox="0 0 14 16" version="1.1" aria-hidden="true">
+            <path fill-rule="evenodd"
+                d="M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0v2h3.6l.9-1.8.9 5.4L9 8.5l1.6 1.5H14V8h-2.5z"></path>
+        </svg> Summary</h2>
+    <p>
+        <div style="float:left;padding-right:20px">
+            <strong>{{summary.totalCruised}}</strong> modules
+        </div>
+        <div style="float:left;padding-right:20px">
+            <strong>{{summary.totalDependenciesCruised}}</strong> dependencies
+        </div>
+        <div style="float:left;padding-right:20px">
+            <strong>{{summary.error}}</strong> errors
+        </div>
+        <div style="float:left;padding-right:20px">
+            <strong>{{summary.warn}}</strong> warnings
+        </div>
+        <div style="float:left;padding-right:20px">
+            <strong>{{summary.info}}</strong> informational
+        </div>
+        &nbsp;
+    </p>
+    <table>
+        <tbody>
             <thead>
                 <tr>
+                    <th></th>
                     <th>severity</th>
                     <th>rule</th>
-                    <th>from</th>
-                    <th>to</th>
+                    <th>#&nbsp;violations</th>
+                    <th>explanation</th>
                 </tr>
             </thead>
-            <tbody>
-                {{#summary.violations}}
-                <tr>
-                    <td class="{{rule.severity}}">{{rule.severity}}</td>
-                    <td class="nowrap"><a href="#{{rule.name}}" class="noiseless">{{rule.name}}</a></td>
-                    <td><a href="{{../summary.optionsUsed.prefix}}{{from}}">{{from}}</a></td>
-                    <td>{{{to}}}</td>
-                    
-                </tr>
-                {{/summary.violations}}
-            </tbody>
-        </table>
-        {{else}}
-        <h2><span aria-hidden="true">&hearts;</span> No violations found</h2>
-        <p>Get gummy bears to celebrate.</p>
-        {{/if}}
-        <footer>
-            <p><a href="https://github.com/sverweij/dependency-cruiser">{{summary.depcruiseVersion}}</a> / {{summary.runDate}}</p>
-        </footer>
-    </body>
+            {{#summary.agggregateViolations}}
+            <tr {{#if unviolated}}class="unviolated" {{/if}}>
+                <td>{{#if unviolated}}<span class="ok">&check;</span>{{else}}<span
+                        class="{{severity}}">&cross;</span>{{/if}}</td>
+                <td class={{#if unviolated}}"{{ok}}"{{else}}"{{severity}}"{{/if}}>{{severity}}</td>
+                <td class="nowrap"><a href="#{{name}}-instance" id="{{name}}-definition" class="noiseless">{{name}}</a>
+                </td>
+                <td><strong>{{count}}</strong></td>
+                <td>{{comment}}</td>
+            </tr>
+            {{/summary.agggregateViolations}}
+            <tr>
+                <td colspan="5" class="controls">
+                    <div id="show-unviolated">
+                        &downarrow; <a href="#show-all-the-rules">also show unviolated rules</a>
+                    </div>
+                    <div id="hide-unviolated">
+                        &uparrow; <a href="">hide unviolated rules</a>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    {{#if summary.violations}}
+    <h2><svg class="p__svg--inline" viewBox="0 0 12 16" version="1.1" aria-hidden="true">
+            <path fill-rule="evenodd"
+                d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z">
+            </path>
+        </svg> All violations</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>severity</th>
+                <th>rule</th>
+                <th>from</th>
+                <th>to</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#summary.violations}}
+            <tr>
+                <td class="{{rule.severity}}">{{rule.severity}}</td>
+                <td class="nowrap"><a href="#{{rule.name}}-definition" id="{{rule.name}}-instance"
+                        class="noiseless">{{rule.name}}</a></td>
+                <td><a href="{{../summary.optionsUsed.prefix}}{{from}}">{{from}}</a></td>
+                <td>{{{to}}}</td>
+
+            </tr>
+            {{/summary.violations}}
+        </tbody>
+    </table>
+    {{else}}
+    <h2><span aria-hidden="true">&hearts;</span> No violations found</h2>
+    <p>Get gummy bears to celebrate.</p>
+    {{/if}}
+    <footer>
+        <p><a href="https://github.com/sverweij/dependency-cruiser">{{summary.depcruiseVersion}}</a> /
+            {{summary.runDate}}</p>
+    </footer>
+</body>
+
 </html>

--- a/src/report/err-html/err-html.template.js
+++ b/src/report/err-html/err-html.template.js
@@ -7,25 +7,27 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
         return undefined
     };
 
-  return "                <tr "
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"unviolated") : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":149,"column":20},"end":{"line":149,"column":63}}})) != null ? stack1 : "")
-    + ">\n                    <td>"
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"unviolated") : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data,"loc":{"start":{"line":150,"column":24},"end":{"line":150,"column":129}}})) != null ? stack1 : "")
-    + "</td>\n                    <td class="
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"unviolated") : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0),"inverse":container.program(10, data, 0),"data":data,"loc":{"start":{"line":151,"column":30},"end":{"line":151,"column":85}}})) != null ? stack1 : "")
+  return "            <tr "
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"unviolated") : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":183,"column":16},"end":{"line":183,"column":60}}})) != null ? stack1 : "")
+    + ">\n                <td>"
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"unviolated") : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data,"loc":{"start":{"line":184,"column":20},"end":{"line":185,"column":66}}})) != null ? stack1 : "")
+    + "</td>\n                <td class="
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"unviolated") : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0),"inverse":container.program(10, data, 0),"data":data,"loc":{"start":{"line":186,"column":26},"end":{"line":186,"column":81}}})) != null ? stack1 : "")
     + ">"
-    + alias4(((helper = (helper = lookupProperty(helpers,"severity") || (depth0 != null ? lookupProperty(depth0,"severity") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"severity","hash":{},"data":data,"loc":{"start":{"line":151,"column":86},"end":{"line":151,"column":98}}}) : helper)))
-    + "</td>\n                    <td class=\"nowrap\"><a id=\""
-    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":152,"column":46},"end":{"line":152,"column":54}}}) : helper)))
-    + "\" class=\"noiseless\">"
-    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":152,"column":74},"end":{"line":152,"column":82}}}) : helper)))
-    + "</a></td>\n                    <td><strong>"
-    + alias4(((helper = (helper = lookupProperty(helpers,"count") || (depth0 != null ? lookupProperty(depth0,"count") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"count","hash":{},"data":data,"loc":{"start":{"line":153,"column":32},"end":{"line":153,"column":41}}}) : helper)))
-    + "</strong></td>\n                    <td>"
-    + alias4(((helper = (helper = lookupProperty(helpers,"comment") || (depth0 != null ? lookupProperty(depth0,"comment") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"comment","hash":{},"data":data,"loc":{"start":{"line":154,"column":24},"end":{"line":154,"column":35}}}) : helper)))
-    + "</td>\n                </tr>\n";
+    + alias4(((helper = (helper = lookupProperty(helpers,"severity") || (depth0 != null ? lookupProperty(depth0,"severity") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"severity","hash":{},"data":data,"loc":{"start":{"line":186,"column":82},"end":{"line":186,"column":94}}}) : helper)))
+    + "</td>\n                <td class=\"nowrap\"><a href=\"#"
+    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":187,"column":45},"end":{"line":187,"column":53}}}) : helper)))
+    + "-instance\" id=\""
+    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":187,"column":68},"end":{"line":187,"column":76}}}) : helper)))
+    + "-definition\" class=\"noiseless\">"
+    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":187,"column":107},"end":{"line":187,"column":115}}}) : helper)))
+    + "</a>\n                </td>\n                <td><strong>"
+    + alias4(((helper = (helper = lookupProperty(helpers,"count") || (depth0 != null ? lookupProperty(depth0,"count") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"count","hash":{},"data":data,"loc":{"start":{"line":189,"column":28},"end":{"line":189,"column":37}}}) : helper)))
+    + "</strong></td>\n                <td>"
+    + alias4(((helper = (helper = lookupProperty(helpers,"comment") || (depth0 != null ? lookupProperty(depth0,"comment") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"comment","hash":{},"data":data,"loc":{"start":{"line":190,"column":20},"end":{"line":190,"column":31}}}) : helper)))
+    + "</td>\n            </tr>\n";
 },"2":function(container,depth0,helpers,partials,data) {
-    return "class=\"unviolated\"";
+    return "class=\"unviolated\" ";
 },"4":function(container,depth0,helpers,partials,data) {
     return "<span class=\"ok\">&check;</span>";
 },"6":function(container,depth0,helpers,partials,data) {
@@ -36,8 +38,8 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
         return undefined
     };
 
-  return "<span class=\""
-    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"severity") || (depth0 != null ? lookupProperty(depth0,"severity") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"severity","hash":{},"data":data,"loc":{"start":{"line":150,"column":94},"end":{"line":150,"column":106}}}) : helper)))
+  return "<span\n                        class=\""
+    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"severity") || (depth0 != null ? lookupProperty(depth0,"severity") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"severity","hash":{},"data":data,"loc":{"start":{"line":185,"column":31},"end":{"line":185,"column":43}}}) : helper)))
     + "\">&cross;</span>";
 },"8":function(container,depth0,helpers,partials,data) {
     var helper, lookupProperty = container.lookupProperty || function(parent, propertyName) {
@@ -48,7 +50,7 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
     };
 
   return "\""
-    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"ok") || (depth0 != null ? lookupProperty(depth0,"ok") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"ok","hash":{},"data":data,"loc":{"start":{"line":151,"column":49},"end":{"line":151,"column":55}}}) : helper)))
+    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"ok") || (depth0 != null ? lookupProperty(depth0,"ok") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"ok","hash":{},"data":data,"loc":{"start":{"line":186,"column":45},"end":{"line":186,"column":51}}}) : helper)))
     + "\"";
 },"10":function(container,depth0,helpers,partials,data) {
     var helper, lookupProperty = container.lookupProperty || function(parent, propertyName) {
@@ -59,7 +61,7 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
     };
 
   return "\""
-    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"severity") || (depth0 != null ? lookupProperty(depth0,"severity") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"severity","hash":{},"data":data,"loc":{"start":{"line":151,"column":65},"end":{"line":151,"column":77}}}) : helper)))
+    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"severity") || (depth0 != null ? lookupProperty(depth0,"severity") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"severity","hash":{},"data":data,"loc":{"start":{"line":186,"column":61},"end":{"line":186,"column":73}}}) : helper)))
     + "\"";
 },"12":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, lookupProperty = container.lookupProperty || function(parent, propertyName) {
@@ -69,9 +71,9 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
         return undefined
     };
 
-  return "        <h2><svg class=\"p__svg--inline\" viewBox=\"0 0 12 16\" version=\"1.1\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z\"></path></svg> All violations</h2>\n        <table>\n            <thead>\n                <tr>\n                    <th>severity</th>\n                    <th>rule</th>\n                    <th>from</th>\n                    <th>to</th>\n                </tr>\n            </thead>\n            <tbody>\n"
-    + ((stack1 = container.hooks.blockHelperMissing.call(depth0,container.lambda(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"violations") : stack1), depth0),{"name":"summary.violations","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":182,"column":16},"end":{"line":190,"column":39}}})) != null ? stack1 : "")
-    + "            </tbody>\n        </table>\n";
+  return "    <h2><svg class=\"p__svg--inline\" viewBox=\"0 0 12 16\" version=\"1.1\" aria-hidden=\"true\">\n            <path fill-rule=\"evenodd\"\n                d=\"M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z\">\n            </path>\n        </svg> All violations</h2>\n    <table>\n        <thead>\n            <tr>\n                <th>severity</th>\n                <th>rule</th>\n                <th>from</th>\n                <th>to</th>\n            </tr>\n        </thead>\n        <tbody>\n"
+    + ((stack1 = container.hooks.blockHelperMissing.call(depth0,container.lambda(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"violations") : stack1), depth0),{"name":"summary.violations","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":222,"column":12},"end":{"line":231,"column":35}}})) != null ? stack1 : "")
+    + "        </tbody>\n    </table>\n";
 },"13":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, alias1=container.lambda, alias2=container.escapeExpression, alias3=depth0 != null ? depth0 : (container.nullContext || {}), alias4=container.hooks.helperMissing, alias5="function", lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
@@ -80,24 +82,26 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
         return undefined
     };
 
-  return "                <tr>\n                    <td class=\""
+  return "            <tr>\n                <td class=\""
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? lookupProperty(stack1,"severity") : stack1), depth0))
     + "\">"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? lookupProperty(stack1,"severity") : stack1), depth0))
-    + "</td>\n                    <td class=\"nowrap\"><a href=\"#"
+    + "</td>\n                <td class=\"nowrap\"><a href=\"#"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? lookupProperty(stack1,"name") : stack1), depth0))
-    + "\" class=\"noiseless\">"
+    + "-definition\" id=\""
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? lookupProperty(stack1,"name") : stack1), depth0))
-    + "</a></td>\n                    <td><a href=\""
+    + "-instance\"\n                        class=\"noiseless\">"
+    + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? lookupProperty(stack1,"name") : stack1), depth0))
+    + "</a></td>\n                <td><a href=\""
     + alias2(alias1(((stack1 = ((stack1 = (depths[1] != null ? lookupProperty(depths[1],"summary") : depths[1])) != null ? lookupProperty(stack1,"optionsUsed") : stack1)) != null ? lookupProperty(stack1,"prefix") : stack1), depth0))
-    + alias2(((helper = (helper = lookupProperty(helpers,"from") || (depth0 != null ? lookupProperty(depth0,"from") : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"from","hash":{},"data":data,"loc":{"start":{"line":186,"column":66},"end":{"line":186,"column":74}}}) : helper)))
+    + alias2(((helper = (helper = lookupProperty(helpers,"from") || (depth0 != null ? lookupProperty(depth0,"from") : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"from","hash":{},"data":data,"loc":{"start":{"line":227,"column":62},"end":{"line":227,"column":70}}}) : helper)))
     + "\">"
-    + alias2(((helper = (helper = lookupProperty(helpers,"from") || (depth0 != null ? lookupProperty(depth0,"from") : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"from","hash":{},"data":data,"loc":{"start":{"line":186,"column":76},"end":{"line":186,"column":84}}}) : helper)))
-    + "</a></td>\n                    <td>"
-    + ((stack1 = ((helper = (helper = lookupProperty(helpers,"to") || (depth0 != null ? lookupProperty(depth0,"to") : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"to","hash":{},"data":data,"loc":{"start":{"line":187,"column":24},"end":{"line":187,"column":32}}}) : helper))) != null ? stack1 : "")
-    + "</td>\n                    \n                </tr>\n";
+    + alias2(((helper = (helper = lookupProperty(helpers,"from") || (depth0 != null ? lookupProperty(depth0,"from") : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"from","hash":{},"data":data,"loc":{"start":{"line":227,"column":72},"end":{"line":227,"column":80}}}) : helper)))
+    + "</a></td>\n                <td>"
+    + ((stack1 = ((helper = (helper = lookupProperty(helpers,"to") || (depth0 != null ? lookupProperty(depth0,"to") : depth0)) != null ? helper : alias4),(typeof helper === alias5 ? helper.call(alias3,{"name":"to","hash":{},"data":data,"loc":{"start":{"line":228,"column":20},"end":{"line":228,"column":28}}}) : helper))) != null ? stack1 : "")
+    + "</td>\n\n            </tr>\n";
 },"15":function(container,depth0,helpers,partials,data) {
-    return "        <h2><span aria-hidden=\"true\">&hearts;</span> No violations found</h2>\n        <p>Get gummy bears to celebrate.</p>\n";
+    return "    <h2><span aria-hidden=\"true\">&hearts;</span> No violations found</h2>\n    <p>Get gummy bears to celebrate.</p>\n";
 },"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, alias1=container.lambda, alias2=container.escapeExpression, lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
@@ -106,23 +110,23 @@ templates['err-html.template.hbs'] = template({"1":function(container,depth0,hel
         return undefined
     };
 
-  return "<!DOCTYPE html>\n<html lang=\"en\">\n    <head>\n        <title>dependency-cruiser - results</title>\n        <meta charset=\"utf-8\">\n        <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n        \n        <style type=\"text/css\">\n            body{\n                font-family:sans-serif;\n                margin:0 auto;\n                max-width:90%;\n                line-height:1.6;\n                font-size:14px;\n                color:#444;\n                padding:0 10px;\n                background-color:#fff;\n            }\n            footer{\n                color: gray;\n                margin-top: 1.4em;\n                border-top: solid 1px currentColor\n            }\n            a {\n                text-decoration: none\n            }\n            a.noiseless {\n                color: currentColor\n            }\n            h1,h2,h3{\n                line-height:1.2\n            }\n            table {\n                border-collapse: collapse;\n                width: 100%;\n            }\n            th, td {\n                text-align: left;\n                padding: 4px;\n            }\n            tbody tr:nth-child(odd){\n                background-color: rgba(128,128,128,0.2);\n            }\n            .error {\n                color: red;\n            }\n            .warn {\n                color: orange;\n            }\n            .info {\n                color: blue;\n            }\n            .ok {\n                color: limegreen;\n            }\n            td.nowrap {\n                white-space: nowrap\n            }\n            svg{\n                fill:currentColor\n            }\n            #show-unviolated {\n                display: block\n                \n            }\n            #hide-unviolated {\n                display: none\n            }\n            #show-all-the-rules:target #show-unviolated{\n                display: none\n            }\n            #show-all-the-rules:target #hide-unviolated{\n                display: block\n            }\n            tr.unviolated {\n                display: none\n            }\n            #show-all-the-rules:target tr.unviolated {\n                display: table-row;\n                color: gray;\n            }\n            .p__svg--inline{\n                vertical-align: top;\n                width: 1.2em;\n                height: 1.2em\n            }\n            .controls {\n                background-color: #fff;\n                vertical-align: bottom;\n                text-align: center\n            }\n            .controls:hover {\n                opacity: 1;\n            }\n            .controls a {\n                text-decoration: none;\n                color: gray;\n            }\n            .controls a:hover {\n                text-decoration: underline;\n                color: blue;\n            }\n            .extra {\n                color: gray;\n            }\n        </style>\n        <style type=\"text/css\" media=\"print\">\n            th, td {\n                border: 1px solid #444;\n            }\n            .controls {\n                display: none\n            }\n        </style>\n    </head>\n    <body id=\"show-all-the-rules\">\n        <h1>Forbidden dependency check - results</h1>\n        <h2><svg class=\"p__svg--inline\" viewBox=\"0 0 14 16\" version=\"1.1\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0v2h3.6l.9-1.8.9 5.4L9 8.5l1.6 1.5H14V8h-2.5z\"></path></svg> Summary</h2>\n        <p>\n            <div style=\"float:left;padding-right:20px\">\n                <strong>"
+  return "<!DOCTYPE html>\n<html lang=\"en\">\n\n<head>\n    <title>dependency-cruiser - results</title>\n    <meta charset=\"utf-8\">\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\n    <style type=\"text/css\">\n        body {\n            font-family: sans-serif;\n            margin: 0 auto;\n            max-width: 90%;\n            line-height: 1.6;\n            font-size: 14px;\n            color: #444;\n            padding: 0 10px;\n            background-color: #fff;\n        }\n\n        footer {\n            color: gray;\n            margin-top: 1.4em;\n            border-top: solid 1px currentColor\n        }\n\n        a {\n            text-decoration: none\n        }\n\n        a.noiseless {\n            color: currentColor\n        }\n\n        h1,\n        h2,\n        h3 {\n            line-height: 1.2\n        }\n\n        table {\n            border-collapse: collapse;\n            width: 100%;\n        }\n\n        th,\n        td {\n            text-align: left;\n            padding: 4px;\n        }\n\n        tbody tr:nth-child(odd) {\n            background-color: rgba(128, 128, 128, 0.2);\n        }\n\n        .error {\n            color: red;\n        }\n\n        .warn {\n            color: orange;\n        }\n\n        .info {\n            color: blue;\n        }\n\n        .ok {\n            color: limegreen;\n        }\n\n        td.nowrap {\n            white-space: nowrap\n        }\n\n        svg {\n            fill: currentColor\n        }\n\n        #show-unviolated {\n            display: block\n        }\n\n        #hide-unviolated {\n            display: none\n        }\n\n        #show-all-the-rules:target #show-unviolated {\n            display: none\n        }\n\n        #show-all-the-rules:target #hide-unviolated {\n            display: block\n        }\n\n        tr.unviolated {\n            display: none\n        }\n\n        #show-all-the-rules:target tr.unviolated {\n            display: table-row;\n            color: gray;\n        }\n\n        .p__svg--inline {\n            vertical-align: top;\n            width: 1.2em;\n            height: 1.2em\n        }\n\n        .controls {\n            background-color: #fff;\n            vertical-align: bottom;\n            text-align: center\n        }\n\n        .controls:hover {\n            opacity: 1;\n        }\n\n        .controls a {\n            text-decoration: none;\n            color: gray;\n        }\n\n        .controls a:hover {\n            text-decoration: underline;\n            color: blue;\n        }\n\n        .extra {\n            color: gray;\n        }\n    </style>\n    <style type=\"text/css\" media=\"print\">\n        th,\n        td {\n            border: 1px solid #444;\n        }\n\n        .controls {\n            display: none\n        }\n    </style>\n</head>\n\n<body id=\"show-all-the-rules\">\n    <h1>Forbidden dependency check - results</h1>\n    <h2><svg class=\"p__svg--inline\" viewBox=\"0 0 14 16\" version=\"1.1\" aria-hidden=\"true\">\n            <path fill-rule=\"evenodd\"\n                d=\"M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0v2h3.6l.9-1.8.9 5.4L9 8.5l1.6 1.5H14V8h-2.5z\"></path>\n        </svg> Summary</h2>\n    <p>\n        <div style=\"float:left;padding-right:20px\">\n            <strong>"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"totalCruised") : stack1), depth0))
-    + "</strong> modules\n            </div>\n            <div style=\"float:left;padding-right:20px\">\n                <strong>"
+    + "</strong> modules\n        </div>\n        <div style=\"float:left;padding-right:20px\">\n            <strong>"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"totalDependenciesCruised") : stack1), depth0))
-    + "</strong> dependencies\n            </div>\n            <div style=\"float:left;padding-right:20px\">\n                <strong>"
+    + "</strong> dependencies\n        </div>\n        <div style=\"float:left;padding-right:20px\">\n            <strong>"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"error") : stack1), depth0))
-    + "</strong> errors\n            </div>\n            <div style=\"float:left;padding-right:20px\">\n                <strong>"
+    + "</strong> errors\n        </div>\n        <div style=\"float:left;padding-right:20px\">\n            <strong>"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"warn") : stack1), depth0))
-    + "</strong> warnings\n            </div>\n            <div style=\"float:left;padding-right:20px\">\n                <strong>"
+    + "</strong> warnings\n        </div>\n        <div style=\"float:left;padding-right:20px\">\n            <strong>"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"info") : stack1), depth0))
-    + "</strong> informational\n            </div>\n            &nbsp;\n        </p>\n        <table>\n            <tbody>\n                <thead>\n                    <tr>\n                        <th></th>\n                        <th>severity</th>\n                        <th>rule</th>\n                        <th>#&nbsp;violations</th>\n                        <th>explanation</th>\n                    </tr>\n                </thead>\n"
-    + ((stack1 = container.hooks.blockHelperMissing.call(depth0,alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"agggregateViolations") : stack1), depth0),{"name":"summary.agggregateViolations","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":148,"column":16},"end":{"line":156,"column":49}}})) != null ? stack1 : "")
-    + "                <tr>\n                    <td colspan=\"5\" class=\"controls\">\n                        <div id=\"show-unviolated\">\n                            &downarrow; <a href=\"#show-all-the-rules\">also show unviolated rules</a>\n                        </div>\n                        <div id=\"hide-unviolated\">\n                            &uparrow; <a href=\"\">hide unviolated rules</a>\n                        </div>\n                    </td>\n                </tr>\n            </tbody>\n        </table>\n\n"
-    + ((stack1 = lookupProperty(helpers,"if").call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"violations") : stack1),{"name":"if","hash":{},"fn":container.program(12, data, 0, blockParams, depths),"inverse":container.program(15, data, 0, blockParams, depths),"data":data,"loc":{"start":{"line":170,"column":8},"end":{"line":196,"column":15}}})) != null ? stack1 : "")
-    + "        <footer>\n            <p><a href=\"https://github.com/sverweij/dependency-cruiser\">"
+    + "</strong> informational\n        </div>\n        &nbsp;\n    </p>\n    <table>\n        <tbody>\n            <thead>\n                <tr>\n                    <th></th>\n                    <th>severity</th>\n                    <th>rule</th>\n                    <th>#&nbsp;violations</th>\n                    <th>explanation</th>\n                </tr>\n            </thead>\n"
+    + ((stack1 = container.hooks.blockHelperMissing.call(depth0,alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"agggregateViolations") : stack1), depth0),{"name":"summary.agggregateViolations","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":182,"column":12},"end":{"line":192,"column":45}}})) != null ? stack1 : "")
+    + "            <tr>\n                <td colspan=\"5\" class=\"controls\">\n                    <div id=\"show-unviolated\">\n                        &downarrow; <a href=\"#show-all-the-rules\">also show unviolated rules</a>\n                    </div>\n                    <div id=\"hide-unviolated\">\n                        &uparrow; <a href=\"\">hide unviolated rules</a>\n                    </div>\n                </td>\n            </tr>\n        </tbody>\n    </table>\n\n"
+    + ((stack1 = lookupProperty(helpers,"if").call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"violations") : stack1),{"name":"if","hash":{},"fn":container.program(12, data, 0, blockParams, depths),"inverse":container.program(15, data, 0, blockParams, depths),"data":data,"loc":{"start":{"line":206,"column":4},"end":{"line":237,"column":11}}})) != null ? stack1 : "")
+    + "    <footer>\n        <p><a href=\"https://github.com/sverweij/dependency-cruiser\">"
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"depcruiseVersion") : stack1), depth0))
-    + "</a> / "
+    + "</a> /\n            "
     + alias2(alias1(((stack1 = (depth0 != null ? lookupProperty(depth0,"summary") : depth0)) != null ? lookupProperty(stack1,"runDate") : stack1), depth0))
-    + "</p>\n        </footer>\n    </body>\n</html>\n";
+    + "</p>\n    </footer>\n</body>\n\n</html>";
 },"useData":true,"useDepths":true});


### PR DESCRIPTION
## Description
- When you click on the name of a rule in the summary of your violation report, the report will navigate to the first dependency that violated the rule.

## Motivation and Context
If there's a _lot_ of rule violations it's practical to navigate directly to the first violation of a certain type to see what's violating it a.o.t. `ctrl-F` 'ing it.

## How Has This Been Tested?
eyeballs + automated non-regression testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:
  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).





