### PR TITLE
feature(validate): enables using 'required' rules

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -23,6 +23,7 @@
    - [`forbidden`](#forbidden)
    - [`allowed`](#allowed)
    - [`allowedSeverity`](#allowedSeverity)
+   - [`required`](#required)
    - [`extends`](#extends)
    - [`options`](#options)
 2. [The structure of an individual rule](#the-structure-of-an-individual-rule)
@@ -61,12 +62,14 @@
 
 The typical dependency-cruiser config is json file (although you can use JavaScript -
 see [below](#configurations-in-javascript))). The three most important sections
-are `forbidden`, `allowed` and `options`, so a skeleton config could look something like this:
+are `forbidden`, `allowed`, `required` and `options`, so a skeleton config could
+look something like this:
 
 ```json
 {
   "forbidden": [],
   "allowed": [],
+  "required": [],
   "options": {}
 }
 ```
@@ -91,6 +94,37 @@ default, but you can override it with `allowedSeverity`
 The severity to use in reports when a dependency is not in the `allowed`
 list of rules. It takes the same values as other `severity` fields and
 also defaults to `warn`.
+
+### `required`
+
+A list of rules that describe what dependencies modules _must_ have, like 'every
+controller _must depend on_ the base controller'.
+
+'Required' rules have slightly different semantics from the `forbidden` and
+`allowed` types. There's a mandatory `module` attribute that specifies which
+modules the rule applies to and the `to` describes what dependencies that module
+should exactly have.
+
+```javascript
+{
+  required: [
+    {
+      name: "controllers-inherit-from-base",
+      comment:
+        "Each controller should inherit from the framework's base controller",
+      module: {
+        // every module that matches the pattern specified in path & pathNot ...
+        path: "-controller\\.js$",
+        pathNot: "framework/base-controller\\.js$",
+      },
+      to: {
+        // ... must depend at least once on the framework's base controller
+        path: "^src/framework/base-controller\\.js$",
+      },
+    },
+  ];
+}
+```
 
 ### `extends`
 
@@ -170,9 +204,8 @@ Options that influence what is cruised, and how it is cruised. See
 
 ## The structure of an individual rule
 
-An individual rule consists at least of a `from` and a `to`
-attribute that contain one or more conditions that trigger the rule, so
-a minimal rule will look like this:
+A rule consists at least of a `from` and a `to` attribute that contain one or
+more conditions that trigger the rule, so a minimal rule will look like this:
 
 ```json
 {

--- a/src/enrich/add-rule-set-used.js
+++ b/src/enrich/add-rule-set-used.js
@@ -14,10 +14,12 @@ module.exports = function addRuleSetUsed(pOptions) {
   const lForbidden = _get(pOptions, "ruleSet.forbidden");
   const lAllowed = _get(pOptions, "ruleSet.allowed");
   const lAllowedSeverity = _get(pOptions, "ruleSet.allowedSeverity");
+  const lRequired = _get(pOptions, "ruleSet.required");
 
   return Object.assign(
     lForbidden ? { forbidden: lForbidden } : {},
     lAllowed ? { allowed: lAllowed.map(removeNames) } : {},
-    lAllowedSeverity ? { allowedSeverity: lAllowedSeverity } : {}
+    lAllowedSeverity ? { allowedSeverity: lAllowedSeverity } : {},
+    lRequired ? { required: lRequired } : {}
   );
 };

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -23,6 +23,7 @@ function normalizeRule(pRule) {
     name: normalizeName(pRule.name),
     from: normalizeREProperties(pRule.from),
     to: normalizeREProperties(pRule.to),
+    ...(pRule.module ? { module: normalizeREProperties(pRule.module) } : {}),
   };
 }
 
@@ -53,6 +54,12 @@ module.exports = (pRuleSet) => {
 
   if (Object.prototype.hasOwnProperty.call(pRuleSet, "forbidden")) {
     pRuleSet.forbidden = pRuleSet.forbidden
+      .map(normalizeRule)
+      .filter((pRule) => pRule.severity !== "ignore");
+  }
+
+  if (Object.prototype.hasOwnProperty.call(pRuleSet, "required")) {
+    pRuleSet.required = pRuleSet.required
       .map(normalizeRule)
       .filter((pRule) => pRule.severity !== "ignore");
   }

--- a/src/report/error-html/index.js
+++ b/src/report/error-html/index.js
@@ -21,6 +21,7 @@ function aggregateViolations(pViolations, pRuleSetUsed) {
   }, {});
 
   return _get(pRuleSetUsed, "forbidden", [])
+    .concat(_get(pRuleSetUsed, "required", []))
     .concat(getFormattedAllowedRule(pRuleSetUsed))
     .map((pRule) => mergeCountIntoRule(pRule, lViolationCounts))
     .sort(

--- a/src/report/teamcity.js
+++ b/src/report/teamcity.js
@@ -13,18 +13,16 @@ function severity2teamcitySeverity(pSeverity) {
   return SEVERITY2TEAMCITY_SEVERITY[pSeverity];
 }
 
-function reportForbiddenRules(pForbiddenRules, pViolations) {
-  return pForbiddenRules
-    .filter((pForbiddenRule) =>
-      pViolations.some(
-        (pViolation) => pForbiddenRule.name === pViolation.rule.name
-      )
+function reportRules(pRules, pViolations) {
+  return pRules
+    .filter((pRule) =>
+      pViolations.some((pViolation) => pRule.name === pViolation.rule.name)
     )
-    .map((pForbiddenRule) =>
+    .map((pRule) =>
       tsm.inspectionType({
-        id: pForbiddenRule.name,
-        name: pForbiddenRule.name,
-        description: pForbiddenRule.comment || pForbiddenRule.name,
+        id: pRule.name,
+        name: pRule.name,
+        description: pRule.comment || pRule.name,
         category: CATEGORY,
       })
     );
@@ -48,10 +46,9 @@ function reportAllowedRule(pAllowedRule, pViolations) {
 }
 
 function reportViolatedRules(pRuleSetUsed, pViolations) {
-  return reportForbiddenRules(
-    _get(pRuleSetUsed, "forbidden", []),
-    pViolations
-  ).concat(reportAllowedRule(_get(pRuleSetUsed, "allowed", []), pViolations));
+  return reportRules(_get(pRuleSetUsed, "forbidden", []), pViolations)
+    .concat(reportAllowedRule(_get(pRuleSetUsed, "allowed", []), pViolations))
+    .concat(reportRules(_get(pRuleSetUsed, "required", []), pViolations));
 }
 
 function determineTo(pViolation) {

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -20,6 +20,11 @@
       "$ref": "#/definitions/SeverityType",
       "description": "Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'"
     },
+    "required": {
+      "type": "array",
+      "despcription": "",
+      "items": { "$ref": "#/definitions/RequiredRuleType" }
+    },
     "options": { "$ref": "#/definitions/OptionsType" },
     "extends": { "$ref": "#/definitions/ExtendsType" }
   },
@@ -41,6 +46,11 @@
         "allowedSeverity": {
           "$ref": "#/definitions/SeverityType",
           "description": "Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'"
+        },
+        "required": {
+          "type": "array",
+          "despcription": "",
+          "items": { "$ref": "#/definitions/RequiredRuleType" }
         }
       }
     },
@@ -104,6 +114,18 @@
         "comment": { "type": "string" },
         "from": { "$ref": "#/definitions/ReachabilityFromRestrictionType" },
         "to": { "$ref": "#/definitions/ReachabilityToRestrictionType" }
+      }
+    },
+    "RequiredRuleType": {
+      "type": "object",
+      "required": ["module", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "severity": { "$ref": "#/definitions/SeverityType" },
+        "comment": { "type": "string" },
+        "module": { "$ref": "#/definitions/RequiredModuleRestrictionType" },
+        "to": { "$ref": "#/definitions/RequiredToRestrictionType" }
       }
     },
     "FromRestrictionType": {
@@ -216,6 +238,32 @@
         "reachable": {
           "type": "boolean",
           "description": "Whether or not to match modules that aren't reachable from the from part of the rule."
+        }
+      }
+    },
+    "RequiredModuleRestrictionType": {
+      "description": "Criteria to select the module(s) this restriction should apply to",
+      "required": [],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "$ref": "#/definitions/REAsStringsType"
+        },
+        "pathNot": {
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "$ref": "#/definitions/REAsStringsType"
+        }
+      }
+    },
+    "RequiredToRestrictionType": {
+      "description": "Criteria for modules the associated module must depend on.",
+      "required": [],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -22,7 +22,7 @@
     },
     "required": {
       "type": "array",
-      "despcription": "",
+      "despcription": "A list of rules that describe what dependencies modules _must_ have. E.g. - every controller needs to (directly) depend on a base controller. - each source file should be the dependency of a spec file with the same    base name",
       "items": { "$ref": "#/definitions/RequiredRuleType" }
     },
     "options": { "$ref": "#/definitions/OptionsType" },
@@ -49,7 +49,7 @@
         },
         "required": {
           "type": "array",
-          "despcription": "",
+          "despcription": "A list of rules that describe what dependencies modules _must_ have. E.g. - every controller needs to (directly) depend on a base controller. - each source file should be the dependency of a spec file with the same    base name",
           "items": { "$ref": "#/definitions/RequiredRuleType" }
         }
       }
@@ -262,7 +262,7 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "description": "Criteria at least one dependency of each matching module mustadhere to.",
           "$ref": "#/definitions/REAsStringsType"
         }
       }

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -341,7 +341,7 @@
         },
         "required": {
           "type": "array",
-          "despcription": "",
+          "despcription": "A list of rules that describe what dependencies modules _must_ have. E.g. - every controller needs to (directly) depend on a base controller. - each source file should be the dependency of a spec file with the same    base name",
           "items": { "$ref": "#/definitions/RequiredRuleType" }
         }
       }
@@ -554,7 +554,7 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "description": "Criteria at least one dependency of each matching module mustadhere to.",
           "$ref": "#/definitions/REAsStringsType"
         }
       }

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -338,6 +338,11 @@
         "allowedSeverity": {
           "$ref": "#/definitions/SeverityType",
           "description": "Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'"
+        },
+        "required": {
+          "type": "array",
+          "despcription": "",
+          "items": { "$ref": "#/definitions/RequiredRuleType" }
         }
       }
     },
@@ -401,6 +406,18 @@
         "comment": { "type": "string" },
         "from": { "$ref": "#/definitions/ReachabilityFromRestrictionType" },
         "to": { "$ref": "#/definitions/ReachabilityToRestrictionType" }
+      }
+    },
+    "RequiredRuleType": {
+      "type": "object",
+      "required": ["module", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "severity": { "$ref": "#/definitions/SeverityType" },
+        "comment": { "type": "string" },
+        "module": { "$ref": "#/definitions/RequiredModuleRestrictionType" },
+        "to": { "$ref": "#/definitions/RequiredToRestrictionType" }
       }
     },
     "FromRestrictionType": {
@@ -513,6 +530,32 @@
         "reachable": {
           "type": "boolean",
           "description": "Whether or not to match modules that aren't reachable from the from part of the rule."
+        }
+      }
+    },
+    "RequiredModuleRestrictionType": {
+      "description": "Criteria to select the module(s) this restriction should apply to",
+      "required": [],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "$ref": "#/definitions/REAsStringsType"
+        },
+        "pathNot": {
+          "description": "A regular expression or an array of regular expressions an end of a dependency should NOT match to be caught by this rule.",
+          "$ref": "#/definitions/REAsStringsType"
+        }
+      }
+    },
+    "RequiredToRestrictionType": {
+      "description": "Criteria for modules the associated module must depend on.",
+      "required": [],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A regular expression or an array of regular expressions an end of a dependency should match to be caught by this rule.",
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -1,5 +1,6 @@
 const matchModuleRule = require("./match-module-rule");
 const matchDependencyRule = require("./match-dependency-rule");
+const violatesRequiredRule = require("./violates-required-rule");
 
 function compareSeverity(pFirst, pSecond) {
   const SEVERITY2INT = {
@@ -44,6 +45,20 @@ function validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo) {
     }));
 }
 
+function validateAgainstRequiredRules(pRuleSet, pModule) {
+  let lFoundRequiredRuleViolations = [];
+
+  if (Object.prototype.hasOwnProperty.call(pRuleSet, "required")) {
+    lFoundRequiredRuleViolations = pRuleSet.required
+      .filter((pRule) => violatesRequiredRule(pRule, pModule))
+      .map((pMatchedRule) => ({
+        severity: pMatchedRule.severity,
+        name: pMatchedRule.name,
+      }));
+  }
+  return lFoundRequiredRuleViolations;
+}
+
 function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
   let lReturnValue = { valid: true };
 
@@ -54,6 +69,7 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
     pTo
   )
     .concat(validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo))
+    .concat(validateAgainstRequiredRules(pRuleSet, pFrom))
     .sort(compareSeverity);
 
   lReturnValue.valid = lFoundRuleViolations.length === 0;

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -45,11 +45,12 @@ function validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo) {
     }));
 }
 
-function validateAgainstRequiredRules(pRuleSet, pModule) {
+function validateAgainstRequiredRules(pRuleSet, pModule, pMatchModule) {
   let lFoundRequiredRuleViolations = [];
 
   if (Object.prototype.hasOwnProperty.call(pRuleSet, "required")) {
     lFoundRequiredRuleViolations = pRuleSet.required
+      .filter(pMatchModule.isInteresting)
       .filter((pRule) => violatesRequiredRule(pRule, pModule))
       .map((pMatchedRule) => ({
         severity: pMatchedRule.severity,
@@ -69,7 +70,7 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
     pTo
   )
     .concat(validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo))
-    .concat(validateAgainstRequiredRules(pRuleSet, pFrom))
+    .concat(validateAgainstRequiredRules(pRuleSet, pFrom, pMatchModule))
     .sort(compareSeverity);
 
   lReturnValue.valid = lFoundRuleViolations.length === 0;

--- a/src/validate/is-module-only-rule.js
+++ b/src/validate/is-module-only-rule.js
@@ -4,9 +4,10 @@
  */
 function isModuleOnlyRule(pRule) {
   return (
-    Object.prototype.hasOwnProperty.call(pRule.from, "orphan") ||
+    Object.prototype.hasOwnProperty.call(pRule.from || {}, "orphan") ||
+    // note: the to might become optional for required rules
     Object.prototype.hasOwnProperty.call(pRule.to, "reachable") ||
-    Object.prototype.hasOwnProperty.call(pRule.to, "module")
+    Object.prototype.hasOwnProperty.call(pRule, "module")
   );
 }
 

--- a/src/validate/is-module-only-rule.js
+++ b/src/validate/is-module-only-rule.js
@@ -5,7 +5,8 @@
 function isModuleOnlyRule(pRule) {
   return (
     Object.prototype.hasOwnProperty.call(pRule.from, "orphan") ||
-    Object.prototype.hasOwnProperty.call(pRule.to, "reachable")
+    Object.prototype.hasOwnProperty.call(pRule.to, "reachable") ||
+    Object.prototype.hasOwnProperty.call(pRule.to, "module")
   );
 }
 

--- a/src/validate/match-dependency-rule.js
+++ b/src/validate/match-dependency-rule.js
@@ -1,5 +1,6 @@
 const isModuleOnlyRule = require("./is-module-only-rule");
 const matchers = require("./matchers");
+const { extractGroups } = require("./utl");
 
 function propertyEquals(pTo, pRule, pProperty) {
   // ignore security/detect-object-injection because:
@@ -9,28 +10,6 @@ function propertyEquals(pTo, pRule, pProperty) {
     ? // eslint-disable-next-line security/detect-object-injection
       pTo[pProperty] === pRule.to[pProperty]
     : true;
-}
-
-/* if there is at least one group expression in the given pRulePath
-   return the first matched one.
-   return null in all other cases
-
-   This fills our current need. Later we can expand it to return all group
-   matches.
-*/
-function extractGroups(pRule, pActualPath) {
-  let lReturnValue = [];
-
-  if (Boolean(pRule.path)) {
-    let lMatchResult = pActualPath.match(pRule.path);
-
-    if (Boolean(lMatchResult) && lMatchResult.length > 1) {
-      lReturnValue = lMatchResult.filter(
-        (pResult) => typeof pResult === "string"
-      );
-    }
-  }
-  return lReturnValue;
 }
 
 function match(pFrom, pTo) {

--- a/src/validate/matchers.js
+++ b/src/validate/matchers.js
@@ -10,6 +10,16 @@ function fromPathNot(pRule, pModule) {
   );
 }
 
+function modulePath(pRule, pModule) {
+  return Boolean(!pRule.module.path || pModule.source.match(pRule.module.path));
+}
+
+function modulePathNot(pRule, pModule) {
+  return Boolean(
+    !pRule.module.pathNot || !pModule.source.match(pRule.module.pathNot)
+  );
+}
+
 function _replaceGroupPlaceholders(pString, pExtractedGroups) {
   return pExtractedGroups.reduce(
     (pAll, pThis, pIndex) =>
@@ -96,6 +106,8 @@ module.exports = {
   fromPathNot,
   toPath,
   toModulePath,
+  modulePath,
+  modulePathNot,
   toPathNot,
   toModulePathNot,
   toDependencyTypes,

--- a/src/validate/utl.js
+++ b/src/validate/utl.js
@@ -1,0 +1,25 @@
+/* if there is at least one group expression in the given pRulePath
+   return the first matched one.
+   return null in all other cases
+
+   This fills our current need. Later we can expand it to return all group
+   matches.
+*/
+function extractGroups(pRule, pActualPath) {
+  let lReturnValue = [];
+
+  if (Boolean(pRule.path)) {
+    let lMatchResult = pActualPath.match(pRule.path);
+
+    if (Boolean(lMatchResult) && lMatchResult.length > 1) {
+      lReturnValue = lMatchResult.filter(
+        (pResult) => typeof pResult === "string"
+      );
+    }
+  }
+  return lReturnValue;
+}
+
+module.exports = {
+  extractGroups,
+};

--- a/src/validate/violates-required-rule.js
+++ b/src/validate/violates-required-rule.js
@@ -1,0 +1,18 @@
+const matchers = require("./matchers");
+const { extractGroups } = require("./utl");
+
+module.exports = function violatesRequiredRule(pRule, pModule) {
+  let lReturnValue = false;
+
+  if (
+    matchers.modulePath(pRule, pModule) &&
+    matchers.modulePathNot(pRule, pModule)
+  ) {
+    const lGroups = extractGroups(pRule.module, pModule.source);
+
+    lReturnValue = !pModule.dependencies.some((pDependency) =>
+      matchers.toPath(pRule, pDependency, lGroups)
+    );
+  }
+  return lReturnValue;
+};

--- a/test/cli/compile-config/index.spec.js
+++ b/test/cli/compile-config/index.spec.js
@@ -78,7 +78,6 @@ describe("cli/compile-config", () => {
         },
       ],
       allowedSeverity: "warn",
-      forbidden: [],
       options: {
         doNotFollow: "node_modules",
       },

--- a/test/cli/compile-config/merge-rule-sets.spec.js
+++ b/test/cli/compile-config/merge-rule-sets.spec.js
@@ -274,6 +274,34 @@ describe("cli/mergeRuleSets - allowedSeverity", () => {
   });
 });
 
+describe("cli/mergeRuleSets - required", () => {
+  it("extending an existing named rule - the extended wins", () => {
+    expect(
+      merge(
+        { required: [{ name: "already-in-base", from: "bin", to: "test" }] },
+        { required: [{ name: "already-in-base", from: "src", to: "test" }] }
+      )
+    ).to.deep.equal({
+      required: [{ name: "already-in-base", from: "bin", to: "test" }],
+      options: {},
+    });
+  });
+
+  it("merging two disjunct required rule sets", () => {
+    expect(
+      merge(
+        { required: [{ name: "only-in-base", from: "bin", to: "test" }] },
+        { required: [{ name: "only-in-extends", from: "src", to: "test" }] }
+      )
+    ).to.deep.equal({
+      required: [
+        { name: "only-in-base", from: "bin", to: "test" },
+        { name: "only-in-extends", from: "src", to: "test" },
+      ],
+      options: {},
+    });
+  });
+});
 describe("cli/mergeRuleSets - options", () => {
   it("extending empty options with some options yield those options", () => {
     expect(

--- a/test/cli/compile-config/merge-rule-sets.spec.js
+++ b/test/cli/compile-config/merge-rule-sets.spec.js
@@ -4,9 +4,6 @@ const merge = require("../../../src/cli/compile-config/merge-configs");
 describe("cli/mergeRuleSets - general", () => {
   it("two empty rule sets yield an empty rule set with named attributes", () => {
     expect(merge({}, {})).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
-      forbidden: [],
       options: {},
     });
   });
@@ -17,8 +14,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
     expect(
       merge({ forbidden: [{ from: "src", to: "test" }] }, {})
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [{ from: "src", to: "test" }],
       options: {},
     });
@@ -31,8 +26,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         { forbidden: [{ from: "src", to: "test" }] }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [{ from: "src", to: "test" }],
       options: {},
     });
@@ -42,8 +35,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
     expect(
       merge({}, { forbidden: [{ from: "src", to: "test" }] })
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [{ from: "src", to: "test" }],
       options: {},
     });
@@ -56,8 +47,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         { forbidden: [{ from: "src", to: "test" }] }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [
         { from: "bin", to: "test" },
         { from: "src", to: "test" },
@@ -73,8 +62,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         { forbidden: [{ name: "already-in-base", from: "src", to: "test" }] }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [{ name: "already-in-base", from: "bin", to: "test" }],
       options: {},
     });
@@ -104,8 +91,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [
         {
           name: "already-in-base",
@@ -142,8 +127,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [
         {
           name: "already-in-base",
@@ -171,8 +154,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [
         {
           name: "already-in-base",
@@ -192,8 +173,6 @@ describe("cli/mergeRuleSets - forbidden", () => {
         { forbidden: [{ name: "already-in-base", from: "src", to: "test" }] }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
       forbidden: [
         { name: "not-in-base", from: "bin", to: "test" },
         { name: "already-in-base", from: "src", to: "test" },
@@ -209,7 +188,6 @@ describe("cli/mergeRuleSets - allowed", () => {
       {
         allowed: [{ from: "test", to: "src" }],
         allowedSeverity: "warn",
-        forbidden: [],
         options: {},
       }
     );
@@ -224,7 +202,6 @@ describe("cli/mergeRuleSets - allowed", () => {
     ).to.deep.equal({
       allowed: [{ from: "test", to: "src" }],
       allowedSeverity: "warn",
-      forbidden: [],
       options: {},
     });
   });
@@ -234,7 +211,6 @@ describe("cli/mergeRuleSets - allowed", () => {
       {
         allowed: [{ from: "test", to: "src" }],
         allowedSeverity: "warn",
-        forbidden: [],
         options: {},
       }
     );
@@ -247,52 +223,52 @@ describe("cli/mergeRuleSets - allowed", () => {
         { allowed: [{ from: "src", to: "test" }] }
       )
     ).to.deep.equal({
+      allowedSeverity: "warn",
       allowed: [
         { from: "bin", to: "test" },
         { from: "src", to: "test" },
       ],
-      allowedSeverity: "warn",
-      forbidden: [],
       options: {},
     });
   });
 });
 
 describe("cli/mergeRuleSets - allowedSeverity", () => {
-  it("extending empty allowed yields allowedSeverity warn", () => {
-    expect(merge({}, {})).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
-      forbidden: [],
+  it("extending empty set with only an allowedSeverity error yields no allowedSeverity", () => {
+    expect(merge({ allowedSeverity: "error" }, {})).to.deep.equal({
       options: {},
     });
   });
 
-  it("extending empty set with allowedSeverity error yields allowedSeverity error", () => {
-    expect(merge({ allowedSeverity: "error" }, {})).to.deep.equal({
-      allowed: [],
+  it("extending empty set with allowed + allowedSeverity error yields allowedSeverity error", () => {
+    expect(
+      merge({}, { allowed: [{ from: {}, to: {} }], allowedSeverity: "error" })
+    ).to.deep.equal({
+      allowed: [{ from: {}, to: {} }],
       allowedSeverity: "error",
-      forbidden: [],
       options: {},
     });
   });
 
   it("extending allowedSeverity error with nothing yields allowedSeverity error", () => {
-    expect(merge({}, { allowedSeverity: "error" })).to.deep.equal({
-      allowed: [],
+    expect(
+      merge({ allowed: [{ from: {}, to: {} }], allowedSeverity: "error" }, {})
+    ).to.deep.equal({
+      allowed: [{ from: {}, to: {} }],
       allowedSeverity: "error",
-      forbidden: [],
       options: {},
     });
   });
 
   it("extending allowedSeverity error with info yields allowedSeverity info", () => {
     expect(
-      merge({ allowedSeverity: "info" }, { allowedSeverity: "error" })
+      merge(
+        { allowedSeverity: "info" },
+        { allowed: [{ from: {}, to: {} }], allowedSeverity: "error" }
+      )
     ).to.deep.equal({
-      allowed: [],
+      allowed: [{ from: {}, to: {} }],
       allowedSeverity: "info",
-      forbidden: [],
       options: {},
     });
   });
@@ -311,9 +287,6 @@ describe("cli/mergeRuleSets - options", () => {
         {}
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
-      forbidden: [],
       options: {
         doNotFollow: "node_modules",
         tsConfig: {
@@ -335,9 +308,6 @@ describe("cli/mergeRuleSets - options", () => {
         }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
-      forbidden: [],
       options: {
         doNotFollow: "node_modules",
         tsConfig: {
@@ -359,9 +329,6 @@ describe("cli/mergeRuleSets - options", () => {
         }
       )
     ).to.deep.equal({
-      allowed: [],
-      allowedSeverity: "warn",
-      forbidden: [],
       options: {
         doNotFollow: "node_modules",
         tsConfig: {},

--- a/test/cli/compile-config/mocks/extends/merged-array-1.json
+++ b/test/cli/compile-config/mocks/extends/merged-array-1.json
@@ -1,18 +1,19 @@
 {
-    "allowed": [],
-    "allowedSeverity": "warn",
-    "forbidden": [{
-        "name": "no-circular",
-        "severity": "ignore",
-        "from": {},
-        "to": { "circular": true }
-    },{
-        "name": "only-in-extending",
-        "severity": "info",
-        "from": { "pathNot": "^test" },
-        "to": { "path": "^test" }
-    }],
-    "options": {
-        "doNotFollow": "node_modules"
+  "forbidden": [
+    {
+      "name": "no-circular",
+      "severity": "ignore",
+      "from": {},
+      "to": { "circular": true }
+    },
+    {
+      "name": "only-in-extending",
+      "severity": "info",
+      "from": { "pathNot": "^test" },
+      "to": { "path": "^test" }
     }
+  ],
+  "options": {
+    "doNotFollow": "node_modules"
+  }
 }

--- a/test/cli/compile-config/mocks/extends/merged-array-2.json
+++ b/test/cli/compile-config/mocks/extends/merged-array-2.json
@@ -1,23 +1,25 @@
 {
-    "allowed": [],
-    "allowedSeverity": "warn",
-    "forbidden": [{
-        "name": "no-circular",
-        "severity": "ignore",
-        "from": {},
-        "to": { "circular": true }
-    },{
-        "name": "only-in-extending",
-        "severity": "info",
-        "from": { "pathNot": "^test" },
-        "to": { "path": "^test" }
-    },{
-        "name": "rule-from-second-base",
-        "severity": "error",
-        "from": { "orphan": true },
-        "to": {}
-    }],
-    "options": {
-        "doNotFollow": "node_modules"
+  "forbidden": [
+    {
+      "name": "no-circular",
+      "severity": "ignore",
+      "from": {},
+      "to": { "circular": true }
+    },
+    {
+      "name": "only-in-extending",
+      "severity": "info",
+      "from": { "pathNot": "^test" },
+      "to": { "path": "^test" }
+    },
+    {
+      "name": "rule-from-second-base",
+      "severity": "error",
+      "from": { "orphan": true },
+      "to": {}
     }
+  ],
+  "options": {
+    "doNotFollow": "node_modules"
+  }
 }

--- a/test/cli/compile-config/mocks/extends/merged.json
+++ b/test/cli/compile-config/mocks/extends/merged.json
@@ -1,13 +1,13 @@
 {
-    "allowed": [],
-    "allowedSeverity": "warn",
-    "forbidden": [{
-        "name": "no-circular",
-        "severity": "error",
-        "from": {},
-        "to": { "circular": true }
-    }],
-    "options": {
-        "doNotFollow": "node_modules"
+  "forbidden": [
+    {
+      "name": "no-circular",
+      "severity": "error",
+      "from": {},
+      "to": { "circular": true }
     }
+  ],
+  "options": {
+    "doNotFollow": "node_modules"
+  }
 }

--- a/test/cli/validate-node-environment.spec.js
+++ b/test/cli/validate-node-environment.spec.js
@@ -29,7 +29,7 @@ describe("cli/validateNodeEnv", () => {
   it("doesn't throw when an undefined node version is passed (assuming test is run on a supported platform)", () => {
     expect(() => {
       // eslint-disable-next-line no-undefined
-      validateNodeEnvironment(undefined);
+      validateNodeEnvironment();
     }).to.not.throw();
   });
 

--- a/test/enrich/summarize.spec.js
+++ b/test/enrich/summarize.spec.js
@@ -1,0 +1,34 @@
+const { expect } = require("chai");
+const summarize = require("~/src/enrich/summarize");
+
+describe("enrich/summarize", () => {
+  it("doesn't add a rule set when there isn't one", () => {
+    expect(summarize([], {}, [])).to.deep.equal({
+      error: 0,
+      info: 0,
+      optionsUsed: {
+        args: "",
+      },
+      totalCruised: 0,
+      totalDependenciesCruised: 0,
+      violations: [],
+      warn: 0,
+    });
+  });
+  it("adds a rule set when there is one", () => {
+    expect(summarize([], { ruleSet: { required: [] } }, [])).to.deep.equal({
+      error: 0,
+      info: 0,
+      optionsUsed: {
+        args: "",
+      },
+      ruleSetUsed: {
+        required: [],
+      },
+      totalCruised: 0,
+      totalDependenciesCruised: 0,
+      violations: [],
+      warn: 0,
+    });
+  });
+});

--- a/test/main/rule-set/normalize.spec.js
+++ b/test/main/rule-set/normalize.spec.js
@@ -11,8 +11,8 @@ describe("main/rule-set/normalize", () => {
       normalize({
         allowed: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
           },
         ],
       })
@@ -20,8 +20,8 @@ describe("main/rule-set/normalize", () => {
       allowed: [
         {
           name: "not-in-allowed",
-          from: ".+",
-          to: ".+",
+          from: { path: ".+" },
+          to: { path: ".+" },
         },
       ],
       allowedSeverity: "warn",
@@ -33,8 +33,8 @@ describe("main/rule-set/normalize", () => {
       normalize({
         allowed: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
           },
         ],
         allowedSeverity: "error",
@@ -43,8 +43,8 @@ describe("main/rule-set/normalize", () => {
       allowed: [
         {
           name: "not-in-allowed",
-          from: ".+",
-          to: ".+",
+          from: { path: ".+" },
+          to: { path: ".+" },
         },
       ],
       allowedSeverity: "error",
@@ -56,8 +56,8 @@ describe("main/rule-set/normalize", () => {
       normalize({
         forbidden: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
             severity: "unrecognized",
             name: "all-ok",
           },
@@ -66,8 +66,8 @@ describe("main/rule-set/normalize", () => {
     ).to.deep.equal({
       forbidden: [
         {
-          from: ".+",
-          to: ".+",
+          from: { path: ".+" },
+          to: { path: ".+" },
           severity: "warn",
           name: "all-ok",
         },
@@ -80,8 +80,8 @@ describe("main/rule-set/normalize", () => {
       normalize({
         forbidden: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
             severity: "error",
             name: "all-ok",
           },
@@ -90,8 +90,8 @@ describe("main/rule-set/normalize", () => {
     ).to.deep.equal({
       forbidden: [
         {
-          from: ".+",
-          to: ".+",
+          from: { path: ".+" },
+          to: { path: ".+" },
           severity: "error",
           name: "all-ok",
         },
@@ -104,8 +104,8 @@ describe("main/rule-set/normalize", () => {
       normalize({
         forbidden: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
             severity: "error",
             name: "all-ok",
             comment: "this comment is kept",
@@ -115,8 +115,8 @@ describe("main/rule-set/normalize", () => {
     ).to.deep.equal({
       forbidden: [
         {
-          from: ".+",
-          to: ".+",
+          from: { path: ".+" },
+          to: { path: ".+" },
           severity: "error",
           name: "all-ok",
           comment: "this comment is kept",
@@ -130,8 +130,8 @@ describe("main/rule-set/normalize", () => {
       normalize({
         forbidden: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
             severity: "ignore",
             name: "all-ok",
             comment: "this comment is kept",
@@ -143,13 +143,31 @@ describe("main/rule-set/normalize", () => {
     });
   });
 
+  it("filters out required rules with severity 'ignore'", () => {
+    expect(
+      normalize({
+        required: [
+          {
+            from: { path: ".+" },
+            to: { path: ".+" },
+            severity: "ignore",
+            name: "all-ok",
+            comment: "this comment is kept",
+          },
+        ],
+      })
+    ).to.deep.equal({
+      required: [],
+    });
+  });
+
   it("removes the allowed rules & allowedSeverity when allowedSeverity === 'ignore'", () => {
     expect(
       normalize({
         allowed: [
           {
-            from: ".+",
-            to: ".+",
+            from: { path: ".+" },
+            to: { path: ".+" },
           },
         ],
         allowedSeverity: "ignore",
@@ -187,6 +205,40 @@ describe("main/rule-set/normalize", () => {
           to: {
             path: "super/exclusive|donot/gohere|norhere",
             pathNot: "super/exclusive/this-is-ok-though\\.js|snorhere",
+          },
+        },
+      ],
+    });
+  });
+
+  it("normalizes arrays of re's in paths to regular regular expressions (required)", () => {
+    expect(
+      normalize({
+        required: [
+          {
+            name: "regularize-regular",
+            severity: "warn",
+            from: {
+              path: ["src", "bin"],
+              pathNot: ["src/exceptions", "bin/aural"],
+            },
+            to: {
+              path: ["super/exclusive", "donot/gohere", "norhere"],
+            },
+          },
+        ],
+      })
+    ).to.deep.equal({
+      required: [
+        {
+          name: "regularize-regular",
+          severity: "warn",
+          from: {
+            path: "src|bin",
+            pathNot: "src/exceptions|bin/aural",
+          },
+          to: {
+            path: "super/exclusive|donot/gohere|norhere",
           },
         },
       ],

--- a/test/report/teamcity/mocks/required-errors-teamcity-format.txt
+++ b/test/report/teamcity/mocks/required-errors-teamcity-format.txt
@@ -1,0 +1,8 @@
+##teamcity[inspectionType id='no-orphans' name='no-orphans' description='Modules without any incoming or outgoing dependencies are might indicate unused code.' category='dependency-cruiser' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspectionType id='not-to-unresolvable' name='not-to-unresolvable' description='not-to-unresolvable' category='dependency-cruiser' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspectionType id='some-required-rule' name='some-required-rule' description='Don|'t allow dependencies from src/app/lib to a development only package' category='dependency-cruiser' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspection typeId='some-required-rule' message='src/asneeze.js -> node_modules/eslint/lib/api.js' file='src/asneeze.js' SEVERITY='ERROR' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspection typeId='not-to-unresolvable' message='src/index.js -> ./medontexist.json' file='src/index.js' SEVERITY='ERROR' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspection typeId='some-required-rule' message='src/index.js -> node_modules/dependency-cruiser/src/main/index.js' file='src/index.js' SEVERITY='ERROR' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspection typeId='some-required-rule' message='src/index.js -> node_modules/eslint/lib/api.js' file='src/index.js' SEVERITY='ERROR' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']
+##teamcity[inspection typeId='no-orphans' message='src/orphan.js' file='src/orphan.js' SEVERITY='ERROR' flowId='2395574063' timestamp='2020-07-05T15:18:39.154']

--- a/test/report/teamcity/mocks/required-errors.json
+++ b/test/report/teamcity/mocks/required-errors.json
@@ -1,0 +1,276 @@
+{
+  "modules": [
+    {
+      "source": "src/asneeze.js",
+      "dependencies": [
+        {
+          "resolved": "node_modules/eslint/lib/api.js",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["npm-dev"],
+          "license": "MIT",
+          "module": "eslint",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": true,
+          "circular": false,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "error",
+              "name": "some-required-rule"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "node_modules/eslint/lib/api.js",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": false,
+      "matchesDoNotFollow": true,
+      "dependencyTypes": ["npm-dev"],
+      "dependencies": [],
+      "valid": true
+    },
+    {
+      "source": "src/hunkydory.js",
+      "dependencies": [],
+      "valid": true
+    },
+    {
+      "source": "src/index.js",
+      "dependencies": [
+        {
+          "resolved": "src/asneeze.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "module": "./asneeze",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        },
+        {
+          "resolved": "src/hunkydory.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": ["local"],
+          "module": "./hunkydory",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        },
+        {
+          "resolved": "./medontexist.json",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": true,
+          "dependencyTypes": ["unknown"],
+          "module": "./medontexist.json",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "error",
+              "name": "not-to-unresolvable"
+            }
+          ]
+        },
+        {
+          "resolved": "node_modules/dependency-cruiser/src/main/index.js",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["npm-dev"],
+          "license": "MIT",
+          "module": "dependency-cruiser",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": true,
+          "circular": false,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "error",
+              "name": "some-required-rule"
+            }
+          ]
+        },
+        {
+          "resolved": "node_modules/eslint/lib/api.js",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": false,
+          "dependencyTypes": ["npm-dev"],
+          "license": "MIT",
+          "module": "eslint",
+          "moduleSystem": "cjs",
+          "matchesDoNotFollow": true,
+          "circular": false,
+          "valid": false,
+          "rules": [
+            {
+              "severity": "error",
+              "name": "some-required-rule"
+            }
+          ]
+        }
+      ],
+      "valid": true
+    },
+    {
+      "source": "./medontexist.json",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": true,
+      "matchesDoNotFollow": false,
+      "dependencyTypes": ["unknown"],
+      "dependencies": [],
+      "valid": true
+    },
+    {
+      "source": "node_modules/dependency-cruiser/src/main/index.js",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": false,
+      "matchesDoNotFollow": true,
+      "dependencyTypes": ["npm-dev"],
+      "dependencies": [],
+      "valid": true
+    },
+    {
+      "source": "src/orphan.js",
+      "dependencies": [],
+      "orphan": true,
+      "valid": false,
+      "rules": [
+        {
+          "severity": "error",
+          "name": "no-orphans"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "violations": [
+      {
+        "from": "src/asneeze.js",
+        "to": "node_modules/eslint/lib/api.js",
+        "rule": {
+          "severity": "error",
+          "name": "some-required-rule"
+        }
+      },
+      {
+        "from": "src/index.js",
+        "to": "./medontexist.json",
+        "rule": {
+          "severity": "error",
+          "name": "not-to-unresolvable"
+        }
+      },
+      {
+        "from": "src/index.js",
+        "to": "node_modules/dependency-cruiser/src/main/index.js",
+        "rule": {
+          "severity": "error",
+          "name": "some-required-rule"
+        }
+      },
+      {
+        "from": "src/index.js",
+        "to": "node_modules/eslint/lib/api.js",
+        "rule": {
+          "severity": "error",
+          "name": "some-required-rule"
+        }
+      },
+      {
+        "from": "src/orphan.js",
+        "to": "src/orphan.js",
+        "rule": {
+          "severity": "error",
+          "name": "no-orphans"
+        }
+      }
+    ],
+    "error": 5,
+    "warn": 0,
+    "info": 0,
+    "totalCruised": 7,
+    "optionsUsed": {
+      "args": ["src"],
+      "combinedDependencies": false,
+      "doNotFollow": {
+        "dependencyTypes": [
+          "npm",
+          "npm-dev",
+          "npm-optional",
+          "npm-peer",
+          "npm-bundled",
+          "npm-no-pkg"
+        ]
+      },
+      "externalModuleResolutionStrategy": "node_modules",
+      "moduleSystems": ["amd", "cjs", "es6"],
+      "outputTo": "-",
+      "outputType": "json",
+      "preserveSymlinks": false,
+      "rulesFile": ".dependency-cruiser.js",
+      "tsPreCompilationDeps": false
+    },
+    "ruleSetUsed": {
+      "required": [
+        {
+          "name": "some-required-rule",
+          "severity": "error",
+          "comment": "Don't allow dependencies from src/app/lib to a development only package",
+          "from": {
+            "path": "^(src|app|lib)",
+            "pathNot": "\\.spec\\.(js|ts|ls|coffee|litcoffee|coffee\\.md)$"
+          },
+          "to": {
+            "path": "things-thou-shalt-depend-upon"
+          }
+        }
+      ],
+      "forbidden": [
+        {
+          "name": "no-orphans",
+          "comment": "Modules without any incoming or outgoing dependencies are might indicate unused code.",
+          "severity": "error",
+          "from": {
+            "orphan": true,
+            "pathNot": "\\.d\\.ts$"
+          },
+          "to": {}
+        },
+        {
+          "name": "no-circular",
+          "comment": "circular dependencies will make you dizzy",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "circular": true
+          }
+        },
+        {
+          "name": "not-to-unresolvable",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "couldNotResolve": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/report/teamcity/teamcity.spec.js
+++ b/test/report/teamcity/teamcity.spec.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { expect } = require("chai");
 const okdeps = require("./mocks/everything-fine.json");
 const moduleErrs = require("./mocks/module-errors.json");
+const requiredErrs = require("./mocks/required-errors.json");
 const circulars = require("./mocks/circular-deps.json");
 const vias = require("./mocks/via-deps.json");
 const render = require("~/src/report/teamcity");
@@ -29,6 +30,20 @@ describe("report/teamcity", () => {
       "utf8"
     );
     const lResult = render(moduleErrs);
+
+    expect(removePerSessionAttributes(lResult.output)).to.equal(
+      removePerSessionAttributes(lFixture)
+    );
+    // eslint-disable-next-line no-magic-numbers
+    expect(lResult.exitCode).to.equal(5);
+  });
+
+  it("renders 'required' violations", () => {
+    const lFixture = fs.readFileSync(
+      path.join(__dirname, "mocks", "required-errors-teamcity-format.txt"),
+      "utf8"
+    );
+    const lResult = render(requiredErrs);
 
     expect(removePerSessionAttributes(lResult.output)).to.equal(
       removePerSessionAttributes(lFixture)

--- a/test/utl/add-focus.spec.js
+++ b/test/utl/add-focus.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-useless-undefined */
 const { expect } = require("chai");
 const $input = require("./fixtures/focus/dependency-cruiser-only-src.json");
 const $focus = require("./fixtures/focus/dependency-cruiser-focus-on-main.json");

--- a/test/validate/fixtures/rules.required.json
+++ b/test/validate/fixtures/rules.required.json
@@ -1,0 +1,14 @@
+{
+  "required": [
+    {
+      "name": "thou-shalt-inherit-from-base",
+      "module": {
+        "path": ".+-controller\\.ts$",
+        "pathNot": "random-trials"
+      },
+      "to": {
+        "path": "src/base-controller/index\\.ts$"
+      }
+    }
+  ]
+}

--- a/test/validate/index.required-rules.spec.js
+++ b/test/validate/index.required-rules.spec.js
@@ -1,0 +1,76 @@
+const { expect } = require("chai");
+const readRuleSet = require("./readruleset.utl");
+const validate = require("~/src/validate");
+
+describe("validate/index - required rules", () => {
+  it("modules not matching the module criteria from the required rule are okeliedokelie", () => {
+    expect(
+      validate.module(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.required.json"),
+        { source: "something" }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("modules matching the module criteria with no dependencies bork", () => {
+    expect(
+      validate.module(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.required.json"),
+        { source: "grub-controller.ts", dependencies: [] }
+      )
+    ).to.deep.equal({
+      rules: [{ name: "thou-shalt-inherit-from-base", severity: "warn" }],
+      valid: false,
+    });
+  });
+
+  it("modules matching the module criteria with no matching dependencies bork", () => {
+    expect(
+      validate.module(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.required.json"),
+        {
+          source: "grub-controller.ts",
+          dependencies: [
+            {
+              resolved: "src/not-the-base-controller.ts",
+            },
+            {
+              resolved: "src/not-the-base-controller-either.ts",
+            },
+          ],
+        }
+      )
+    ).to.deep.equal({
+      rules: [{ name: "thou-shalt-inherit-from-base", severity: "warn" }],
+      valid: false,
+    });
+  });
+
+  it("modules matching the module criteria with matching dependencies are okeliedokelie", () => {
+    expect(
+      validate.module(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.required.json"),
+        {
+          source: "grub-controller.ts",
+          dependencies: [
+            {
+              resolved: "src/not-the-base-controller.ts",
+            },
+            {
+              resolved: "src/base-controller/index.ts",
+            },
+            {
+              resolved: "src/not-the-base-controller-either.ts",
+            },
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+});

--- a/test/validate/index.required-rules.spec.js
+++ b/test/validate/index.required-rules.spec.js
@@ -49,6 +49,28 @@ describe("validate/index - required rules", () => {
     });
   });
 
+  it("'required' violations don't get flagged as dependency transgressions", () => {
+    expect(
+      validate.dependency(
+        true,
+        readRuleSet("./test/validate/fixtures/rules.required.json"),
+        {
+          source: "grub-controller.ts",
+          dependencies: [
+            {
+              resolved: "src/not-the-base-controller.ts",
+            },
+            {
+              resolved: "src/not-the-base-controller-either.ts",
+            },
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+
   it("modules matching the module criteria with matching dependencies are okeliedokelie", () => {
     expect(
       validate.module(

--- a/test/validate/violates-required-rule.spec.js
+++ b/test/validate/violates-required-rule.spec.js
@@ -1,0 +1,108 @@
+const { expect } = require("chai");
+const violatesRequiredRule = require("~/src/validate/violates-required-rule");
+
+const SIMPLE_RULE = {
+  module: {
+    path: "controllers/[^/]+/.+-controller\\.ts$",
+  },
+  to: {
+    path: "controllers/base-controller\\.ts$",
+  },
+};
+
+const GROUP_MATCHING_RULE = {
+  comment: "spec files should depend on the module they're testing",
+  // note that a rule that goes the other way 'round (each file in src has at
+  // least one associated spec file) could potentially be _super_ useful
+  module: {
+    path: "test/(.+)(\\.spec)\\.js$",
+  },
+  to: {
+    path: "src/$1.js$",
+  },
+};
+describe("validate/violates-required-rule", () => {
+  it("does not violate when the module does not match", () => {
+    expect(
+      violatesRequiredRule(SIMPLE_RULE, { source: "does not match" })
+    ).to.equal(false);
+  });
+
+  it("violates when the module matches and there's no dependencies", () => {
+    expect(
+      violatesRequiredRule(SIMPLE_RULE, {
+        source: "controllers/sprockets/fred-controller.ts",
+        dependencies: [],
+      })
+    ).to.equal(true);
+  });
+
+  it("violates when the module matches and there's no matching dependencies", () => {
+    expect(
+      violatesRequiredRule(SIMPLE_RULE, {
+        source: "controllers/sprockets/fred-controller.ts",
+        dependencies: [
+          {
+            resolved: "path",
+            module: "path",
+          },
+        ],
+      })
+    ).to.equal(true);
+  });
+
+  it("passes when the module matches and there's a matching dependency", () => {
+    expect(
+      violatesRequiredRule(SIMPLE_RULE, {
+        source: "controllers/sprockets/fred-controller.ts",
+        dependencies: [
+          {
+            resolved: "src/controllers/base-controller.ts",
+            module: "../base-controller.ts",
+          },
+        ],
+      })
+    ).to.equal(false);
+  });
+
+  it("violates when the module matches and there's no matching dependency (group matching)", () => {
+    expect(
+      violatesRequiredRule(GROUP_MATCHING_RULE, {
+        source: "test/simsalabim.spec.js",
+        dependencies: [
+          {
+            resolved: "src/hocuspocus.js",
+            module: "~/src/hocuspocus.js",
+          },
+        ],
+      })
+    ).to.equal(true);
+  });
+
+  it("violates when the module matches and there's no dependencies (group matching)", () => {
+    expect(
+      violatesRequiredRule(GROUP_MATCHING_RULE, {
+        source: "test/simsalabim.spec.js",
+        dependencies: [],
+      })
+    ).to.equal(true);
+  });
+
+  it("passes when the module matches and there's no matching dependency (group matching)", () => {
+    expect(
+      violatesRequiredRule(GROUP_MATCHING_RULE, {
+        source: "test/simsalabim.spec.js",
+        dependencies: [
+          {
+            resolved: "src/hocuspocus.js",
+            module: "~/src/hocuspocus.js",
+          },
+          {
+            resolved: "src/simsalabim.js",
+            module: "~/src/simsalabim.js",
+          },
+        ],
+      })
+    ).to.equal(false);
+  });
+});

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -140,6 +140,28 @@ export default {
         },
       },
     },
+    RequiredModuleRestrictionType: {
+      description:
+        "Criteria to select the module(s) this restriction should apply to",
+      required: [],
+      additionalProperties: false,
+      properties: {
+        ...BASE_RESTRICTION,
+      },
+    },
+    RequiredToRestrictionType: {
+      description: "Criteria for modules the associated module must depend on.",
+      required: [],
+      additionalProperties: false,
+      properties: {
+        path: {
+          description:
+            "Criteria at least one dependency of each matching module must" +
+            "adhere to.",
+          $ref: "#/definitions/REAsStringsType",
+        },
+      },
+    },
     ...dependencyType.definitions,
     ...REAsStringsType.definitions,
   },

--- a/tools/schema/rule-set.mjs
+++ b/tools/schema/rule-set.mjs
@@ -33,7 +33,12 @@ const RULE_SET_TYPE_PROPERTIES = {
     },
     required: {
       type: "array",
-      despcription: "",
+      despcription:
+        "A list of rules that describe what dependencies modules _must_ have. " +
+        "E.g." +
+        " - every controller needs to (directly) depend on a base controller." +
+        " - each source file should be the dependency of a spec file with the same " +
+        "   base name",
       items: {
         $ref: "#/definitions/RequiredRuleType",
       },

--- a/tools/schema/rule-set.mjs
+++ b/tools/schema/rule-set.mjs
@@ -31,6 +31,13 @@ const RULE_SET_TYPE_PROPERTIES = {
         "Severity to use when a dependency is not in the 'allowed' set of rules. " +
         "Defaults to 'warn'",
     },
+    required: {
+      type: "array",
+      despcription: "",
+      items: {
+        $ref: "#/definitions/RequiredRuleType",
+      },
+    },
   },
 };
 
@@ -139,6 +146,28 @@ export default {
         },
         to: {
           $ref: "#/definitions/ReachabilityToRestrictionType",
+        },
+      },
+    },
+    RequiredRuleType: {
+      type: "object",
+      required: ["module", "to"],
+      additionalProperties: false,
+      properties: {
+        name: {
+          type: "string",
+        },
+        severity: {
+          $ref: "#/definitions/SeverityType",
+        },
+        comment: {
+          type: "string",
+        },
+        module: {
+          $ref: "#/definitions/RequiredModuleRestrictionType",
+        },
+        to: {
+          $ref: "#/definitions/RequiredToRestrictionType",
         },
       },
     },

--- a/types/rule-set.d.ts
+++ b/types/rule-set.d.ts
@@ -222,6 +222,58 @@ export interface IReachabilityForbiddenRuleType {
   to: IReachabilityToRestrictionType;
 }
 
+export interface IRequiredRuleType {
+  /**
+   * A short name for the rule - will appear in reporters to enable customers to
+   * quickly identify a violated rule. Try to keep them short, eslint style.
+   * E.g. 'not-to-core' for a rule forbidding dependencies on core modules, or
+   * 'not-to-unresolvable' for one that prevents dependencies on modules that
+   * probably don't exist.
+   */
+  name?: string;
+  /**
+   * How severe a violation of the rule is. The 'error' severity will make some
+   * reporters return a non-zero exit code, so if you want e.g. a build to stop
+   * when there's a rule violated: use that.
+   */
+  severity?: SeverityType;
+  /**
+   * You can use this field to document why the rule is there.
+   */
+  comment?: string;
+  /**
+   * Criteria to select the module(s) this restriction should apply to
+   */
+  module: IRequiredModuleRestrictionType;
+  /**
+   * Criteria at least one dependency of each matching module must
+   * adhere to.
+   */
+  to: IRequiredToRestrictionType;
+}
+
+export interface IRequiredModuleRestrictionType {
+  /**
+   * A regular expression or an array of regular expressions that select
+   * the modules this required rule should apply to.
+   */
+  path?: string | string[];
+  /**
+   * A regular expression or an array of regular expressions that select
+   * the modules this required rule should not apply to (you can use this
+   * to make exceptions on the `path` attribute)
+   */
+  pathNot?: string | string[];
+}
+
+export interface IRequiredToRestrictionType {
+  /**
+   * A regular expression or an array of regular expressions at least
+   * one of the dependencies of the module should adhere to.
+   */
+  path?: string | string[];
+}
+
 export interface IFlattenedRuleSet {
   /**
    * A list of rules that describe dependencies that are not allowed.
@@ -240,4 +292,12 @@ export interface IFlattenedRuleSet {
    * Defaults to 'warn'
    */
   allowedSeverity?: SeverityType;
+  /**
+   * A list of rules that describe what dependencies modules _must_ have.
+   * E.g.
+   * - every controller needs to (directly) depend on a base controller.
+   * - each source file should be the dependency of a spec file with the same
+   *   base name
+   */
+  required?: IRequiredRuleType[];
 }


### PR DESCRIPTION
## Description

Enables the specification of 'required' rules; rules that put restrictions on what modules must at least depend on. For example (adapted from @hzaun's description in #328)

```javascript
{
  required: [{
    name: "controllers-inherit-from-base",
    comment: "Each controller should inherit from the framework's base controller",
    module: {
      // every module that matches the pattern specified in path & pathNot ...
      path: "-controller\\.js$",
      pathNot: "^src/framework/base-controller\\.js$",
    },
    to: {
      // ... must depend at least once on the framework's base controller
      path: "^src/framework/base-controller\\.js$",
    }
  }]
}
```

It supports

- `path` and `pathNot` criteria for selecting modules to apply the _required_ rule to.
- `path` criterium (including [group matching](https://github.com/sverweij/dependency-cruiser/blob/develop/doc/rules-reference.md#group-matching)) for describing which dependencies must be matched.

This idea can be expanded upon with other attributes (_reachable_ jumps to mind). This PR, however, concentrates on the need behind issue #328. 

List of changes:
- [x] enable specifying required rules and make them part of the validation step (including updating the json schema)
- [x] normalise the required rules before use
- [x] enable use of group placeholders in the dependency-criteria of required rules
- [x] update the  configuration merge algorithm to take required rules into account
- [x] add required rules the teamcity reporter's output (in all other reporters this comes out of the box)
- [x] update typescript types to match the changes in the json schema
- [-] ~~enable reachable?~~ future feature


## Motivation and Context

fixes #328 

## How Has This Been Tested?

- [x] additional automated tests
- [x] automated non-regression tests
- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
