### PR TITLE
feature(report): add vertical highlight to the html table report

### DIFF
--- a/src/report/html/html.template.hbs
+++ b/src/report/html/html.template.hbs
@@ -1,159 +1,225 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>dependency-cruiser output</title>
-        <style media="screen">
-            html {
-                font-family: sans-serif;
-                font-size: 10pt;
-            }
-            table, td.controls {
-                transition-duration: 0.4s;
-            }
-            table, th, td{
-                border: solid black 1px;
-                border-collapse: collapse;
-                font-size: inherit;
-            }
-            th{
-                text-align:start;
-                vertical-align: bottom;
-                max-width: 1em;
-                max-height: 30em;
-                height: 20em;
-                font-weight: normal;
-                white-space: nowrap;
-                overflow: hidden;
-            }
-            th div {
-                transform: rotateZ(-90deg);
-                transform-origin: 0.5em;
-                text-align: start;
-                height: 1em;
-                width: 30em;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-            td {
-                text-align: center;
-            }
-            td.first-cell {
-                text-align: left;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-            td.top-left {
-                border-top: solid 1px transparent;
-                border-left: solid 1px transparent;
-            }
-            td.top-right {
-                border-top: solid 1px transparent;
-                border-right: solid 1px transparent;
-            }
-            td.bottom-left {
-                border-bottom: solid 1px transparent;
-                border-left: solid 1px transparent;
-            }
-            td.bottom-right {
-                border-bottom: solid 1px transparent;
-                border-right: solid 1px transparent;
-            }
-            tbody tr:hover {
-                background-color: lightgrey;
-            }
-            #table-rotated:target {
-                transform: rotateZ(45deg);
-                transform-origin: bottom left;
-            }
-            #table-rotated:target #unrotate {
-                opacity: 1;
-            }
-            #table-rotated:target #rotate {
-                opacity: 0;
-            }
-            #unrotate {
-                opacity: 0;
-            }
-            #rotate {
-                opacity: 1;
-            }
-            .controls {
-                opacity: 0.2;
-                vertical-align: bottom;
-                padding: 0.5em;
-            }
-            .controls:hover {
-                opacity: 1;
-            }
-            .controls a {
-                font-style: normal;
-                text-decoration: none;
-                background-color: #eee;
-                padding: 0.2em 0.5em 0.2em 0.5em;
-            }
-            .cell-core-module {
-                color: grey;
-                font-style: italic;
-            }
-            .cell-unresolvable-module {
-                color: red;
-                font-style: italic;
-            }
-            .cell-true {
-                background-color: black;
-                opacity: 0.5;
-            }
-            .cell-false {
-                background-color: white;
-                opacity: 0.5;
-            }
-            .cell-error {
-                background-color: red;
-                opacity: 0.5;
-            }
-            .cell-warn {
-                background-color: orange;
-                opacity: 0.5;
-            }
-            .cell-info {
-                background-color: blue;
-                opacity: 0.5;
-            }
-        </style>
-    </head>
-    <body>
-        <table id="table-rotated">
-            <thead>
-                <tr>
-                    <td class="controls top-left">
-                        <a id="rotate" href="#table-rotated">rotate</a>
-                        <a id="unrotate" href="#">rotate back</a>
-                    </td>
-                    {{#modules}}<th><div{{#if coreModule}} class="cell-core-module"{{else}}{{#if couldNotResolve}} class="cell-unresolvable-module"{{/if}}{{/if}}>{{source}}</div></th>{{/modules}}
-                    <td class="top-right"></td>
-                </tr>
-            </thead>
-            <tbody>
-                {{#modules}}
-                <tr>
-                    <td class="first-cell{{#if coreModule}} cell-core-module{{else}}{{#if couldNotResolve}} cell-unresolvable-module{{/if}}{{/if}}">{{source}}</td>
-                    {{#incidences}}<td class="cell cell-{{incidence}}"{{#if hasRelation}} title="{{# if rule}}{{rule}}:
-        {{/if}}{{../source}} ->
-        {{to}}"{{/if}}></td>{{/incidences}}
-                    <td class="first-cell{{#if coreModule}} cell-core-module{{else}}{{#if couldNotResolve}} cell-unresolvable-module{{/if}}{{/if}}">{{source}}</td>
-                </tr>
-                {{/modules}}
-            </tbody>
-            <tfoot>
-                <tr>
-                    <td class="bottom-left"></td>
-                    {{#modules}}<th><div{{#if coreModule}} class="cell-core-module"{{else}}{{#if couldNotResolve}} class="cell-unresolvable-module"{{/if}}{{/if}}>{{source}}</div></th>{{/modules}}
-                    <td class="bottom-right"></td>
-                </tr>
-            </tfoot>
-        </table>
-    </body>
+
+<head>
+  <meta charset="utf-8">
+  <title>dependency-cruiser output</title>
+  <style media="screen">
+    html {
+      font-family: sans-serif;
+      font-size: 10pt;
+    }
+
+    table {
+      overflow: hidden;
+    }
+
+    table,
+    td.controls {
+      transition-duration: 0.3s;
+    }
+
+    table,
+    th,
+    td {
+      border: solid black 1px;
+      border-collapse: collapse;
+      font-size: inherit;
+    }
+
+    td,
+    th {
+      position: relative;
+    }
+
+    th {
+      text-align: start;
+      vertical-align: bottom;
+      max-width: 1em;
+      max-height: 30em;
+      height: 20em;
+      font-weight: normal;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    th div {
+      transform: rotateZ(-90deg);
+      transform-origin: 0.5em;
+      text-align: start;
+      height: 1em;
+      width: 30em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    td {
+      text-align: center;
+    }
+
+    td.first-cell {
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    td.top-left {
+      border-top: solid 1px transparent;
+      border-left: solid 1px transparent;
+    }
+
+    td.top-right {
+      border-top: solid 1px transparent;
+      border-right: solid 1px transparent;
+    }
+
+    td.bottom-left {
+      border-bottom: solid 1px transparent;
+      border-left: solid 1px transparent;
+    }
+
+    td.bottom-right {
+      border-bottom: solid 1px transparent;
+      border-right: solid 1px transparent;
+    }
+
+    {{!-- row highlight --}}
+    tbody tr:hover {
+      background-color: lightgrey;
+    }
+
+    {{!-- column highlight --}}
+    td:hover::after,
+    td:focus::after,
+    th:hover::after,
+    th:focus::after {
+      background-color: #00000077;
+      content: "";
+      height: 5000px;
+      left: 0;
+      position: absolute;
+      top: -2500px;
+      width: 100%;
+      z-index: -1;
+    }
+
+    #table-rotated:target {
+      transform: rotateZ(45deg);
+      transform-origin: bottom left;
+    }
+
+    #table-rotated:target #unrotate {
+      opacity: 1;
+    }
+
+    #table-rotated:target #rotate {
+      opacity: 0;
+    }
+
+    #unrotate {
+      opacity: 0;
+    }
+
+    #rotate {
+      opacity: 1;
+    }
+
+    .controls {
+      opacity: 0.2;
+      vertical-align: bottom;
+      padding: 0.5em;
+    }
+
+    .controls:hover {
+      opacity: 1;
+    }
+
+    .controls a {
+      font-style: normal;
+      text-decoration: none;
+      background-color: #eee;
+      padding: 0.2em 0.5em 0.2em 0.5em;
+    }
+
+    .cell-core-module {
+      color: grey;
+      font-style: italic;
+    }
+
+    .cell-unresolvable-module {
+      color: red;
+      font-style: italic;
+    }
+
+    .cell-true {
+      background-color: black;
+      opacity: 0.5;
+    }
+
+    .cell-false {
+      background-color: white;
+      opacity: 0.5;
+    }
+
+    .cell-error {
+      background-color: red;
+      opacity: 0.5;
+    }
+
+    .cell-warn {
+      background-color: orange;
+      opacity: 0.5;
+    }
+
+    .cell-info {
+      background-color: blue;
+      opacity: 0.5;
+    }
+  </style>
+</head>
+
+<body>
+  <table id="table-rotated">
+    <thead>
+      <tr>
+        <td class="controls top-left">
+          <a id="rotate" href="#table-rotated">rotate</a>
+          <a id="unrotate" href="#">rotate back</a>
+        </td>
+        {{#modules}}<th>
+          <div{{#if coreModule}} class="cell-core-module" {{else}}{{#if couldNotResolve}}
+            class="cell-unresolvable-module" {{/if}}{{/if}}>{{source}}</div>
+        </th>{{/modules}}
+        <td class="top-right"></td>
+      </tr>
+    </thead>
+    <tbody>
+      {{#modules}}
+      <tr>
+        <td
+          class="first-cell{{#if coreModule}} cell-core-module{{else}}{{#if couldNotResolve}} cell-unresolvable-module{{/if}}{{/if}}">
+          {{source}}</td>
+        {{#incidences}}<td class="cell cell-{{incidence}}" {{#if hasRelation}} title="{{# if rule}}{{rule}}:
+    {{/if}}{{../source}} ->
+    {{to}}" {{/if}}></td>{{/incidences}}
+        <td
+          class="first-cell{{#if coreModule}} cell-core-module{{else}}{{#if couldNotResolve}} cell-unresolvable-module{{/if}}{{/if}}">
+          {{source}}</td>
+      </tr>
+      {{/modules}}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class="bottom-left"></td>
+        {{#modules}}<th>
+          <div{{#if coreModule}} class="cell-core-module" {{else}}{{#if couldNotResolve}}
+            class="cell-unresolvable-module" {{/if}}{{/if}}>{{source}}</div>
+        </th>{{/modules}}
+        <td class="bottom-right"></td>
+      </tr>
+    </tfoot>
+  </table>
+</body>
 </html>

--- a/src/report/html/html.template.js
+++ b/src/report/html/html.template.js
@@ -7,13 +7,13 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
         return undefined
     };
 
-  return "<th><div"
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"coreModule") : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.program(4, data, 0),"data":data,"loc":{"start":{"line":135,"column":40},"end":{"line":135,"column":161}}})) != null ? stack1 : "")
+  return "<th>\n          <div"
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"coreModule") : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.program(4, data, 0),"data":data,"loc":{"start":{"line":192,"column":14},"end":{"line":193,"column":59}}})) != null ? stack1 : "")
     + ">"
-    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"source") || (depth0 != null ? lookupProperty(depth0,"source") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"source","hash":{},"data":data,"loc":{"start":{"line":135,"column":162},"end":{"line":135,"column":172}}}) : helper)))
-    + "</div></th>";
+    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"source") || (depth0 != null ? lookupProperty(depth0,"source") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"source","hash":{},"data":data,"loc":{"start":{"line":193,"column":60},"end":{"line":193,"column":70}}}) : helper)))
+    + "</div>\n        </th>";
 },"2":function(container,depth0,helpers,partials,data) {
-    return " class=\"cell-core-module\"";
+    return " class=\"cell-core-module\" ";
 },"4":function(container,depth0,helpers,partials,data) {
     var stack1, lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
@@ -22,9 +22,9 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
         return undefined
     };
 
