### PR TITLE
feature(extract): do not gather doNotFollow pattern

### DIFF
--- a/doc/assets/theming/engineering.svg
+++ b/doc/assets/theming/engineering.svg
@@ -19,16 +19,6 @@
 <path fill="transparent" stroke="white" stroke-width="2" d="M28,-16C28,-16 363.56,-16 363.56,-16 369.56,-16 375.56,-22 375.56,-28 375.56,-28 375.56,-259 375.56,-259 375.56,-265 369.56,-271 363.56,-271 363.56,-271 28,-271 28,-271 22,-271 16,-265 16,-259 16,-259 16,-28 16,-28 16,-22 22,-16 28,-16"/>
 <text text-anchor="middle" x="195.78" y="-259.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00" fill="white">main</text>
 </g>
-<g id="clust5" class="cluster">
-<title>cluster_src/main/resolve&#45;options</title>
-<path fill="transparent" stroke="white" stroke-width="2" d="M114,-107C114,-107 172.01,-107 172.01,-107 178.01,-107 184.01,-113 184.01,-119 184.01,-119 184.01,-146 184.01,-146 184.01,-152 178.01,-158 172.01,-158 172.01,-158 114,-158 114,-158 108,-158 102,-152 102,-146 102,-146 102,-119 102,-119 102,-113 108,-107 114,-107"/>
-<text text-anchor="middle" x="143.01" y="-146.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00" fill="white">resolve&#45;options</text>
-</g>
-<g id="clust6" class="cluster">
-<title>cluster_src/main/rule&#45;set</title>
-<path fill="transparent" stroke="white" stroke-width="2" d="M115,-166C115,-166 171.01,-166 171.01,-166 177.01,-166 183.01,-172 183.01,-178 183.01,-178 183.01,-234 183.01,-234 183.01,-240 177.01,-246 171.01,-246 171.01,-246 115,-246 115,-246 109,-246 103,-240 103,-234 103,-234 103,-178 103,-178 103,-172 109,-166 115,-166"/>
-<text text-anchor="middle" x="143.01" y="-234.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00" fill="white">rule&#45;set</text>
-</g>
 <g id="clust3" class="cluster">
 <title>cluster_src/main/files&#45;and&#45;dirs</title>
 <path fill="transparent" stroke="white" stroke-width="2" d="M115,-24C115,-24 171.01,-24 171.01,-24 177.01,-24 183.01,-30 183.01,-36 183.01,-36 183.01,-63 183.01,-63 183.01,-69 177.01,-75 171.01,-75 171.01,-75 115,-75 115,-75 109,-75 103,-69 103,-63 103,-63 103,-36 103,-36 103,-30 109,-24 115,-24"/>
@@ -38,6 +28,16 @@
 <title>cluster_src/main/options</title>
 <path fill="transparent" stroke="white" stroke-width="2" d="M220.01,-67C220.01,-67 355.56,-67 355.56,-67 361.56,-67 367.56,-73 367.56,-79 367.56,-79 367.56,-135 367.56,-135 367.56,-141 361.56,-147 355.56,-147 355.56,-147 220.01,-147 220.01,-147 214.01,-147 208.01,-141 208.01,-135 208.01,-135 208.01,-79 208.01,-79 208.01,-73 214.01,-67 220.01,-67"/>
 <text text-anchor="middle" x="287.79" y="-135.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00" fill="white">options</text>
