### PR TITLE
bugfix(resolve): changes default resolve order so .vue is resolved after regular language suffixes (like .ts)

### DIFF
--- a/doc/real-world-samples/dependency-cruiser-without-node_modules.svg
+++ b/doc/real-world-samples/dependency-cruiser-without-node_modules.svg
@@ -29,11 +29,6 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M562.17,-1809C562.17,-1809 741.71,-1809 741.71,-1809 747.71,-1809 753.71,-1815 753.71,-1821 753.71,-1821 753.71,-1877 753.71,-1877 753.71,-1883 747.71,-1889 741.71,-1889 741.71,-1889 562.17,-1889 562.17,-1889 556.17,-1889 550.17,-1883 550.17,-1877 550.17,-1877 550.17,-1821 550.17,-1821 550.17,-1815 556.17,-1809 562.17,-1809"/>
 <text text-anchor="middle" x="651.94" y="-1877.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compile&#45;config</text>
 </g>
-<g id="clust5" class="cluster">
-<title>cluster_src/cli/init&#45;config</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-1965C322.84,-1965 628.69,-1965 628.69,-1965 634.69,-1965 640.69,-1971 640.69,-1977 640.69,-1977 640.69,-2106 640.69,-2106 640.69,-2112 634.69,-2118 628.69,-2118 628.69,-2118 322.84,-2118 322.84,-2118 316.84,-2118 310.84,-2112 310.84,-2106 310.84,-2106 310.84,-1977 310.84,-1977 310.84,-1971 316.84,-1965 322.84,-1965"/>
-<text text-anchor="middle" x="475.76" y="-2106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
-</g>
 <g id="clust6" class="cluster">
 <title>cluster_src/cli/tools</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M170.29,-1809C170.29,-1809 267.3,-1809 267.3,-1809 273.3,-1809 279.3,-1815 279.3,-1821 279.3,-1821 279.3,-1848 279.3,-1848 279.3,-1854 273.3,-1860 267.3,-1860 267.3,-1860 170.29,-1860 170.29,-1860 164.29,-1860 158.29,-1854 158.29,-1848 158.29,-1848 158.29,-1821 158.29,-1821 158.29,-1815 164.29,-1809 170.29,-1809"/>
@@ -43,6 +38,66 @@
 <title>cluster_src/cli/utl</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M414.11,-1812C414.11,-1812 517.65,-1812 517.65,-1812 523.65,-1812 529.65,-1818 529.65,-1824 529.65,-1824 529.65,-1909 529.65,-1909 529.65,-1915 523.65,-1921 517.65,-1921 517.65,-1921 414.11,-1921 414.11,-1921 408.11,-1921 402.11,-1915 402.11,-1909 402.11,-1909 402.11,-1824 402.11,-1824 402.11,-1818 408.11,-1812 414.11,-1812"/>
 <text text-anchor="middle" x="465.88" y="-1909.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust5" class="cluster">