-  return ((stack1 = lookupProperty(helpers,"if").call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? lookupProperty(depth0,"couldNotResolve") : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":135,"column":91},"end":{"line":135,"column":154}}})) != null ? stack1 : "");
+  return ((stack1 = lookupProperty(helpers,"if").call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? lookupProperty(depth0,"couldNotResolve") : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":192,"column":66},"end":{"line":193,"column":52}}})) != null ? stack1 : "");
 },"5":function(container,depth0,helpers,partials,data) {
-    return " class=\"cell-unresolvable-module\"";
+    return "\n            class=\"cell-unresolvable-module\" ";
 },"7":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=container.hooks.helperMissing, alias3="function", alias4=container.escapeExpression, lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
@@ -32,19 +32,19 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
         }
         return undefined
     }, buffer = 
-  "                <tr>\n                    <td class=\"first-cell"
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"coreModule") : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.program(10, data, 0, blockParams, depths),"data":data,"loc":{"start":{"line":142,"column":41},"end":{"line":142,"column":146}}})) != null ? stack1 : "")
-    + "\">"
-    + alias4(((helper = (helper = lookupProperty(helpers,"source") || (depth0 != null ? lookupProperty(depth0,"source") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"source","hash":{},"data":data,"loc":{"start":{"line":142,"column":148},"end":{"line":142,"column":158}}}) : helper)))
-    + "</td>\n                    ";
-  stack1 = ((helper = (helper = lookupProperty(helpers,"incidences") || (depth0 != null ? lookupProperty(depth0,"incidences") : depth0)) != null ? helper : alias2),(options={"name":"incidences","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":143,"column":20},"end":{"line":145,"column":43}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  "      <tr>\n        <td\n          class=\"first-cell"
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"coreModule") : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.program(10, data, 0, blockParams, depths),"data":data,"loc":{"start":{"line":202,"column":27},"end":{"line":202,"column":132}}})) != null ? stack1 : "")
+    + "\">\n          "
+    + alias4(((helper = (helper = lookupProperty(helpers,"source") || (depth0 != null ? lookupProperty(depth0,"source") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"source","hash":{},"data":data,"loc":{"start":{"line":203,"column":10},"end":{"line":203,"column":20}}}) : helper)))
+    + "</td>\n        ";
+  stack1 = ((helper = (helper = lookupProperty(helpers,"incidences") || (depth0 != null ? lookupProperty(depth0,"incidences") : depth0)) != null ? helper : alias2),(options={"name":"incidences","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":204,"column":8},"end":{"line":206,"column":40}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!lookupProperty(helpers,"incidences")) { stack1 = container.hooks.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "\n                    <td class=\"first-cell"
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"coreModule") : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.program(10, data, 0, blockParams, depths),"data":data,"loc":{"start":{"line":146,"column":41},"end":{"line":146,"column":146}}})) != null ? stack1 : "")
-    + "\">"
-    + alias4(((helper = (helper = lookupProperty(helpers,"source") || (depth0 != null ? lookupProperty(depth0,"source") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"source","hash":{},"data":data,"loc":{"start":{"line":146,"column":148},"end":{"line":146,"column":158}}}) : helper)))
-    + "</td>\n                </tr>\n";
+  return buffer + "\n        <td\n          class=\"first-cell"
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"coreModule") : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.program(10, data, 0, blockParams, depths),"data":data,"loc":{"start":{"line":208,"column":27},"end":{"line":208,"column":132}}})) != null ? stack1 : "")
+    + "\">\n          "
+    + alias4(((helper = (helper = lookupProperty(helpers,"source") || (depth0 != null ? lookupProperty(depth0,"source") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"source","hash":{},"data":data,"loc":{"start":{"line":209,"column":10},"end":{"line":209,"column":20}}}) : helper)))
+    + "</td>\n      </tr>\n";
 },"8":function(container,depth0,helpers,partials,data) {
     return " cell-core-module";
 },"10":function(container,depth0,helpers,partials,data) {
@@ -55,7 +55,7 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
         return undefined
     };
 
