### PR TITLE
bugfix(schema|types): add the preCompilationOnly attribute of dependencies to the json schema and TypeScript types

### DIFF
--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -192,6 +192,10 @@
           "type": "boolean",
           "description": "'true' if dependency-cruiser could not resulve the module name in the source code to a file name or core module. 'false' in all other cases."
         },
+        "preCompilationOnly": {
+          "type": "boolean",
+          "description": "'true' if the dependency between this dependency and its parent only exists before compilation takes place. 'false in all other cases. Dependency-cruiser will only specify this attribute for TypeScript and then only when the option 'tsPreCompilationDeps' has the value 'specify'."
+        },
         "circular": {
           "type": "boolean",
           "description": "'true' if following this dependency will ultimately return to the source, false in all other cases"

--- a/tools/schema/dependencies.mjs
+++ b/tools/schema/dependencies.mjs
@@ -96,6 +96,14 @@ export default {
             "the source code to a file name or core module. 'false' in all other " +
             "cases.",
         },
+        preCompilationOnly: {
+          type: "boolean",
+          description:
+            "'true' if the dependency between this dependency and its parent only " +
+            "exists before compilation takes place. 'false in all other cases. " +
+            "Dependency-cruiser will only specify this attribute for TypeScript and " +
+            "then only when the option 'tsPreCompilationDeps' has the value 'specify'.",
+        },
         circular: {
           type: "boolean",
           description:

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -103,6 +103,13 @@ export interface IDependency {
    */
   couldNotResolve: boolean;
   /**
+   * 'true' if the dependency between this dependency and its parent only
+   * exists before compilation takes place. 'false in all other cases.
+   * Dependency-cruiser will only specify this attribute for TypeScript and
+   * then only when the option 'tsPreCompilationDeps' has the value 'specify'.
+   */
+  preCompilationOnly?: boolean;
+  /**
    * If following this dependency will ultimately return to the source (circular === true),
    * this attribute will contain an (ordered) array of module names that shows (one of) the
    * circular path(s)


### PR DESCRIPTION
## Description, Motivation and Context

They were missing - which is problematic when you want to pass the output of a cruise to e.g. depcruise-fmt, which validates its input against the schema

## How Has This Been Tested?

- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