+<title>cluster_src/cli/init&#45;config</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-1965C322.84,-1965 628.69,-1965 628.69,-1965 634.69,-1965 640.69,-1971 640.69,-1977 640.69,-1977 640.69,-2106 640.69,-2106 640.69,-2112 634.69,-2118 628.69,-2118 628.69,-2118 322.84,-2118 322.84,-2118 316.84,-2118 310.84,-2112 310.84,-2106 310.84,-2106 310.84,-1977 310.84,-1977 310.84,-1971 316.84,-1965 322.84,-1965"/>
+<text text-anchor="middle" x="475.76" y="-2106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
+</g>
+<g id="clust8" class="cluster">
+<title>cluster_src/extract</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M681.7,-695C681.7,-695 1919.66,-695 1919.66,-695 1925.66,-695 1931.66,-701 1931.66,-707 1931.66,-707 1931.66,-1394 1931.66,-1394 1931.66,-1400 1925.66,-1406 1919.66,-1406 1919.66,-1406 681.7,-1406 681.7,-1406 675.7,-1406 669.7,-1400 669.7,-1394 669.7,-1394 669.7,-707 669.7,-707 669.7,-701 675.7,-695 681.7,-695"/>
+<text text-anchor="middle" x="1300.68" y="-1394.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
+</g>
+<g id="clust9" class="cluster">
+<title>cluster_src/extract/ast&#45;extractors</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M926.27,-703C926.27,-703 1291.9,-703 1291.9,-703 1297.9,-703 1303.9,-709 1303.9,-715 1303.9,-715 1303.9,-785 1303.9,-785 1303.9,-791 1297.9,-797 1291.9,-797 1291.9,-797 926.27,-797 926.27,-797 920.27,-797 914.27,-791 914.27,-785 914.27,-785 914.27,-715 914.27,-715 914.27,-709 920.27,-703 926.27,-703"/>
+<text text-anchor="middle" x="1109.09" y="-785.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
+</g>
+<g id="clust10" class="cluster">
+<title>cluster_src/extract/derive</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M806.99,-1179C806.99,-1179 1015.54,-1179 1015.54,-1179 1021.54,-1179 1027.54,-1185 1027.54,-1191 1027.54,-1191 1027.54,-1369 1027.54,-1369 1027.54,-1375 1021.54,-1381 1015.54,-1381 1015.54,-1381 806.99,-1381 806.99,-1381 800.99,-1381 794.99,-1375 794.99,-1369 794.99,-1369 794.99,-1191 794.99,-1191 794.99,-1185 800.99,-1179 806.99,-1179"/>
+<text text-anchor="middle" x="911.27" y="-1369.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">derive</text>
+</g>
+<g id="clust11" class="cluster">
+<title>cluster_src/extract/derive/circular</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1305C814.99,-1305 1006.79,-1305 1006.79,-1305 1012.79,-1305 1018.79,-1311 1018.79,-1317 1018.79,-1317 1018.79,-1344 1018.79,-1344 1018.79,-1350 1012.79,-1356 1006.79,-1356 1006.79,-1356 814.99,-1356 814.99,-1356 808.99,-1356 802.99,-1350 802.99,-1344 802.99,-1344 802.99,-1317 802.99,-1317 802.99,-1311 808.99,-1305 814.99,-1305"/>
+<text text-anchor="middle" x="910.89" y="-1344.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">circular</text>
+</g>
+<g id="clust12" class="cluster">
+<title>cluster_src/extract/derive/orphan</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1246C814.99,-1246 1007.54,-1246 1007.54,-1246 1013.54,-1246 1019.54,-1252 1019.54,-1258 1019.54,-1258 1019.54,-1285 1019.54,-1285 1019.54,-1291 1013.54,-1297 1007.54,-1297 1007.54,-1297 814.99,-1297 814.99,-1297 808.99,-1297 802.99,-1291 802.99,-1285 802.99,-1285 802.99,-1258 802.99,-1258 802.99,-1252 808.99,-1246 814.99,-1246"/>
+<text text-anchor="middle" x="911.27" y="-1285.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">orphan</text>
+</g>
+<g id="clust13" class="cluster">
+<title>cluster_src/extract/derive/reachable</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1187C814.99,-1187 1005.3,-1187 1005.3,-1187 1011.3,-1187 1017.3,-1193 1017.3,-1199 1017.3,-1199 1017.3,-1226 1017.3,-1226 1017.3,-1232 1011.3,-1238 1005.3,-1238 1005.3,-1238 814.99,-1238 814.99,-1238 808.99,-1238 802.99,-1232 802.99,-1226 802.99,-1226 802.99,-1199 802.99,-1199 802.99,-1193 808.99,-1187 814.99,-1187"/>
+<text text-anchor="middle" x="910.14" y="-1226.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">reachable</text>
+</g>
+<g id="clust14" class="cluster">
+<title>cluster_src/extract/parse</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1070.57,-1083C1070.57,-1083 1151.59,-1083 1151.59,-1083 1157.59,-1083 1163.59,-1089 1163.59,-1095 1163.59,-1095 1163.59,-1151 1163.59,-1151 1163.59,-1157 1157.59,-1163 1151.59,-1163 1151.59,-1163 1070.57,-1163 1070.57,-1163 1064.57,-1163 1058.57,-1157 1058.57,-1151 1058.57,-1151 1058.57,-1095 1058.57,-1095 1058.57,-1089 1064.57,-1083 1070.57,-1083"/>
+<text text-anchor="middle" x="1111.08" y="-1151.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">parse</text>
+</g>
+<g id="clust15" class="cluster">
+<title>cluster_src/extract/resolve</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M957.28,-853C957.28,-853 1666.32,-853 1666.32,-853 1672.32,-853 1678.32,-859 1678.32,-865 1678.32,-865 1678.32,-1063 1678.32,-1063 1678.32,-1069 1672.32,-1075 1666.32,-1075 1666.32,-1075 957.28,-1075 957.28,-1075 951.28,-1075 945.28,-1069 945.28,-1063 945.28,-1063 945.28,-865 945.28,-865 945.28,-859 951.28,-853 957.28,-853"/>
+<text text-anchor="middle" x="1311.8" y="-1063.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
+</g>
+<g id="clust16" class="cluster">
+<title>cluster_src/extract/resolve/get&#45;manifest&#45;dependencies</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-989C1231.64,-989 1470.48,-989 1470.48,-989 1476.48,-989 1482.48,-995 1482.48,-1001 1482.48,-1001 1482.48,-1028 1482.48,-1028 1482.48,-1034 1476.48,-1040 1470.48,-1040 1470.48,-1040 1231.64,-1040 1231.64,-1040 1225.64,-1040 1219.64,-1034 1219.64,-1028 1219.64,-1028 1219.64,-1001 1219.64,-1001 1219.64,-995 1225.64,-989 1231.64,-989"/>
+<text text-anchor="middle" x="1351.06" y="-1028.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">get&#45;manifest&#45;dependencies</text>
+</g>
+<g id="clust17" class="cluster">
+<title>cluster_src/extract/transpile</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-1212C1231.64,-1212 1655.32,-1212 1655.32,-1212 1661.32,-1212 1667.32,-1218 1667.32,-1224 1667.32,-1224 1667.32,-1367 1667.32,-1367 1667.32,-1373 1661.32,-1379 1655.32,-1379 1655.32,-1379 1231.64,-1379 1231.64,-1379 1225.64,-1379 1219.64,-1373 1219.64,-1367 1219.64,-1367 1219.64,-1224 1219.64,-1224 1219.64,-1218 1225.64,-1212 1231.64,-1212"/>
+<text text-anchor="middle" x="1443.48" y="-1367.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
+</g>
+<g id="clust18" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-966C1710.6,-966 1911.66,-966 1911.66,-966 1917.66,-966 1923.66,-972 1923.66,-978 1923.66,-978 1923.66,-1092 1923.66,-1092 1923.66,-1098 1917.66,-1104 1911.66,-1104 1911.66,-1104 1710.6,-1104 1710.6,-1104 1704.6,-1104 1698.6,-1098 1698.6,-1092 1698.6,-1092 1698.6,-978 1698.6,-978 1698.6,-972 1704.6,-966 1710.6,-966"/>
+<text text-anchor="middle" x="1811.13" y="-1092.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
 <g id="clust19" class="cluster">
 <title>cluster_src/main</title>
@@ -113,61 +168,6 @@
 <title>cluster_src/validate</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M957.28,-16C957.28,-16 1301.4,-16 1301.4,-16 1307.4,-16 1313.4,-22 1313.4,-28 1313.4,-28 1313.4,-84 1313.4,-84 1313.4,-90 1307.4,-96 1301.4,-96 1301.4,-96 957.28,-96 957.28,-96 951.28,-96 945.28,-90 945.28,-84 945.28,-84 945.28,-28 945.28,-28 945.28,-22 951.28,-16 957.28,-16"/>
 <text text-anchor="middle" x="1129.34" y="-84.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">validate</text>