+</g>
+<g id="clust5" class="cluster">
+<title>cluster_src/main/resolve&#45;options</title>
+<path fill="transparent" stroke="white" stroke-width="2" d="M114,-107C114,-107 172.01,-107 172.01,-107 178.01,-107 184.01,-113 184.01,-119 184.01,-119 184.01,-146 184.01,-146 184.01,-152 178.01,-158 172.01,-158 172.01,-158 114,-158 114,-158 108,-158 102,-152 102,-146 102,-146 102,-119 102,-119 102,-113 108,-107 114,-107"/>
+<text text-anchor="middle" x="143.01" y="-146.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00" fill="white">resolve&#45;options</text>
+</g>
+<g id="clust6" class="cluster">
+<title>cluster_src/main/rule&#45;set</title>
+<path fill="transparent" stroke="white" stroke-width="2" d="M115,-166C115,-166 171.01,-166 171.01,-166 177.01,-166 183.01,-172 183.01,-178 183.01,-178 183.01,-234 183.01,-234 183.01,-240 177.01,-246 171.01,-246 171.01,-246 115,-246 115,-246 109,-246 103,-240 103,-234 103,-234 103,-178 103,-178 103,-172 109,-166 115,-166"/>
+<text text-anchor="middle" x="143.01" y="-234.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00" fill="white">rule&#45;set</text>
 </g>
 <!-- src/main/files&#45;and&#45;dirs/normalize.js -->
 <g id="node1" class="node">

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -183,12 +183,12 @@ module.exports = {
       dot: {
         theme: {
           graph: {
-            splines: "ortho"
-          }
-        }
-      }
-    }
-  }
+            splines: "ortho",
+          },
+        },
+      },
+    },
+  },
 };
 ```
 

--- a/doc/real-world-samples/dependency-cruiser-dir-graph.svg
+++ b/doc/real-world-samples/dependency-cruiser-dir-graph.svg
@@ -14,6 +14,11 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M20,-8C20,-8 953,-8 953,-8 959,-8 965,-14 965,-20 965,-20 965,-345.9 965,-345.9 965,-351.9 959,-357.9 953,-357.9 953,-357.9 20,-357.9 20,-357.9 14,-357.9 8,-351.9 8,-345.9 8,-345.9 8,-20 8,-20 8,-14 14,-8 20,-8"/>
 <text text-anchor="middle" x="486.5" y="-346.7" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">src</text>
 </g>
+<g id="clust6" class="cluster">
+<title>cluster_src/main</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M118,-138.3C118,-138.3 347,-138.3 347,-138.3 353,-138.3 359,-144.3 359,-150.3 359,-150.3 359,-270.9 359,-270.9 359,-276.9 353,-282.9 347,-282.9 347,-282.9 118,-282.9 118,-282.9 112,-282.9 106,-276.9 106,-270.9 106,-270.9 106,-150.3 106,-150.3 106,-144.3 112,-138.3 118,-138.3"/>
+<text text-anchor="middle" x="232.5" y="-271.7" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">main</text>
+</g>
 <g id="clust2" class="cluster">
 <title>cluster_src/cli</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M379,-239.6C379,-239.6 577,-239.6 577,-239.6 583,-239.6 589,-245.6 589,-251.6 589,-251.6 589,-320.9 589,-320.9 589,-326.9 583,-332.9 577,-332.9 577,-332.9 379,-332.9 379,-332.9 373,-332.9 367,-326.9 367,-320.9 367,-320.9 367,-251.6 367,-251.6 367,-245.6 373,-239.6 379,-239.6"/>
@@ -33,11 +38,6 @@
 <title>cluster_src/extract/resolve</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M821,-87C821,-87 937,-87 937,-87 943,-87 949,-93 949,-99 949,-99 949,-169.6 949,-169.6 949,-175.6 943,-181.6 937,-181.6 937,-181.6 821,-181.6 821,-181.6 815,-181.6 809,-175.6 809,-169.6 809,-169.6 809,-99 809,-99 809,-93 815,-87 821,-87"/>
 <text text-anchor="middle" x="879" y="-170.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
-</g>
-<g id="clust6" class="cluster">
-<title>cluster_src/main</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M118,-138.3C118,-138.3 347,-138.3 347,-138.3 353,-138.3 359,-144.3 359,-150.3 359,-150.3 359,-270.9 359,-270.9 359,-276.9 353,-282.9 347,-282.9 347,-282.9 118,-282.9 118,-282.9 112,-282.9 106,-276.9 106,-270.9 106,-270.9 106,-150.3 106,-150.3 106,-144.3 112,-138.3 118,-138.3"/>
-<text text-anchor="middle" x="232.5" y="-271.7" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">main</text>
 </g>
 <g id="clust7" class="cluster">
 <title>cluster_src/report</title>

--- a/doc/real-world-samples/dependency-cruiser-without-node_modules.svg
+++ b/doc/real-world-samples/dependency-cruiser-without-node_modules.svg
@@ -24,15 +24,15 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M157.01,-1840C157.01,-1840 749.71,-1840 749.71,-1840 755.71,-1840 761.71,-1846 761.71,-1852 761.71,-1852 761.71,-2169 761.71,-2169 761.71,-2175 755.71,-2181 749.71,-2181 749.71,-2181 157.01,-2181 157.01,-2181 151.01,-2181 145.01,-2175 145.01,-2169 145.01,-2169 145.01,-1852 145.01,-1852 145.01,-1846 151.01,-1840 157.01,-1840"/>
 <text text-anchor="middle" x="453.36" y="-2169.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
 </g>
-<g id="clust5" class="cluster">
-<title>cluster_src/cli/init&#45;config</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-2004C322.84,-2004 628.69,-2004 628.69,-2004 634.69,-2004 640.69,-2010 640.69,-2016 640.69,-2016 640.69,-2144 640.69,-2144 640.69,-2150 634.69,-2156 628.69,-2156 628.69,-2156 322.84,-2156 322.84,-2156 316.84,-2156 310.84,-2150 310.84,-2144 310.84,-2144 310.84,-2016 310.84,-2016 310.84,-2010 316.84,-2004 322.84,-2004"/>
-<text text-anchor="middle" x="475.76" y="-2144.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
-</g>
 <g id="clust4" class="cluster">
 <title>cluster_src/cli/compile&#45;config</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M562.17,-1848C562.17,-1848 741.71,-1848 741.71,-1848 747.71,-1848 753.71,-1854 753.71,-1860 753.71,-1860 753.71,-1916 753.71,-1916 753.71,-1922 747.71,-1928 741.71,-1928 741.71,-1928 562.17,-1928 562.17,-1928 556.17,-1928 550.17,-1922 550.17,-1916 550.17,-1916 550.17,-1860 550.17,-1860 550.17,-1854 556.17,-1848 562.17,-1848"/>
 <text text-anchor="middle" x="651.94" y="-1916.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compile&#45;config</text>
+</g>
+<g id="clust5" class="cluster">
+<title>cluster_src/cli/init&#45;config</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-2004C322.84,-2004 628.69,-2004 628.69,-2004 634.69,-2004 640.69,-2010 640.69,-2016 640.69,-2016 640.69,-2144 640.69,-2144 640.69,-2150 634.69,-2156 628.69,-2156 628.69,-2156 322.84,-2156 322.84,-2156 316.84,-2156 310.84,-2150 310.84,-2144 310.84,-2144 310.84,-2016 310.84,-2016 310.84,-2010 316.84,-2004 322.84,-2004"/>
+<text text-anchor="middle" x="475.76" y="-2144.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
 </g>
 <g id="clust6" class="cluster">
 <title>cluster_src/cli/tools</title>
@@ -74,16 +74,6 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1216C814.99,-1216 1013.3,-1216 1013.3,-1216 1019.3,-1216 1025.3,-1222 1025.3,-1228 1025.3,-1228 1025.3,-1255 1025.3,-1255 1025.3,-1261 1019.3,-1267 1013.3,-1267 1013.3,-1267 814.99,-1267 814.99,-1267 808.99,-1267 802.99,-1261 802.99,-1255 802.99,-1255 802.99,-1228 802.99,-1228 802.99,-1222 808.99,-1216 814.99,-1216"/>
 <text text-anchor="middle" x="914.14" y="-1255.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">reachable</text>
 </g>
-<g id="clust17" class="cluster">
-<title>cluster_src/extract/transpile</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1088.08,-1253C1088.08,-1253 1474.23,-1253 1474.23,-1253 1480.23,-1253 1486.23,-1259 1486.23,-1265 1486.23,-1265 1486.23,-1408 1486.23,-1408 1486.23,-1414 1480.23,-1420 1474.23,-1420 1474.23,-1420 1088.08,-1420 1088.08,-1420 1082.08,-1420 1076.08,-1414 1076.08,-1408 1076.08,-1408 1076.08,-1265 1076.08,-1265 1076.08,-1259 1082.08,-1253 1088.08,-1253"/>
-<text text-anchor="middle" x="1281.15" y="-1408.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
-</g>
-<g id="clust18" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-867C1710.6,-867 1911.66,-867 1911.66,-867 1917.66,-867 1923.66,-873 1923.66,-879 1923.66,-879 1923.66,-993 1923.66,-993 1923.66,-999 1917.66,-1005 1911.66,-1005 1911.66,-1005 1710.6,-1005 1710.6,-1005 1704.6,-1005 1698.6,-999 1698.6,-993 1698.6,-993 1698.6,-879 1698.6,-879 1698.6,-873 1704.6,-867 1710.6,-867"/>
-<text text-anchor="middle" x="1811.13" y="-993.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
 <g id="clust14" class="cluster">
 <title>cluster_src/extract/parse</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M939.77,-1082C939.77,-1082 1020.79,-1082 1020.79,-1082 1026.79,-1082 1032.79,-1088 1032.79,-1094 1032.79,-1094 1032.79,-1150 1032.79,-1150 1032.79,-1156 1026.79,-1162 1020.79,-1162 1020.79,-1162 939.77,-1162 939.77,-1162 933.77,-1162 927.77,-1156 927.77,-1150 927.77,-1150 927.77,-1094 927.77,-1094 927.77,-1088 933.77,-1082 939.77,-1082"/>
@@ -98,6 +88,16 @@
 <title>cluster_src/extract/resolve/get&#45;manifest&#45;dependencies</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-723C1231.64,-723 1470.48,-723 1470.48,-723 1476.48,-723 1482.48,-729 1482.48,-735 1482.48,-735 1482.48,-762 1482.48,-762 1482.48,-768 1476.48,-774 1470.48,-774 1470.48,-774 1231.64,-774 1231.64,-774 1225.64,-774 1219.64,-768 1219.64,-762 1219.64,-762 1219.64,-735 1219.64,-735 1219.64,-729 1225.64,-723 1231.64,-723"/>
 <text text-anchor="middle" x="1351.06" y="-762.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">get&#45;manifest&#45;dependencies</text>
+</g>
+<g id="clust17" class="cluster">
+<title>cluster_src/extract/transpile</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1088.08,-1253C1088.08,-1253 1474.23,-1253 1474.23,-1253 1480.23,-1253 1486.23,-1259 1486.23,-1265 1486.23,-1265 1486.23,-1408 1486.23,-1408 1486.23,-1414 1480.23,-1420 1474.23,-1420 1474.23,-1420 1088.08,-1420 1088.08,-1420 1082.08,-1420 1076.08,-1414 1076.08,-1408 1076.08,-1408 1076.08,-1265 1076.08,-1265 1076.08,-1259 1082.08,-1253 1088.08,-1253"/>
+<text text-anchor="middle" x="1281.15" y="-1408.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
+</g>
+<g id="clust18" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-867C1710.6,-867 1911.66,-867 1911.66,-867 1917.66,-867 1923.66,-873 1923.66,-879 1923.66,-879 1923.66,-993 1923.66,-993 1923.66,-999 1917.66,-1005 1911.66,-1005 1911.66,-1005 1710.6,-1005 1710.6,-1005 1704.6,-1005 1698.6,-999 1698.6,-993 1698.6,-993 1698.6,-879 1698.6,-879 1698.6,-873 1704.6,-867 1710.6,-867"/>
+<text text-anchor="middle" x="1811.13" y="-993.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
 <g id="clust19" class="cluster">
 <title>cluster_src/main</title>

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -789,7 +789,7 @@ use with this is "node_modules":
 
 > It's not possible to use this on the command line
 
-`--do-not-follow` to specify a regular expression
+It is possible to specify a regular expression
 for files that dependency-cruiser should cruise, but not follow any further.
 In the options section you can restrict what gets cruised by specifying
 [dependency types](#dependencytypes). So if e.g. you don't want dependency-cruiser
@@ -812,13 +812,25 @@ to follow external dependencies, in stead of specifying the "node_modules" path:
 
 > #### How `doNotFollow` influences what gets cruised
 >
-> <!-- this is correct but copy CBB => TODO-->
+> There's a few steps dependency-cruiser takes when you fire it of:
 >
-> If files in the arguments to dependency-cruiser match the doNotFollow regular
-> expression (e.g. `depcruise --do-not-follow node_modules -T text src test node_modules`),
-> dependency-cruiser will exclude them in the first pass and only visit them when
-> they're used in (so in the example above only if `src` or `test` uses something
-> from `node_modules`).
+> 1. gather all files specified as an argument, filtering out the stuff in `exclude`
+>    and `doNotFollow` and that which is not in `includeOnly`.
+> 2. starting from the gathered files: crawl all dependencies it can find. Crawling
+>    stops when a module matches `doNotFollow` rule or a modules' dependency matches
+>    either `exclude` or does not match `includeOnly`.
+> 3. apply any rules over the result & report it.
+>
+> So in the first step `doNotFollow` behaves itself exactly like `exclude` would.
+> Only in the second step it allows files matching its pattern to be visited
+> (but not followed any further).
+>
+> This means dependency-cruise _will_ encounter files matching `doNotFollow`
+> but only when they are dependencies of other modules. This a.o. prevents unexpected
+> behavior where specifying node modules as `doNotFollow` pattern would still
+> traverse all node_modules when the node_modules were part of the arguments
+> e.g. in `depcruise --do-not-follow node_modules --validate -- src test node_modules`
+> or, more subtly with `depcruise --don-not-follow node_modules -- validate -- .`.
 
 ### `includeOnly`: only include modules satisfying a pattern
 
@@ -838,7 +850,7 @@ exclude all node_modules, core modules and modules otherwise outside it):
 }
 ```
 
