### PR TITLE
feature(*): allows path and pathNot to accept an array of RE's

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -19,7 +19,14 @@
         "pathNot": "^(src/cli/compile-config/index\\.js)$"
       },
       "to": {
-        "pathNot": "^src/(main|utl)/|^node_modules|^fs$|^path$|$1|^package.json$"
+        "pathNot": [
+          "^src/(main|utl)/",
+          "^node_modules",
+          "^fs$",
+          "^path$",
+          "$1",
+          "^package.json$"
+        ]
       }
     },
     {
@@ -28,7 +35,12 @@
       "severity": "warn",
       "from": { "path": "^(src/cli/compile-config/index\\.js)$" },
       "to": {
-        "pathNot": "$1|^src/(cli|main)|^node_modules|^(fs|path|package.json)$"
+        "pathNot": [
+          "$1",
+          "^src/(cli|main)",
+          "^node_modules",
+          "^(fs|path|package.json)$"
+        ]
       }
     },
     {
@@ -39,7 +51,7 @@
         "path": "(^src/report/)"
       },
       "to": {
-        "pathNot": "$1|^node_modules|^(path|package.json)$|^src/utl"
+        "pathNot": ["$1", "^node_modules", "^(path|package.json)$", "^src/utl"]
       }
     },
     {
@@ -50,7 +62,12 @@
         "path": "(^src/extract/)"
       },
       "to": {
-        "pathNot": "$1|^node_modules|^(path|fs|module|package.json)$|^src/utl",
+        "pathNot": [
+          "$1",
+          "^node_modules",
+          "^(path|fs|module|package.json)$",
+          "^src/utl"
+        ],
         "exoticallyRequired": false
       }
     },
@@ -59,14 +76,18 @@
       "comment": "This module in the bin/ folder depends on something not in the cli interface. This means it either contains code that doesn't belong in bin/, or the thing it depends upon should be put in the cli interface. ",
       "severity": "error",
       "from": { "path": "(^bin/)" },
-      "to": { "pathNot": "^src/cli|^node_modules|^package.json$" }
+      "to": { "pathNot": ["^src/cli", "^node_modules", "^package.json$"] }
     },
     {
       "name": "restrict-fs-access",
       "comment": "This module depends on a the node 'fs' module, and it resides in a spot where that is not allowed.",
       "severity": "error",
       "from": {
-        "pathNot": "^src/(extract/parse|extract/resolve|extract/gather-initial-sources\\.js|cli)|^test|^tools"
+        "pathNot": [
+          "^src/(extract/parse|extract/resolve|extract/gather-initial-sources\\.js|cli)",
+          "^test",
+          "^tools"
+        ]
       },
       "to": { "path": "^fs$" }
     },
@@ -75,7 +96,7 @@
       "comment": "This test depends on something in the test tree that is neither a utility, nor a mock nor a fixture.",
       "severity": "error",
       "from": { "path": "(^test/[^\\/]+/)[^\\.]+\\.spec\\.js" },