-</g>
-<g id="clust8" class="cluster">
-<title>cluster_src/extract</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M681.7,-695C681.7,-695 1919.66,-695 1919.66,-695 1925.66,-695 1931.66,-701 1931.66,-707 1931.66,-707 1931.66,-1394 1931.66,-1394 1931.66,-1400 1925.66,-1406 1919.66,-1406 1919.66,-1406 681.7,-1406 681.7,-1406 675.7,-1406 669.7,-1400 669.7,-1394 669.7,-1394 669.7,-707 669.7,-707 669.7,-701 675.7,-695 681.7,-695"/>
-<text text-anchor="middle" x="1300.68" y="-1394.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
-</g>
-<g id="clust10" class="cluster">
-<title>cluster_src/extract/derive</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M806.99,-1179C806.99,-1179 1015.54,-1179 1015.54,-1179 1021.54,-1179 1027.54,-1185 1027.54,-1191 1027.54,-1191 1027.54,-1369 1027.54,-1369 1027.54,-1375 1021.54,-1381 1015.54,-1381 1015.54,-1381 806.99,-1381 806.99,-1381 800.99,-1381 794.99,-1375 794.99,-1369 794.99,-1369 794.99,-1191 794.99,-1191 794.99,-1185 800.99,-1179 806.99,-1179"/>
-<text text-anchor="middle" x="911.27" y="-1369.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">derive</text>
-</g>
-<g id="clust11" class="cluster">
-<title>cluster_src/extract/derive/circular</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1305C814.99,-1305 1006.79,-1305 1006.79,-1305 1012.79,-1305 1018.79,-1311 1018.79,-1317 1018.79,-1317 1018.79,-1344 1018.79,-1344 1018.79,-1350 1012.79,-1356 1006.79,-1356 1006.79,-1356 814.99,-1356 814.99,-1356 808.99,-1356 802.99,-1350 802.99,-1344 802.99,-1344 802.99,-1317 802.99,-1317 802.99,-1311 808.99,-1305 814.99,-1305"/>
-<text text-anchor="middle" x="910.89" y="-1344.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">circular</text>
-</g>
-<g id="clust12" class="cluster">
-<title>cluster_src/extract/derive/orphan</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1246C814.99,-1246 1007.54,-1246 1007.54,-1246 1013.54,-1246 1019.54,-1252 1019.54,-1258 1019.54,-1258 1019.54,-1285 1019.54,-1285 1019.54,-1291 1013.54,-1297 1007.54,-1297 1007.54,-1297 814.99,-1297 814.99,-1297 808.99,-1297 802.99,-1291 802.99,-1285 802.99,-1285 802.99,-1258 802.99,-1258 802.99,-1252 808.99,-1246 814.99,-1246"/>
-<text text-anchor="middle" x="911.27" y="-1285.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">orphan</text>
-</g>
-<g id="clust13" class="cluster">
-<title>cluster_src/extract/derive/reachable</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M814.99,-1187C814.99,-1187 1005.3,-1187 1005.3,-1187 1011.3,-1187 1017.3,-1193 1017.3,-1199 1017.3,-1199 1017.3,-1226 1017.3,-1226 1017.3,-1232 1011.3,-1238 1005.3,-1238 1005.3,-1238 814.99,-1238 814.99,-1238 808.99,-1238 802.99,-1232 802.99,-1226 802.99,-1226 802.99,-1199 802.99,-1199 802.99,-1193 808.99,-1187 814.99,-1187"/>
-<text text-anchor="middle" x="910.14" y="-1226.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">reachable</text>
-</g>
-<g id="clust9" class="cluster">
-<title>cluster_src/extract/ast&#45;extractors</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M926.27,-703C926.27,-703 1291.9,-703 1291.9,-703 1297.9,-703 1303.9,-709 1303.9,-715 1303.9,-715 1303.9,-785 1303.9,-785 1303.9,-791 1297.9,-797 1291.9,-797 1291.9,-797 926.27,-797 926.27,-797 920.27,-797 914.27,-791 914.27,-785 914.27,-785 914.27,-715 914.27,-715 914.27,-709 920.27,-703 926.27,-703"/>
-<text text-anchor="middle" x="1109.09" y="-785.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
-</g>
-<g id="clust14" class="cluster">
-<title>cluster_src/extract/parse</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1070.57,-1083C1070.57,-1083 1151.59,-1083 1151.59,-1083 1157.59,-1083 1163.59,-1089 1163.59,-1095 1163.59,-1095 1163.59,-1151 1163.59,-1151 1163.59,-1157 1157.59,-1163 1151.59,-1163 1151.59,-1163 1070.57,-1163 1070.57,-1163 1064.57,-1163 1058.57,-1157 1058.57,-1151 1058.57,-1151 1058.57,-1095 1058.57,-1095 1058.57,-1089 1064.57,-1083 1070.57,-1083"/>
-<text text-anchor="middle" x="1111.08" y="-1151.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">parse</text>
-</g>
-<g id="clust15" class="cluster">
-<title>cluster_src/extract/resolve</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M957.28,-853C957.28,-853 1666.32,-853 1666.32,-853 1672.32,-853 1678.32,-859 1678.32,-865 1678.32,-865 1678.32,-1063 1678.32,-1063 1678.32,-1069 1672.32,-1075 1666.32,-1075 1666.32,-1075 957.28,-1075 957.28,-1075 951.28,-1075 945.28,-1069 945.28,-1063 945.28,-1063 945.28,-865 945.28,-865 945.28,-859 951.28,-853 957.28,-853"/>
-<text text-anchor="middle" x="1311.8" y="-1063.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
-</g>
-<g id="clust16" class="cluster">
-<title>cluster_src/extract/resolve/get&#45;manifest&#45;dependencies</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-989C1231.64,-989 1470.48,-989 1470.48,-989 1476.48,-989 1482.48,-995 1482.48,-1001 1482.48,-1001 1482.48,-1028 1482.48,-1028 1482.48,-1034 1476.48,-1040 1470.48,-1040 1470.48,-1040 1231.64,-1040 1231.64,-1040 1225.64,-1040 1219.64,-1034 1219.64,-1028 1219.64,-1028 1219.64,-1001 1219.64,-1001 1219.64,-995 1225.64,-989 1231.64,-989"/>
-<text text-anchor="middle" x="1351.06" y="-1028.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">get&#45;manifest&#45;dependencies</text>
-</g>
-<g id="clust17" class="cluster">
-<title>cluster_src/extract/transpile</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-1212C1231.64,-1212 1655.32,-1212 1655.32,-1212 1661.32,-1212 1667.32,-1218 1667.32,-1224 1667.32,-1224 1667.32,-1367 1667.32,-1367 1667.32,-1373 1661.32,-1379 1655.32,-1379 1655.32,-1379 1231.64,-1379 1231.64,-1379 1225.64,-1379 1219.64,-1373 1219.64,-1367 1219.64,-1367 1219.64,-1224 1219.64,-1224 1219.64,-1218 1225.64,-1212 1231.64,-1212"/>
-<text text-anchor="middle" x="1443.48" y="-1367.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
-</g>
-<g id="clust18" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-966C1710.6,-966 1911.66,-966 1911.66,-966 1917.66,-966 1923.66,-972 1923.66,-978 1923.66,-978 1923.66,-1092 1923.66,-1092 1923.66,-1098 1917.66,-1104 1911.66,-1104 1911.66,-1104 1710.6,-1104 1710.6,-1104 1704.6,-1104 1698.6,-1098 1698.6,-1092 1698.6,-1092 1698.6,-978 1698.6,-978 1698.6,-972 1704.6,-966 1710.6,-966"/>
-<text text-anchor="middle" x="1811.13" y="-1092.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
 <!-- bin/depcruise&#45;fmt.js -->
 <g id="node1" class="node">
@@ -1114,8 +1114,8 @@
 <!-- src/extract/resolve/resolve&#45;amd.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge85" class="edge">
 <title>src/extract/resolve/resolve&#45;amd.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1148.3,-955C1244.82,-955 1495.66,-955 1495.66,-955 1495.66,-955 1495.66,-1008.21 1495.66,-1008.21 1495.66,-1008.21 1729.84,-1008.21 1729.84,-1008.21"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.84,-1010.31 1735.84,-1008.21 1729.84,-1006.11 1729.84,-1010.31"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1148.43,-955C1245.94,-955 1500.66,-955 1500.66,-955 1500.66,-955 1500.66,-1008.21 1500.66,-1008.21 1500.66,-1008.21 1729.95,-1008.21 1729.95,-1008.21"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.95,-1010.31 1735.95,-1008.21 1729.95,-1006.11 1729.95,-1010.31"/>
 </g>
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js -->
 <g id="node59" class="node">