-If you specify both an include and an exclude (see below), dependency-cruiser takes
+If you specify both an includeOnly and an exclude (see below), dependency-cruiser takes
 them _both_ into account.
 
 ### `exclude`: exclude dependencies from being cruised

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -153,11 +153,11 @@ module.exports = {
       // but at least temporarily don't let it break our build
       // by setting the severity to "warn" here
       name: "no-deprecated-core",
-      severity: "warn"
+      severity: "warn",
       // no need to specify the from and to, because they're already
       // defined in 'recommended'
-    }
-  ]
+    },
+  ],
 };
 ```
 
@@ -810,6 +810,16 @@ to follow external dependencies, in stead of specifying the "node_modules" path:
     }
 ```
 
+> #### How `doNotFollow` influences what gets cruised
+>
+> <!-- this is correct but copy CBB => TODO-->
+>
+> If files in the arguments to dependency-cruiser match the doNotFollow regular
+> expression (e.g. `depcruise --do-not-follow node_modules -T text src test node_modules`),
+> dependency-cruiser will exclude them in the first pass and only visit them when
+> they're used in (so in the example above only if `src` or `test` uses something
+> from `node_modules`).
+
 ### `includeOnly`: only include modules satisfying a pattern
 
 > command line option equivalent: `--include-only`