-  return ((stack1 = lookupProperty(helpers,"if").call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? lookupProperty(depth0,"couldNotResolve") : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":142,"column":84},"end":{"line":142,"column":139}}})) != null ? stack1 : "");
+  return ((stack1 = lookupProperty(helpers,"if").call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? lookupProperty(depth0,"couldNotResolve") : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":202,"column":70},"end":{"line":202,"column":125}}})) != null ? stack1 : "");
 },"11":function(container,depth0,helpers,partials,data) {
     return " cell-unresolvable-module";
 },"13":function(container,depth0,helpers,partials,data,blockParams,depths) {
@@ -67,9 +67,9 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
     };
 
   return "<td class=\"cell cell-"
-    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"incidence") || (depth0 != null ? lookupProperty(depth0,"incidence") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"incidence","hash":{},"data":data,"loc":{"start":{"line":143,"column":56},"end":{"line":143,"column":69}}}) : helper)))
-    + "\""
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"hasRelation") : depth0),{"name":"if","hash":{},"fn":container.program(14, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":143,"column":70},"end":{"line":145,"column":22}}})) != null ? stack1 : "")
+    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"incidence") || (depth0 != null ? lookupProperty(depth0,"incidence") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"incidence","hash":{},"data":data,"loc":{"start":{"line":204,"column":44},"end":{"line":204,"column":57}}}) : helper)))
+    + "\" "
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"hasRelation") : depth0),{"name":"if","hash":{},"fn":container.program(14, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":204,"column":59},"end":{"line":206,"column":19}}})) != null ? stack1 : "")
     + "></td>";
 },"14":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=container.escapeExpression, lookupProperty = container.lookupProperty || function(parent, propertyName) {
@@ -80,11 +80,11 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
     };
 
   return " title=\""
-    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"rule") : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":143,"column":97},"end":{"line":144,"column":15}}})) != null ? stack1 : "")
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"rule") : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":204,"column":86},"end":{"line":205,"column":11}}})) != null ? stack1 : "")
     + alias2(container.lambda((depths[1] != null ? lookupProperty(depths[1],"source") : depths[1]), depth0))
-    + " ->\n        "
-    + alias2(((helper = (helper = lookupProperty(helpers,"to") || (depth0 != null ? lookupProperty(depth0,"to") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"to","hash":{},"data":data,"loc":{"start":{"line":145,"column":8},"end":{"line":145,"column":14}}}) : helper)))
-    + "\"";
+    + " ->\n    "
+    + alias2(((helper = (helper = lookupProperty(helpers,"to") || (depth0 != null ? lookupProperty(depth0,"to") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"to","hash":{},"data":data,"loc":{"start":{"line":206,"column":4},"end":{"line":206,"column":10}}}) : helper)))
+    + "\" ";
 },"15":function(container,depth0,helpers,partials,data) {
     var helper, lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
@@ -93,8 +93,8 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
         return undefined
     };
 
-  return container.escapeExpression(((helper = (helper = lookupProperty(helpers,"rule") || (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"rule","hash":{},"data":data,"loc":{"start":{"line":143,"column":110},"end":{"line":143,"column":118}}}) : helper)))
-    + ":\n        ";
+  return container.escapeExpression(((helper = (helper = lookupProperty(helpers,"rule") || (depth0 != null ? lookupProperty(depth0,"rule") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"rule","hash":{},"data":data,"loc":{"start":{"line":204,"column":99},"end":{"line":204,"column":107}}}) : helper)))
+    + ":\n    ";
 },"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=container.hooks.helperMissing, alias3="function", alias4=container.hooks.blockHelperMissing, lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