-      "to": { "path": "^test/[^\\/]+/.+", "pathNot": "utl|$1.+\\.json$" }
+      "to": { "path": "^test/[^\\/]+/.+", "pathNot": ["utl", "$1.+\\.json$"] }
     },
     {
       "name": "prefer-lodash-individuals",

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -608,7 +608,7 @@ APL in the "license" attribute of its package.json (e.g.
 [SPDX](https://spdx.org) compatible expressions like `GPL-3.0`, `APL-1.0` and
 `MIT OR GPL-3.0` but also on non SPDX compatible)
 
-To only allow licenses from an approved list (e.g. a whitelist provided by your
+To only allow licenses from an approved list (e.g. a greenlist provided by your
 legal department):
 
 ```json
@@ -616,9 +616,12 @@ legal department):
   "name": "only-licenses-approved-by-legal",
   "severity": "warn",
   "from": {},
-  "to": { "licenseNot": "MIT|ISC" }
+  "to": { "licenseNot": ["MIT", " ISC"] }
 }
 ```
+
+> Just with _path_ and _pathNot_ you can pass an array of regular expressions
+> as well if you think that's more legible.
 
 Note: dependency-cruiser can help out a bit here, but you remain responsible
 for managing your own legal stuff. To re-iterate what is in the

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -361,6 +361,46 @@ group matching:
 ... which makes sure dependency-cruiser does not match stuff in the from folder
 currently being matched.
 
+#### Using an array of regular expressions
+
+When your regular expressions grow bigger, you might want to express them
+as an array of regular expressions instead of just one regular expression to
+improve legibility.
+
+<details>
+<summary>example ...</summary>
+
+```javascript
+{
+  from: {
+    path: "(^src/report/)"
+  },
+  to: {
+    pathNot: "$1|^node_modules|^(path|package.json)$|^src/utl"
+  }
+}
+```
+
+```javascript
+{
+  from: {
+    path: "(^src/report/)"
+  },
+  to: {
+      pathNot: [
+        "$1",
+        "^node_modules",
+        "^(path|package.json)$",
+        "^src/utl"
+      ]
+  }
+}
+```
+
+![focus](assets/filtering/focus.svg)
+
+</details>
+
 ### orphans
 
 A Boolean indicating whether or not to match modules that have no incoming

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -14,11 +14,25 @@ function normalizeName(pRule) {
   return pRule ? pRule : DEFAULT_RULE;
 }
 
+function normalizePaths(pDependencyEnd) {
+  let lDependencyEnd = pDependencyEnd;
+
+  if (Array.isArray(lDependencyEnd.path)) {
+    lDependencyEnd.path = lDependencyEnd.path.join("|");
+  }
+  if (Array.isArray(lDependencyEnd.pathNot)) {
+    lDependencyEnd.pathNot = lDependencyEnd.pathNot.join("|");
+  }
+  return lDependencyEnd;
+}
+
 function normalizeRule(pRule) {
   return {
     ...pRule,
     severity: normalizeSeverity(pRule.severity),
     name: normalizeName(pRule.name),
+    from: normalizePaths(pRule.from),
+    to: normalizePaths(pRule.to),
   };
 }
 
@@ -41,6 +55,8 @@ module.exports = (pRuleSet) => {
       pRuleSet.allowed = pRuleSet.allowed.map((pRule) => ({
         ...pRule,
         name: "not-in-allowed",
+        from: normalizePaths(pRule.from),
+        to: normalizePaths(pRule.to),
       }));
     }
   }

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-object-injection */
 const VALID_SEVERITIES = /^(error|warn|info|ignore)$/;
 const DEFAULT_SEVERITY = "warn";
 const DEFAULT_RULE = "unnamed";
@@ -16,12 +17,19 @@ function normalizeName(pRule) {
 
 function normalizePaths(pDependencyEnd) {
   let lDependencyEnd = pDependencyEnd;
+  const lArrayOrStringProperties = [
+    "path",
+    "pathNot",
+    "license",
+    "licenseNot",
+    "exoticRequire",
+    "exoticRequireNot",
+  ];
 
-  if (Array.isArray(lDependencyEnd.path)) {
-    lDependencyEnd.path = lDependencyEnd.path.join("|");
-  }
-  if (Array.isArray(lDependencyEnd.pathNot)) {
-    lDependencyEnd.pathNot = lDependencyEnd.pathNot.join("|");
+  for (const lProperty of lArrayOrStringProperties) {
+    if (Array.isArray(lDependencyEnd[lProperty])) {
+      lDependencyEnd[lProperty] = lDependencyEnd[lProperty].join("|");
+    }
   }
   return lDependencyEnd;
 }

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -1,4 +1,5 @@
-/* eslint-disable security/detect-object-injection */
+const normalizeREProperties = require("../utl/normalize-re-properties");
+
 const VALID_SEVERITIES = /^(error|warn|info|ignore)$/;
 const DEFAULT_SEVERITY = "warn";
 const DEFAULT_RULE = "unnamed";
@@ -11,27 +12,8 @@ function normalizeSeverity(pSeverity) {
     : DEFAULT_SEVERITY;
 }
 
-function normalizeName(pRule) {
-  return pRule ? pRule : DEFAULT_RULE;
-}
-
-function normalizePaths(pDependencyEnd) {
-  let lDependencyEnd = pDependencyEnd;
-  const lArrayOrStringProperties = [
-    "path",
-    "pathNot",
-    "license",
-    "licenseNot",
-    "exoticRequire",
-    "exoticRequireNot",
-  ];
-
-  for (const lProperty of lArrayOrStringProperties) {
-    if (Array.isArray(lDependencyEnd[lProperty])) {
-      lDependencyEnd[lProperty] = lDependencyEnd[lProperty].join("|");
-    }
-  }
-  return lDependencyEnd;
+function normalizeName(pRuleName) {
+  return pRuleName ? pRuleName : DEFAULT_RULE;
 }
 
 function normalizeRule(pRule) {
@@ -39,8 +21,8 @@ function normalizeRule(pRule) {
     ...pRule,
     severity: normalizeSeverity(pRule.severity),
     name: normalizeName(pRule.name),
-    from: normalizePaths(pRule.from),
-    to: normalizePaths(pRule.to),
+    from: normalizeREProperties(pRule.from),
+    to: normalizeREProperties(pRule.to),
   };
 }
 
@@ -63,8 +45,8 @@ module.exports = (pRuleSet) => {
       pRuleSet.allowed = pRuleSet.allowed.map((pRule) => ({
         ...pRule,
         name: "not-in-allowed",
-        from: normalizePaths(pRule.from),
-        to: normalizePaths(pRule.to),
+        from: normalizeREProperties(pRule.from),
+        to: normalizeREProperties(pRule.to),
       }));
     }
   }

--- a/src/main/utl/normalize-re-properties.js
+++ b/src/main/utl/normalize-re-properties.js
@@ -1,0 +1,24 @@
+/* eslint-disable security/detect-object-injection */
+
+const RE_PROPERTIES = [
+  "path",
+  "pathNot",
+  "license",
+  "licenseNot",
+  "exoticRequire",
+  "exoticRequireNot",
+];
+
+module.exports = function normalizeREProperties(
+  pDependencyEnd,
+  pREProperties = RE_PROPERTIES
+) {
+  let lDependencyEnd = pDependencyEnd;
+
+  for (const lProperty of pREProperties) {
+    if (Array.isArray(lDependencyEnd[lProperty])) {
+      lDependencyEnd[lProperty] = lDependencyEnd[lProperty].join("|");
+    }
+  }
+  return lDependencyEnd;
+};

--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -1,5 +1,5 @@
-- The JSON schemas here are generated with `utl/generate-schemas.utl.js`.
+- The JSON schemas here are generated with `tools/generate-schemas.utl.js`.
 - If you need to modify the schemas:
-  - do so in [`utl/schema/`](../../utl/schema)
-  - re-run the schema generation script (either with `make clean dev-build` or by manually 
-    running `node utl/generate-schemas.utl.js`)
+  - do so in [`tools/schema/`](../../tools/schema)
+  - re-run the schema generation script (either with `make clean dev-build` or by manually
+    running `node tools/generate-schemas.utl.js`)

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -112,12 +112,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "orphan": {
           "type": "boolean",
@@ -131,12 +137,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         }
       }
     },
@@ -146,12 +158,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "couldNotResolve": {
           "type": "boolean",
@@ -206,12 +224,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "reachable": {
           "type": "boolean",

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -188,12 +188,18 @@
           "description": "Whether or not to match when the dependency is exotically required."
         },
         "exoticRequire": {
-          "type": "string",
-          "description": "A regular expression to match against any 'exotic' require strings"
+          "description": "A regular expression to match against any 'exotic' require strings",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "exoticRequireNot": {
-          "type": "string",
-          "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule"
+          "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "preCompilationOnly": {
           "type": "boolean",
@@ -209,12 +215,18 @@
           "description": "If true matches dependencies with more than one dependency type (e.g. defined in _both_ npm and npm-dev)"
         },
         "license": {
-          "type": "string",
-          "description": "Whether or not to match modules that were released under one of the mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible with the GPL) use \"GPL\""
+          "description": "Whether or not to match modules that were released under one of the mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible with the GPL) use \"GPL\"",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "licenseNot": {
-          "type": "string",
-          "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here"
+          "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         }
       }
     },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -405,12 +405,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "orphan": {
           "type": "boolean",
@@ -424,12 +430,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         }
       }
     },
@@ -439,12 +451,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "couldNotResolve": {
           "type": "boolean",
@@ -499,12 +517,18 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "pathNot": {
-          "type": "string",
-          "description": "A regular expression an end of a dependency should NOT match to be catched by this rule."
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "reachable": {
           "type": "boolean",

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -481,12 +481,18 @@
           "description": "Whether or not to match when the dependency is exotically required."
         },
         "exoticRequire": {
-          "type": "string",
-          "description": "A regular expression to match against any 'exotic' require strings"
+          "description": "A regular expression to match against any 'exotic' require strings",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "exoticRequireNot": {
-          "type": "string",
-          "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule"
+          "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "preCompilationOnly": {
           "type": "boolean",
@@ -502,12 +508,18 @@
           "description": "If true matches dependencies with more than one dependency type (e.g. defined in _both_ npm and npm-dev)"
         },
         "license": {
-          "type": "string",
-          "description": "Whether or not to match modules that were released under one of the mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible with the GPL) use \"GPL\""
+          "description": "Whether or not to match modules that were released under one of the mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible with the GPL) use \"GPL\"",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "licenseNot": {
-          "type": "string",
-          "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here"
+          "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         }
       }
     },

--- a/test/main/rule-set/normalize.spec.js
+++ b/test/main/rule-set/normalize.spec.js
@@ -226,4 +226,96 @@ describe("main/rule-set/normalize", () => {
       allowedSeverity: "warn",
     });
   });
+
+  it("normalizes arrays of re's in licenses to regular regular expressions", () => {
+    expect(
+      normalize({
+        forbidden: [
+          {
+            name: "license-thing",
+            severity: "warn",
+            from: {},
+            to: {
+              licenseNot: ["MIT", "ISC", "Apache-2\\.0"],
+            },
+          },
+        ],
+        allowed: [
+          {
+            from: {},
+            to: {
+              license: ["MIT", "ISC", "Apache-2\\.0"],
+            },
+          },
+        ],
+      })
+    ).to.deep.equal({
+      forbidden: [
+        {
+          name: "license-thing",
+          severity: "warn",
+          from: {},
+          to: {
+            licenseNot: "MIT|ISC|Apache-2\\.0",
+          },
+        },
+      ],
+      allowed: [
+        {
+          name: "not-in-allowed",
+          from: {},
+          to: {
+            license: "MIT|ISC|Apache-2\\.0",
+          },
+        },
+      ],
+      allowedSeverity: "warn",
+    });
+  });
+
+  it("normalizes arrays of re's in exoticRequires to regular regular expressions", () => {
+    expect(
+      normalize({
+        forbidden: [
+          {
+            name: "exotic-require-thing",
+            severity: "warn",
+            from: {},
+            to: {
+              exoticRequireNot: ["want", "need", "mustHave"],
+            },
+          },
+        ],
+        allowed: [
+          {
+            from: {},
+            to: {
+              exoticRequire: ["want", "need", "mustHave"],
+            },
+          },
+        ],
+      })
+    ).to.deep.equal({
+      forbidden: [
+        {
+          name: "exotic-require-thing",
+          severity: "warn",
+          from: {},
+          to: {
+            exoticRequireNot: "want|need|mustHave",
+          },
+        },
+      ],
+      allowed: [
+        {
+          name: "not-in-allowed",
+          from: {},
+          to: {
+            exoticRequire: "want|need|mustHave",
+          },
+        },
+      ],
+      allowedSeverity: "warn",
+    });
+  });
 });

--- a/test/main/rule-set/normalize.spec.js
+++ b/test/main/rule-set/normalize.spec.js
@@ -156,4 +156,74 @@ describe("main/rule-set/normalize", () => {
       })
     ).to.deep.equal({});
   });