@@ -1190,8 +1200,8 @@ As a base, take this part of dependency-cruisers code:
 module.exports = {
   options: {
     includeOnly: "^src/main",
-    exclude: "/filesAndDirs/"
-  }
+    exclude: "/filesAndDirs/",
+  },
 };
 ```
 
@@ -1218,47 +1228,47 @@ module.exports = {
             color: "white",
             fontcolor: "white",
             fillcolor: "transparent",
-            splines: "ortho"
+            splines: "ortho",
           },
           node: {
             color: "white",
             fillcolor: "#ffffff33",
-            fontcolor: "white"
+            fontcolor: "white",
           },
           edge: {
             arrowhead: "vee",
             arrowsize: "0.5",
             penwidth: "1.0",
             color: "white",
-            fontcolor: "white"
+            fontcolor: "white",
           },
           modules: [
             {
               criteria: { source: "\\.json$" },
               attributes: {
                 shape: "cylinder",
-                fillcolor: "#ffffff33:#ffffff88"
-              }
+                fillcolor: "#ffffff33:#ffffff88",
+              },
             },
             {
               criteria: { coreModule: true },
               attributes: {
                 color: "white",
                 fillcolor: "#ffffff33",
-                fontcolor: "white"
-              }
-            }
+                fontcolor: "white",
+              },
+            },
           ],
           dependencies: [
             {
               criteria: { resolved: "\\.json$" },
-              attributes: { arrowhead: "obox" }
-            }
-          ]
-        }
-      }
-    }
-  }
+              attributes: { arrowhead: "obox" },
+            },
+          ],
+        },
+      },
+    },
+  },
 };
 ```
 
@@ -1279,11 +1289,11 @@ module.exports = {
     reporterOptions: {
       dot: {
         theme: {
-          graph: { rankdir: "TD" }
-        }
-      }
-    }
-  }
+          graph: { rankdir: "TD" },
+        },
+      },
+    },
+  },
 };
 ```
 
@@ -1305,11 +1315,11 @@ module.exports = {
     reporterOptions: {
       dot: {
         theme: {
-          replace: true
-        }
-      }
-    }
-  }
+          replace: true,
+        },
+      },
+    },
+  },
 };
 ```
 
@@ -1333,10 +1343,10 @@ module.exports = {
   options: {
     reporterOptions: {
       archi: {
-        collapsePattern: "^(src/[^/]+|bin)"
-      }
-    }
-  }
+        collapsePattern: "^(src/[^/]+|bin)",
+      },
+    },
+  },
 };
 ```
 
@@ -1514,8 +1524,8 @@ module.exports = {
   forbidden: [subNotAllowed, noInterComponents],
   options: {
     tsConfig: {
-      fileName: "./tsconfig.json"
-    }
-  }
+      fileName: "./tsconfig.json",
+    },
+  },
 };
 ```