@@ -1252,8 +1252,8 @@
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge53" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1308.85,-1178C1392.79,-1178 1544.66,-1178 1544.66,-1178 1544.66,-1178 1544.66,-1011.36 1544.66,-1011.36 1544.66,-1011.36 1729.87,-1011.36 1729.87,-1011.36"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.87,-1013.46 1735.87,-1011.36 1729.87,-1009.26 1729.87,-1013.46"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1308.7,-1178C1392.86,-1178 1545.66,-1178 1545.66,-1178 1545.66,-1178 1545.66,-1011.36 1545.66,-1011.36 1545.66,-1011.36 1730.04,-1011.36 1730.04,-1011.36"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1730.04,-1013.46 1736.04,-1011.36 1730.04,-1009.26 1730.04,-1013.46"/>
 </g>
 <!-- src/extract/transpile/coffeescript&#45;wrap.js -->
 <g id="node69" class="node">
@@ -1354,8 +1354,8 @@
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/ast&#45;extractors/extract&#45;es6&#45;deps.js -->
 <g id="edge57" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/ast&#45;extractors/extract&#45;es6&#45;deps.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M886.12,-800.21C954.53,-800.21 1071.66,-800.21 1071.66,-800.21 1071.66,-800.21 1071.66,-777.63 1071.66,-777.63"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1073.76,-777.63 1071.66,-771.63 1069.56,-777.63 1073.76,-777.63"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M886.33,-800.21C955.03,-800.21 1072.66,-800.21 1072.66,-800.21 1072.66,-800.21 1072.66,-777.63 1072.66,-777.63"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1074.76,-777.63 1072.66,-771.63 1070.56,-777.63 1074.76,-777.63"/>
 </g>
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/ast&#45;extractors/extract&#45;typescript&#45;deps.js -->
 <g id="edge58" class="edge">
@@ -1372,8 +1372,8 @@
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/parse/to&#45;typescript&#45;ast.js -->
 <g id="edge60" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/parse/to&#45;typescript&#45;ast.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M886.27,-805.07C954.17,-805.07 1069.66,-805.07 1069.66,-805.07 1069.66,-805.07 1069.66,-1085.49 1069.66,-1085.49"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1067.56,-1085.49 1069.66,-1091.49 1071.76,-1085.49 1067.56,-1085.49"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M886.06,-805.07C953.67,-805.07 1068.66,-805.07 1068.66,-805.07 1068.66,-805.07 1068.66,-1085.49 1068.66,-1085.49"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1066.56,-1085.49 1068.66,-1091.49 1070.76,-1085.49 1066.56,-1085.49"/>
 </g>
 <!-- src/utl/array&#45;util.js -->
 <g id="node52" class="node">
@@ -1429,29 +1429,29 @@
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge78" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1007.35,-894.83C1118.45,-894.83 1533.66,-894.83 1533.66,-894.83 1533.66,-894.83 1533.66,-1005.07 1533.66,-1005.07 1533.66,-1005.07 1729.91,-1005.07 1729.91,-1005.07"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.91,-1007.17 1735.91,-1005.07 1729.91,-1002.97 1729.91,-1007.17"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1007.5,-892C1119.2,-892 1536.66,-892 1536.66,-892 1536.66,-892 1536.66,-1005.07 1536.66,-1005.07 1536.66,-1005.07 1729.86,-1005.07 1729.86,-1005.07"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.86,-1007.17 1735.86,-1005.07 1729.86,-1002.97 1729.86,-1007.17"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/is&#45;relative&#45;module&#45;name.js -->
 <g id="edge79" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/is&#45;relative&#45;module&#45;name.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1007.34,-889.17C1122.47,-889.17 1565.66,-889.17 1565.66,-889.17 1565.66,-889.17 1565.66,-899.31 1565.66,-899.31"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.56,-899.31 1565.66,-905.31 1567.76,-899.31 1563.56,-899.31"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1007.34,-887.75C1122.47,-887.75 1565.66,-887.75 1565.66,-887.75 1565.66,-887.75 1565.66,-899.4 1565.66,-899.4"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.56,-899.4 1565.66,-905.4 1567.76,-899.4 1563.56,-899.4"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js -->
 <g id="node63" class="node">
 <title>src/extract/resolve/resolve&#45;cjs.js</title>
 <g id="a_node63"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-cjs.js" xlink:title="resolve&#45;cjs.js">
-<path fill="#ccffcc" stroke="black" d="M1139.42,-926.5C1139.42,-926.5 1082.73,-926.5 1082.73,-926.5 1079.9,-926.5 1077.07,-923.67 1077.07,-920.83 1077.07,-920.83 1077.07,-915.17 1077.07,-915.17 1077.07,-912.33 1079.9,-909.5 1082.73,-909.5 1082.73,-909.5 1139.42,-909.5 1139.42,-909.5 1142.25,-909.5 1145.09,-912.33 1145.09,-915.17 1145.09,-915.17 1145.09,-920.83 1145.09,-920.83 1145.09,-923.67 1142.25,-926.5 1139.42,-926.5"/>
-<text text-anchor="middle" x="1111.08" y="-915.3" font-family="Helvetica,sans-Serif" font-size="9.00">resolve&#45;cjs.js</text>
+<path fill="#ccffcc" stroke="black" d="M1139.42,-925.5C1139.42,-925.5 1082.73,-925.5 1082.73,-925.5 1079.9,-925.5 1077.07,-922.67 1077.07,-919.83 1077.07,-919.83 1077.07,-914.17 1077.07,-914.17 1077.07,-911.33 1079.9,-908.5 1082.73,-908.5 1082.73,-908.5 1139.42,-908.5 1139.42,-908.5 1142.25,-908.5 1145.09,-911.33 1145.09,-914.17 1145.09,-914.17 1145.09,-919.83 1145.09,-919.83 1145.09,-922.67 1142.25,-925.5 1139.42,-925.5"/>
+<text text-anchor="middle" x="1111.08" y="-914.3" font-family="Helvetica,sans-Serif" font-size="9.00">resolve&#45;cjs.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;cjs.js -->
 <g id="edge81" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;cjs.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M989.66,-900.51C989.66,-908.1 989.66,-918 989.66,-918 989.66,-918 1070.93,-918 1070.93,-918"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1070.93,-920.1 1076.93,-918 1070.93,-915.9 1070.93,-920.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M989.66,-900.51C989.66,-906.76 989.66,-914.17 989.66,-914.17 989.66,-914.17 1070.93,-914.17 1070.93,-914.17"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1070.93,-916.27 1076.93,-914.17 1070.93,-912.07 1070.93,-916.27"/>
 </g>
 <!-- src/extract/utl/compare.js -->
 <g id="node68" class="node">
