### PR TITLE
feature(report): by default visually distinguishes pre-compilation only dependencies in all dot reports

### DIFF
--- a/src/report/dot/defaultTheme.json
+++ b/src/report/dot/defaultTheme.json
@@ -126,6 +126,10 @@
       "attributes": { "arrowhead": "normalnoneodot" }
     },
     {
+      "criteria": { "preCompilationOnly": true },
+      "attributes": { "arrowhead": "onormal", "penwidth": "1.0" }
+    },
+    {
       "criteria": { "coreModule": true },
       "attributes": { "style": "dashed", "penwidth": "1.0" }
     },


### PR DESCRIPTION
## Description

- By default in dot reports, if a dependency is determined to be pre-compilation only (with the option `tsPrecompilationDeps: "specify"`) they will now show up visually distinguishable from post-compilation-also dependencies (currently with an open instead of a closed arrow, and with a slightly smaller line thickness).

This was already possible by using a customised theme 

## Motivation and Context

- You might want to treat dependencies that exist before compilation only (e.g. type imports) different from others. Having them visually distinguished by default will aid in making these decisions.

## How Has This Been Tested?

Eyeballs. Green CI.

## Screenshots

This gives an overview of [http-proxy-middleware](chimurai/http-proxy-middleware)'s internal and external dependencies. You'll see that all dependencies on `types.ts` as well as the external dependency on `express` and the builtins `http` and `net` are there only for typing - which you can only see in the _after_ picture:

### before

![dependencygraph-before](https://user-images.githubusercontent.com/4822597/74603893-aaebb500-50b8-11ea-9212-9775c74238df.png)


### after

![dependencygraph-after](https://user-images.githubusercontent.com/4822597/74603894-b048ff80-50b8-11ea-8348-8abf9960076a.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