--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -114,6 +114,41 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1345.42,-404C1345.42,-404 1811.88,-404 1811.88,-404 1817.88,-404 1823.88,-410 1823.88,-416 1823.88,-416 1823.88,-501 1823.88,-501 1823.88,-507 1817.88,-513 1811.88,-513 1811.88,-513 1345.42,-513 1345.42,-513 1339.42,-513 1333.42,-507 1333.42,-501 1333.42,-501 1333.42,-416 1333.42,-416 1333.42,-410 1339.42,-404 1345.42,-404"/>
 <text text-anchor="middle" x="1578.65" y="-501.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
+<g id="clust30" class="cluster">
+<title>cluster_src/schema</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M781.71,-1477C781.71,-1477 894.27,-1477 894.27,-1477 900.27,-1477 906.27,-1483 906.27,-1489 906.27,-1489 906.27,-1557 906.27,-1557 906.27,-1563 900.27,-1569 894.27,-1569 894.27,-1569 781.71,-1569 781.71,-1569 775.71,-1569 769.71,-1563 769.71,-1557 769.71,-1557 769.71,-1489 769.71,-1489 769.71,-1483 775.71,-1477 781.71,-1477"/>
+<text text-anchor="middle" x="837.99" y="-1557.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">schema</text>
+</g>
+<g id="clust31" class="cluster">
+<title>cluster_src/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1384.7,-42C1384.7,-42 1472.23,-42 1472.23,-42 1478.23,-42 1484.23,-48 1484.23,-54 1484.23,-54 1484.23,-110 1484.23,-110 1484.23,-116 1478.23,-122 1472.23,-122 1472.23,-122 1384.7,-122 1384.7,-122 1378.7,-122 1372.7,-116 1372.7,-110 1372.7,-110 1372.7,-54 1372.7,-54 1372.7,-48 1378.7,-42 1384.7,-42"/>
+<text text-anchor="middle" x="1428.47" y="-110.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust3" class="cluster">
+<title>cluster_src/cli</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M157.01,-1840C157.01,-1840 749.71,-1840 749.71,-1840 755.71,-1840 761.71,-1846 761.71,-1852 761.71,-1852 761.71,-2169 761.71,-2169 761.71,-2175 755.71,-2181 749.71,-2181 749.71,-2181 157.01,-2181 157.01,-2181 151.01,-2181 145.01,-2175 145.01,-2169 145.01,-2169 145.01,-1852 145.01,-1852 145.01,-1846 151.01,-1840 157.01,-1840"/>
+<text text-anchor="middle" x="453.36" y="-2169.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
+</g>
+<g id="clust4" class="cluster">
+<title>cluster_src/cli/compile&#45;config</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M562.17,-1848C562.17,-1848 741.71,-1848 741.71,-1848 747.71,-1848 753.71,-1854 753.71,-1860 753.71,-1860 753.71,-1916 753.71,-1916 753.71,-1922 747.71,-1928 741.71,-1928 741.71,-1928 562.17,-1928 562.17,-1928 556.17,-1928 550.17,-1922 550.17,-1916 550.17,-1916 550.17,-1860 550.17,-1860 550.17,-1854 556.17,-1848 562.17,-1848"/>
+<text text-anchor="middle" x="651.94" y="-1916.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compile&#45;config</text>
+</g>
+<g id="clust5" class="cluster">
+<title>cluster_src/cli/init&#45;config</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-2004C322.84,-2004 628.69,-2004 628.69,-2004 634.69,-2004 640.69,-2010 640.69,-2016 640.69,-2016 640.69,-2144 640.69,-2144 640.69,-2150 634.69,-2156 628.69,-2156 628.69,-2156 322.84,-2156 322.84,-2156 316.84,-2156 310.84,-2150 310.84,-2144 310.84,-2144 310.84,-2016 310.84,-2016 310.84,-2010 316.84,-2004 322.84,-2004"/>
+<text text-anchor="middle" x="475.76" y="-2144.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
+</g>
+<g id="clust6" class="cluster">
+<title>cluster_src/cli/tools</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M170.29,-1848C170.29,-1848 267.3,-1848 267.3,-1848 273.3,-1848 279.3,-1854 279.3,-1860 279.3,-1860 279.3,-1887 279.3,-1887 279.3,-1893 273.3,-1899 267.3,-1899 267.3,-1899 170.29,-1899 170.29,-1899 164.29,-1899 158.29,-1893 158.29,-1887 158.29,-1887 158.29,-1860 158.29,-1860 158.29,-1854 164.29,-1848 170.29,-1848"/>
+<text text-anchor="middle" x="218.79" y="-1887.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">tools</text>
+</g>
+<g id="clust7" class="cluster">
+<title>cluster_src/cli/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M414.11,-1851C414.11,-1851 517.65,-1851 517.65,-1851 523.65,-1851 529.65,-1857 529.65,-1863 529.65,-1863 529.65,-1948 529.65,-1948 529.65,-1954 523.65,-1960 517.65,-1960 517.65,-1960 414.11,-1960 414.11,-1960 408.11,-1960 402.11,-1954 402.11,-1948 402.11,-1948 402.11,-1863 402.11,-1863 402.11,-1857 408.11,-1851 414.11,-1851"/>
+<text text-anchor="middle" x="465.88" y="-1948.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
 <g id="clust8" class="cluster">
 <title>cluster_src/extract</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M681.7,-691C681.7,-691 1919.66,-691 1919.66,-691 1925.66,-691 1931.66,-697 1931.66,-703 1931.66,-703 1931.66,-1433 1931.66,-1433 1931.66,-1439 1925.66,-1445 1919.66,-1445 1919.66,-1445 681.7,-1445 681.7,-1445 675.7,-1445 669.7,-1439 669.7,-1433 669.7,-1433 669.7,-703 669.7,-703 669.7,-697 675.7,-691 681.7,-691"/>
