### PR TITLE
bugfix(extract): disregards the module system when determining pre-compilation-ness

### DIFF
--- a/src/extract/utl/compare.js
+++ b/src/extract/utl/compare.js
@@ -26,9 +26,15 @@ function violations(pFirstViolation, pSecondViolation) {
 }
 
 function dependenciesEqual(pLeftDependency) {
+  // As we're using this to compare (typescript) pre-compilation dependencies
+  // with post-compilation dependencies we donot consider the moduleSystem.
+  //
+  // In typescript the module system will typically be es6. Compiled down to
+  // javascript it can be es6, but also cjs (depends on the `module` setting
+  // in your tsconfig). In the latter case, we're still looking at the same
+  // dependency even though the module systems differ.
   return pRightDependency =>
     pLeftDependency.module === pRightDependency.module &&
-    pLeftDependency.moduleSystem === pRightDependency.moduleSystem &&
     pLeftDependency.dynamic === pRightDependency.dynamic &&
     pLeftDependency.exoticRequire === pRightDependency.exoticRequire;
 }

--- a/test/extract/utl/compare.dependenciesEqual.spec.js
+++ b/test/extract/utl/compare.dependenciesEqual.spec.js
@@ -31,7 +31,7 @@ describe("extract/utl/compare - dependencyEquals", () => {
     ).to.equal(true);
   });
 
-  it("same module name, different module system => neq", () => {
+  it("same module name, different module system => eq", () => {
     expect(
       compare.dependenciesEqual({
         module: "foo",
@@ -40,7 +40,7 @@ describe("extract/utl/compare - dependencyEquals", () => {
         module: "foo",
         moduleSystem: "cjs"
       })
-    ).to.equal(false);
+    ).to.equal(true);
   });
 
   it("different module name, same module system => neq", () => {

--- a/test/extract/utl/detectPreCompilationNess.spec.js
+++ b/test/extract/utl/detectPreCompilationNess.spec.js
@@ -32,7 +32,7 @@ describe("extract/utl/detectPreCompilationNess", () => {
         [{ module: "foo", moduleSystem: "cjs" }]
       )
     ).to.deep.equal([
-      { module: "foo", moduleSystem: "es6", preCompilationOnly: true }
+      { module: "foo", moduleSystem: "es6", preCompilationOnly: false }
     ]);
   });
 


### PR DESCRIPTION
## Description, Motivation and Context

Disregards the module system when determining pre-compilation-ness.

In typescript the module system will typically be es6. Compiled down to
javascript it can be es6, but also cjs (depends on the `module` setting
in your tsconfig). In the latter case, we're still looking at the same
dependency even though the module systems differ.

## How Has This Been Tested?

Automated non-regression tests, adapted unit tests - live repos. Green CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
