### PR TITLE
feature(init): basic mono-repo config init

### DIFF
--- a/src/cli/init-config/environment-helpers.js
+++ b/src/cli/init-config/environment-helpers.js
@@ -3,6 +3,7 @@ const _get = require("lodash/get");
 
 const LIKELY_SOURCE_FOLDERS = ["src", "lib", "app", "bin"];
 const LIKELY_TEST_FOLDERS = ["test", "spec", "tests", "specs", "bdd"];
+const LIKELY_PACKAGES_FOLDERS = ["packages"];
 
 /**
  * Read the package manifest ('package.json') and return it as a javascript object
@@ -51,31 +52,22 @@ function getFolderNames(pFolderName) {
 }
 
 function isLikelyMonoRepo(pFolderNames = getFolderNames(".")) {
-  return pFolderNames.some((pFolderName) => pFolderName === "packages");
+  return pFolderNames.includes("packages");
 }
 
 function hasTestsWithinSource(pTestLocations, pSourceLocations) {
   return (
     pTestLocations.length === 0 ||
     pTestLocations.every((pTestLocation) =>
-      pSourceLocations.some(
-        (pSourceLocation) => pSourceLocation === pTestLocation
-      )
+      pSourceLocations.includes(pTestLocation)
     )
   );
 }
 
 function getFolderCandidates(pCandidateFolderArray) {
   return (pFolderNames = getFolderNames(".")) => {
-    if (isLikelyMonoRepo(pFolderNames)) {
-      // when it's likely a monorepo return what we used to return until
-      // version 8.1.1. That way we won't break backwards compatibility
-      return pCandidateFolderArray;
-    }
     return pFolderNames.filter((pFolderName) =>
-      pCandidateFolderArray.some(
-        (pCandidateFolder) => pCandidateFolder === pFolderName
-      )
+      pCandidateFolderArray.includes(pFolderName)
     );
   };
 }
@@ -103,4 +95,5 @@ module.exports = {
   getFolderCandidates,
   getSourceFolderCandidates: getFolderCandidates(LIKELY_SOURCE_FOLDERS),
   getTestFolderCandidates: getFolderCandidates(LIKELY_TEST_FOLDERS),
+  getMonoRepoPackagesCandidates: getFolderCandidates(LIKELY_PACKAGES_FOLDERS),
 };

--- a/src/cli/init-config/get-user-input.js
+++ b/src/cli/init-config/get-user-input.js
@@ -5,6 +5,7 @@ const {
   getFirstExistingFileName,
   getSourceFolderCandidates,
   getTestFolderCandidates,
+  getMonoRepoPackagesCandidates,
   hasTestsWithinSource,
   isLikelyMonoRepo,
   pnpIsEnabled,
@@ -21,12 +22,27 @@ const BABEL_CONFIG_NAME_SEARCH_ARRAY = $defaults.BABEL_CONFIG_NAME_SEARCH_ARRAY;
 
 const INQUIRER_QUESTIONS = [
   {
+    name: "isMonoRepo",
+    type: "confirm",
+    message: "This looks like a mono repo. Is that correct?",
+    default: isLikelyMonoRepo(),
+    when: () => isLikelyMonoRepo(),
+  },
+  {
+    name: "sourceLocation",
+    type: "input",
+    message: "Mono repo it is! Where do your packages live?",
+    default: getMonoRepoPackagesCandidates(),
+    validate: validateLocation,
+    when: (pAnswers) => pAnswers.isMonoRepo,
+  },
+  {
     name: "sourceLocation",
     type: "input",
     message: "Where do your source files live?",
     default: getSourceFolderCandidates(),
     validate: validateLocation,
-    when: () => !isLikelyMonoRepo(),
+    when: (pAnswers) => !pAnswers.isMonoRepo,
   },
   {
     name: "hasTestsOutsideSource",
@@ -38,7 +54,7 @@ const INQUIRER_QUESTIONS = [
         toSourceLocationArray(pAnswers.sourceLocation)
       );
     },
-    when: () => !isLikelyMonoRepo(),
+    when: (pAnswers) => !pAnswers.isMonoRepo,
   },
   {
     name: "testLocation",
@@ -46,8 +62,9 @@ const INQUIRER_QUESTIONS = [
     message: "Where do your test files live?",
     default: getTestFolderCandidates(),
     validate: validateLocation,
-    when: (pAnswers) => pAnswers.hasTestsOutsideSource && !isLikelyMonoRepo(),
+    when: (pAnswers) => pAnswers.hasTestsOutsideSource && !pAnswers.isMonoRepo,
   },
+
   {
     name: "useYarnPnP",
     type: "confirm",

--- a/src/cli/init-config/index.js
+++ b/src/cli/init-config/index.js
@@ -4,6 +4,7 @@ const buildConfig = require("./build-config");
 const writeConfig = require("./write-config");
 const getUserInput = require("./get-user-input");
 const {
+  isLikelyMonoRepo,
   pnpIsEnabled,
   fileExists,
   getFirstExistingFileName,
@@ -17,6 +18,7 @@ const PACKAGE_MANIFEST = `./${$defaults.PACKAGE_MANIFEST}`;
 
 function getOneshotConfig(pOneShotConfigId) {
   const BASE_CONFIG = {
+    isMonoRepo: isLikelyMonoRepo(),
     useTsConfig: fileExists(TYPESCRIPT_CONFIG),
     tsConfig: TYPESCRIPT_CONFIG,
     tsPreCompilationDeps: fileExists(TYPESCRIPT_CONFIG),

--- a/src/cli/init-config/normalize-init-options.js
+++ b/src/cli/init-config/normalize-init-options.js
@@ -15,9 +15,11 @@ function populate(pInitOptions) {
     sourceLocation: toSourceLocationArray(
       pInitOptions.sourceLocation || getSourceFolderCandidates()
     ),
-    testLocation: toSourceLocationArray(
-      pInitOptions.testLocation || getTestFolderCandidates()
-    ),
+    testLocation: pInitOptions.isMonoRepo
+      ? []
+      : toSourceLocationArray(
+          pInitOptions.testLocation || getTestFolderCandidates()
+        ),
   };
 }
 
@@ -33,10 +35,12 @@ module.exports = function normalizeInitOptions(pInitOptions) {
   if (
     !Object.prototype.hasOwnProperty.call(lReturnValue, "hasTestsOutsideSource")
   ) {
-    lReturnValue.hasTestsOutsideSource = !hasTestsWithinSource(
-      lReturnValue.testLocation,
-      lReturnValue.sourceLocation
-    );
+    lReturnValue.hasTestsOutsideSource =
+      !pInitOptions.isMonoRepo &&
+      !hasTestsWithinSource(
+        lReturnValue.testLocation,
+        lReturnValue.sourceLocation
+      );
   }
   return lReturnValue;
 };

--- a/test/cli/init-config/environment-helpers.spec.js
+++ b/test/cli/init-config/environment-helpers.spec.js
@@ -108,16 +108,7 @@ describe("cli/init-config/environment-helpers - hasTestsWithinSource", () => {
 });
 
 describe("cli/init-config/environment-helpers - getFolderCandidates", () => {
-  it("returns candidates verbatim when it's likely a mono repo", () => {
-    const lCandidates = ["src", "bin"];
-    const lRealFolders = ["packages", "src", "lib", "node_modules"];
-
-    expect(getFolderCandidates(lCandidates)(lRealFolders)).to.deep.equal(
-      lCandidates
-    );
-  });
-
-  it("returns only existing folders when it's not a monorepo", () => {
+  it("returns only existing folders", () => {
     const lCandidates = ["src", "bin"];
     const lRealFolders = ["src", "lib", "node_modules"];
 

--- a/test/cli/init-config/normalize-init-options.spec.js
+++ b/test/cli/init-config/normalize-init-options.spec.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-unused-expressions */
+const expect = require("chai").expect;
+const normalizeInitOptions = require("../../../src/cli/init-config/normalize-init-options");
+
+describe("cli/init-config/normalize-init-options", () => {
+  it("If it's a mono repo, doesn't return a testLocation array", () => {
+    expect(
+      normalizeInitOptions({ isMonoRepo: true }).testLocation
+    ).to.deep.equal([]);
+  });
+
+  it("If it's a mono repo, hasTestOutsideSource is false", () => {
+    expect(
+      normalizeInitOptions({ isMonoRepo: true }).hasTestsOutsideSource
+    ).to.equal(false);
+  });
+
+  // TODO: add scenarios now covered by more integration/ e2e style tests
+  // as well
+});


### PR DESCRIPTION
## Description

- If the current folder looks like a mono-repo, use the folder with _packages_ in them (user specifiable, defaulting to `packages`) for sources and (for now) skip any test folder questions

## Motivation and Context

dependency-cruiser is useful especially in big and humongous repositories. So setup should be peanuts for the first time user.

## How Has This Been Tested?

- [x] additional automated tests
- [x] automated non-regression tests
- [x] with eyeballs against some public mono-repos
- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