@@ -139,25 +174,10 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1216C814.99,-1216 1013.3,-1216 1013.3,-1216 1019.3,-1216 1025.3,-1222 1025.3,-1228 1025.3,-1228 1025.3,-1255 1025.3,-1255 1025.3,-1261 1019.3,-1267 1013.3,-1267 1013.3,-1267 814.99,-1267 814.99,-1267 808.99,-1267 802.99,-1261 802.99,-1255 802.99,-1255 802.99,-1228 802.99,-1228 802.99,-1222 808.99,-1216 814.99,-1216"/>
 <text text-anchor="middle" x="914.14" y="-1255.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">reachable</text>
 </g>
-<g id="clust9" class="cluster">
-<title>cluster_src/extract/ast&#45;extractors</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M926.27,-979C926.27,-979 1291.9,-979 1291.9,-979 1297.9,-979 1303.9,-985 1303.9,-991 1303.9,-991 1303.9,-1062 1303.9,-1062 1303.9,-1068 1297.9,-1074 1291.9,-1074 1291.9,-1074 926.27,-1074 926.27,-1074 920.27,-1074 914.27,-1068 914.27,-1062 914.27,-1062 914.27,-991 914.27,-991 914.27,-985 920.27,-979 926.27,-979"/>
-<text text-anchor="middle" x="1109.09" y="-1062.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
-</g>
 <g id="clust14" class="cluster">
 <title>cluster_src/extract/parse</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M939.77,-1082C939.77,-1082 1020.79,-1082 1020.79,-1082 1026.79,-1082 1032.79,-1088 1032.79,-1094 1032.79,-1094 1032.79,-1150 1032.79,-1150 1032.79,-1156 1026.79,-1162 1020.79,-1162 1020.79,-1162 939.77,-1162 939.77,-1162 933.77,-1162 927.77,-1156 927.77,-1150 927.77,-1150 927.77,-1094 927.77,-1094 927.77,-1088 933.77,-1082 939.77,-1082"/>
 <text text-anchor="middle" x="980.28" y="-1150.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">parse</text>
-</g>
-<g id="clust18" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-867C1710.6,-867 1911.66,-867 1911.66,-867 1917.66,-867 1923.66,-873 1923.66,-879 1923.66,-879 1923.66,-993 1923.66,-993 1923.66,-999 1917.66,-1005 1911.66,-1005 1911.66,-1005 1710.6,-1005 1710.6,-1005 1704.6,-1005 1698.6,-999 1698.6,-993 1698.6,-993 1698.6,-879 1698.6,-879 1698.6,-873 1704.6,-867 1710.6,-867"/>
-<text text-anchor="middle" x="1811.13" y="-993.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust17" class="cluster">
-<title>cluster_src/extract/transpile</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1088.08,-1253C1088.08,-1253 1474.23,-1253 1474.23,-1253 1480.23,-1253 1486.23,-1259 1486.23,-1265 1486.23,-1265 1486.23,-1408 1486.23,-1408 1486.23,-1414 1480.23,-1420 1474.23,-1420 1474.23,-1420 1088.08,-1420 1088.08,-1420 1082.08,-1420 1076.08,-1414 1076.08,-1408 1076.08,-1408 1076.08,-1265 1076.08,-1265 1076.08,-1259 1082.08,-1253 1088.08,-1253"/>
-<text text-anchor="middle" x="1281.15" y="-1408.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
 </g>
 <g id="clust15" class="cluster">
 <title>cluster_src/extract/resolve</title>
@@ -169,40 +189,20 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-723C1231.64,-723 1470.48,-723 1470.48,-723 1476.48,-723 1482.48,-729 1482.48,-735 1482.48,-735 1482.48,-762 1482.48,-762 1482.48,-768 1476.48,-774 1470.48,-774 1470.48,-774 1231.64,-774 1231.64,-774 1225.64,-774 1219.64,-768 1219.64,-762 1219.64,-762 1219.64,-735 1219.64,-735 1219.64,-729 1225.64,-723 1231.64,-723"/>
 <text text-anchor="middle" x="1351.06" y="-762.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">get&#45;manifest&#45;dependencies</text>
 </g>
-<g id="clust3" class="cluster">
-<title>cluster_src/cli</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M157.01,-1840C157.01,-1840 749.71,-1840 749.71,-1840 755.71,-1840 761.71,-1846 761.71,-1852 761.71,-1852 761.71,-2169 761.71,-2169 761.71,-2175 755.71,-2181 749.71,-2181 749.71,-2181 157.01,-2181 157.01,-2181 151.01,-2181 145.01,-2175 145.01,-2169 145.01,-2169 145.01,-1852 145.01,-1852 145.01,-1846 151.01,-1840 157.01,-1840"/>
-<text text-anchor="middle" x="453.36" y="-2169.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
+<g id="clust17" class="cluster">
+<title>cluster_src/extract/transpile</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1088.08,-1253C1088.08,-1253 1474.23,-1253 1474.23,-1253 1480.23,-1253 1486.23,-1259 1486.23,-1265 1486.23,-1265 1486.23,-1408 1486.23,-1408 1486.23,-1414 1480.23,-1420 1474.23,-1420 1474.23,-1420 1088.08,-1420 1088.08,-1420 1082.08,-1420 1076.08,-1414 1076.08,-1408 1076.08,-1408 1076.08,-1265 1076.08,-1265 1076.08,-1259 1082.08,-1253 1088.08,-1253"/>
+<text text-anchor="middle" x="1281.15" y="-1408.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
 </g>