+
+  it("normalizes arrays of re's in paths to regular regular expressions (forbidden)", () => {
+    expect(
+      normalize({
+        forbidden: [
+          {
+            name: "regularize-regular",
+            severity: "warn",
+            from: {
+              path: ["src", "bin"],
+              pathNot: ["src/exceptions", "bin/aural"],
+            },
+            to: {
+              path: ["super/exclusive", "donot/gohere", "norhere"],
+              pathNot: ["super/exclusive/this-is-ok-though\\.js", "snorhere"],
+            },
+          },
+        ],
+      })
+    ).to.deep.equal({
+      forbidden: [
+        {
+          name: "regularize-regular",
+          severity: "warn",
+          from: {
+            path: "src|bin",
+            pathNot: "src/exceptions|bin/aural",
+          },
+          to: {
+            path: "super/exclusive|donot/gohere|norhere",
+            pathNot: "super/exclusive/this-is-ok-though\\.js|snorhere",
+          },
+        },
+      ],
+    });
+  });
+
+  it("normalizes arrays of re's in paths to regular regular expressions (allowed)", () => {
+    expect(
+      normalize({
+        allowed: [
+          {
+            from: {
+              path: ["src", "bin"],
+              pathNot: ["src/exceptions", "bin/aural"],
+            },
+            to: {
+              path: ["super/exclusive", "donot/gohere", "norhere"],
+              pathNot: ["super/exclusive/this-is-ok-though\\.js", "snorhere"],
+            },
+          },
+        ],
+      })
+    ).to.deep.equal({
+      allowed: [
+        {
+          name: "not-in-allowed",
+          from: {
+            path: "src|bin",
+            pathNot: "src/exceptions|bin/aural",
+          },
+          to: {
+            path: "super/exclusive|donot/gohere|norhere",
+            pathNot: "super/exclusive/this-is-ok-though\\.js|snorhere",
+          },
+        },
+      ],
+      allowedSeverity: "warn",
+    });
+  });
 });

