### PR TITLE
feature(*): allow filter options to accept an array of RE's

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -184,7 +184,7 @@
     // "doNotFollow": "node_modules",
 
     /* pattern specifying which files to exclude (regular expression) */
-    "exclude": "mocks|fixtures|test/integration",
+    "exclude": ["mocks", "fixtures", "test/integration"],
 
     /* list of module systems to cruise */
     // "moduleSystems": ["amd", "cjs", "es6", "tsd"],

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -843,6 +843,54 @@ make it beyond the pre-compilation step:
 
 ## The `options`
 
+### Filter options: _doNotFollow_, _includeOnly_, _focus_ and _exclude_
+
+Dependency-cruiser sports some filters that enable you to leave out certain
+parts of dependency-trees you're not particularly interested in. They work
+from the command line (as --do-not-follow, --include-only, --focus and --exclude
+respectively) but you can also specify them in the configuration file.
+
+On the command line you can pass a single regular expression for each of them.
+The filters will use that to match against the (resolved) paths of modules
+in your dependency tree.
+
+The configuration file gives a little bit more flexibility. Apart from the path
+you can specify additional properties, and pass an array of regular expressions
+(which in some instances will enhance legibility).
+
+You can pass the path in one of three ways:
+
+As a single regular expression:
+
+```javascript
+options: {
+  includeOnly: {
+    path: "^bin|^src|^test|^packages";
+  }
+}
+```
+
+As an array of regular expressions:
+
+```javascript
+options: {
+  includeOnly: {
+    path: ["^bin", "^src", "^test", "^packages"];
+  }
+}
+```
+
+Or in shorthand:
+
+```javascript
+options: {
+  includeOnly: ["^bin", "^src", "^test", "^packages"];
+}
+```
+
+The next sections contain details on what each filter does and what extra
+attributes you can pass.
+
 ### `doNotFollow`: don't cruise modules any further
 
 > command line option equivalent: `--do-not-follow` (string values passed to 'path' only)

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -1,3 +1,4 @@
+const normalizeREProperties = require("../utl/normalize-re-properties");
 const defaults = require("./defaults.json");
 
 function uniq(pArray) {
@@ -5,14 +6,14 @@ function uniq(pArray) {
 }
 
 function normalizeFilterOption(pFilterOption) {
-  const lFilterOption = pFilterOption || {};
+  let lReturnValue = pFilterOption || {};
 
-  if (typeof lFilterOption === "string") {
-    return {
-      path: lFilterOption,
+  if (typeof lReturnValue === "string" || Array.isArray(lReturnValue)) {
+    lReturnValue = {
+      path: lReturnValue,
     };
   }
-  return lFilterOption;
+  return normalizeREProperties(lReturnValue, ["path"]);
 }
 
 module.exports = (pOptions) => {

--- a/src/main/utl/normalize-re-properties.js
+++ b/src/main/utl/normalize-re-properties.js
@@ -10,15 +10,15 @@ const RE_PROPERTIES = [
 ];
 
 module.exports = function normalizeREProperties(
-  pDependencyEnd,
+  pPropertyContainer,
   pREProperties = RE_PROPERTIES
 ) {
-  let lDependencyEnd = pDependencyEnd;
+  let lPropertyContainer = pPropertyContainer;
 
   for (const lProperty of pREProperties) {
-    if (Array.isArray(lDependencyEnd[lProperty])) {
-      lDependencyEnd[lProperty] = lDependencyEnd[lProperty].join("|");
+    if (Array.isArray(lPropertyContainer[lProperty])) {
+      lPropertyContainer[lProperty] = lPropertyContainer[lProperty].join("|");
     }
   }
-  return lDependencyEnd;
+  return lPropertyContainer;
 };

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -113,17 +113,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "orphan": {
           "type": "boolean",
@@ -138,17 +132,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },
@@ -159,17 +147,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "couldNotResolve": {
           "type": "boolean",
@@ -189,17 +171,11 @@
         },
         "exoticRequire": {
           "description": "A regular expression to match against any 'exotic' require strings",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "exoticRequireNot": {
           "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "preCompilationOnly": {
           "type": "boolean",
@@ -216,17 +192,11 @@
         },
         "license": {
           "description": "Whether or not to match modules that were released under one of the mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible with the GPL) use \"GPL\"",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "licenseNot": {
           "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },
@@ -237,17 +207,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "reachable": {
           "type": "boolean",
@@ -274,6 +238,12 @@
         "unknown"
       ]
     },
+    "REAsStringsType": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
+    },
     "SeverityType": {
       "type": "string",
       "description": "How severe a violation of a rule is. The 'error' severity will make some reporters return a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated: use that.",
@@ -287,28 +257,28 @@
         "doNotFollow": {
           "description": "a regular expression for modules to include, but not follow further",
           "oneOf": [
-            { "type": "string" },
+            { "$ref": "#/definitions/REAsStringsType" },
             { "$ref": "#/definitions/CompoundDoNotFollowType" }
           ]
         },
         "exclude": {
           "description": "a regular expression for modules to exclude from being cruised",
           "oneOf": [
-            { "type": "string" },
+            { "$ref": "#/definitions/REAsStringsType" },
             { "$ref": "#/definitions/CompoundExcludeType" }
           ]
         },
         "includeOnly": {
           "description": "a regular expression for modules to cruise; anything outside it will be skipped",
           "oneOf": [
-            { "type": "string" },
+            { "$ref": "#/definitions/REAsStringsType" },
             { "$ref": "#/definitions/CompoundIncludeOnlyType" }
           ]
         },
         "focus": {
           "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)",
           "oneOf": [
-            { "type": "string" },
+            { "$ref": "#/definitions/REAsStringsType" },
             { "$ref": "#/definitions/CompoundFocusType" }
           ]
         },
@@ -404,13 +374,19 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "a regular expression for modules to exclude from being cruised"
+          "description": "a regular expression for modules to exclude from being cruised",
+          "$ref": "#/definitions/REAsStringsType"
         },
         "dynamic": {
           "type": "boolean",
           "description": "a boolean indicating whether or not to exclude dynamic dependencies"
         }
+      },
+      "REAsStringsType": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       }
     },
     "CompoundDoNotFollowType": {
@@ -419,8 +395,8 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "a regular expression for modules to include, but not follow further"
+          "description": "a regular expression for modules to include, but not follow further",
+          "$ref": "#/definitions/REAsStringsType"
         },
         "dependencyTypes": {
           "type": "array",
@@ -435,9 +411,15 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)"
+          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)",
+          "$ref": "#/definitions/REAsStringsType"
         }
+      },
+      "REAsStringsType": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       }
     },
     "CompoundFocusType": {
@@ -446,9 +428,15 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)"
+          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)",
+          "$ref": "#/definitions/REAsStringsType"
         }