-<g id="clust5" class="cluster">
-<title>cluster_src/cli/init&#45;config</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-2004C322.84,-2004 628.69,-2004 628.69,-2004 634.69,-2004 640.69,-2010 640.69,-2016 640.69,-2016 640.69,-2144 640.69,-2144 640.69,-2150 634.69,-2156 628.69,-2156 628.69,-2156 322.84,-2156 322.84,-2156 316.84,-2156 310.84,-2150 310.84,-2144 310.84,-2144 310.84,-2016 310.84,-2016 310.84,-2010 316.84,-2004 322.84,-2004"/>
-<text text-anchor="middle" x="475.76" y="-2144.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
+<g id="clust18" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-867C1710.6,-867 1911.66,-867 1911.66,-867 1917.66,-867 1923.66,-873 1923.66,-879 1923.66,-879 1923.66,-993 1923.66,-993 1923.66,-999 1917.66,-1005 1911.66,-1005 1911.66,-1005 1710.6,-1005 1710.6,-1005 1704.6,-1005 1698.6,-999 1698.6,-993 1698.6,-993 1698.6,-879 1698.6,-879 1698.6,-873 1704.6,-867 1710.6,-867"/>
+<text text-anchor="middle" x="1811.13" y="-993.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
-<g id="clust6" class="cluster">
-<title>cluster_src/cli/tools</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M170.29,-1848C170.29,-1848 267.3,-1848 267.3,-1848 273.3,-1848 279.3,-1854 279.3,-1860 279.3,-1860 279.3,-1887 279.3,-1887 279.3,-1893 273.3,-1899 267.3,-1899 267.3,-1899 170.29,-1899 170.29,-1899 164.29,-1899 158.29,-1893 158.29,-1887 158.29,-1887 158.29,-1860 158.29,-1860 158.29,-1854 164.29,-1848 170.29,-1848"/>
-<text text-anchor="middle" x="218.79" y="-1887.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">tools</text>
-</g>
-<g id="clust7" class="cluster">
-<title>cluster_src/cli/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M414.11,-1851C414.11,-1851 517.65,-1851 517.65,-1851 523.65,-1851 529.65,-1857 529.65,-1863 529.65,-1863 529.65,-1948 529.65,-1948 529.65,-1954 523.65,-1960 517.65,-1960 517.65,-1960 414.11,-1960 414.11,-1960 408.11,-1960 402.11,-1954 402.11,-1948 402.11,-1948 402.11,-1863 402.11,-1863 402.11,-1857 408.11,-1851 414.11,-1851"/>
-<text text-anchor="middle" x="465.88" y="-1948.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust4" class="cluster">
-<title>cluster_src/cli/compile&#45;config</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M562.17,-1848C562.17,-1848 741.71,-1848 741.71,-1848 747.71,-1848 753.71,-1854 753.71,-1860 753.71,-1860 753.71,-1916 753.71,-1916 753.71,-1922 747.71,-1928 741.71,-1928 741.71,-1928 562.17,-1928 562.17,-1928 556.17,-1928 550.17,-1922 550.17,-1916 550.17,-1916 550.17,-1860 550.17,-1860 550.17,-1854 556.17,-1848 562.17,-1848"/>
-<text text-anchor="middle" x="651.94" y="-1916.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compile&#45;config</text>
-</g>
-<g id="clust30" class="cluster">
-<title>cluster_src/schema</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M781.71,-1477C781.71,-1477 894.27,-1477 894.27,-1477 900.27,-1477 906.27,-1483 906.27,-1489 906.27,-1489 906.27,-1557 906.27,-1557 906.27,-1563 900.27,-1569 894.27,-1569 894.27,-1569 781.71,-1569 781.71,-1569 775.71,-1569 769.71,-1563 769.71,-1557 769.71,-1557 769.71,-1489 769.71,-1489 769.71,-1483 775.71,-1477 781.71,-1477"/>
-<text text-anchor="middle" x="837.99" y="-1557.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">schema</text>
-</g>
-<g id="clust31" class="cluster">
-<title>cluster_src/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1384.7,-42C1384.7,-42 1472.23,-42 1472.23,-42 1478.23,-42 1484.23,-48 1484.23,-54 1484.23,-54 1484.23,-110 1484.23,-110 1484.23,-116 1478.23,-122 1472.23,-122 1472.23,-122 1384.7,-122 1384.7,-122 1378.7,-122 1372.7,-116 1372.7,-110 1372.7,-110 1372.7,-54 1372.7,-54 1372.7,-48 1378.7,-42 1384.7,-42"/>
-<text text-anchor="middle" x="1428.47" y="-110.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+<g id="clust9" class="cluster">
+<title>cluster_src/extract/ast&#45;extractors</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M926.27,-979C926.27,-979 1291.9,-979 1291.9,-979 1297.9,-979 1303.9,-985 1303.9,-991 1303.9,-991 1303.9,-1062 1303.9,-1062 1303.9,-1068 1297.9,-1074 1291.9,-1074 1291.9,-1074 926.27,-1074 926.27,-1074 920.27,-1074 914.27,-1068 914.27,-1062 914.27,-1062 914.27,-991 914.27,-991 914.27,-985 920.27,-979 926.27,-979"/>
+<text text-anchor="middle" x="1109.09" y="-1062.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
 </g>
 <g id="clust32" class="cluster">
 <title>cluster_src/validate</title>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "8.2.0",
