### PR TITLE
bugfix(report): don't emit dummy nodes in the custom level dot reports

### DIFF
--- a/src/report/dot/index.js
+++ b/src/report/dot/index.js
@@ -22,7 +22,7 @@ function report(pResults, pTheme, pGranularity, pCollapsePatterns) {
     graphAttrs: moduleUtl.attributizeObject(lTheme.graph || {}),
     nodeAttrs: moduleUtl.attributizeObject(lTheme.node || {}),
     edgeAttrs: moduleUtl.attributizeObject(lTheme.edge || {}),
-    clustersHaveOwnNode: ["folder", "custom"].includes(pGranularity),
+    clustersHaveOwnNode: "folder" === pGranularity,
     // eslint-disable-next-line security/detect-object-injection
     modules: (GRANULARITY2FUNCTION[pGranularity] || prepareModuleLevel)(
       pResults,

--- a/test/report/dot/customLevel/mocks/dependency-cruiser-2020-01-25.dot
+++ b/test/report/dot/customLevel/mocks/dependency-cruiser-2020-01-25.dot
@@ -3,44 +3,44 @@ strict digraph "dependency-cruiser output"{
     
     
 
-    subgraph "cluster_bin" {label="bin" "bin" [width="0.05" shape="point" style="invis"] "bin/depcruise-fmt.js" [label="depcruise-fmt.js" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/bin/depcruise-fmt.js" ] }
+    subgraph "cluster_bin" {label="bin" "bin/depcruise-fmt.js" [label="depcruise-fmt.js" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/bin/depcruise-fmt.js" ] }
     "bin/depcruise-fmt.js" -> "src/cli"
-    subgraph "cluster_bin" {label="bin" "bin" [width="0.05" shape="point" style="invis"] "bin/dependency-cruise.js" [label="dependency-cruise.js" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/bin/dependency-cruise.js" ] }
+    subgraph "cluster_bin" {label="bin" "bin/dependency-cruise.js" [label="dependency-cruise.js" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/bin/dependency-cruise.js" ] }
     "bin/dependency-cruise.js" -> "src/cli"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/cli" [label="cli" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli" ] }
+    subgraph "cluster_src" {label="src" "src/cli" [label="cli" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli" ] }
     "src/cli" -> "src/main"
     "src/cli" -> "src/extract" [xlabel="cli-to-main-only-warn" tooltip="cli-to-main-only-warn" ]
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/extract" [label="extract" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract" ] }
+    subgraph "cluster_src" {label="src" "src/extract" [label="extract" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract" ] }
     "src/extract" -> "src/validate"
     "src/extract" -> "src/utl"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/main" [label="main" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main" ] }
+    subgraph "cluster_src" {label="src" "src/main" [label="main" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/main" ] }
     "src/main" -> "src/extract"
     "src/main" -> "src/report"
     "src/main" -> "src/schema"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/report" [label="report" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report" ] }
+    subgraph "cluster_src" {label="src" "src/report" [label="report" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/report" ] }
     "src/report" -> "src/utl"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/schema" [label="schema" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/schema" ] }
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/utl" [label="utl" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/utl" ] }
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/validate" [label="validate" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/validate" ] }
+    subgraph "cluster_src" {label="src" "src/schema" [label="schema" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/schema" ] }
+    subgraph "cluster_src" {label="src" "src/utl" [label="utl" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/utl" ] }
+    subgraph "cluster_src" {label="src" "src/validate" [label="validate" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/src/validate" ] }
     "src/validate" -> "src/utl"
-    subgraph "cluster_test" {label="test" "test" [width="0.05" shape="point" style="invis"] "test/cli" [label="cli" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/cli" ] }
+    subgraph "cluster_test" {label="test" "test/cli" [label="cli" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/cli" ] }
     "test/cli" -> "src/cli"
     "test/cli" -> "test/utl"
     "test/cli" -> "src/schema"
     "test/cli" -> "src/extract"
-    subgraph "cluster_test" {label="test" "test" [width="0.05" shape="point" style="invis"] "test/extract" [label="extract" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/extract" ] }
+    subgraph "cluster_test" {label="test" "test/extract" [label="extract" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/extract" ] }
     "test/extract" -> "src/extract"
     "test/extract" -> "src/main"
     "test/extract" -> "src/schema"
     "test/extract" -> "src/cli"
-    subgraph "cluster_test" {label="test" "test" [width="0.05" shape="point" style="invis"] "test/main" [label="main" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/main" ] }
+    subgraph "cluster_test" {label="test" "test/main" [label="main" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/main" ] }
     "test/main" -> "src/main"
     "test/main" -> "src/schema"
-    subgraph "cluster_test" {label="test" "test" [width="0.05" shape="point" style="invis"] "test/report" [label="report" tooltip="no-orphans" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/report" ] }
+    subgraph "cluster_test" {label="test" "test/report" [label="report" tooltip="no-orphans" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/report" ] }
     "test/report" -> "src/report"
-    subgraph "cluster_test" {label="test" "test" [width="0.05" shape="point" style="invis"] "test/utl" [label="utl" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/utl" ] }
+    subgraph "cluster_test" {label="test" "test/utl" [label="utl" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/utl" ] }
     "test/utl" -> "src/utl"
-    subgraph "cluster_test" {label="test" "test" [width="0.05" shape="point" style="invis"] "test/validate" [label="validate" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/validate" ] }
+    subgraph "cluster_test" {label="test" "test/validate" [label="validate" URL="https://github.com/sverweij/dependency-cruiser/blob/develop/test/validate" ] }
     "test/validate" -> "src/validate"
     "test/validate" -> "src/main"
 }

--- a/test/report/dot/customLevel/mocks/rxjs.dot
+++ b/test/report/dot/customLevel/mocks/rxjs.dot
@@ -3,47 +3,47 @@ strict digraph "dependency-cruiser output"{
     
     
 
-    subgraph "cluster_compat" {label="compat" "compat" [width="0.05" shape="point" style="invis"] "compat/Rx.ts" [label="Rx.ts" URL="compat/Rx.ts" ] }
+    subgraph "cluster_compat" {label="compat" "compat/Rx.ts" [label="Rx.ts" URL="compat/Rx.ts" ] }
     "compat/Rx.ts" -> "compat/add"
     "compat/Rx.ts" -> "src/index.ts"
     "compat/Rx.ts" -> "src/ajax"
     "compat/Rx.ts" -> "src/internal-compatibility"
     "compat/Rx.ts" -> "src/operators"
     "compat/Rx.ts" -> "src/testing"
-    subgraph "cluster_compat" {label="compat" "compat" [width="0.05" shape="point" style="invis"] "compat/add" [label="add" URL="compat/add" ] }
+    subgraph "cluster_compat" {label="compat" "compat/add" [label="add" URL="compat/add" ] }
     "compat/add" -> "src/index.ts"
     "compat/add" -> "src/ajax"
     "compat/add" -> "src/webSocket"
     "compat/add" -> "compat/operator"
-    subgraph "cluster_compat" {label="compat" "compat" [width="0.05" shape="point" style="invis"] "compat/index.ts" [label="index.ts" URL="compat/index.ts" ] }
+    subgraph "cluster_compat" {label="compat" "compat/index.ts" [label="index.ts" URL="compat/index.ts" ] }
     "compat/index.ts" -> "compat/Rx.ts"
-    subgraph "cluster_compat" {label="compat" "compat" [width="0.05" shape="point" style="invis"] "compat/operator" [label="operator" URL="compat/operator" ] }
+    subgraph "cluster_compat" {label="compat" "compat/operator" [label="operator" URL="compat/operator" ] }
     "compat/operator" -> "src/operators"
     "compat/operator" -> "src/index.ts"
     "compat/operator" -> "src/internal-compatibility"
-    subgraph "cluster_dist" {label="dist" "dist" [width="0.05" shape="point" style="invis"] subgraph "cluster_dist/package" {label="package" "dist/package" [width="0.05" shape="point" style="invis"] "dist/package/Rx.js" [label="Rx.js" URL="dist/package/Rx.js" ] } }
+    subgraph "cluster_dist" {label="dist" subgraph "cluster_dist/package" {label="package" "dist/package/Rx.js" [label="Rx.js" URL="dist/package/Rx.js" ] } }
     "dist/package/Rx.js" -> "compat/index.ts"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/MiscJSDoc.ts" [label="MiscJSDoc.ts" URL="src/MiscJSDoc.ts" ] }
+    subgraph "cluster_src" {label="src" "src/MiscJSDoc.ts" [label="MiscJSDoc.ts" URL="src/MiscJSDoc.ts" ] }
     "src/MiscJSDoc.ts" -> "src/internal"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/Rx.global.js" [label="Rx.global.js" URL="src/Rx.global.js" ] }
+    subgraph "cluster_src" {label="src" "src/Rx.global.js" [label="Rx.global.js" URL="src/Rx.global.js" ] }
     "src/Rx.global.js" -> "dist/package/Rx.js"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/ajax" [label="ajax" URL="src/ajax" ] }
+    subgraph "cluster_src" {label="src" "src/ajax" [label="ajax" URL="src/ajax" ] }
     "src/ajax" -> "src/internal"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/index.ts" [label="index.ts" URL="src/index.ts" ] }
+    subgraph "cluster_src" {label="src" "src/index.ts" [label="index.ts" URL="src/index.ts" ] }
     "src/index.ts" -> "src/internal"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/internal" [label="internal" URL="src/internal" ] }
+    subgraph "cluster_src" {label="src" "src/internal" [label="internal" URL="src/internal" ] }
     "src/internal" -> "compat/add"
     "src/internal" -> "src/ajax"
     "src/internal" -> "src/index.ts"
     "src/internal" -> "src/operators"
     "src/internal" -> "src/testing"
     "src/internal" -> "src/webSocket"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/internal-compatibility" [label="internal-compatibility" URL="src/internal-compatibility" ] }
+    subgraph "cluster_src" {label="src" "src/internal-compatibility" [label="internal-compatibility" URL="src/internal-compatibility" ] }
     "src/internal-compatibility" -> "src/internal"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/operators" [label="operators" URL="src/operators" ] }
+    subgraph "cluster_src" {label="src" "src/operators" [label="operators" URL="src/operators" ] }
     "src/operators" -> "src/internal"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/testing" [label="testing" URL="src/testing" ] }
+    subgraph "cluster_src" {label="src" "src/testing" [label="testing" URL="src/testing" ] }
     "src/testing" -> "src/internal"
-    subgraph "cluster_src" {label="src" "src" [width="0.05" shape="point" style="invis"] "src/webSocket" [label="webSocket" URL="src/webSocket" ] }
+    subgraph "cluster_src" {label="src" "src/webSocket" [label="webSocket" URL="src/webSocket" ] }
     "src/webSocket" -> "src/internal"
 }


### PR DESCRIPTION
## Description
- the custom level graph reporter still emitted dummy nodes - which are only necessary for the dir level reporter

## Motivation and Context
- simplifies the output (and makes dot happier)

## How Has This Been Tested?
Automated non-regression tests, adapted automated tests - green CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:
  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).





