### PR TITLE
require array for doNotFollow.dependencyTypes

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -12,7 +12,7 @@ export interface IDoNotFollowType {
   /**
    * an array of dependency types to include, but not follow further
    */
-  dependencyTypes?: DependencyType;
+  dependencyTypes?: DependencyType[];
 }
 
 export interface IExcludeType {


### PR DESCRIPTION
## Description

Fix type declaration for options.doNotFollow.dependencyTypes. All uses in the code base are passing in an array so I assume that is the expected type.

## Motivation and Context

The `dependencyTypes` property of the option `doNotFollow` is [documented as accepting an array](https://github.com/sverweij/dependency-cruiser/blob/develop/doc/rules-reference.md#specifying-dependency-types-in-donotfollow) of DeclarationType: `DeclarationType[]`. This is currently not reflected in the type declaration files.

## How Has This Been Tested?

I ran `npm run check:full` but this is a tiny type change so I'm not sure if anything is testing that anyway.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