@@ -1507,8 +1507,8 @@
 <!-- src/extract/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge71" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M731.72,-1163.5C869.75,-1163.5 1489.66,-1163.5 1489.66,-1163.5 1489.66,-1163.5 1489.66,-1009.79 1489.66,-1009.79 1489.66,-1009.79 1729.9,-1009.79 1729.9,-1009.79"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.9,-1011.89 1735.9,-1009.79 1729.9,-1007.69 1729.9,-1011.89"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M731.82,-1163.5C870.38,-1163.5 1492.66,-1163.5 1492.66,-1163.5 1492.66,-1163.5 1492.66,-1009.79 1492.66,-1009.79 1492.66,-1009.79 1730.01,-1009.79 1730.01,-1009.79"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1730.01,-1011.89 1736.01,-1009.79 1730.01,-1007.69 1730.01,-1011.89"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/get&#45;dependencies.js -->
 <g id="edge69" class="edge">
@@ -1573,38 +1573,38 @@
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/is&#45;relative&#45;module&#45;name.js -->
 <g id="edge75" class="edge">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/is&#45;relative&#45;module&#45;name.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1320.66,-919.46C1320.66,-917.26 1320.66,-915.5 1320.66,-915.5 1320.66,-915.5 1542.99,-915.5 1542.99,-915.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1542.99,-917.6 1548.99,-915.5 1542.99,-913.4 1542.99,-917.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1320.66,-919.46C1320.66,-914.84 1320.66,-910.07 1320.66,-910.07 1320.66,-910.07 1542.99,-910.07 1542.99,-910.07"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1542.99,-912.17 1548.99,-910.07 1542.99,-907.97 1542.99,-912.17"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge95" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.31,-913.5C1240.38,-913.5 1500.66,-913.5 1500.66,-913.5 1500.66,-913.5 1500.66,-1036.75 1500.66,-1036.75 1500.66,-1036.75 1576.36,-1036.75 1576.36,-1036.75"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1576.36,-1038.85 1582.36,-1036.75 1576.36,-1034.65 1576.36,-1038.85"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1076.98,-919.83C1073.19,-919.83 1070.66,-919.83 1070.66,-919.83 1070.66,-919.83 1070.66,-1036.75 1070.66,-1036.75 1070.66,-1036.75 1576.46,-1036.75 1576.46,-1036.75"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1576.46,-1038.85 1582.46,-1036.75 1576.46,-1034.65 1576.46,-1038.85"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/get&#45;manifest&#45;dependencies/index.js -->
 <g id="edge92" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/get&#45;manifest&#45;dependencies/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.32,-924.75C1149.13,-924.75 1151.66,-924.75 1151.66,-924.75 1151.66,-924.75 1151.66,-1001.75 1151.66,-1001.75 1151.66,-1001.75 1221.58,-1001.75 1221.58,-1001.75"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1221.58,-1003.85 1227.58,-1001.75 1221.58,-999.65 1221.58,-1003.85"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.32,-916.36C1155.82,-916.36 1164.66,-916.36 1164.66,-916.36 1164.66,-916.36 1164.66,-1001.75 1164.66,-1001.75 1164.66,-1001.75 1221.15,-1001.75 1221.15,-1001.75"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1221.15,-1003.85 1227.15,-1001.75 1221.15,-999.65 1221.15,-1003.85"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge90" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.4,-911.5C1241.4,-911.5 1505.66,-911.5 1505.66,-911.5 1505.66,-911.5 1505.66,-1006.64 1505.66,-1006.64 1505.66,-1006.64 1730.09,-1006.64 1730.09,-1006.64"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1730.09,-1008.74 1736.09,-1006.64 1730.09,-1004.54 1730.09,-1008.74"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1111.66,-908.08C1111.66,-902.46 1111.66,-896.25 1111.66,-896.25 1111.66,-896.25 1532.66,-896.25 1532.66,-896.25 1532.66,-896.25 1532.66,-1006.64 1532.66,-1006.64 1532.66,-1006.64 1730.02,-1006.64 1730.02,-1006.64"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1730.02,-1008.74 1736.02,-1006.64 1730.02,-1004.54 1730.02,-1008.74"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/determine&#45;dependency&#45;types.js -->
 <g id="edge91" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/determine&#45;dependency&#45;types.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.1,-921.25C1145.1,-921.25 1177.86,-921.25 1177.86,-921.25"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1177.86,-923.35 1183.86,-921.25 1177.86,-919.15 1177.86,-923.35"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.4,-914.79C1169.21,-914.79 1196.66,-914.79 1196.66,-914.79 1196.66,-914.79 1196.66,-915.23 1196.66,-915.23"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1194.56,-913.26 1196.66,-919.26 1198.76,-913.26 1194.56,-913.26"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/is&#45;core.js -->
 <g id="edge93" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/is&#45;core.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.28,-917.5C1225.62,-917.5 1419.66,-917.5 1419.66,-917.5 1419.66,-917.5 1419.66,-921.18 1419.66,-921.18"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1417.56,-921.18 1419.66,-927.18 1421.76,-921.18 1417.56,-921.18"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.28,-913.21C1225.62,-913.21 1419.66,-913.21 1419.66,-913.21 1419.66,-913.21 1419.66,-921.26 1419.66,-921.26"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1417.56,-921.26 1419.66,-927.26 1421.76,-921.26 1417.56,-921.26"/>
 </g>
 <!-- src/extract/resolve/is&#45;followable.js -->
 <g id="node64" class="node">