--- a/test/main/utl/normalize-re-properties.spec.js
+++ b/test/main/utl/normalize-re-properties.spec.js
@@ -1,0 +1,49 @@
+const chai = require("chai");
+const normalizeREProperties = require("../../../src/main/utl/normalize-re-properties");
+
+const expect = chai.expect;
+
+chai.use(require("chai-json-schema"));
+
+const POTENTIAL_ARRAY_PROPERTIES = ["aap", "noot", "mies", "wim"];
+const ARRAYED_OBJECT = {
+  aap: ["re1", "re2", "re3"],
+  noot: { not: "re4", an_array: "re5" },
+  mies: ["re6"],
+  wim: [],
+  zus: "re7|re8",
+  jet: true,
+};
+
+const DE_ARRAYED_OBJECT = {
+  aap: "re1|re2|re3",
+  noot: { not: "re4", an_array: "re5" },
+  mies: "re6",
+  wim: "",
+  zus: "re7|re8",
+  jet: true,
+};
+
+describe("main/utl/normalize-re-properties", () => {
+  it("returns the input when an empty object and an empty array of properties input is passed", () => {
+    expect(normalizeREProperties({}, [])).to.deep.equal({});
+  });
+
+  it("returns the input when an any object and an empty array of properties input is passed", () => {
+    expect(normalizeREProperties(ARRAYED_OBJECT, [])).to.deep.equal(
+      ARRAYED_OBJECT
+    );
+  });
+
+  it("returns the input when an empty input is passed", () => {
+    expect(normalizeREProperties({}, POTENTIAL_ARRAY_PROPERTIES)).to.deep.equal(
+      {}
+    );
+  });
+
+  it("returns the de-arrayed input when an empty input is passed", () => {
+    expect(
+      normalizeREProperties(ARRAYED_OBJECT, POTENTIAL_ARRAY_PROPERTIES)
+    ).to.deep.equal(DE_ARRAYED_OBJECT);
+  });
+});

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,7 +12,7 @@ for ease of maintenance).
 To generate the schemas from their sources run:
 
 ```sh
-node utl/generate-schemas.utl.js
+node tools/generate-schemas.utl.mjs
 ```
 
 > The build and version lifecycle scripts take care of this automatically, so

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -2,16 +2,36 @@ import dependencyType from "./dependency-type.mjs";
 
 const BASE_RESTRICTION = {
   path: {
-    type: "string",
     description:
-      "A regular expression an end of a dependency should match to be catched by " +
-      "this rule.",
+      "A regular expression or an array of regular expressions an end of a " +
+      "dependency should match to be caught by this rule.",
+    oneOf: [
+      {
+        type: "string",
+      },
+      {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+    ],
   },
   pathNot: {
-    type: "string",
     description:
-      "A regular expression an end of a dependency should NOT match to be catched " +
-      "by this rule.",
+      "A regular expression or an array of regular expressions an end of a " +
+      "dependency should NOT match to be caught by this rule.",
+    oneOf: [
+      {
+        type: "string",
+      },
+      {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+    ],
   },
 };
 

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -96,15 +96,35 @@ export default {
             "Whether or not to match when the dependency is exotically required.",
         },
         exoticRequire: {
-          type: "string",
           description:
             "A regular expression to match against any 'exotic' require strings",
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          ],
         },
         exoticRequireNot: {
-          type: "string",
           description:
             "A regular expression to match against any 'exotic' require strings - " +
             "when it should NOT be caught by the rule",
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          ],
         },
         preCompilationOnly: {
           type: "boolean",
@@ -129,17 +149,37 @@ export default {
             "defined in _both_ npm and npm-dev)",
         },
         license: {
-          type: "string",
           description:
             "Whether or not to match modules that were released under one of the " +
             "mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules " +
             '(e.g. because your app is not compatible with the GPL) use "GPL"',
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          ],
         },
         licenseNot: {
-          type: "string",
           description:
             "Whether or not to match modules that were NOT released under one of " +
             'the mentioned licenses. E.g. to flag everyting non MIT use "MIT" here',
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          ],
         },
       },
     },

