### PR TITLE
bugfix(report): sort aggregated rules on severity

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "depcruise:graph:doc:json": "node ./bin/dependency-cruise.js --validate --include-only '^(src|bin)' --output-type json bin src --output-to tmp_graph_deps.json",
     "depcruise:graph:doc:html": "./bin/depcruise-fmt.js -T dot -f - tmp_graph_deps.json | dot -T svg | node utl/embed-svg-in-html.utl.js > docs/dependency-cruiser-dependency-graph.html",
     "depcruise:graph:doc:html-archi": "./bin/depcruise-fmt.js -T archi -f - tmp_graph_deps.json | dot -T svg -Grankdir=TD | node utl/embed-svg-in-html.utl.js > docs/dependency-cruiser-archi-graph.html",
-    "depcruise:graph:doc:html-dir": "./bin/depcruise-fmt.js -T ddot -f - tmp_graph_deps.json | dot -T svg | node utl/embed-svg-in-html.utl.js > docs/dependency-cruiser-dir-graph.html",
+    "depcruise:graph:doc:html-dir": "./bin/depcruise-fmt.js -T ddot -f - tmp_graph_deps.json | dot -T svg -Grankdir=TD | node utl/embed-svg-in-html.utl.js > docs/dependency-cruiser-dir-graph.html",
     "depcruise:graph:doc:svg": "./bin/depcruise-fmt.js -T dot -f - tmp_graph_deps.json | dot -T svg > doc/real-world-samples/dependency-cruiser-without-node_modules.svg",
     "depcruise:graph:doc:svg-archi": "./bin/depcruise-fmt.js -T archi -f - tmp_graph_deps.json | dot -Grankdir=TD -T svg > doc/real-world-samples/dependency-cruiser-archi-graph.svg",
     "depcruise:graph:doc:svg-dir": "./bin/depcruise-fmt.js -T ddot -f - tmp_graph_deps.json | dot -Grankdir=TD -T svg > doc/real-world-samples/dependency-cruiser-dir-graph.svg",

--- a/src/report/dot/compareRules.js
+++ b/src/report/dot/compareRules.js
@@ -1,0 +1,26 @@
+// this is (very close to a) duplicate of a quite similar sorting
+// module in extract/utl/compare.js
+function severity2number(pSeverity) {
+  const SEVERITY2NUMBER = {
+    error: 1,
+    warn: 2,
+    info: 3,
+    ignore: 4
+  };
+
+  // eslint-disable-next-line security/detect-object-injection
+  return SEVERITY2NUMBER[pSeverity] || -1;
+}
+
+function compareSeverities(pRightSeverity, pLeftSeverity) {
+  return Math.sign(
+    severity2number(pRightSeverity) - severity2number(pLeftSeverity)
+  );
+}
+
+module.exports = function compareRules(pLeftRule, pRightRule) {
+  return (
+    compareSeverities(pLeftRule.severity, pRightRule.severity) ||
+    pLeftRule.name.localeCompare(pRightRule.name)
+  );
+};

--- a/src/report/dot/consolidateModuleDependencies.js
+++ b/src/report/dot/consolidateModuleDependencies.js
@@ -2,6 +2,7 @@ const _clone = require("lodash/clone");
 const _get = require("lodash/get");
 const _reject = require("lodash/reject");
 const _uniqBy = require("lodash/uniqBy");
+const compareRules = require("./compareRules");
 
 function mergeDependency(pLeftDependency, pRightDependency) {
   return {
@@ -12,7 +13,9 @@ function mergeDependency(pLeftDependency, pRightDependency) {
         pRightDependency.dependendencyTypes
       )
     ),
-    rules: pLeftDependency.rules.concat(_get(pRightDependency, "rules", [])),
+    rules: pLeftDependency.rules
+      .concat(_get(pRightDependency, "rules", []))
+      .sort(compareRules),
     valid: pLeftDependency.valid && pRightDependency.valid
   };
 }

--- a/src/report/dot/consolidateModules.js
+++ b/src/report/dot/consolidateModules.js
@@ -2,6 +2,7 @@ const _clone = require("lodash/clone");
 const _get = require("lodash/get");
 const _reject = require("lodash/reject");
 const _uniqBy = require("lodash/uniqBy");
+const compareRules = require("./compareRules");
 
 function mergeModule(pLeftModule, pRightModule) {
   return {
@@ -11,7 +12,9 @@ function mergeModule(pLeftModule, pRightModule) {
       pLeftModule.dependencies.concat(pRightModule.dependencies),
       pDependency => pDependency.resolved
     ),
-    rules: pLeftModule.rules.concat(_get(pRightModule, "rules", [])),
+    rules: pLeftModule.rules
+      .concat(_get(pRightModule, "rules", []))
+      .sort(compareRules),
     valid: pLeftModule.valid && pRightModule.valid
   };
 }

--- a/test/report/dot/compareRules.spec.js
+++ b/test/report/dot/compareRules.spec.js
@@ -1,0 +1,49 @@
+const expect = require("chai").expect;
+const compareRules = require("../../../src/report/dot/compareRules");
+
+describe("report/dot/compareRules", () => {
+  it("samesies yield 0", () => {
+    expect(
+      compareRules(
+        { severity: "error", name: "thing" },
+        { severity: "error", name: "thing" }
+      )
+    ).to.equal(0);
+  });
+
+  it("unknown severity > error", () => {
+    expect(
+      compareRules(
+        { severity: "not defined", name: "thing" },
+        { severity: "error", name: "thing" }
+      )
+    ).to.equal(-1);
+  });
+
+  it("same name, different severity sorts on severity", () => {
+    expect(
+      compareRules(
+        { severity: "info", name: "thing" },
+        { severity: "warn", name: "thing" }
+      )
+    ).to.equal(1);
+  });
+
+  it("differnt name, different severity sorts on severity", () => {
+    expect(
+      compareRules(
+        { severity: "info", name: "aaa" },
+        { severity: "warn", name: "zzz" }
+      )
+    ).to.equal(1);
+  });
+
+  it("same severity, different name sorts on name", () => {
+    expect(
+      compareRules(
+        { severity: "info", name: "thing" },
+        { severity: "info", name: "thang" }
+      )
+    ).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Description
- see title

## Motivation and Context
previously just concat'ing the rules - in typical set-ups this will work just fine, but if there's > 1 violated rule per aggregated dependency the most important (severe) one should be on top - and be displayed in any visuals.

## How Has This Been Tested?
automated non-regression tests, additional unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:
  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).





