### PR TITLE
feature(cli): enables reading babel configs from commonjs modules that export an object

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -223,6 +223,9 @@
     //    "env": {},
     //    "args": {}
     // },
+    // "babelConfig": {
+    //   "fileName": "./babel.config.json"
+    // },
     "exoticRequireStrings": ["tryRequire"],
     "reporterOptions": {
       "archi": {

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -1374,10 +1374,12 @@ babelConfig - dependency-cruiser will sort it out for you.
   of the extension). This will cover the majority of the use cases for babel,
   but [raise an issue](https://github.com/sverweij/dependency-cruiser/issues/new?template=feature-request.md&title=Feature+request%3A+use+babel+only+for+specific+extensions?)
   if you need this to be configurable.
-- Only json (/ json5) configurations, either in a separate file or as a key in
-  your package.json.
-  .js, .mjs, .cjs, or configurations might be added when there's a demand for it.
-- Auto detection in [--init](cli.md#--init) looks at some of the likely suspects
+- Dependency-cruiser can process json (/ json5) configurations, either in a
+  separate file or as a key in your package.json. It can also process .js and
+  .cjs configurations, as long as they're commonjs modules and export a simple
+  javascript object. JavaScript configurations that export a function, and/ or
+  that are es modules might be supported in a later stage.
+- Auto detection in [--init](clies.md#--init) looks at some of the likely suspects
   for babel configs - _package.json_ (only if it contains a _babel_ key),
   _.babelrc_, _.babelrc.json_, _babel.config.json_ and any other file with _babel_
   in the name that ends on _json_ or _json5_. - The feature currently works with

--- a/src/cli/parse-babel-config.js
+++ b/src/cli/parse-babel-config.js
@@ -2,19 +2,37 @@
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable node/global-require */
 const fs = require("fs");
+const path = require("path");
 const json5 = require("json5");
 const _get = require("lodash/get");
 const tryRequire = require("semver-try-require");
 const $package = require("../../package.json");
+const makeAbsolute = require("./utl/make-absolute");
+
+const JAVASCRIPT_EXTENSIONS = [".js", ".cjs"];
 
 function getConfig(pBabelConfigFileName) {
   let lReturnValue = {};
 
-  lReturnValue = json5.parse(fs.readFileSync(pBabelConfigFileName, "utf8"));
+  if (JAVASCRIPT_EXTENSIONS.includes(path.extname(pBabelConfigFileName))) {
+    lReturnValue = require(makeAbsolute(pBabelConfigFileName));
 
-  if (pBabelConfigFileName.endsWith("package.json")) {
-    lReturnValue = _get(lReturnValue, "babel", {});
+    if (typeof lReturnValue === "function") {
+      // Function format configs not supported yet. Will need calling the
+      // function with a bunch of params (lReturnValue = lReturnValue(APIPAPI))
+      // TODO: should we pass this in silence or throw?
+      //   +silence: there's nothing wrong (we can detect)
+      //   +throw: at least it's clear we don't support it
+      lReturnValue = {};
+    }
+  } else {
+    lReturnValue = json5.parse(fs.readFileSync(pBabelConfigFileName, "utf8"));
+
+    if (pBabelConfigFileName.endsWith("package.json")) {
+      lReturnValue = _get(lReturnValue, "babel", {});
+    }
   }
+
   return lReturnValue;
 }
 

--- a/test/cli/fixtures/babelconfig-js/babel.config.wildly-unsupported-extension
+++ b/test/cli/fixtures/babelconfig-js/babel.config.wildly-unsupported-extension
@@ -1,0 +1,1 @@
+export default {};

--- a/test/cli/fixtures/babelconfig-js/babel.es-module.config.js
+++ b/test/cli/fixtures/babelconfig-js/babel.es-module.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/cli/fixtures/babelconfig-js/babel.function-export.config.js
+++ b/test/cli/fixtures/babelconfig-js/babel.function-export.config.js
@@ -1,0 +1,3 @@
+module.exports = function (api) {
+  return { plugins: ["@babel/plugin-transform-modules-commonjs"] };
+};

--- a/test/cli/fixtures/babelconfig-js/babel.object-export.config.js
+++ b/test/cli/fixtures/babelconfig-js/babel.object-export.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["@babel/plugin-transform-modules-commonjs"],
+};

--- a/test/cli/parse-babel-config.spec.js
+++ b/test/cli/parse-babel-config.spec.js
@@ -34,7 +34,7 @@ describe("cli/parseBabelConfig", () => {
     }).to.throw();
   });
 
-  it("throws when a config file is passed constains a non-babel option", () => {
+  it("throws when a config file is passed contains a non-babel option", () => {
     expect(() => {
       parseBabelConfig(
         path.join(
@@ -67,6 +67,28 @@ describe("cli/parseBabelConfig", () => {
         path.join(
           __dirname,
           "./fixtures/babelconfig/no-babel-config-in-this-package.json"
+        )
+      )
+    ).to.deep.equal(DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT);
+  });
+
+  it("returns a babel config when a javascript file with a regular object export is passed", () => {
+    expect(
+      parseBabelConfig(
+        path.join(
+          __dirname,
+          "./fixtures/babelconfig-js/babel.object-export.config.js"
+        )
+      ).plugins.length
+    ).to.equal(1);
+  });
+
+  it("returns a babel config when a javascript file with a function export is passed", () => {
+    expect(
+      parseBabelConfig(
+        path.join(
+          __dirname,
+          "./fixtures/babelconfig-js/babel.function-export.config.js"
         )
       )
     ).to.deep.equal(DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT);

--- a/test/cli/parse-babel-config.spec.js
+++ b/test/cli/parse-babel-config.spec.js
@@ -83,14 +83,36 @@ describe("cli/parseBabelConfig", () => {
     ).to.equal(1);
   });
 
-  it("returns a babel config when a javascript file with a function export is passed", () => {
-    expect(
+  it("throws when a javascript file with a function export is passed", () => {
+    expect(() => {
       parseBabelConfig(
         path.join(
           __dirname,
           "./fixtures/babelconfig-js/babel.function-export.config.js"
         )
-      )
-    ).to.deep.equal(DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT);
+      );
+    }).to.throw();
+  });
+
+  it("throws when a config with an unsupported extension is passed", () => {
+    expect(() => {
+      parseBabelConfig(
+        path.join(
+          __dirname,
+          "./fixtures/babelconfig-js/babel.config.wildly-unsupported-extension"
+        )
+      );
+    }).to.throw();
+  });
+
+  it("throws when an es module is passed", () => {
+    expect(() => {
+      parseBabelConfig(
+        path.join(
+          __dirname,
+          "./fixtures/babelconfig-js/babel.es-module.config.js"
+        )
+      );
+    }).to.throw();
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

Adds support for babel configurations expressed in (commonjs) javascript that export a plain javascript object.
Covers some more babel usage scenarios, so dependency-cruiser becomes more usable in that space.

Support for babel configurations that export a function (`function(api) { /* blah */ return { /* config */} }`) and/ or that are written as es/ mjs modules will probably follow in a separate PR.

## How Has This Been Tested?

- [x] additional automated tests
- [x] non-regression tests
- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
