### PR TITLE
bugfix(schema|types): make circular and exoticallyRequired mandatory in schema and type declarations

### DIFF
--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -133,15 +133,17 @@
     "DependencyType": {
       "type": "object",
       "required": [
-        "module",
-        "resolved",
+        "circular",
         "coreModule",
-        "dependencyTypes",
-        "followable",
         "couldNotResolve",
+        "dependencyTypes",
+        "exoticallyRequired",
+        "dynamic",
+        "followable",
+        "module",
         "moduleSystem",
-        "valid",
-        "dynamic"
+        "resolved",
+        "valid"
       ],
       "additionalProperties": false,
       "properties": {

--- a/src/validate/match-dependency-rule.js
+++ b/src/validate/match-dependency-rule.js
@@ -53,7 +53,11 @@ function match(pFrom, pTo) {
       matchers.toLicenseNot(pRule, pTo) &&
       matchers.toExoticRequire(pRule, pTo) &&
       matchers.toExoticRequireNot(pRule, pTo) &&
+      // preCompilationOnly is not a mandatory attribute, but if the attribute
+      // is in the rule but not in the dependency there won't be a match
+      // anyway, so we can use the default propertyEquals method regardless
       propertyEquals(pTo, pRule, "preCompilationOnly") &&
+      // couldNotResolve, circular, dynamic and exoticallyRequired are
       propertyEquals(pTo, pRule, "couldNotResolve") &&
       propertyEquals(pTo, pRule, "circular") &&
       propertyEquals(pTo, pRule, "dynamic") &&

--- a/test/report/anon/anonymize.spec.js
+++ b/test/report/anon/anonymize.spec.js
@@ -37,7 +37,7 @@ const META_SYNTACTIC_VARIABLES = [
   "flob",
 ];
 
-describe("report/anonymous", () => {
+describe("report/anon", () => {
   beforeEach(() => {
     anonymizePathElement.clearCache();
   });

--- a/test/report/anon/fixtures/cycle.json
+++ b/test/report/anon/fixtures/cycle.json
@@ -8,18 +8,14 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./foo",
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
           "circular": true,
-          "cycle": [
-            "src/foo.js",
-            "src/bar.js"
-          ],
+          "cycle": ["src/foo.js", "src/bar.js"],
+          "exoticallyRequired": false,
           "valid": false,
           "rules": [
             {
@@ -40,18 +36,14 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./bar",
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
           "circular": true,
-          "cycle": [
-            "src/bar.js",
-            "src/foo.js"
-          ],
+          "cycle": ["src/bar.js", "src/foo.js"],
+          "exoticallyRequired": false,
           "valid": false,
           "rules": [
             {
@@ -86,10 +78,7 @@
           "severity": "warn",
           "name": "no-circular"
         },
-        "cycle": [
-          "src/foo.js",
-          "src/bar.js"
-        ]
+        "cycle": ["src/foo.js", "src/bar.js"]
       },
       {
         "from": "src/foo.js",
@@ -98,10 +87,7 @@
           "severity": "warn",
           "name": "no-circular"
         },
-        "cycle": [
-          "src/bar.js",
-          "src/foo.js"
-        ]
+        "cycle": ["src/bar.js", "src/foo.js"]
       },
       {
         "from": "src/baz.js",
@@ -131,11 +117,7 @@
         ]
       },
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6"],
       "outputTo": "-",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/report/anon/fixtures/src-report-wordlist.json
+++ b/test/report/anon/fixtures/src-report-wordlist.json
@@ -14,7 +14,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true
@@ -68,7 +70,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/mies/jet.js",
@@ -81,7 +85,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/mies/teun.js",
@@ -94,7 +100,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/vuur/gijs.js",
@@ -107,7 +115,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/vuur/lam.js",
@@ -120,7 +130,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/vuur/kees.template.js",
@@ -133,7 +145,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true
@@ -157,7 +171,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/mies/jet.js",
@@ -170,7 +186,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/mies/teun.js",
@@ -183,7 +201,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/aap/noot/bok/noot.template.js",
@@ -196,7 +216,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true

--- a/test/report/anon/fixtures/src-report.json
+++ b/test/report/anon/fixtures/src-report.json
@@ -14,7 +14,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true
@@ -68,7 +70,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/baz/quuz.js",
@@ -81,7 +85,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/baz/corge.js",
@@ -94,7 +100,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/grault/garply.js",
@@ -107,7 +115,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/grault/waldo.js",
@@ -120,7 +130,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/grault/fred.template.js",
@@ -133,7 +145,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true
@@ -157,7 +171,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/baz/quuz.js",
@@ -170,7 +186,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/baz/corge.js",
@@ -183,7 +201,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         },
         {
           "resolved": "src/foo/bar/plugh/bar.template.js",
@@ -196,7 +216,9 @@
           "dynamic": false,
           "matchesDoNotFollow": false,
           "valid": true,
-          "cycle": []
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true

--- a/test/report/anon/mocks/cycle.json
+++ b/test/report/anon/mocks/cycle.json
@@ -8,18 +8,14 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./yo",
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
           "circular": true,
-          "cycle": [
-            "src/yo.js",
-            "src/entrypoint.js"
-          ],
+          "cycle": ["src/yo.js", "src/entrypoint.js"],
+          "exoticallyRequired": false,
           "valid": false,
           "rules": [
             {
@@ -40,18 +36,14 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./entrypoint",
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
           "circular": true,
-          "cycle": [
-            "src/entrypoint.js",
-            "src/yo.js"
-          ],
+          "cycle": ["src/entrypoint.js", "src/yo.js"],
+          "exoticallyRequired": false,
           "valid": false,
           "rules": [
             {
@@ -86,10 +78,7 @@
           "severity": "warn",
           "name": "no-circular"
         },
-        "cycle": [
-          "src/yo.js",
-          "src/entrypoint.js"
-        ]
+        "cycle": ["src/yo.js", "src/entrypoint.js"]
       },
       {
         "from": "src/yo.js",
@@ -98,10 +87,7 @@
           "severity": "warn",
           "name": "no-circular"
         },
-        "cycle": [
-          "src/entrypoint.js",
-          "src/yo.js"
-        ]
+        "cycle": ["src/entrypoint.js", "src/yo.js"]
       },
       {
         "from": "src/remi.js",
@@ -130,11 +116,7 @@
         ]
       },
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6"],
       "outputTo": "-",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/report/anon/mocks/src-report-wordlist.json
+++ b/test/report/anon/mocks/src-report-wordlist.json
@@ -13,7 +13,10 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
-          "valid": true
+          "valid": true,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true
@@ -66,6 +69,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -78,6 +84,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -90,6 +99,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -102,6 +114,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -114,6 +129,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -126,6 +144,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         }
       ],
@@ -149,6 +170,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -161,6 +185,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -173,6 +200,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -185,6 +215,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         }
       ],

--- a/test/report/anon/mocks/src-report.json
+++ b/test/report/anon/mocks/src-report.json
@@ -13,7 +13,10 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
-          "valid": true
+          "valid": true,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false
         }
       ],
       "valid": true
@@ -66,6 +69,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -78,6 +84,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -90,6 +99,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -102,6 +114,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -114,6 +129,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -126,6 +144,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         }
       ],
