### PR TITLE
test(extract): add unit tests to verify new types of imports & exports in typescript 3.8+ work

### DIFF
--- a/test/extract/ast-extractors/allShapesOfImportExport.md
+++ b/test/extract/ast-extractors/allShapesOfImportExport.md
@@ -1,10 +1,12 @@
 Regular commonjs:
+
 ```typescript
-require('./cjs-thing-execute');
-const cjsThing = require('./cjs-thing');
-const cjsThingThing = require('./cjs-thing').thing;
-const wappie = require('zoinks!./wappie');
+require("./cjs-thing-execute");
+const cjsThing = require("./cjs-thing");
+const cjsThingThing = require("./cjs-thing").thing;
+const wappie = require("zoinks!./wappie");
 ```
+
 These all land up post compile time => can be handled by acorn/
 the javascript AST.
 
@@ -15,22 +17,26 @@ try catch, you're using the require keyword for something else) or just for
 the lulz:
 
 ```javascript
-const tryRequire = require('semver-try-require');
+const tryRequire = require("semver-try-require");
 const need = require;
-const whoadash = need('whoadash');
-const dunnoItBeThere = tryRequire('nodash');
+const whoadash = need("whoadash");
+const dunnoItBeThere = tryRequire("nodash");
 ```
 
 Export equals imports are specific for typescript:
+
 ```typescript
-import thing = require('./thing-that-uses-export-equals');
+import thing = require("./thing-that-uses-export-equals");
 ```
-They translate into 
+
+They translate into
+
 ```javascript
-var thing = require()
+var thing = require();
 ```
-... which is neat & dandy unless your target is something 
-modern, in which case the typescript compiler barfs. In our 
+
+... which is neat & dandy unless your target is something
+modern, in which case the typescript compiler barfs. In our
 case (we're on ES2015 as compilation target in `extract/transpile`)
 these things won't end up post compile either and will have to
 be handled by surfing the typescript AST.
@@ -39,8 +45,9 @@ Dynamic imports are not in the javascript standard yet, but typescript
 already has it:
 
 ```typescript
-import('aju').then(aju => aju.paraplu());
+import("aju").then(aju => aju.paraplu());
 ```
+
 Same shortcoming as the import `yadda = require('aju')` thing when
 downcompiling - and likewise supported when ts-precompilation-deps
 are _on_.
@@ -48,21 +55,27 @@ are _on_.
 Regular (es6 style) imports need to be handled by surfing the typescript AST,
 as the typescript compiler output won't contain references to types
 nor references to modules that are unused
+
 ```typescript
 import './import-for-side-effects';
 import { SomeSingleExport } from './ts-thing';
 import { SomeSingleExport as RenamedSingleExport } from './ts-thing';
 import * as entireTsOtherThingAsVariable from './ts-other-thing';
+import type { SomeType } from './some-module';
 ```
 
 ... as do (re-exports)
+
 ```typescript
 export * from './StringValidator';
 export { ReExport as RenamedReExport } from "./ts-thing-for-re-exports"
+export * as utilities from "./utilities.js";
 ```
+
 (take care not to ignore exports that are not a re-exports into account: `export thing;`)
 
 ... and triple-slash directives
+
 ```typescript
 /// <reference path="..." />
 /// <reference types="..." />

--- a/test/extract/ast-extractors/extract-typescript-exports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-exports.spec.js
@@ -33,4 +33,17 @@ describe("ast-extractors/extract-typescript - re-exports", () => {
       extractTypescript("export { ReExport as RenamedReExport };")
     ).to.deep.equal([]);
   });
+
+  it("extracts re-export under a different name (typescript 3.8+, ecmascript 2020)", () => {
+    expect(
+      extractTypescript("export * as woehahaha from './damodule'")
+    ).to.deep.equal([
+      {
+        module: "./damodule",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false
+      }
+    ]);
+  });
 });

--- a/test/extract/ast-extractors/extract-typescript-imports.spec.js
+++ b/test/extract/ast-extractors/extract-typescript-imports.spec.js
@@ -127,4 +127,17 @@ describe("ast-extractors/extract-typescript - regular imports", () => {
       extractTypescript("import protocol = ts.server.protocol")
     ).to.deep.equal([]);
   });
+
+  it("extracts type imports (typescript 3.8+)", () => {
+    expect(
+      extractTypescript("import type { SomeType } from './some-module'")
+    ).to.deep.equal([
+      {
+        module: "./some-module",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
… and keep working

## Description, Motivation and Context

typescript 3.8 introduces [type only imports](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports) and [export yadda as namespace](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#export-star-as-namespace-syntax). This PR makes sure it works and will verifiably keep working by adding unit tests (it already worked out of the box).


## How Has This Been Tested?

Automated non-regression tests, new unit tests, green CI.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Expansion of tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