@@ -1618,20 +1618,20 @@
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/is&#45;followable.js -->
 <g id="edge94" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/is&#45;followable.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1111.66,-909.2C1111.66,-895.34 1111.66,-870 1111.66,-870 1111.66,-870 1211.45,-870 1211.45,-870"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.45,-872.1 1217.45,-870 1211.45,-867.9 1211.45,-872.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.11,-911.64C1187.57,-911.64 1254.66,-911.64 1254.66,-911.64 1254.66,-911.64 1254.66,-884.83 1254.66,-884.83"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1256.76,-884.83 1254.66,-878.83 1252.56,-884.83 1256.76,-884.83"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve&#45;helpers.js -->
 <g id="edge96" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.45,-923C1150.3,-923 1153.66,-923 1153.66,-923 1153.66,-923 1153.66,-969.17 1153.66,-969.17 1153.66,-969.17 1205.52,-969.17 1205.52,-969.17"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1205.52,-971.27 1211.52,-969.17 1205.52,-967.07 1205.52,-971.27"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1145.42,-917.93C1149.73,-917.93 1152.66,-917.93 1152.66,-917.93 1152.66,-917.93 1152.66,-969.17 1152.66,-969.17 1152.66,-969.17 1205.39,-969.17 1205.39,-969.17"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1205.39,-971.27 1211.39,-969.17 1205.39,-967.07 1205.39,-971.27"/>
 </g>
 <!-- src/extract/resolve/is&#45;followable.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge82" class="edge">
 <title>src/extract/resolve/is&#45;followable.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1291.77,-870C1368.76,-870 1538.66,-870 1538.66,-870 1538.66,-870 1538.66,-1070 1538.66,-1070 1538.66,-1070 1728.86,-1070 1728.86,-1070"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1728.86,-1072.1 1734.86,-1070 1728.86,-1067.9 1728.86,-1072.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1291.87,-870C1369.53,-870 1541.66,-870 1541.66,-870 1541.66,-870 1541.66,-1070 1541.66,-1070 1541.66,-1070 1729.11,-1070 1729.11,-1070"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1729.11,-1072.1 1735.11,-1070 1729.11,-1067.9 1729.11,-1072.1"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/local&#45;npm&#45;helpers.js -->
 <g id="edge97" class="edge">
@@ -2071,8 +2071,8 @@
 <!-- src/report/utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/report/utl/consolidate&#45;modules.js -->
 <g id="edge157" class="edge">
 <title>src/report/utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/report/utl/consolidate&#45;modules.js</title>
-<path fill="none" stroke="#ff00ff" stroke-width="2" stroke-opacity="0.466667" d="M1481.92,-480.17C1497.62,-480.17 1510.66,-480.17 1510.66,-480.17 1510.66,-480.17 1510.66,-458.25 1510.66,-458.25 1510.66,-458.25 1549.77,-458.25 1549.77,-458.25"/>
-<polygon fill="#ff00ff" fill-opacity="0.466667" stroke="#ff00ff" stroke-width="2" stroke-opacity="0.466667" points="1549.77,-460.35 1555.77,-458.25 1549.77,-456.15 1549.77,-460.35"/>
+<path fill="none" stroke="#ff00ff" stroke-width="2" stroke-opacity="0.466667" d="M1481.51,-480.17C1496.43,-480.17 1508.66,-480.17 1508.66,-480.17 1508.66,-480.17 1508.66,-458.25 1508.66,-458.25 1508.66,-458.25 1549.86,-458.25 1549.86,-458.25"/>
+<polygon fill="#ff00ff" fill-opacity="0.466667" stroke="#ff00ff" stroke-width="2" stroke-opacity="0.466667" points="1549.86,-460.35 1555.86,-458.25 1549.86,-456.15 1549.86,-460.35"/>
 </g>
 <!-- src/report/error&#45;html/error&#45;html.template.js -->
 <g id="node98" class="node">
@@ -2107,8 +2107,8 @@
 <!-- src/report/error.js&#45;&gt;src/utl/find&#45;rule&#45;by&#45;name.js -->
 <g id="edge141" class="edge">
 <title>src/report/error.js&#45;&gt;src/utl/find&#45;rule&#45;by&#45;name.js</title>
-<path fill="none" stroke="#aaaaaa" stroke-width="2" stroke-opacity="0.466667" d="M1138.12,-297C1160.86,-297 1189.66,-297 1189.66,-297 1189.66,-297 1189.66,-94.83 1189.66,-94.83 1189.66,-94.83 1374.71,-94.83 1374.71,-94.83"/>
-<polygon fill="#aaaaaa" fill-opacity="0.466667" stroke="#aaaaaa" stroke-width="2" stroke-opacity="0.466667" points="1374.71,-96.93 1380.71,-94.83 1374.71,-92.73 1374.71,-96.93"/>
+<path fill="none" stroke="#aaaaaa" stroke-width="2" stroke-opacity="0.466667" d="M1138.21,-297C1160.59,-297 1188.66,-297 1188.66,-297 1188.66,-297 1188.66,-94.83 1188.66,-94.83 1188.66,-94.83 1374.8,-94.83 1374.8,-94.83"/>
+<polygon fill="#aaaaaa" fill-opacity="0.466667" stroke="#aaaaaa" stroke-width="2" stroke-opacity="0.466667" points="1374.8,-96.93 1380.8,-94.83 1374.8,-92.73 1374.8,-96.93"/>
 </g>
 <!-- src/report/html/html.template.js -->
 <g id="node102" class="node">
@@ -2191,8 +2191,8 @@
 <!-- src/validate/match&#45;module&#45;rule.js&#45;&gt;src/validate/matchers.js -->
 <g id="edge165" class="edge">
 <title>src/validate/match&#45;module&#45;rule.js&#45;&gt;src/validate/matchers.js</title>
-<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1161.15,-37.25C1178.95,-37.25 1194.66,-37.25 1194.66,-37.25 1194.66,-37.25 1194.66,-59.17 1194.66,-59.17 1194.66,-59.17 1217.6,-59.17 1217.6,-59.17"/>
-<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1217.6,-61.27 1223.6,-59.17 1217.6,-57.07 1217.6,-61.27"/>
+<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1161.35,-37.25C1178.14,-37.25 1192.66,-37.25 1192.66,-37.25 1192.66,-37.25 1192.66,-59.17 1192.66,-59.17 1192.66,-59.17 1217.29,-59.17 1217.29,-59.17"/>
+<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1217.29,-61.27 1223.29,-59.17 1217.29,-57.07 1217.29,-61.27"/>
 </g>
 <!-- src/validate/matchers.js&#45;&gt;src/utl/array&#45;util.js -->
 <g id="edge166" class="edge">

--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -59,31 +59,6 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M149.01,-8C149.01,-8 1927.66,-8 1927.66,-8 1933.66,-8 1939.66,-14 1939.66,-20 1939.66,-20 1939.66,-2156 1939.66,-2156 1939.66,-2162 1933.66,-2168 1927.66,-2168 1927.66,-2168 149.01,-2168 149.01,-2168 143.01,-2168 137.01,-2162 137.01,-2156 137.01,-2156 137.01,-20 137.01,-20 137.01,-14 143.01,-8 149.01,-8"/>
 <text text-anchor="middle" x="1038.34" y="-2156.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">src</text>
 </g>