+      },
+      "REAsStringsType": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       }
     },
     "ReporterOptionsType": {

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -406,17 +406,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "orphan": {
           "type": "boolean",
@@ -431,17 +425,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },
@@ -452,17 +440,11 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "couldNotResolve": {
           "type": "boolean",
@@ -482,17 +464,11 @@
         },
         "exoticRequire": {
           "description": "A regular expression to match against any 'exotic' require strings",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "exoticRequireNot": {
           "description": "A regular expression to match against any 'exotic' require strings - when it should NOT be caught by the rule",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "preCompilationOnly": {
           "type": "boolean",
@@ -509,17 +485,11 @@
         },
         "license": {
           "description": "Whether or not to match modules that were released under one of the mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules (e.g. because your app is not compatible with the GPL) use \"GPL\"",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "licenseNot": {
           "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },
@@ -530,23 +500,23 @@
       "properties": {
         "path": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "pathNot": {
           "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+          "$ref": "#/definitions/REAsStringsType"
         },
         "reachable": {
           "type": "boolean",
           "description": "Whether or not to match modules that aren't reachable from the from part of the rule."
         }
       }
+    },
+    "REAsStringsType": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
     },
     "OptionsUsedType": {
       "type": "object",
@@ -558,7 +528,7 @@
         "includeOnly": {
           "description": "a regular expression for modules to cruise; anything outside it will be skipped",
           "oneOf": [
-            { "type": "string" },
+            { "$ref": "#/definitions/REAsStringsType" },
             { "$ref": "#/definitions/CompoundIncludeOnlyType" }
           ]
         },
@@ -682,13 +652,19 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "a regular expression for modules to exclude from being cruised"
+          "description": "a regular expression for modules to exclude from being cruised",
+          "$ref": "#/definitions/REAsStringsType"
         },
         "dynamic": {
           "type": "boolean",
           "description": "a boolean indicating whether or not to exclude dynamic dependencies"
         }
+      },
+      "REAsStringsType": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       }
     },
     "CompoundDoNotFollowType": {
@@ -697,8 +673,8 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "a regular expression for modules to include, but not follow further"
+          "description": "a regular expression for modules to include, but not follow further",
+          "$ref": "#/definitions/REAsStringsType"
         },
         "dependencyTypes": {
           "type": "array",
@@ -713,9 +689,15 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)"
+          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)",
+          "$ref": "#/definitions/REAsStringsType"
         }