@@ -149,6 +170,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -161,6 +185,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -173,6 +200,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         },
         {
@@ -185,6 +215,9 @@
           "moduleSystem": "cjs",
           "dynamic": false,
           "matchesDoNotFollow": false,
+          "circular": false,
+          "cycle": [],
+          "exoticallyRequired": false,
           "valid": true
         }
       ],

--- a/test/validate/index.pre-compilation-only.spec.js
+++ b/test/validate/index.pre-compilation-only.spec.js
@@ -27,4 +27,15 @@ describe("validate/index - preCompilationOnly", () => {
       valid: false,
     });
   });
+
+  it("Unknown whether stuff that only exists before compilation - okeleedokelee", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.pre-compilation-only.json"),
+        { source: "something" },
+        { resolved: "types.d.ts" }
+      )
+    ).to.deep.equal({ valid: true });
+  });
 });

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -91,7 +91,7 @@ export interface IDependency {
    * 'true' if following this dependency will ultimately return to the source, false in all
    * other cases
    */
-  circular?: boolean;
+  circular: boolean;
   /**
    * Whether or not this is a node.js core module - deprecated in favor of dependencyType ===
    * core

--- a/utl/schema/dependencies.mjs
+++ b/utl/schema/dependencies.mjs
@@ -11,15 +11,17 @@ export default {
     DependencyType: {
       type: "object",
       required: [
-        "module",
-        "resolved",
+        "circular",
         "coreModule",
-        "dependencyTypes",
-        "followable",
         "couldNotResolve",
-        "moduleSystem",
-        "valid",
+        "dependencyTypes",
+        "exoticallyRequired",
         "dynamic",
+        "followable",
+        "module",
+        "moduleSystem",
+        "resolved",
+        "valid",
       ],
       additionalProperties: false,
       properties: {


### PR DESCRIPTION
## Description, Motivation and Context

The attributes "circular" and "exoticallyRequired" are always present in the result tree. This PR makes them both mandatory in the json schema and the type declarations) so it's clear they can be used safely without null checks (note: exoticallyRequired already was mandatory in the type declarations).

## How Has This Been Tested?

- [x] additional unit test
- [x] adapted unit test (schema validation of the anonymous reporter)
- [x] automated non-regression tests
- [x] green ci

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