-<g id="clust3" class="cluster">
-<title>cluster_src/cli</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M157.01,-1801C157.01,-1801 749.71,-1801 749.71,-1801 755.71,-1801 761.71,-1807 761.71,-1813 761.71,-1813 761.71,-2131 761.71,-2131 761.71,-2137 755.71,-2143 749.71,-2143 749.71,-2143 157.01,-2143 157.01,-2143 151.01,-2143 145.01,-2137 145.01,-2131 145.01,-2131 145.01,-1813 145.01,-1813 145.01,-1807 151.01,-1801 157.01,-1801"/>
-<text text-anchor="middle" x="453.36" y="-2131.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
-</g>
-<g id="clust4" class="cluster">
-<title>cluster_src/cli/compile&#45;config</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M562.17,-1809C562.17,-1809 741.71,-1809 741.71,-1809 747.71,-1809 753.71,-1815 753.71,-1821 753.71,-1821 753.71,-1877 753.71,-1877 753.71,-1883 747.71,-1889 741.71,-1889 741.71,-1889 562.17,-1889 562.17,-1889 556.17,-1889 550.17,-1883 550.17,-1877 550.17,-1877 550.17,-1821 550.17,-1821 550.17,-1815 556.17,-1809 562.17,-1809"/>
-<text text-anchor="middle" x="651.94" y="-1877.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compile&#45;config</text>
-</g>
-<g id="clust5" class="cluster">
-<title>cluster_src/cli/init&#45;config</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-1965C322.84,-1965 628.69,-1965 628.69,-1965 634.69,-1965 640.69,-1971 640.69,-1977 640.69,-1977 640.69,-2106 640.69,-2106 640.69,-2112 634.69,-2118 628.69,-2118 628.69,-2118 322.84,-2118 322.84,-2118 316.84,-2118 310.84,-2112 310.84,-2106 310.84,-2106 310.84,-1977 310.84,-1977 310.84,-1971 316.84,-1965 322.84,-1965"/>
-<text text-anchor="middle" x="475.76" y="-2106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
-</g>
-<g id="clust6" class="cluster">
-<title>cluster_src/cli/tools</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M170.29,-1809C170.29,-1809 267.3,-1809 267.3,-1809 273.3,-1809 279.3,-1815 279.3,-1821 279.3,-1821 279.3,-1848 279.3,-1848 279.3,-1854 273.3,-1860 267.3,-1860 267.3,-1860 170.29,-1860 170.29,-1860 164.29,-1860 158.29,-1854 158.29,-1848 158.29,-1848 158.29,-1821 158.29,-1821 158.29,-1815 164.29,-1809 170.29,-1809"/>
-<text text-anchor="middle" x="218.79" y="-1848.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">tools</text>
-</g>
-<g id="clust7" class="cluster">
-<title>cluster_src/cli/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M414.11,-1812C414.11,-1812 517.65,-1812 517.65,-1812 523.65,-1812 529.65,-1818 529.65,-1824 529.65,-1824 529.65,-1909 529.65,-1909 529.65,-1915 523.65,-1921 517.65,-1921 517.65,-1921 414.11,-1921 414.11,-1921 408.11,-1921 402.11,-1915 402.11,-1909 402.11,-1909 402.11,-1824 402.11,-1824 402.11,-1818 408.11,-1812 414.11,-1812"/>
-<text text-anchor="middle" x="465.88" y="-1909.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
 <g id="clust8" class="cluster">
 <title>cluster_src/extract</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M681.7,-695C681.7,-695 1919.66,-695 1919.66,-695 1925.66,-695 1931.66,-701 1931.66,-707 1931.66,-707 1931.66,-1394 1931.66,-1394 1931.66,-1400 1925.66,-1406 1919.66,-1406 1919.66,-1406 681.7,-1406 681.7,-1406 675.7,-1406 669.7,-1400 669.7,-1394 669.7,-1394 669.7,-707 669.7,-707 669.7,-701 675.7,-695 681.7,-695"/>
@@ -93,6 +68,11 @@
 <title>cluster_src/extract/ast&#45;extractors</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M926.27,-703C926.27,-703 1291.9,-703 1291.9,-703 1297.9,-703 1303.9,-709 1303.9,-715 1303.9,-715 1303.9,-785 1303.9,-785 1303.9,-791 1297.9,-797 1291.9,-797 1291.9,-797 926.27,-797 926.27,-797 920.27,-797 914.27,-791 914.27,-785 914.27,-785 914.27,-715 914.27,-715 914.27,-709 920.27,-703 926.27,-703"/>
 <text text-anchor="middle" x="1109.09" y="-785.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
+</g>
+<g id="clust18" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-966C1710.6,-966 1911.66,-966 1911.66,-966 1917.66,-966 1923.66,-972 1923.66,-978 1923.66,-978 1923.66,-1092 1923.66,-1092 1923.66,-1098 1917.66,-1104 1911.66,-1104 1911.66,-1104 1710.6,-1104 1710.6,-1104 1704.6,-1104 1698.6,-1098 1698.6,-1092 1698.6,-1092 1698.6,-978 1698.6,-978 1698.6,-972 1704.6,-966 1710.6,-966"/>
+<text text-anchor="middle" x="1811.13" y="-1092.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
 <g id="clust10" class="cluster">
 <title>cluster_src/extract/derive</title>
@@ -133,11 +113,6 @@
 <title>cluster_src/extract/transpile</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1231.64,-1212C1231.64,-1212 1655.32,-1212 1655.32,-1212 1661.32,-1212 1667.32,-1218 1667.32,-1224 1667.32,-1224 1667.32,-1367 1667.32,-1367 1667.32,-1373 1661.32,-1379 1655.32,-1379 1655.32,-1379 1231.64,-1379 1231.64,-1379 1225.64,-1379 1219.64,-1373 1219.64,-1367 1219.64,-1367 1219.64,-1224 1219.64,-1224 1219.64,-1218 1225.64,-1212 1231.64,-1212"/>
 <text text-anchor="middle" x="1443.48" y="-1367.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
-</g>
-<g id="clust18" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1710.6,-966C1710.6,-966 1911.66,-966 1911.66,-966 1917.66,-966 1923.66,-972 1923.66,-978 1923.66,-978 1923.66,-1092 1923.66,-1092 1923.66,-1098 1917.66,-1104 1911.66,-1104 1911.66,-1104 1710.6,-1104 1710.6,-1104 1704.6,-1104 1698.6,-1098 1698.6,-1092 1698.6,-1092 1698.6,-978 1698.6,-978 1698.6,-972 1704.6,-966 1710.6,-966"/>
-<text text-anchor="middle" x="1811.13" y="-1092.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
 </g>
 <g id="clust19" class="cluster">
 <title>cluster_src/main</title>
@@ -193,6 +168,31 @@
 <title>cluster_src/report/utl</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1345.42,-408C1345.42,-408 1811.88,-408 1811.88,-408 1817.88,-408 1823.88,-414 1823.88,-420 1823.88,-420 1823.88,-505 1823.88,-505 1823.88,-511 1817.88,-517 1811.88,-517 1811.88,-517 1345.42,-517 1345.42,-517 1339.42,-517 1333.42,-511 1333.42,-505 1333.42,-505 1333.42,-420 1333.42,-420 1333.42,-414 1339.42,-408 1345.42,-408"/>
 <text text-anchor="middle" x="1578.65" y="-505.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust3" class="cluster">