+      },
+      "REAsStringsType": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       }
     },
     "CompoundFocusType": {
@@ -724,9 +706,15 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)"
+          "description": "dependency-cruiser will include modules matching this regular expression in its output, as well as their neighbours (direct dependencies and dependents)",
+          "$ref": "#/definitions/REAsStringsType"
         }
+      },
+      "REAsStringsType": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       }
     },
     "ReporterOptionsType": {

--- a/test/main/options/normalize.spec.js
+++ b/test/main/options/normalize.spec.js
@@ -36,6 +36,26 @@ describe("main/options/normalize", () => {
       path: "42",
     });
   });
+
+  it("makes exclude arrays into an object with a string", () => {
+    expect(
+      normalizeOptions({
+        exclude: ["^aap", "^noot", "mies$"],
+      }).exclude
+    ).to.deep.equal({
+      path: "^aap|^noot|mies$",
+    });
+  });
+
+  it("makes exclude object with an array for path into an exclude path with a string for path", () => {
+    expect(
+      normalizeOptions({
+        exclude: { path: ["^aap", "^noot", "mies$"] },
+      }).exclude
+    ).to.deep.equal({
+      path: "^aap|^noot|mies$",
+    });
+  });
 });
 
 /* eslint no-magic-numbers: 0*/

--- a/tools/schema/compound-donot-follow-type.mjs
+++ b/tools/schema/compound-donot-follow-type.mjs
@@ -1,3 +1,5 @@
+import REAsStringsType from "./re-as-strings-type.mjs";
+
 export default {
   definitions: {
     CompoundDoNotFollowType: {
@@ -6,9 +8,9 @@ export default {
       additionalProperties: false,
       properties: {
         path: {
-          type: "string",
           description:
             "a regular expression for modules to include, but not follow further",
+          $ref: "#/definitions/REAsStringsType",
         },
         dependencyTypes: {
           type: "array",
@@ -18,5 +20,6 @@ export default {
         },
       },
     },
+    ...REAsStringsType.definitions,
   },
 };

--- a/tools/schema/compound-exclude-type.mjs
+++ b/tools/schema/compound-exclude-type.mjs
@@ -1,3 +1,5 @@
+import REAsStringsType from "./re-as-strings-type.mjs";
+
 export default {
   definitions: {
     CompoundExcludeType: {
@@ -6,9 +8,9 @@ export default {
       additionalProperties: false,
       properties: {
         path: {
-          type: "string",
           description:
             "a regular expression for modules to exclude from being cruised",
+          $ref: "#/definitions/REAsStringsType",
         },
         dynamic: {
           type: "boolean",
@@ -16,6 +18,7 @@ export default {
             "a boolean indicating whether or not to exclude dynamic dependencies",
         },
       },
+      ...REAsStringsType.definitions,
     },
   },
 };

--- a/tools/schema/compound-focus-type.mjs
+++ b/tools/schema/compound-focus-type.mjs
@@ -1,3 +1,5 @@
+import REAsStringsType from "./re-as-strings-type.mjs";
+
 export default {
   definitions: {
     CompoundFocusType: {
@@ -6,13 +8,14 @@ export default {
       additionalProperties: false,
       properties: {
         path: {
-          type: "string",
           description:
             "dependency-cruiser will include modules matching this regular expression " +
             "in its output, as well as their neighbours (direct dependencies and " +
             "dependents)",
+          $ref: "#/definitions/REAsStringsType",
         },
       },
+      ...REAsStringsType.definitions,
     },
   },
 };

--- a/tools/schema/compound-include-only-type.mjs
+++ b/tools/schema/compound-include-only-type.mjs
@@ -1,3 +1,5 @@
+import REAsStringsType from "./re-as-strings-type.mjs";
+
 export default {
   definitions: {
     CompoundIncludeOnlyType: {
@@ -6,13 +8,14 @@ export default {
       additionalProperties: false,
       properties: {
         path: {
-          type: "string",
           description:
             "dependency-cruiser will include modules matching this regular expression " +
             "in its output, as well as their neighbours (direct dependencies and " +
             "dependents)",
+          $ref: "#/definitions/REAsStringsType",
         },
       },
+      ...REAsStringsType.definitions,
     },
   },
 };

--- a/tools/schema/options.mjs
+++ b/tools/schema/options.mjs
@@ -1,3 +1,4 @@
+import REAsStringsType from "./re-as-strings-type.mjs";
 import compoundDoNotFollowType from "./compound-donot-follow-type.mjs";
 import compoundExcludeType from "./compound-exclude-type.mjs";
 import compoundFocusType from "./compound-focus-type.mjs";
@@ -17,9 +18,7 @@ export default {
           description:
             "a regular expression for modules to include, but not follow further",
           oneOf: [
-            {
-              type: "string",
-            },
+            { $ref: "#/definitions/REAsStringsType" },
             { $ref: "#/definitions/CompoundDoNotFollowType" },
           ],
         },
@@ -27,9 +26,7 @@ export default {
           description:
             "a regular expression for modules to exclude from being cruised",
           oneOf: [
-            {
-              type: "string",
-            },
+            { $ref: "#/definitions/REAsStringsType" },
             { $ref: "#/definitions/CompoundExcludeType" },
           ],
         },
@@ -38,9 +35,7 @@ export default {
             "a regular expression for modules to cruise; anything outside it will " +
             "be skipped",
           oneOf: [
-            {
-              type: "string",
-            },
+            { $ref: "#/definitions/REAsStringsType" },
             { $ref: "#/definitions/CompoundIncludeOnlyType" },
           ],
         },
@@ -50,9 +45,7 @@ export default {
             "in its output, as well as their neighbours (direct dependencies and " +
             "dependents)",
           oneOf: [
-            {
-              type: "string",
-            },
+            { $ref: "#/definitions/REAsStringsType" },
             { $ref: "#/definitions/CompoundFocusType" },
           ],
         },
@@ -186,5 +179,6 @@ export default {
     ...compoundIncludeOnlyType.definitions,
     ...compoundFocusType.definitions,
     ...reporterOptions.definitions,
+    ...REAsStringsType.definitions,
   },
 };

--- a/tools/schema/re-as-strings-type.mjs
+++ b/tools/schema/re-as-strings-type.mjs
@@ -1,0 +1,17 @@
+export default {
+  definitions: {
+    REAsStringsType: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      ],
+    },
+  },
+};

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -1,3 +1,4 @@
+import REAsStringsType from "./re-as-strings-type.mjs";
 import dependencyType from "./dependency-type.mjs";
 
 const BASE_RESTRICTION = {
@@ -5,33 +6,13 @@ const BASE_RESTRICTION = {
     description:
       "A regular expression or an array of regular expressions an end of a " +
       "dependency should match to be caught by this rule.",
-    oneOf: [
-      {
-        type: "string",
-      },
-      {
-        type: "array",
-        items: {
-          type: "string",
-        },
-      },
-    ],
+    $ref: "#/definitions/REAsStringsType",
   },
   pathNot: {
     description:
       "A regular expression or an array of regular expressions an end of a " +
       "dependency should NOT match to be caught by this rule.",
-    oneOf: [
-      {
-        type: "string",
-      },
-      {
-        type: "array",
-        items: {
-          type: "string",
-        },
-      },
-    ],
+    $ref: "#/definitions/REAsStringsType",
   },
 };
 
@@ -98,33 +79,13 @@ export default {
         exoticRequire: {
           description:
             "A regular expression to match against any 'exotic' require strings",
-          oneOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "array",
-              items: {
-                type: "string",
-              },
-            },
-          ],
+          $ref: "#/definitions/REAsStringsType",
         },
         exoticRequireNot: {
           description:
             "A regular expression to match against any 'exotic' require strings - " +
             "when it should NOT be caught by the rule",
-          oneOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "array",
-              items: {
-                type: "string",
-              },
-            },
-          ],
+          $ref: "#/definitions/REAsStringsType",
         },
         preCompilationOnly: {
           type: "boolean",
@@ -153,33 +114,13 @@ export default {
             "Whether or not to match modules that were released under one of the " +
             "mentioned licenses. E.g. to flag GPL-1.0, GPL-2.0 licensed modules " +
             '(e.g. because your app is not compatible with the GPL) use "GPL"',
-          oneOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "array",
-              items: {
-                type: "string",
-              },
-            },
-          ],
+          $ref: "#/definitions/REAsStringsType",
         },
         licenseNot: {
           description:
             "Whether or not to match modules that were NOT released under one of " +
             'the mentioned licenses. E.g. to flag everyting non MIT use "MIT" here',
-          oneOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "array",
-              items: {
-                type: "string",
-              },
-            },
-          ],
+          $ref: "#/definitions/REAsStringsType",
         },
       },
     },