--- a/types/reporter-options.d.ts
+++ b/types/reporter-options.d.ts
@@ -1,9 +1,4 @@
-import {
-  IExcludeType,
-  IIncludeOnlyType,
-  IDoNotFollowType,
-  IFocusType,
-} from "./filter-types";
+import { IExcludeType, IIncludeOnlyType, IFocusType } from "./filter-types";
 
 export interface IReporterOptions {
   /**

--- a/types/rule-set.d.ts
+++ b/types/rule-set.d.ts
@@ -56,11 +56,11 @@ export interface IToRestriction {
   /**
    * A regular expression to match against any 'exotic' require strings
    */
-  exoticRequire?: string;
+  exoticRequire?: string | string[];
   /**
    * A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule
    */
-  exoticRequireNot?: string;
+  exoticRequireNot?: string | string[];
   /**
    * true if this dependency only exists before compilation (like type only imports),
    * false in all other cases. Only returned when the tsPreCompilationDeps is set to 'specify'.
@@ -80,12 +80,12 @@ export interface IToRestriction {
    * licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app
    * is not compatible with the GPL) use "GPL"
    */
-  license?: string;
+  license?: string | string[];
   /**
    * Whether or not to match modules that were NOT released under one of the mentioned
    * licenses. E.g. to flag everyting non MIT use "MIT" here
    */
-  licenseNot?: string;
+  licenseNot?: string | string[];
 }
 
 export interface IReachabilityFromRestrictionType {

--- a/types/rule-set.d.ts
+++ b/types/rule-set.d.ts
@@ -2,13 +2,15 @@ import { DependencyType, SeverityType } from "./shared-types";
 
 export interface IFromRestriction {
   /**
-   * A regular expression an end of a dependency should match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should match to be caught by this rule.
    */
-  path?: string;
+  path?: string | string[];
   /**
-   * A regular expression an end of a dependency should NOT match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should NOT match to be caught by this rule.
    */
-  pathNot?: string;
+  pathNot?: string | string[];
   /**
    * Whether or not to match when the module is an orphan (= has no incoming or outgoing
    * dependencies). When this property it is part of a rule, dependency-cruiser will
@@ -19,13 +21,15 @@ export interface IFromRestriction {
 
 export interface IToRestriction {
   /**
-   * A regular expression an end of a dependency should match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should match to be caught by this rule.
    */
-  path?: string;
+  path?: string | string[];
   /**
-   * A regular expression an end of a dependency should NOT match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should NOT match to be caught by this rule.
    */
-  pathNot?: string;
+  pathNot?: string | string[];
   /**
    * Whether or not to match modules dependency-cruiser could not resolve (and probably
    * aren't on disk). For this one too: leave out if you don't care either way.
@@ -86,24 +90,28 @@ export interface IToRestriction {
 
 export interface IReachabilityFromRestrictionType {
   /**
-   * A regular expression an end of a dependency should match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should match to be caught by this rule.
    */
-  path?: string;
+  path?: string | string[];
   /**
-   * A regular expression an end of a dependency should NOT match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should NOT match to be caught by this rule.
    */
-  pathNot?: string;
+  pathNot?: string | string[];
 }
 
 export interface IReachabilityToRestrictionType {
   /**
-   * A regular expression an end of a dependency should match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should match to be caught by this rule.
    */
-  path?: string;
+  path?: string | string[];
   /**
-   * A regular expression an end of a dependency should NOT match to be catched by this rule.
+   * A regular expression or an array of regular expressions an end of a
+   * dependency should NOT match to be caught by this rule.
    */
-  pathNot?: string;
+  pathNot?: string | string[];
   /**
    * Whether or not to match modules that aren't reachable from the from part of the rule.
    */


### PR DESCRIPTION
## Description

- Allows `path` and `pathNot` to accept an array of RE'sin addition to just a string, so in stead of 

```javascript
{
  from: {
    path: "(^src/report/)"
  },
  to: {
    pathNot: "$1|^node_modules|^(path|package.json)$|^src/utl"
  }
}
```

... you can now write like this in stead, which will more legible in many situations:
```javascript
{
  from: {
    path: "(^src/report/)"
  },
  to: {
      pathNot: [
        "$1",
        "^node_modules",
        "^(path|package.json)$",
        "^src/utl"
      ]
  }
}
```

- does the same for the `license`, `licenseNot`, `exoticRequire` and `exoticRequireNot` attributes

## Motivation and Context

- for `path` and `pathNot`: fixes #316 
- for the other attributes: consistency is the king of DX

## How Has This Been Tested?

- [x] additional automated tests
- [x] automated non-regression tests pass
- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