+<title>cluster_src/cli</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M157.01,-1801C157.01,-1801 749.71,-1801 749.71,-1801 755.71,-1801 761.71,-1807 761.71,-1813 761.71,-1813 761.71,-2131 761.71,-2131 761.71,-2137 755.71,-2143 749.71,-2143 749.71,-2143 157.01,-2143 157.01,-2143 151.01,-2143 145.01,-2137 145.01,-2131 145.01,-2131 145.01,-1813 145.01,-1813 145.01,-1807 151.01,-1801 157.01,-1801"/>
+<text text-anchor="middle" x="453.36" y="-2131.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">cli</text>
+</g>
+<g id="clust5" class="cluster">
+<title>cluster_src/cli/init&#45;config</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M322.84,-1965C322.84,-1965 628.69,-1965 628.69,-1965 634.69,-1965 640.69,-1971 640.69,-1977 640.69,-1977 640.69,-2106 640.69,-2106 640.69,-2112 634.69,-2118 628.69,-2118 628.69,-2118 322.84,-2118 322.84,-2118 316.84,-2118 310.84,-2112 310.84,-2106 310.84,-2106 310.84,-1977 310.84,-1977 310.84,-1971 316.84,-1965 322.84,-1965"/>
+<text text-anchor="middle" x="475.76" y="-2106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">init&#45;config</text>
+</g>
+<g id="clust6" class="cluster">
+<title>cluster_src/cli/tools</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M170.29,-1809C170.29,-1809 267.3,-1809 267.3,-1809 273.3,-1809 279.3,-1815 279.3,-1821 279.3,-1821 279.3,-1848 279.3,-1848 279.3,-1854 273.3,-1860 267.3,-1860 267.3,-1860 170.29,-1860 170.29,-1860 164.29,-1860 158.29,-1854 158.29,-1848 158.29,-1848 158.29,-1821 158.29,-1821 158.29,-1815 164.29,-1809 170.29,-1809"/>
+<text text-anchor="middle" x="218.79" y="-1848.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">tools</text>
+</g>
+<g id="clust7" class="cluster">
+<title>cluster_src/cli/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M414.11,-1812C414.11,-1812 517.65,-1812 517.65,-1812 523.65,-1812 529.65,-1818 529.65,-1824 529.65,-1824 529.65,-1909 529.65,-1909 529.65,-1915 523.65,-1921 517.65,-1921 517.65,-1921 414.11,-1921 414.11,-1921 408.11,-1921 402.11,-1915 402.11,-1909 402.11,-1909 402.11,-1824 402.11,-1824 402.11,-1818 408.11,-1812 414.11,-1812"/>
+<text text-anchor="middle" x="465.88" y="-1909.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust4" class="cluster">
+<title>cluster_src/cli/compile&#45;config</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M562.17,-1809C562.17,-1809 741.71,-1809 741.71,-1809 747.71,-1809 753.71,-1815 753.71,-1821 753.71,-1821 753.71,-1877 753.71,-1877 753.71,-1883 747.71,-1889 741.71,-1889 741.71,-1889 562.17,-1889 562.17,-1889 556.17,-1889 550.17,-1883 550.17,-1877 550.17,-1877 550.17,-1821 550.17,-1821 550.17,-1815 556.17,-1809 562.17,-1809"/>
+<text text-anchor="middle" x="651.94" y="-1877.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">compile&#45;config</text>
 </g>
 <g id="clust30" class="cluster">
 <title>cluster_src/schema</title>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser",
-  "version": "9.0.0",
+  "version": "9.0.1-beta-1",
   "description": "Validate and visualize dependencies. With your rules. JavaScript, TypeScript, CoffeeScript. ES6, CommonJS, AMD.",
   "keywords": [
     "static analysis",

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -23,7 +23,6 @@ const EXTENSION2WRAPPER = {
   ".js": javaScriptWrap,
   ".mjs": javaScriptWrap,
   ".jsx": javaScriptWrap,
-  ".vue": vueWrap,
   ".ts": typeScriptWrap,
   ".tsx": tsxWrap,
   ".d.ts": typeScriptWrap,
@@ -33,6 +32,7 @@ const EXTENSION2WRAPPER = {
   ".coffee.md": litCoffeeWrap,
   ".csx": coffeeWrap,
   ".cjsx": coffeeWrap,
+  ".vue": vueWrap,
 };
 
 const TRANSPILER2WRAPPER = {

--- a/test/extract/resolve/fixtures/vue-last/x.ts
+++ b/test/extract/resolve/fixtures/vue-last/x.ts
@@ -1,0 +1,3 @@
+import * as x from "./y";
+
+console.log(x.value)

--- a/test/extract/resolve/fixtures/vue-last/y.ts
+++ b/test/extract/resolve/fixtures/vue-last/y.ts
@@ -1,0 +1,3 @@
+import * as y from './y.vue'
+
+export const value = `ts ${y.value}`

--- a/test/extract/resolve/fixtures/vue-last/y.vue
+++ b/test/extract/resolve/fixtures/vue-last/y.vue
@@ -1,0 +1,1 @@
+export const value = "vue"

--- a/test/extract/resolve/index.spec.js
+++ b/test/extract/resolve/index.spec.js
@@ -154,6 +154,31 @@ describe("extract/resolve/index", () => {
     });
   });
 
+  it("resolves to ts before it considers vue", () => {
+    expect(
+      resolve(
+        {
+          module: "./x",
+          moduleSystem: "es6",
+        },
+        path.join(__dirname, "fixtures"),
+        path.join(__dirname, "fixtures", "vue-last"),
+        normalizeResolveOptions(
+          {
+            bustTheCache: true,
+          },
+          {}
+        )
+      )
+    ).to.deep.equal({
+      coreModule: false,
+      couldNotResolve: false,
+      dependencyTypes: ["local"],
+      followable: true,
+      resolved: "vue-last/x.ts",
+    });
+  });
+
   it("considers passed (webpack) aliases", () => {
     expect(
       resolve(

--- a/test/extract/transpile/meta.spec.js
+++ b/test/extract/transpile/meta.spec.js
@@ -9,7 +9,6 @@ describe("transpiler meta", () => {
       ".js",
       ".mjs",
       ".jsx",
-      ".vue",
       ".ts",
       ".tsx",
       ".d.ts",
@@ -18,6 +17,7 @@ describe("transpiler meta", () => {
       ".coffee.md",
       ".csx",
       ".cjsx",
+      ".vue",
     ]);
   });
 


### PR DESCRIPTION
## Description

See title

## Motivation and Context

Fixes #291 

## How Has This Been Tested?

- Additional unit tests
- Green CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