@@ -200,5 +141,6 @@ export default {
       },
     },
     ...dependencyType.definitions,
+    ...REAsStringsType.definitions,
   },
 };

--- a/types/filter-types.d.ts
+++ b/types/filter-types.d.ts
@@ -4,7 +4,7 @@ export interface IDoNotFollowType {
   /**
    * a regular expression for modules to include, but not follow further
    */
-  path?: string;
+  path?: string | string[];
   /**
    * an array of dependency types to include, but not follow further
    */
@@ -15,7 +15,7 @@ export interface IExcludeType {
   /**
    * a regular expression for modules to exclude
    */
-  path?: string;
+  path?: string | string[];
   /**
    * a boolean indicating whether or not to exclude dynamic dependencies
    * leave out to match both
@@ -28,7 +28,7 @@ export interface IIncludeOnlyType {
    * regular expression describing which dependencies the function
    * should cruise - anything not matching this will be skipped
    */
-  path?: string;
+  path?: string | string[];
 }
 
 export interface IFocusType {
@@ -37,5 +37,5 @@ export interface IFocusType {
    * in its output, as well as their neighbours (direct dependencies and
    * dependents)
    */
-  path?: string;
+  path?: string | string[];
 }

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -34,23 +34,23 @@ export interface ICruiseOptions {
    *
    * ... or conditions that describe what dependencies not to follow
    */
-  doNotFollow?: string | IDoNotFollowType;
+  doNotFollow?: string | string[] | IDoNotFollowType;
   /**
    * regular expression describing which dependencies the function
    * should not cruise
    */
-  exclude?: string | IExcludeType;
+  exclude?: string | string[] | IExcludeType;
   /**
    * regular expression describing which dependencies the function
    * should cruise - anything not matching this will be skipped
    */
-  includeOnly?: string | IIncludeOnlyType;
+  includeOnly?: string | string[] | IIncludeOnlyType;
   /**
    * dependency-cruiser will include modules matching this regular expression
    * in its output, as well as their neighbours (direct dependencies and
    * dependents)
    */
-  focus?: string | IFocusType;
+  focus?: string | string[] | IFocusType;
   /**
    * the maximum depth to cruise; 0 <= n <= 99
    * (default: 0, which means 'infinite depth')

--- a/types/reporter-options.d.ts
+++ b/types/reporter-options.d.ts
@@ -43,7 +43,7 @@ export interface IDotReporterOptions {
    * Regular expressions to collapse to. For the "dot" reporter defaults
    * to null, but "node_modules/[^/]+" is recommended for most use cases.
    */
-  collapsePattern?: string;
+  collapsePattern?: string | string[];
   /**
    * filters to apply to the reporter before rendering it (e.g. to leave
    * out details from the graphical output that are not relevant for the


### PR DESCRIPTION
## Description

Just like #317, but for the filtering options instead of for rules. So now instead of writing

```javascript
  options: {
    doNotFollow: "^node_modules|vendor_stuff|not/very/interesting_either"
  }
```

you could write in stead 
```javascript
  options: {
    doNotFollow: [
      "^node_modules",
      "vendor_stuff",
      "not/very/interesting_either"
    ]
  }
```

or 

```javascript
  options: {
    doNotFollow: {
      path: [
        "^node_modules",
        "vendor_stuff",
        "not/very/interesting_either"
      ]
    }
  }
```

Implemented for all filter options: _doNotFollow_, _exclude_, _includeOnly_ and _focus_.

> The same expansion will be implemented for reporter options that accept RE's - in a separate PR, though

## Motivation and Context

Ease of use & readability, just like in #317 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] additional automated tests
- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