@@ -102,17 +102,17 @@ templates['html.template.hbs'] = template({"1":function(container,depth0,helpers
         }
         return undefined
     }, buffer = 
-  "<!DOCTYPE html>\n<html>\n    <head>\n        <meta charset=\"utf-8\">\n        <title>dependency-cruiser output</title>\n        <style media=\"screen\">\n            html {\n                font-family: sans-serif;\n                font-size: 10pt;\n            }\n            table, td.controls {\n                transition-duration: 0.4s;\n            }\n            table, th, td{\n                border: solid black 1px;\n                border-collapse: collapse;\n                font-size: inherit;\n            }\n            th{\n                text-align:start;\n                vertical-align: bottom;\n                max-width: 1em;\n                max-height: 30em;\n                height: 20em;\n                font-weight: normal;\n                white-space: nowrap;\n                overflow: hidden;\n            }\n            th div {\n                transform: rotateZ(-90deg);\n                transform-origin: 0.5em;\n                text-align: start;\n                height: 1em;\n                width: 30em;\n                white-space: nowrap;\n                overflow: hidden;\n                text-overflow: ellipsis;\n            }\n            td {\n                text-align: center;\n            }\n            td.first-cell {\n                text-align: left;\n                white-space: nowrap;\n                overflow: hidden;\n                text-overflow: ellipsis;\n            }\n            td.top-left {\n                border-top: solid 1px transparent;\n                border-left: solid 1px transparent;\n            }\n            td.top-right {\n                border-top: solid 1px transparent;\n                border-right: solid 1px transparent;\n            }\n            td.bottom-left {\n                border-bottom: solid 1px transparent;\n                border-left: solid 1px transparent;\n            }\n            td.bottom-right {\n                border-bottom: solid 1px transparent;\n                border-right: solid 1px transparent;\n            }\n            tbody tr:hover {\n                background-color: lightgrey;\n            }\n            #table-rotated:target {\n                transform: rotateZ(45deg);\n                transform-origin: bottom left;\n            }\n            #table-rotated:target #unrotate {\n                opacity: 1;\n            }\n            #table-rotated:target #rotate {\n                opacity: 0;\n            }\n            #unrotate {\n                opacity: 0;\n            }\n            #rotate {\n                opacity: 1;\n            }\n            .controls {\n                opacity: 0.2;\n                vertical-align: bottom;\n                padding: 0.5em;\n            }\n            .controls:hover {\n                opacity: 1;\n            }\n            .controls a {\n                font-style: normal;\n                text-decoration: none;\n                background-color: #eee;\n                padding: 0.2em 0.5em 0.2em 0.5em;\n            }\n            .cell-core-module {\n                color: grey;\n                font-style: italic;\n            }\n            .cell-unresolvable-module {\n                color: red;\n                font-style: italic;\n            }\n            .cell-true {\n                background-color: black;\n                opacity: 0.5;\n            }\n            .cell-false {\n                background-color: white;\n                opacity: 0.5;\n            }\n            .cell-error {\n                background-color: red;\n                opacity: 0.5;\n            }\n            .cell-warn {\n                background-color: orange;\n                opacity: 0.5;\n            }\n            .cell-info {\n                background-color: blue;\n                opacity: 0.5;\n            }\n        </style>\n    </head>\n    <body>\n        <table id=\"table-rotated\">\n            <thead>\n                <tr>\n                    <td class=\"controls top-left\">\n                        <a id=\"rotate\" href=\"#table-rotated\">rotate</a>\n                        <a id=\"unrotate\" href=\"#\">rotate back</a>\n                    </td>\n                    ";
-  stack1 = ((helper = (helper = lookupProperty(helpers,"modules") || (depth0 != null ? lookupProperty(depth0,"modules") : depth0)) != null ? helper : alias2),(options={"name":"modules","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":135,"column":20},"end":{"line":135,"column":195}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  "<!DOCTYPE html>\n<html>\n\n<head>\n  <meta charset=\"utf-8\">\n  <title>dependency-cruiser output</title>\n  <style media=\"screen\">\n    html {\n      font-family: sans-serif;\n      font-size: 10pt;\n    }\n\n    table {\n      overflow: hidden;\n    }\n\n\n    table,\n    th,\n    td {\n      border: solid black 1px;\n      border-collapse: collapse;\n      font-size: inherit;\n    }\n\n    td,\n    th {\n      position: relative;\n    }\n\n    th {\n      text-align: start;\n      vertical-align: bottom;\n      max-width: 1em;\n      max-height: 30em;\n      height: 20em;\n      font-weight: normal;\n      white-space: nowrap;\n      overflow: hidden;\n    }\n\n    th div {\n      transform: rotateZ(-90deg);\n      transform-origin: 0.5em;\n      text-align: start;\n      height: 1em;\n      width: 30em;\n      white-space: nowrap;\n      overflow: hidden;\n      text-overflow: ellipsis;\n    }\n\n    td {\n      text-align: center;\n    }\n\n    td.first-cell {\n      text-align: left;\n      white-space: nowrap;\n      overflow: hidden;\n      text-overflow: ellipsis;\n    }\n\n    td.top-left {\n      border-top: solid 1px transparent;\n      border-left: solid 1px transparent;\n    }\n\n    td.top-right {\n      border-top: solid 1px transparent;\n      border-right: solid 1px transparent;\n    }\n\n    td.bottom-left {\n      border-bottom: solid 1px transparent;\n      border-left: solid 1px transparent;\n    }\n\n    td.bottom-right {\n      border-bottom: solid 1px transparent;\n      border-right: solid 1px transparent;\n    }\n\n    tbody tr:hover {\n      background-color: lightgrey;\n    }\n\n    td:hover::after,\n    td:focus::after,\n    th:hover::after,\n    th:focus::after {\n      background-color: #00000077;\n      content: \"\";\n      height: 5000px;\n      left: 0;\n      position: absolute;\n      top: -2500px;\n      width: 100%;\n      z-index: -1;\n    }\n\n    #table-rotated:target {\n      transform: rotateZ(45deg);\n      transform-origin: bottom left;\n    }\n\n    #table-rotated:target #unrotate {\n      opacity: 1;\n    }\n\n    #table-rotated:target #rotate {\n      opacity: 0;\n    }\n\n    #unrotate {\n      opacity: 0;\n    }\n\n    #rotate {\n      opacity: 1;\n    }\n\n    .controls {\n      opacity: 0.2;\n      vertical-align: bottom;\n      padding: 0.5em;\n    }\n\n    .controls:hover {\n      opacity: 1;\n    }\n\n    .controls a {\n      font-style: normal;\n      text-decoration: none;\n      background-color: #eee;\n      padding: 0.2em 0.5em 0.2em 0.5em;\n    }\n\n    .cell-core-module {\n      color: grey;\n      font-style: italic;\n    }\n\n    .cell-unresolvable-module {\n      color: red;\n      font-style: italic;\n    }\n\n    .cell-true {\n      background-color: black;\n      opacity: 0.5;\n    }\n\n    .cell-false {\n      background-color: white;\n      opacity: 0.5;\n    }\n\n    .cell-error {\n      background-color: red;\n      opacity: 0.5;\n    }\n\n    .cell-warn {\n      background-color: orange;\n      opacity: 0.5;\n    }\n\n    .cell-info {\n      background-color: blue;\n      opacity: 0.5;\n    }\n  </style>\n</head>\n\n<body>\n  <table id=\"table-rotated\">\n    <thead>\n      <tr>\n        <td class=\"controls top-left\">\n          <a id=\"rotate\" href=\"#table-rotated\">rotate</a>\n          <a id=\"unrotate\" href=\"#\">rotate back</a>\n        </td>\n        ";
+  stack1 = ((helper = (helper = lookupProperty(helpers,"modules") || (depth0 != null ? lookupProperty(depth0,"modules") : depth0)) != null ? helper : alias2),(options={"name":"modules","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":191,"column":8},"end":{"line":194,"column":25}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!lookupProperty(helpers,"modules")) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  buffer += "\n                    <td class=\"top-right\"></td>\n                </tr>\n            </thead>\n            <tbody>\n";
-  stack1 = ((helper = (helper = lookupProperty(helpers,"modules") || (depth0 != null ? lookupProperty(depth0,"modules") : depth0)) != null ? helper : alias2),(options={"name":"modules","hash":{},"fn":container.program(7, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":140,"column":16},"end":{"line":148,"column":28}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  buffer += "\n        <td class=\"top-right\"></td>\n      </tr>\n    </thead>\n    <tbody>\n";
+  stack1 = ((helper = (helper = lookupProperty(helpers,"modules") || (depth0 != null ? lookupProperty(depth0,"modules") : depth0)) != null ? helper : alias2),(options={"name":"modules","hash":{},"fn":container.program(7, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":199,"column":6},"end":{"line":211,"column":18}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!lookupProperty(helpers,"modules")) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  buffer += "            </tbody>\n            <tfoot>\n                <tr>\n                    <td class=\"bottom-left\"></td>\n                    ";
-  stack1 = ((helper = (helper = lookupProperty(helpers,"modules") || (depth0 != null ? lookupProperty(depth0,"modules") : depth0)) != null ? helper : alias2),(options={"name":"modules","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":153,"column":20},"end":{"line":153,"column":195}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  buffer += "    </tbody>\n    <tfoot>\n      <tr>\n        <td class=\"bottom-left\"></td>\n        ";
+  stack1 = ((helper = (helper = lookupProperty(helpers,"modules") || (depth0 != null ? lookupProperty(depth0,"modules") : depth0)) != null ? helper : alias2),(options={"name":"modules","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data,"loc":{"start":{"line":216,"column":8},"end":{"line":219,"column":25}}}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!lookupProperty(helpers,"modules")) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "\n                    <td class=\"bottom-right\"></td>\n                </tr>\n            </tfoot>\n        </table>\n    </body>\n</html>\n";
+  return buffer + "\n        <td class=\"bottom-right\"></td>\n      </tr>\n    </tfoot>\n  </table>\n</body>\n</html>";
 },"useData":true,"useDepths":true});

--- a/test/cli/fixtures/cjs.dir.filtered.html
+++ b/test/cli/fixtures/cjs.dir.filtered.html
@@ -1,229 +1,375 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>dependency-cruiser output</title>
-        <style media="screen">
-            html {
-                font-family: sans-serif;
-                font-size: 10pt;
-            }
-            table, td.controls {
-                transition-duration: 0.4s;
-            }
-            table, th, td{
-                border: solid black 1px;
-                border-collapse: collapse;
-                font-size: inherit;
-            }
-            th{
-                text-align:start;
-                vertical-align: bottom;
-                max-width: 1em;
-                max-height: 30em;
-                height: 20em;
-                font-weight: normal;
-                white-space: nowrap;
-                overflow: hidden;
-            }
-            th div {
-                transform: rotateZ(-90deg);
-                transform-origin: 0.5em;
-                text-align: start;
-                height: 1em;
-                width: 30em;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-            td {
-                text-align: center;
-            }
-            td.first-cell {
-                text-align: left;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-            td.top-left {
-                border-top: solid 1px transparent;
-                border-left: solid 1px transparent;
-            }
-            td.top-right {
-                border-top: solid 1px transparent;
-                border-right: solid 1px transparent;
-            }
-            td.bottom-left {
-                border-bottom: solid 1px transparent;
-                border-left: solid 1px transparent;
-            }
-            td.bottom-right {
-                border-bottom: solid 1px transparent;
-                border-right: solid 1px transparent;
-            }
-            tbody tr:hover {
-                background-color: lightgrey;
-            }
-            #table-rotated:target {
-                transform: rotateZ(45deg);
-                transform-origin: bottom left;
-            }
-            #table-rotated:target #unrotate {
-                opacity: 1;
-            }
-            #table-rotated:target #rotate {
-                opacity: 0;
-            }
-            #unrotate {
-                opacity: 0;
-            }
-            #rotate {
-                opacity: 1;
-            }
-            .controls {
-                opacity: 0.2;
-                vertical-align: bottom;
-                padding: 0.5em;
-            }
-            .controls:hover {
-                opacity: 1;
-            }
-            .controls a {
-                font-style: normal;
-                text-decoration: none;
-                background-color: #eee;
-                padding: 0.2em 0.5em 0.2em 0.5em;
-            }
-            .cell-core-module {
-                color: grey;
-                font-style: italic;
-            }
-            .cell-unresolvable-module {
-                color: red;
-                font-style: italic;
-            }
-            .cell-true {
-                background-color: black;
-                opacity: 0.5;
-            }
-            .cell-false {
-                background-color: white;
-                opacity: 0.5;
-            }
-            .cell-error {
-                background-color: red;
-                opacity: 0.5;
-            }
-            .cell-warn {
-                background-color: orange;
-                opacity: 0.5;
-            }
-            .cell-info {
-                background-color: blue;
-                opacity: 0.5;
-            }
-        </style>
-    </head>
-    <body>
-        <table id="table-rotated">
-            <thead>
-                <tr>
-                    <td class="controls top-left">
-                        <a id="rotate" href="#table-rotated">rotate</a>
-                        <a id="unrotate" href="#">rotate back</a>
-                    </td>
-                    <th><div>test/cli/fixtures/cjs/one_only_one.js</div></th><th><div>test/cli/fixtures/cjs/one_only_two.js</div></th><th><div>test/cli/fixtures/cjs/root_one.js</div></th><th><div>test/cli/fixtures/cjs/root_two.js</div></th><th><div>test/cli/fixtures/cjs/shared.js</div></th><th><div>test/cli/fixtures/cjs/somedata.json</div></th><th><div>test/cli/fixtures/cjs/sub/depindir.js</div></th><th><div>test/cli/fixtures/cjs/sub/dir.js</div></th><th><div>test/cli/fixtures/cjs/two_only_one.js</div></th><th><div class="cell-core-module">fs</div></th><th><div class="cell-core-module">http</div></th><th><div class="cell-core-module">path</div></th>
-                    <td class="top-right"></td>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/one_only_one.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/one_only_one.js ->
-        path"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/one_only_one.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/one_only_two.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/one_only_two.js ->
-        path"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/one_only_two.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/root_one.js</td>
-                    <td class="cell cell-true" title="test/cli/fixtures/cjs/root_one.js ->
-        test/cli/fixtures/cjs/one_only_one.js"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_one.js ->
-        test/cli/fixtures/cjs/one_only_two.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_one.js ->
-        test/cli/fixtures/cjs/shared.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="sub-not-allowed:
-        test/cli/fixtures/cjs/root_one.js ->
-        test/cli/fixtures/cjs/sub/dir.js"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_one.js ->
-        fs"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/root_one.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/root_two.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_two.js ->
-        test/cli/fixtures/cjs/shared.js"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_two.js ->
-        test/cli/fixtures/cjs/somedata.json"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_two.js ->
-        test/cli/fixtures/cjs/two_only_one.js"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/root_two.js ->
-        http"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/root_two.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/shared.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/shared.js ->
-        path"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/shared.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/somedata.json</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/somedata.json</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/sub/depindir.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/sub/depindir.js ->
-        path"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/sub/depindir.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/sub/dir.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="sub-not-allowed:
-        test/cli/fixtures/cjs/sub/dir.js ->
-        test/cli/fixtures/cjs/sub/depindir.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-true" title="test/cli/fixtures/cjs/sub/dir.js ->
-        path"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/sub/dir.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">test/cli/fixtures/cjs/two_only_one.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="sub-not-allowed:
-        test/cli/fixtures/cjs/two_only_one.js ->
-        test/cli/fixtures/cjs/sub/dir.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">test/cli/fixtures/cjs/two_only_one.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-core-module">fs</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell cell-core-module">fs</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-core-module">http</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell cell-core-module">http</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-core-module">path</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell cell-core-module">path</td>
-                </tr>
-            </tbody>
-            <tfoot>
-                <tr>
-                    <td class="bottom-left"></td>
-                    <th><div>test/cli/fixtures/cjs/one_only_one.js</div></th><th><div>test/cli/fixtures/cjs/one_only_two.js</div></th><th><div>test/cli/fixtures/cjs/root_one.js</div></th><th><div>test/cli/fixtures/cjs/root_two.js</div></th><th><div>test/cli/fixtures/cjs/shared.js</div></th><th><div>test/cli/fixtures/cjs/somedata.json</div></th><th><div>test/cli/fixtures/cjs/sub/depindir.js</div></th><th><div>test/cli/fixtures/cjs/sub/dir.js</div></th><th><div>test/cli/fixtures/cjs/two_only_one.js</div></th><th><div class="cell-core-module">fs</div></th><th><div class="cell-core-module">http</div></th><th><div class="cell-core-module">path</div></th>
-                    <td class="bottom-right"></td>
-                </tr>
-            </tfoot>
-        </table>
-    </body>
+
+<head>
+  <meta charset="utf-8">
+  <title>dependency-cruiser output</title>
+  <style media="screen">
+    html {
+      font-family: sans-serif;
+      font-size: 10pt;
+    }
+
+    table {
+      overflow: hidden;
+    }
+
+
+    table,
+    th,
+    td {
+      border: solid black 1px;
+      border-collapse: collapse;
+      font-size: inherit;
+    }
+
+    td,
+    th {
+      position: relative;
+    }
+
+    th {
+      text-align: start;
+      vertical-align: bottom;
+      max-width: 1em;
+      max-height: 30em;
+      height: 20em;
+      font-weight: normal;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    th div {
+      transform: rotateZ(-90deg);
+      transform-origin: 0.5em;
+      text-align: start;
+      height: 1em;
+      width: 30em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    td {
+      text-align: center;
+    }
+
+    td.first-cell {
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    td.top-left {
+      border-top: solid 1px transparent;
+      border-left: solid 1px transparent;
+    }
+
+    td.top-right {
+      border-top: solid 1px transparent;
+      border-right: solid 1px transparent;
+    }
+
+    td.bottom-left {
+      border-bottom: solid 1px transparent;
+      border-left: solid 1px transparent;
+    }
+
+    td.bottom-right {
+      border-bottom: solid 1px transparent;
+      border-right: solid 1px transparent;
+    }
+
+    tbody tr:hover {
+      background-color: lightgrey;
+    }
+
+    td:hover::after,
+    td:focus::after,
+    th:hover::after,
+    th:focus::after {
+      background-color: #00000077;
+      content: "";
+      height: 5000px;
+      left: 0;
+      position: absolute;
+      top: -2500px;
+      width: 100%;
+      z-index: -1;
+    }
+
+    #table-rotated:target {
+      transform: rotateZ(45deg);
+      transform-origin: bottom left;
+    }
+
+    #table-rotated:target #unrotate {
+      opacity: 1;
+    }
+
+    #table-rotated:target #rotate {
+      opacity: 0;
+    }
+
+    #unrotate {
+      opacity: 0;
+    }
+
+    #rotate {
+      opacity: 1;
+    }
+
+    .controls {
+      opacity: 0.2;
+      vertical-align: bottom;
+      padding: 0.5em;
+    }
+
+    .controls:hover {
+      opacity: 1;
+    }
+
+    .controls a {
+      font-style: normal;
+      text-decoration: none;
+      background-color: #eee;
+      padding: 0.2em 0.5em 0.2em 0.5em;
+    }
+
+    .cell-core-module {
+      color: grey;
+      font-style: italic;
+    }
+
+    .cell-unresolvable-module {
+      color: red;
+      font-style: italic;
+    }
+
+    .cell-true {
+      background-color: black;
+      opacity: 0.5;
+    }
+
+    .cell-false {
+      background-color: white;
+      opacity: 0.5;
+    }
+
+    .cell-error {
+      background-color: red;
+      opacity: 0.5;
+    }
+
+    .cell-warn {
+      background-color: orange;
+      opacity: 0.5;
+    }
+
+    .cell-info {
+      background-color: blue;
+      opacity: 0.5;
+    }
+  </style>
+</head>
+
+<body>
+  <table id="table-rotated">
+    <thead>
+      <tr>
+        <td class="controls top-left">
+          <a id="rotate" href="#table-rotated">rotate</a>
+          <a id="unrotate" href="#">rotate back</a>
+        </td>
+        <th>
+          <div>test/cli/fixtures/cjs/one_only_one.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/one_only_two.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/root_one.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/root_two.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/shared.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/somedata.json</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/sub/depindir.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/sub/dir.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/two_only_one.js</div>
+        </th><th>
+          <div class="cell-core-module" >fs</div>
+        </th><th>
+          <div class="cell-core-module" >http</div>
+        </th><th>
+          <div class="cell-core-module" >path</div>
+        </th>
+        <td class="top-right"></td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/one_only_one.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/one_only_one.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/one_only_one.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/one_only_two.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/one_only_two.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/one_only_two.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/root_one.js</td>
+        <td class="cell cell-true"  title="test/cli/fixtures/cjs/root_one.js ->
+    test/cli/fixtures/cjs/one_only_one.js" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_one.js ->
+    test/cli/fixtures/cjs/one_only_two.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_one.js ->
+    test/cli/fixtures/cjs/shared.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="sub-not-allowed:
+    test/cli/fixtures/cjs/root_one.js ->
+    test/cli/fixtures/cjs/sub/dir.js" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_one.js ->
+    fs" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/root_one.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/root_two.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_two.js ->
+    test/cli/fixtures/cjs/shared.js" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_two.js ->
+    test/cli/fixtures/cjs/somedata.json" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_two.js ->
+    test/cli/fixtures/cjs/two_only_one.js" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/root_two.js ->
+    http" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/root_two.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/shared.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/shared.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/shared.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/somedata.json</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/somedata.json</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/sub/depindir.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/sub/depindir.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/sub/depindir.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/sub/dir.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="sub-not-allowed:
+    test/cli/fixtures/cjs/sub/dir.js ->
+    test/cli/fixtures/cjs/sub/depindir.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-true"  title="test/cli/fixtures/cjs/sub/dir.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/sub/dir.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/two_only_one.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="sub-not-allowed:
+    test/cli/fixtures/cjs/two_only_one.js ->
+    test/cli/fixtures/cjs/sub/dir.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          test/cli/fixtures/cjs/two_only_one.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-core-module">
+          fs</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell cell-core-module">
+          fs</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-core-module">
+          http</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell cell-core-module">
+          http</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-core-module">
+          path</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell cell-core-module">
+          path</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class="bottom-left"></td>
+        <th>
+          <div>test/cli/fixtures/cjs/one_only_one.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/one_only_two.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/root_one.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/root_two.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/shared.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/somedata.json</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/sub/depindir.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/sub/dir.js</div>
+        </th><th>
+          <div>test/cli/fixtures/cjs/two_only_one.js</div>
+        </th><th>
+          <div class="cell-core-module" >fs</div>
+        </th><th>
+          <div class="cell-core-module" >http</div>
+        </th><th>
+          <div class="cell-core-module" >path</div>
+        </th>
+        <td class="bottom-right"></td>
+      </tr>
+    </tfoot>
+  </table>
+</body>
 </html>

--- a/test/report/html/mocks/cjs-no-dependency-valid.html
+++ b/test/report/html/mocks/cjs-no-dependency-valid.html
@@ -1,263 +1,435 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>dependency-cruiser output</title>
-        <style media="screen">
-            html {
-                font-family: sans-serif;
-                font-size: 10pt;
-            }
-            table, td.controls {
-                transition-duration: 0.4s;
-            }
-            table, th, td{
-                border: solid black 1px;
-                border-collapse: collapse;
-                font-size: inherit;
-            }
-            th{
-                text-align:start;
-                vertical-align: bottom;
-                max-width: 1em;
-                max-height: 30em;
-                height: 20em;
-                font-weight: normal;
-                white-space: nowrap;
-                overflow: hidden;
-            }
-            th div {
-                transform: rotateZ(-90deg);
-                transform-origin: 0.5em;
-                text-align: start;
-                height: 1em;
-                width: 30em;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-            td {
-                text-align: center;
-            }
-            td.first-cell {
-                text-align: left;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-            td.top-left {
-                border-top: solid 1px transparent;
-                border-left: solid 1px transparent;
-            }
-            td.top-right {
-                border-top: solid 1px transparent;
-                border-right: solid 1px transparent;
-            }
-            td.bottom-left {
-                border-bottom: solid 1px transparent;
-                border-left: solid 1px transparent;
-            }
-            td.bottom-right {
-                border-bottom: solid 1px transparent;
-                border-right: solid 1px transparent;
-            }
-            tbody tr:hover {
-                background-color: lightgrey;
-            }
-            #table-rotated:target {
-                transform: rotateZ(45deg);
-                transform-origin: bottom left;
-            }
-            #table-rotated:target #unrotate {
-                opacity: 1;
-            }
-            #table-rotated:target #rotate {
-                opacity: 0;
-            }
-            #unrotate {
-                opacity: 0;
-            }
-            #rotate {
-                opacity: 1;
-            }
-            .controls {
-                opacity: 0.2;
-                vertical-align: bottom;
-                padding: 0.5em;
-            }
-            .controls:hover {
-                opacity: 1;
-            }
-            .controls a {
-                font-style: normal;
-                text-decoration: none;
-                background-color: #eee;
-                padding: 0.2em 0.5em 0.2em 0.5em;
-            }
-            .cell-core-module {
-                color: grey;
-                font-style: italic;
-            }
-            .cell-unresolvable-module {
-                color: red;
-                font-style: italic;
-            }
-            .cell-true {
-                background-color: black;
-                opacity: 0.5;
-            }
-            .cell-false {
-                background-color: white;
-                opacity: 0.5;
-            }
-            .cell-error {
-                background-color: red;
-                opacity: 0.5;
-            }
-            .cell-warn {
-                background-color: orange;
-                opacity: 0.5;
-            }
-            .cell-info {
-                background-color: blue;
-                opacity: 0.5;
-            }
-        </style>
-    </head>
-    <body>
-        <table id="table-rotated">
-            <thead>
-                <tr>
-                    <td class="controls top-left">
-                        <a id="rotate" href="#table-rotated">rotate</a>
-                        <a id="unrotate" href="#">rotate back</a>
-                    </td>
-                    <th><div>node_modules/somemodule/node_modules/someothermodule/main.js</div></th><th><div>node_modules/somemodule/src/moar-javascript.js</div></th><th><div>node_modules/somemodule/src/somemodule.js</div></th><th><div>one_only_one.js</div></th><th><div>one_only_two.js</div></th><th><div>root_one.js</div></th><th><div>root_two.js</div></th><th><div class="cell-unresolvable-module">shared.js</div></th><th><div>somedata.json</div></th><th><div>sub/depindir.js</div></th><th><div>sub/dir.js</div></th><th><div>two_only_one.js</div></th><th><div class="cell-core-module">fs</div></th><th><div class="cell-core-module">http</div></th><th><div class="cell-core-module">path</div></th>
-                    <td class="top-right"></td>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td class="first-cell">node_modules/somemodule/node_modules/someothermodule/main.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">node_modules/somemodule/node_modules/someothermodule/main.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">node_modules/somemodule/src/moar-javascript.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">node_modules/somemodule/src/moar-javascript.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">node_modules/somemodule/src/somemodule.js</td>
-                    <td class="cell cell-warn" title="unnamed:
-        node_modules/somemodule/src/somemodule.js ->
-        node_modules/somemodule/node_modules/someothermodule/main.js"></td><td class="cell cell-warn" title="unnamed:
-        node_modules/somemodule/src/somemodule.js ->
-        node_modules/somemodule/src/moar-javascript.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">node_modules/somemodule/src/somemodule.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">one_only_one.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        one_only_one.js ->
-        path"></td>
-                    <td class="first-cell">one_only_one.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">one_only_two.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        one_only_two.js ->
-        path"></td>
-                    <td class="first-cell">one_only_two.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">root_one.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_one.js ->
-        node_modules/somemodule/src/somemodule.js"></td><td class="cell cell-warn" title="unnamed:
-        root_one.js ->
-        one_only_one.js"></td><td class="cell cell-warn" title="unnamed:
-        root_one.js ->
-        one_only_two.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_one.js ->
-        shared.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_one.js ->
-        sub/dir.js"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_one.js ->
-        fs"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">root_one.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">root_two.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_two.js ->
-        shared.js"></td><td class="cell cell-warn" title="unnamed:
-        root_two.js ->
-        somedata.json"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_two.js ->
-        two_only_one.js"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        root_two.js ->
-        http"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">root_two.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-unresolvable-module">shared.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        shared.js ->
-        path"></td>
-                    <td class="first-cell cell-unresolvable-module">shared.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">somedata.json</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">somedata.json</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">sub/depindir.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        sub/depindir.js ->
-        path"></td>
-                    <td class="first-cell">sub/depindir.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">sub/dir.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        sub/dir.js ->
-        sub/depindir.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        sub/dir.js ->
-        path"></td>
-                    <td class="first-cell">sub/dir.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell">two_only_one.js</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-warn" title="unnamed:
-        two_only_one.js ->
-        sub/dir.js"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell">two_only_one.js</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-core-module">fs</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell cell-core-module">fs</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-core-module">http</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell cell-core-module">http</td>
-                </tr>
-                <tr>
-                    <td class="first-cell cell-core-module">path</td>
-                    <td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td><td class="cell cell-false"></td>
-                    <td class="first-cell cell-core-module">path</td>
-                </tr>
-            </tbody>
-            <tfoot>
-                <tr>
-                    <td class="bottom-left"></td>
-                    <th><div>node_modules/somemodule/node_modules/someothermodule/main.js</div></th><th><div>node_modules/somemodule/src/moar-javascript.js</div></th><th><div>node_modules/somemodule/src/somemodule.js</div></th><th><div>one_only_one.js</div></th><th><div>one_only_two.js</div></th><th><div>root_one.js</div></th><th><div>root_two.js</div></th><th><div class="cell-unresolvable-module">shared.js</div></th><th><div>somedata.json</div></th><th><div>sub/depindir.js</div></th><th><div>sub/dir.js</div></th><th><div>two_only_one.js</div></th><th><div class="cell-core-module">fs</div></th><th><div class="cell-core-module">http</div></th><th><div class="cell-core-module">path</div></th>
-                    <td class="bottom-right"></td>
-                </tr>
-            </tfoot>
-        </table>
-    </body>
+
+<head>
+  <meta charset="utf-8">
+  <title>dependency-cruiser output</title>
+  <style media="screen">
+    html {
+      font-family: sans-serif;
+      font-size: 10pt;
+    }
+
+    table {
+      overflow: hidden;
+    }
+
+
+    table,
+    th,
+    td {
+      border: solid black 1px;
+      border-collapse: collapse;
+      font-size: inherit;
+    }
+
+    td,
+    th {
+      position: relative;
+    }
+
+    th {
+      text-align: start;
+      vertical-align: bottom;
+      max-width: 1em;
+      max-height: 30em;
+      height: 20em;
+      font-weight: normal;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    th div {
+      transform: rotateZ(-90deg);
+      transform-origin: 0.5em;
+      text-align: start;
+      height: 1em;
+      width: 30em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    td {
+      text-align: center;
+    }
+
+    td.first-cell {
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    td.top-left {
+      border-top: solid 1px transparent;
+      border-left: solid 1px transparent;
+    }
+
+    td.top-right {
+      border-top: solid 1px transparent;
+      border-right: solid 1px transparent;
+    }
+
+    td.bottom-left {
+      border-bottom: solid 1px transparent;
+      border-left: solid 1px transparent;
+    }
+
+    td.bottom-right {
+      border-bottom: solid 1px transparent;
+      border-right: solid 1px transparent;
+    }
+
+    tbody tr:hover {
+      background-color: lightgrey;
+    }
+
+    td:hover::after,
+    td:focus::after,
+    th:hover::after,
+    th:focus::after {
+      background-color: #00000077;
+      content: "";
+      height: 5000px;
+      left: 0;
+      position: absolute;
+      top: -2500px;
+      width: 100%;
+      z-index: -1;
+    }
+
+    #table-rotated:target {
+      transform: rotateZ(45deg);
+      transform-origin: bottom left;
+    }
+
+    #table-rotated:target #unrotate {
+      opacity: 1;
+    }
+
+    #table-rotated:target #rotate {
+      opacity: 0;
+    }
+
+    #unrotate {
+      opacity: 0;
+    }
+
+    #rotate {
+      opacity: 1;
+    }
+
+    .controls {
+      opacity: 0.2;
+      vertical-align: bottom;
+      padding: 0.5em;
+    }
+
+    .controls:hover {
+      opacity: 1;
+    }
+
+    .controls a {
+      font-style: normal;
+      text-decoration: none;
+      background-color: #eee;
+      padding: 0.2em 0.5em 0.2em 0.5em;
+    }
+
+    .cell-core-module {
+      color: grey;
+      font-style: italic;
+    }
+
+    .cell-unresolvable-module {
+      color: red;
+      font-style: italic;
+    }
+
+    .cell-true {
+      background-color: black;
+      opacity: 0.5;
+    }
+
+    .cell-false {
+      background-color: white;
+      opacity: 0.5;
+    }
+
+    .cell-error {
+      background-color: red;
+      opacity: 0.5;
+    }
+
+    .cell-warn {
+      background-color: orange;
+      opacity: 0.5;
+    }
+
+    .cell-info {
+      background-color: blue;
+      opacity: 0.5;
+    }
+  </style>
+</head>
+
+<body>
+  <table id="table-rotated">
+    <thead>
+      <tr>
+        <td class="controls top-left">
+          <a id="rotate" href="#table-rotated">rotate</a>
+          <a id="unrotate" href="#">rotate back</a>
+        </td>
+        <th>
+          <div>node_modules/somemodule/node_modules/someothermodule/main.js</div>
+        </th><th>
+          <div>node_modules/somemodule/src/moar-javascript.js</div>
+        </th><th>
+          <div>node_modules/somemodule/src/somemodule.js</div>
+        </th><th>
+          <div>one_only_one.js</div>
+        </th><th>
+          <div>one_only_two.js</div>
+        </th><th>
+          <div>root_one.js</div>
+        </th><th>
+          <div>root_two.js</div>
+        </th><th>
+          <div
+            class="cell-unresolvable-module" >shared.js</div>
+        </th><th>
+          <div>somedata.json</div>
+        </th><th>
+          <div>sub/depindir.js</div>
+        </th><th>
+          <div>sub/dir.js</div>
+        </th><th>
+          <div>two_only_one.js</div>
+        </th><th>
+          <div class="cell-core-module" >fs</div>
+        </th><th>
+          <div class="cell-core-module" >http</div>
+        </th><th>
+          <div class="cell-core-module" >path</div>
+        </th>
+        <td class="top-right"></td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td
+          class="first-cell">
+          node_modules/somemodule/node_modules/someothermodule/main.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          node_modules/somemodule/node_modules/someothermodule/main.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          node_modules/somemodule/src/moar-javascript.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          node_modules/somemodule/src/moar-javascript.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          node_modules/somemodule/src/somemodule.js</td>
+        <td class="cell cell-warn"  title="unnamed:
+    node_modules/somemodule/src/somemodule.js ->
+    node_modules/somemodule/node_modules/someothermodule/main.js" ></td><td class="cell cell-warn"  title="unnamed:
+    node_modules/somemodule/src/somemodule.js ->
+    node_modules/somemodule/src/moar-javascript.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          node_modules/somemodule/src/somemodule.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          one_only_one.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    one_only_one.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          one_only_one.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          one_only_two.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    one_only_two.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          one_only_two.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          root_one.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_one.js ->
+    node_modules/somemodule/src/somemodule.js" ></td><td class="cell cell-warn"  title="unnamed:
+    root_one.js ->
+    one_only_one.js" ></td><td class="cell cell-warn"  title="unnamed:
+    root_one.js ->
+    one_only_two.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_one.js ->
+    shared.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_one.js ->
+    sub/dir.js" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_one.js ->
+    fs" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          root_one.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          root_two.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_two.js ->
+    shared.js" ></td><td class="cell cell-warn"  title="unnamed:
+    root_two.js ->
+    somedata.json" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_two.js ->
+    two_only_one.js" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    root_two.js ->
+    http" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          root_two.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-unresolvable-module">
+          shared.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    shared.js ->
+    path" ></td>
+        <td
+          class="first-cell cell-unresolvable-module">
+          shared.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          somedata.json</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          somedata.json</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          sub/depindir.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    sub/depindir.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          sub/depindir.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          sub/dir.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    sub/dir.js ->
+    sub/depindir.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    sub/dir.js ->
+    path" ></td>
+        <td
+          class="first-cell">
+          sub/dir.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell">
+          two_only_one.js</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-warn"  title="unnamed:
+    two_only_one.js ->
+    sub/dir.js" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell">
+          two_only_one.js</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-core-module">
+          fs</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell cell-core-module">
+          fs</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-core-module">
+          http</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell cell-core-module">
+          http</td>
+      </tr>
+      <tr>
+        <td
+          class="first-cell cell-core-module">
+          path</td>
+        <td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td><td class="cell cell-false" ></td>
+        <td
+          class="first-cell cell-core-module">
+          path</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class="bottom-left"></td>
+        <th>
+          <div>node_modules/somemodule/node_modules/someothermodule/main.js</div>
+        </th><th>
+          <div>node_modules/somemodule/src/moar-javascript.js</div>
+        </th><th>
+          <div>node_modules/somemodule/src/somemodule.js</div>
+        </th><th>
+          <div>one_only_one.js</div>
+        </th><th>
+          <div>one_only_two.js</div>
+        </th><th>
+          <div>root_one.js</div>
+        </th><th>
+          <div>root_two.js</div>
+        </th><th>
+          <div
+            class="cell-unresolvable-module" >shared.js</div>
+        </th><th>
+          <div>somedata.json</div>
+        </th><th>
+          <div>sub/depindir.js</div>
+        </th><th>
+          <div>sub/dir.js</div>
+        </th><th>
+          <div>two_only_one.js</div>
+        </th><th>
+          <div class="cell-core-module" >fs</div>
+        </th><th>
+          <div class="cell-core-module" >http</div>
+        </th><th>
+          <div class="cell-core-module" >path</div>
+        </th>
+        <td class="bottom-right"></td>
+      </tr>
+    </tfoot>
+  </table>
+</body>
 </html>


### PR DESCRIPTION
## Description

On hovering cells in the html  matrix report highlight the vertical as well as the horizontal rows.

## Motivation and Context

Eases use 

## How Has This Been Tested?

Automated non-regression, green ci

## Screenshots

### Before
<img width="767" alt="image" src="https://user-images.githubusercontent.com/4822597/73974584-e5b95480-4924-11ea-89a2-591f5379d6b4.png">

### After
<img width="767" alt="image" src="https://user-images.githubusercontent.com/4822597/73974688-18fbe380-4925-11ea-8308-3e9316809501.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