+  "version": "8.3.0-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/extract/gather-initial-sources.js
+++ b/src/extract/gather-initial-sources.js
@@ -11,6 +11,17 @@ function matchesPattern(pFullPathToFile, pPattern) {
   return RegExp(pPattern, "g").test(pFullPathToFile);
 }
 
+function keepNonExcluded(pFullPathToFile, pOptions) {
+  return (
+    (!_get(pOptions, "exclude.path") ||
+      !matchesPattern(pathToPosix(pFullPathToFile), pOptions.exclude.path)) &&
+    (!pOptions.includeOnly ||
+      matchesPattern(pathToPosix(pFullPathToFile), pOptions.includeOnly)) &&
+    (!_get(pOptions, "doNotFollow.path") ||
+      !matchesPattern(pathToPosix(pFullPathToFile), pOptions.doNotFollow.path))
+  );
+}
+
 function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
   return fs
     .readdirSync(pDirectoryName)
@@ -30,21 +41,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
       }
       return pSum;
     }, [])
-    .filter(
-      pFullPathToFile =>
-        (!_get(pOptions, "exclude.path") ||
-          !matchesPattern(
-            pathToPosix(pFullPathToFile),
-            pOptions.exclude.path
-          )) &&
-        (!pOptions.includeOnly ||
-          matchesPattern(pathToPosix(pFullPathToFile), pOptions.includeOnly)) &&
-        (!_get(pOptions, "doNotFollow.path") ||
-          !matchesPattern(
-            pathToPosix(pFullPathToFile),
-            pOptions.doNotFollow.path
-          ))
-    );
+    .filter(pFullPathToFile => keepNonExcluded(pFullPathToFile, pOptions));
 }
 
 /**

--- a/src/extract/gather-initial-sources.js
+++ b/src/extract/gather-initial-sources.js
@@ -38,7 +38,12 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
             pOptions.exclude.path
           )) &&
         (!pOptions.includeOnly ||
-          matchesPattern(pathToPosix(pFullPathToFile), pOptions.includeOnly))
+          matchesPattern(pathToPosix(pFullPathToFile), pOptions.includeOnly)) &&
+        (!_get(pOptions, "doNotFollow.path") ||
+          !matchesPattern(
+            pathToPosix(pFullPathToFile),
+            pOptions.doNotFollow.path
+          ))
     );
 }
 

--- a/test/extract/gather-initial-sources.spec.js
+++ b/test/extract/gather-initial-sources.spec.js
@@ -181,6 +181,23 @@ describe("extract/gatherInitialSources", () => {
     ]);
   });
 
+  it("filters out the stuff in the doNotFollow pattern", () => {
+    expect(
+      gather(["test/extract/fixtures/gather-globbing/**/src"], {
+        doNotFollow: { path: "/deep/ly/" }
+      }).map(pathToPosix)
+    ).to.deep.equal([
+      "test/extract/fixtures/gather-globbing/packages/baldr/src/bow.js",
+      "test/extract/fixtures/gather-globbing/packages/baldr/src/index.js",
+      "test/extract/fixtures/gather-globbing/packages/baldr/src/typo.ts",
+      "test/extract/fixtures/gather-globbing/packages/loki/src/fake/nothing.to.see.here.ts",
+      "test/extract/fixtures/gather-globbing/packages/loki/src/index.spec.ts",
+      "test/extract/fixtures/gather-globbing/packages/loki/src/index.ts",
+      "test/extract/fixtures/gather-globbing/packages/odin/src/deep/ly.js",
+      "test/extract/fixtures/gather-globbing/packages/odin/src/deep/ly.spec.js"
+    ]);
+  });
+
   it("only gathers stuff in the includeOnly pattern", () => {
     expect(
       gather(["test/extract/fixtures/gather-globbing/packages"], {
@@ -194,32 +211,4 @@ describe("extract/gatherInitialSources", () => {
       "test/extract/fixtures/gather-globbing/packages/loki/src/index.ts"
     ]);
   });
-
-  /*
-    it("using the same file twice as input has the same result as using it once", () => {
-        expect(
-            gather([
-                "test/extract/fixtures/ts/index.ts",
-                "test/extract/fixtures/ts/index.ts"
-            ]).map(p2p)
-        ).to.deep.equal(
-            gather([
-                "test/extract/fixtures/ts/index.ts"
-            ])
-        );
-    });
-
-    it("using the same folder twice as input has the same result as using it once", () => {
-        expect(
-            gather([
-                "test/extract/fixtures/ts",
-                "test/extract/fixtures/ts"
-            ]).map(p2p)
-        ).to.deep.equal(
-            gather([
-                "test/extract/fixtures/ts"
-            ])
-        );
-    });
-    */
 });


### PR DESCRIPTION
## Description

Exclude files that match the doNotFollow pattern in the first extraction pass (gathering files from disk based on the arguments passed), so they won't (unexpectedly) get fully traversed.

## Motivation and Context

- Potentially fixes #281
- When the user passes doNotFollow she's probably not directly interested in them, even when she passes them as part of the arguments she passes (e.g. even though node_modules get matched by `packages/*`or `./` - if she's passing node_modules as doNotFollow she wouldn't care less about node_modules content other then the first thing the rest of her code is touching in there).
- As far as I could see there's no real non-regression involved 


## How Has This Been Tested?

- Additional unit tests
- Automated non-regression tests
- Green ci
- Live test against a warty mono repo

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
