### PR TITLE
doc(cli): re-write the copy for the two commands

### DIFF
--- a/bin/depcruise-fmt.js
+++ b/bin/depcruise-fmt.js
@@ -18,28 +18,25 @@ try {
   const format = require("../src/cli/format");
 
   program
-    .version($package.version)
     .description(
       "Format dependency-cruiser output json.\nDetails: https://github.com/sverweij/dependency-cruiser"
     )
     .option(
       "-f, --output-to <file>",
-      `file to write output to; - for stdout
-                         `,
+      "file to write output to; - for stdout",
       "-"
     )
     .option(
       "-T, --output-type <type>",
-      `output type - err|err-long|err-html|dot|ddot|archi|json
-                         `,
+      "output type; e.g. err, err-html, dot, ddot, archi or json",
       "err"
     )
     .option(
       "-e, --exit-code",
-      `exit with a non-zero exit code when the input json
-                          contains error level dependency violations. Works for
-                          err, err-long and teamcity output types`
+      "exit with a non-zero exit code when the input json contains error level " +
+        "dependency violations. Works for err, err-long and teamcity output types"
     )
+    .version($package.version)
     .arguments("<dependency-cruiser-json>")
     .parse(process.argv);
 

--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -13,80 +13,68 @@ try {
   const cli = require("../src/cli");
 
   program
-    .version($package.version)
     .description(
       "Validate and visualize dependencies.\nDetails: https://github.com/sverweij/dependency-cruiser"
     )
     .option(
-      "-i, --info",
-      `shows what languages and extensions
-                              dependency-cruiser supports`
+      "--init [oneshot]",
+      "set up dependency-cruiser for use in your environment (<<< recommended!)"
     )
     .option(
       "-c, --config [file]",
-      `read rules and options from [file]
-                              (default: .dependency-cruiser.json)`
-    )
-    .option("-v, --validate [file]", `alias for --config`)
-    .option(
-      "-f, --output-to <file>",
-      `file to write output to; - for stdout
-                             `,
-      "-"
-    )
-    .option(
-      "-X, --do-not-follow <regex>",
-      `include modules matching the regex,
-                              but don't follow them any further`
-    )
-    .option("-x, --exclude <regex>", "exclude all modules matching the regex")
-    .option("--include-only <regex>", "only include modules matching the regex")
-    .option(
-      "--focus <regex>",
-      `only output modules matching the regex,
-                              + their direct neighbours`
-    )
-    .option(
-      "-d, --max-depth <n>",
-      `the maximum depth to cruise; 0 <= n <= 99
-                              (default: 0, which means 'infinite depth')`
-    )
-    .option(
-      "-M, --module-systems <items>",
-      `list of module systems (default: amd,cjs,es6,tsd)`
+      "read rules and options from [file] (e.g. .dependency-cruiser.js)"
     )
     .option(
       "-T, --output-type <type>",
-      `output type - err|err-long|err-html|dot|ddot|archi|json
-                              (default: err)`
+      "output type; e.g. err, err-html, dot, ddot, archi or json\n(default: err)"
     )
     .option(
-      "-P, --prefix <prefix>",
-      `prefix to use for links in the dot, err and
-                              err-html reporters`
+      "-f, --output-to <file>",
+      "file to write output to; - for stdout",
+      "-"
     )
-    .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
+    .option("--include-only <regex>", "only include modules matching the regex")
     .option(
-      "--ts-pre-compilation-deps",
-      `detect dependencies that only exist before
-                              typescript-to-javascript compilation
-                              (off by default)`
+      "--focus <regex>",
+      "only include modules matching the regex + their direct neighbours"
+    )
+    .option("-x, --exclude <regex>", "exclude all modules matching the regex")
+    .option(
+      "-X, --do-not-follow <regex>",
+      "include modules matching the regex, but don't follow their dependencies"
     )
     .option(
       "--ts-config [file]",
-      `use a typescript configuration ('project')
-                              (default: tsconfig.json)`
+      "use a typescript configuration (e.g. tsconfig.json)"
     )
     .option(
       "--webpack-config [file]",
-      `use a webpack configuration
-                              (default: webpack.config.js)`
+      "use a webpack configuration (e.g. webpack.config.js)"
     )
     .option(
-      "--init [oneshot]",
-      `write a .dependency-cruiser config with basic
-                              validations to the current folder.`
+      "--ts-pre-compilation-deps",
+      "detect dependencies that only exist before typescript-to-javascript " +
+        "compilation (off by default)"
     )
+    .option(
+      "-d, --max-depth <n>",
+      "limit cruise depth; 0 <= n <= 99 (default: 0 - no limit)"
+    )
+    .option(
+      "-M, --module-systems <items>",
+      "list of module systems (default: amd, cjs, es6, tsd)"
+    )
+    .option(
+      "-P, --prefix <prefix>",
+      "prefix to use for links in the dot and err-html reporters"
+    )
+    .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
+    .option("-v, --validate [file]", `alias for --config`)
+    .option(
+      "-i, --info",
+      "shows what languages and extensions dependency-cruiser supports"
+    )
+    .version($package.version)
     .arguments("<files-or-directories>")
     .parse(process.argv);
 

--- a/test/cli/utl/io.spec.js
+++ b/test/cli/utl/io.spec.js
@@ -17,10 +17,15 @@ function removeDammit(pFileName) {
 }
 
 describe("cli/utl/io", () => {
+  const NR_OF_NUMBERS = 17;
   const OUTFILE = path.join(
     __dirname,
     "output",
-    `tmp_hello_${Math.random().toString().slice("0.".length)}.json`
+    `tmp_hello_${Math.random()
+      .toString()
+      .split(".")
+      .pop()
+      .padEnd(NR_OF_NUMBERS, "0")}.json`
   );
 
   before("set up", () => {


### PR DESCRIPTION
## Description, Motivation and Context

Updates the copy of the dependency-cruise and depcruise-fmt commands & reorganises it a bit so it's easier to read 🤞 .

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci 

## Screenshots

```
Usage: dependency-cruise [options] <files-or-directories>

Validate and visualize dependencies.
Details: https://github.com/sverweij/dependency-cruiser

Options:
  --init [oneshot]              set up dependency-cruiser for use in your environment (<<<
                                recommended!)
  -c, --config [file]           read rules and options from [file] (e.g. .dependency-cruiser.js)
  -T, --output-type <type>      output type; e.g. err, err-html, dot, ddot, archi or json
                                (default: err)
  -f, --output-to <file>        file to write output to; - for stdout (default: "-")
  --include-only <regex>        only include modules matching the regex
  --focus <regex>               only include modules matching the regex + their direct neighbours
  -x, --exclude <regex>         exclude all modules matching the regex
  -X, --do-not-follow <regex>   include modules matching the regex, but don't follow their
                                dependencies
  --ts-config [file]            use a typescript configuration (e.g. tsconfig.json)
  --webpack-config [file]       use a webpack configuration (e.g. webpack.config.js)
  --ts-pre-compilation-deps     detect dependencies that only exist before typescript-to-javascript
                                compilation (off by default)
  -d, --max-depth <n>           limit cruise depth; 0 <= n <= 99 (default: 0 - no limit)
  -M, --module-systems <items>  list of module systems (default: amd, cjs, es6, tsd)
  -P, --prefix <prefix>         prefix to use for links in the dot and err-html reporters
  --preserve-symlinks           leave symlinks unchanged (off by default)
  -v, --validate [file]         alias for --config
  -i, --info                    shows what languages and extensions dependency-cruiser supports
  -V, --version                 output the version number
  -h, --help                    display help for command
```


```
Usage: depcruise-fmt [options] <dependency-cruiser-json>

Format dependency-cruiser output json.
Details: https://github.com/sverweij/dependency-cruiser

Options:
  -f, --output-to <file>    file to write output to; - for stdout (default: "-")
  -T, --output-type <type>  output type; e.g. err, err-html, dot, ddot, archi or json (default:
                            "err")
  -e, --exit-code           exit with a non-zero exit code when the input json contains error level
                            dependency violations. Works for err, err-long and teamcity output
                            types
  -V, --version             output the version number
  -h, --help                display help for command
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
