### PR TITLE
bugfix(extract): reduces memory usage by using new version of enhanced-resolve

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -84,7 +84,7 @@
       "severity": "error",
       "from": {
         "pathNot": [
-          "^src/(extract/parse|extract/resolve|extract/gather-initial-sources\\.js|cli)",
+          "^src/(main/resolve-options/normalize\\.js|extract/parse|extract/resolve|extract/gather-initial-sources\\.js|cli)",
           "^test",
           "^tools"
         ]
@@ -225,6 +225,11 @@
     // },
     // "babelConfig": {
     //   "fileName": "./babel.config.json"
+    // },
+    // "enhancedResolveOptions": {
+    //   "cachedInputFileSystem": {
+    //     "cacheDuration": 1800000
+    //   }
     // },
     "exoticRequireStrings": ["tryRequire"],
     "reporterOptions": {

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -1922,6 +1922,52 @@ E.g.:
 }
 ```
 
+#### enhancedResolveOptions
+
+> Likely you will not need to use these.
+
+Under the hood dependency-cruiser uses webpack's
+[enhanced-resolve](https://github.com/webpack/enhanced-resolve).
+to resolve dependencies to disk. You can influence how dependency-cruiser uses
+it directly by passing resolver options in a
+[webpack config](#webpackconfig-use-the-resolution-options-of-a-webpack-configuration)
+for most things. The only exception is the way enhanced-resolve accesses
+the file system - the amount of which we want to have a slightly tighter control
+over as with the wrong settings a lot can go wrong. There's one thing you
+might still want the ability to change though, in a limited number of
+circumstances and that is the time enhanced resolve's files systems retains
+resolutions in memory.
+
+With `cacheDuration` you can tweak the number of milliseconds
+[enhanced-resolve](https://github.com/webpack/enhanced-resolve)'s cached
+file system should use for cache duration. Typicially you won't have to touch
+this - the default works well for repos up to 5000 modules/ 20000 dependencies,
+and likely for numbers above as well. If you experience memory problems on a
+(humongous) repository you can use the cacheDuration attribute to tame
+enhanced-resolve's memory usage by lowering the cache duration trading off against
+some (for values over 1000ms) or significant (for values below 500ms) performance.
+Dependency-cruiser currently uses 4000ms, and in the past has used 1000ms - both
+with good results.
+
+E.g. to set the cache duration to 1337ms, you can use this:
+
+```javascript
+{
+  // ...
+ "options": {
+    // ...
+    "enhancedResolveOptions": {
+      "cachedInputFileSystem": {
+        "cacheDuration": 1000
+      }
+    }
+    // ...
+  }
+}
+```
+
+The cache duration is limited from 0ms (~ don't use a cache) to 1800000ms (0.5h).
+
 ## Configurations in JavaScript
 
 From version 4.7.0 you can pass a JavaScript module to `--validate`.

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ajv": "6.12.3",
     "chalk": "4.1.0",
     "commander": "6.0.0",
-    "enhanced-resolve": "4.3.0",
+    "enhanced-resolve": "5.0.0-beta.10",
     "figures": "3.2.0",
     "get-stream": "5.1.0",
     "glob": "7.1.6",
@@ -172,6 +172,14 @@
     "vue-template-compiler": "2.6.11",
     "yarn": "1.22.4",
     "~": "file:."
+  },
+  "upem": {
+    "donotup": [
+      {
+        "package": "enhanced-resolve",
+        "because": "we're running with enhanced-resolve version 5, which is faster, uses less memory - but also still is in beta"
+      }
+    ]
   },
   "nyc": {
     "statements": 99.85,

--- a/src/enrich/add-validations.js
+++ b/src/enrich/add-validations.js
@@ -13,11 +13,12 @@ function addDependencyViolations(pModule, pDependency, pRuleSet, pValidate) {
  * - when there's a transgression: adds it
  * - when everything is hunky-dory: adds the dependency is valid
  *
- * @param  {Object} pModules [description]
- * @param  {Object} pRuleSet [description]
- * @return {Object}               the same dependencies, but for each
- *                                of them added whether or not it is
- *                                part of
+ * @param  {Partial<import("../../types/cruise-result").IModule>[]} pModules array of modules
+ * @param  {import("../../types/rule-set").IFlattenedRuleSet} pRuleSet normalized & validated rule set
+ * @param {boolean} pValidate - whether or not to validate (typically you want to pass 'true' here)
+ * @return {import("../../types/cruise-result").IModule[]} the same array of modules, with for each
+ *                  of them added whether or not it is
+ *                  valid and if not which rules were violated
  */
 module.exports = (pModules, pRuleSet, pValidate) =>
   pModules.map((pModule) => ({

--- a/src/enrich/summarize-options.js
+++ b/src/enrich/summarize-options.js
@@ -22,6 +22,7 @@ const SHAREABLE_OPTIONS = [
   "exoticallyRequired",
   "exoticRequireStrings",
   "reporterOptions",
+  "enhancedResolveOptions",
 ];
 
 function makeOptionsPresentable(pOptions) {

--- a/src/enrich/summarize.js
+++ b/src/enrich/summarize.js
@@ -2,6 +2,19 @@ const summarizeModules = require("./summarize-modules");
 const summarizeOptions = require("./summarize-options");
 const addRuleSetUsed = require("./add-rule-set-used");
 
+/**
+ *
+ * @param {import("../../types/cruise-result").IModule[]} pModules -
+ *    cruised modules that have been enriched with mandatory attributes &
+ *    have been validated against rules as passed in the options
+ * @param {import("../../types/options").ICruiseOptions} pOptions -
+ *
+ * @param {string[]} pFileDirectoryArray -
+ *    the files/ directories originally passed to be cruised
+ *
+ * @returns {import("../../types/cruise-result").ISummary} -
+ *    a summary of the found modules, dependencies and any violations
+ */
 module.exports = function makeSummary(pModules, pOptions, pFileDirectoryArray) {
   return Object.assign(
     summarizeModules(pModules, pOptions.ruleSet),

--- a/src/extract/clear-caches.js
+++ b/src/extract/clear-caches.js
@@ -5,7 +5,7 @@ const readPackageDeps = require("./resolve/get-manifest-dependencies");
 const resolveAMD = require("./resolve/resolve-amd");
 const resolve = require("./resolve/resolve");
 
-module.exports = () => {
+module.exports = function clearCaches() {
   toTypescriptAST.clearCache();
   toJavascriptAST.clearCache();
   localNpmHelpers.clearCache();

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -140,7 +140,7 @@ module.exports = (
 ) => {
   clearCaches();
 
-  return _uniqBy(
+  const lReturnValue = _uniqBy(
     extractFileDirectoryArray(
       pFileDirectoryArray,
       pCruiseOptions,
@@ -151,4 +151,7 @@ module.exports = (
   ).map((pModule) =>
     filterExcludedDynamicDependencies(pModule, pCruiseOptions.exclude)
   );
+  pResolveOptions.fileSystem.purge();
+  clearCaches();
+  return lReturnValue;
 };

--- a/src/main/resolve-options/normalize.js
+++ b/src/main/resolve-options/normalize.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const _get = require("lodash/get");
 const _has = require("lodash/has");
 const enhancedResolve = require("enhanced-resolve");
@@ -5,7 +6,7 @@ const PnpWebpackPlugin = require("pnp-webpack-plugin");
 const TsConfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const transpileMeta = require("../../extract/transpile/meta");
 
-const CACHE_DURATION = 4000;
+const DEFAULT_CACHE_DURATION = 4000;
 const DEFAULT_RESOLVE_OPTIONS = {
   // for later: check semantics of enhanced-resolve symlinks and
   // node's preserveSymlinks. They seem to be
@@ -30,26 +31,25 @@ const DEFAULT_RESOLVE_OPTIONS = {
   modules: ["node_modules", "node_modules/@types"],
 };
 
-const NON_OVERRIDABLE_RESOLVE_OPTIONS = {
-  // This should cover most of the bases of dependency-cruiser's
-  // uses. Not overridable for now because for other
-  // file systems it's not sure we can use sync system calls
-  // Also: passing a non-cached filesystem makes performance
-  // worse.
-  fileSystem: new enhancedResolve.CachedInputFileSystem(
-    new enhancedResolve.NodeJsInputFileSystem(),
-    CACHE_DURATION
-  ),
-  // our code depends on sync behavior, so having this
-  // overriden is not an option
-  useSyncFileSystemCalls: true,
-};
+function getNonOverridableResolveOptions(pCacheDuration) {
+  return {
+    // This should cover most of the bases of dependency-cruiser's
+    // uses. Not overridable for now because for other
+    // file systems it's not sure we can use sync system calls
+    // Also: passing a non-cached filesystem makes performance
+    // worse.
+    fileSystem: new enhancedResolve.CachedInputFileSystem(fs, pCacheDuration),
+    // our code depends on sync behavior, so having this
+    // overriden is not an option
+    useSyncFileSystemCalls: true,
+  };
+}
 
 function pushPlugin(pPlugins, pPluginToPush) {
   return (pPlugins || []).concat(pPluginToPush);
 }
 
-function compileResolveOptions(pResolveOptions, pTSConfig) {
+function compileResolveOptions(pResolveOptions, pTSConfig, pCacheDuration) {
   let lResolveOptions = {};
 
   // TsConfigPathsPlugin requires a baseUrl to be present in the
@@ -84,7 +84,7 @@ function compileResolveOptions(pResolveOptions, pTSConfig) {
     ...DEFAULT_RESOLVE_OPTIONS,
     ...lResolveOptions,
     ...pResolveOptions,
-    ...NON_OVERRIDABLE_RESOLVE_OPTIONS,
+    ...getNonOverridableResolveOptions(pCacheDuration),
   };
 }
 
@@ -92,23 +92,28 @@ module.exports = (pResolveOptions, pOptions, pTSConfig) =>
   compileResolveOptions(
     {
       /*
-            for later: check semantics of enhanced-resolve symlinks and
-            node's preserveSymlinks. They seem to be
-            symlink === !preserveSymlinks - but using it that way
-            breaks backwards compatibility
-        */
+        for later: check semantics of enhanced-resolve symlinks and
+        node's preserveSymlinks. They seem to be
+        symlink === !preserveSymlinks - but using it that way
+        breaks backwards compatibility
+      */
       symlinks: pOptions.preserveSymlinks,
       tsConfig: _get(pOptions, "ruleSet.options.tsConfig.fileName", null),
 
       /* squirel the externalModuleResolutionStrategy and combinedDependencies
-            thing into the resolve options
-            - they're not for enhanced resolve, but they are for what we consider
-            resolve options ...
-        */
+         thing into the resolve options
+         - they're not for enhanced resolve, but they are for what we consider
+         resolve options ...
+       */
       externalModuleResolutionStrategy:
         pOptions.externalModuleResolutionStrategy,
       combinedDependencies: pOptions.combinedDependencies,
       ...(pResolveOptions || {}),
     },
-    pTSConfig || {}
+    pTSConfig || {},
+    _get(
+      pOptions,
+      "enhancedResolveOptions.cachedInputFileSystem.cacheDuration",
+      DEFAULT_CACHE_DURATION
+    )
   );

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -331,7 +331,7 @@
           ]
         },
         "maxDepth": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "maximum": 99,
           "description": "The maximum cruise depth specified. 0 means no maximum specified"
@@ -385,6 +385,25 @@
             "arguments": {
               "type": "object",
               "description": "Arguments to pass if your config file returns a function. E.g. {mode: 'production'} if you want to use webpack 4's 'mode' feature"
+            }
+          }
+        },
+        "enhancedResolveOptions": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Options used in module resolution that for dependency-cruiser's use cannot go in a webpack config.",
+          "properties": {
+            "cachedInputFileSystem": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cacheDuration": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 1800000,
+                  "description": "The number of milliseconds [enhanced-resolve](webpack/enhanced-resolve)'s cached file system should use for cache duration. Typicially you won't have to touch this - the default works well for repos up to 5000 modules/ 20000 dependencies, and likely for numbers above as well. If you experience memory problems on a (humongous) repository you can use the cacheDuration attribute to tame enhanced-resolve's memory usage by lowering the cache duration trading off against some (for values over 1000ms) or significant (for values below 500ms) performance. Dependency-cruiser currently uses 1000ms, and in the past has used 4000ms - both with good results."
+                }
+              }
             }
           }
         },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -581,7 +581,7 @@
         },
         "focus": { "$ref": "#/definitions/CompoundFocusType" },
         "maxDepth": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "maximum": 99,
           "description": "The maximum cruise depth specified. 0 means no maximum specified"
@@ -635,6 +635,25 @@
             "arguments": {
               "type": "object",
               "description": "Arguments to pass if your config file returns a function. E.g. {mode: 'production'} if you want to use webpack 4's 'mode' feature"
+            }
+          }
+        },
+        "enhancedResolveOptions": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Options used in module resolution that for dependency-cruiser's use cannot go in a webpack config.",
+          "properties": {
+            "cachedInputFileSystem": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cacheDuration": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 1800000,
+                  "description": "The number of milliseconds [enhanced-resolve](webpack/enhanced-resolve)'s cached file system should use for cache duration. Typicially you won't have to touch this - the default works well for repos up to 5000 modules/ 20000 dependencies, and likely for numbers above as well. If you experience memory problems on a (humongous) repository you can use the cacheDuration attribute to tame enhanced-resolve's memory usage by lowering the cache duration trading off against some (for values over 1000ms) or significant (for values below 500ms) performance. Dependency-cruiser currently uses 1000ms, and in the past has used 4000ms - both with good results."
+                }
+              }
             }
           }
         },

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -84,11 +84,13 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
  * If pValidate equals true, validates the pFrom and pTo
  * dependency pair against the given ruleset pRuleSet
  *
- * @param  {object} pRuleSet  a ruleset (adhering to
- *                            [the ruleset schema](jsonschema.json))
- * @param  {object} pFrom     The from part of the dependency
- * @param  {object} pTo       The 'to' part of the dependency
- * @return {object}           an object with as attributes:
+ * @param  {import("../../types/rule-set").IFlattenedRuleSet} pRuleSet
+ *    a ruleset (adhering to  [the ruleset schema](jsonschema.json))
+ * @param  {import("../../types/cruise-result").IModule} pFrom
+ *    The from part of the dependency
+ * @param  {import("../../types/cruise-result").IModule} pTo
+ *    The 'to' part of the dependency
+ * @return {any}           an object with as attributes:
  *                            - valid: (boolean) true if the relation
  *                              between pTo and pFalse is valid (as far as the
  *                              given ruleset is concerend). false in all other

--- a/src/validate/match-module-rule.js
+++ b/src/validate/match-module-rule.js
@@ -4,7 +4,6 @@ const matchers = require("./matchers");
 function matchesOrphanRule(pRule, pModule) {
   return (
     Object.prototype.hasOwnProperty.call(pRule.from, "orphan") &&
-    Object.prototype.hasOwnProperty.call(pModule, "orphan") &&
     pModule.orphan === pRule.from.orphan &&
     matchers.fromPath(pRule, pModule) &&
     matchers.fromPathNot(pRule, pModule)

--- a/test/extract/resolve/local-npm-helpers.spec.js
+++ b/test/extract/resolve/local-npm-helpers.spec.js
@@ -1,18 +1,30 @@
 const { expect } = require("chai");
+const clearCaches = require("~/src/extract/clear-caches");
 const localNpmHelpers = require("~/src/extract/resolve/local-npm-helpers");
+const normalizeResolveOptions = require("~/src/main/resolve-options/normalize");
+const normalizeOptions = require("~/src/main/options/normalize");
 
+const BASIC_RESOLVE_OPTIONS = normalizeResolveOptions({}, normalizeOptions({}));
 describe("extract/resolve/localNpmHelpers.getPackageJson", () => {
+  beforeEach(() => {
+    clearCaches();
+  });
   it("returns null if the module does not exist", () => {
-    expect(localNpmHelpers.getPackageJson("./module-does-not-exist", ".", {}))
-      .to.be.null;
+    expect(
+      localNpmHelpers.getPackageJson(
+        "./module-does-not-exist",
+        process.cwd(),
+        BASIC_RESOLVE_OPTIONS
+      )
+    ).to.be.null;
   });
 
   it("returns null if there's no package.json for the module (no basePath specified)", () => {
     expect(
       localNpmHelpers.getPackageJson(
         "test/extract/fixtures/deprecated-node-module/require-something-deprecated",
-        ".",
-        {}
+        process.cwd(),
+        BASIC_RESOLVE_OPTIONS
       )
     ).to.be.null;
   });
@@ -22,13 +34,20 @@ describe("extract/resolve/localNpmHelpers.getPackageJson", () => {
       localNpmHelpers.getPackageJson(
         "./require-something-deprecated",
         "./fixtures/deprecated-node-module/",
-        {}
+        BASIC_RESOLVE_OPTIONS
       )
     ).to.be.null;
   });
 
-  it("returns a package.json when there is one", () => {
-    let lPackageJson = localNpmHelpers.getPackageJson("chai", ".", {});
+  it("returns a package.json when there is one (root)", () => {
+    let lPackageJson = localNpmHelpers.getPackageJson(
+      "chai",
+      // TODO: workaround for what looks like a defect in enhanced-resolve@beta;
+      //       "." as context doesn't work anymore, so passing process.cwd()
+      //       in stead.
+      process.cwd(),
+      BASIC_RESOLVE_OPTIONS
+    );
 
     expect(lPackageJson).to.be.not.null;
     expect(Object.prototype.hasOwnProperty.call(lPackageJson, "name")).to.be
@@ -40,7 +59,7 @@ describe("extract/resolve/localNpmHelpers.getPackageJson", () => {
     let lPackageJson = localNpmHelpers.getPackageJson(
       "deprecated-at-the-start-for-test-purposes",
       "./test/main/fixtures/cruise-reporterless/deprecated-node-module/",
-      {}
+      BASIC_RESOLVE_OPTIONS
     );
 
     expect(lPackageJson).to.be.not.null;

--- a/tools/schema/options.mjs
+++ b/tools/schema/options.mjs
@@ -50,7 +50,7 @@ export default {
           ],
         },
         maxDepth: {
-          type: "number",
+          type: "integer",
           minimum: 0,
           maximum: 99,
           description:
@@ -139,6 +139,38 @@ export default {
               description:
                 "Arguments to pass if your config file returns a function. E.g. " +
                 "{mode: 'production'} if you want to use webpack 4's 'mode' feature",
+            },
+          },
+        },
+        enhancedResolveOptions: {
+          type: "object",
+          additionalProperties: false,
+          description:
+            "Options used in module resolution that for dependency-cruiser's " +
+            "use cannot go in a webpack config.",
+          properties: {
+            cachedInputFileSystem: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                cacheDuration: {
+                  type: "integer",
+                  minimum: 0,
+                  // half an hour cache duration should suffice methinks
+                  maximum: 1800000,
+                  description:
+                    "The number of milliseconds [enhanced-resolve](webpack/enhanced-resolve)'s " +
+                    "cached file system should use for cache duration. Typicially you won't " +
+                    "have to touch this - the default works well for repos up to 5000 modules/ " +
+                    "20000 dependencies, and likely for numbers above as well. " +
+                    "If you experience memory problems on a (humongous) repository you can " +
+                    "use the cacheDuration attribute to tame enhanced-resolve's memory " +
+                    "usage by lowering the cache duration trading off against some (for " +
+                    "values over 1000ms) or significant (for values below 500ms) performance. " +
+                    "Dependency-cruiser currently uses 1000ms, and in the past has " +
+                    "used 4000ms - both with good results.",
+                },
+              },
             },
           },
         },

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -125,4 +125,28 @@ export interface ICruiseOptions {
    * Options to tweak the output of reporters
    */
   reporterOptions?: IReporterOptions;
+
+  /**
+   * Options used in module resolution that for dependency-cruiser's
+   * use cannot go in a webpack config.
+   */
+  enhancedResolveOptions?: {
+    cachedInputFileSystem?: {
+      /**
+       * The number of milliseconds [enhanced-resolve](webpack/enhanced-resolve)'s
+       * cached file system should use for cache duration. Typicially you won't
+       * have to touch this - the default works well for repos up to 5000 modules/
+       * 20000 dependencies, and likely for numbers above as well.
+       *
+       * If you experience memory problems on a (humongous) repository you can
+       * use the cacheDuration attribute to tame enhanced-resolve's memory
+       * usage by lowering the cache duration trading off against some (for
+       * values over 1000ms) or significant (for values below 500ms) performance.
+       *
+       * Dependency-cruiser currently uses 1000ms, and in the past has
+       * used 4000ms - both with good results.
+       */
+      cacheDuration: number;
+    };
+  };
 }


### PR DESCRIPTION
## Description

- makes it work with the new version of enhanced-resolve (v5.x.x - currently still in beta...)
- frees additional memory after the extract step by calling ehr's purge & clearing the memoization-caches (not only the nice to do, but also useful for those using the API and doing multiple cruises per session).
- adds an option in the configuration that enables you to tweak the enhanced-resolve's cached file system's cache duration (see below for an example - minimum duration: 0ms maximum duration: 1800000ms (0.5h))
- ~~lowers the default cache duration from 4000ms to 1000ms (both turn out to be approximately as fast, but the latter consumes way less memory).~~ (_keeps_ the cache duration at 4s as on slower file systems (and fast file systems with a virus scanner activated ...) the impact on processing speed between 1s and 4s of cache is quite noticeable).

To set the cache duration to 1337ms, you can use this: 

```javascript
{
  // ...
 "options": {
    // ...
    "enhancedResolveOptions": {
      "cachedInputFileSystem": {
        "cacheDuration": 1337
      }
    }
    // ...
  }
}
```

> - [x] I'm still a bit in doubt whether I should open up the whole file system options, in stead of this very specific pass-through:
> pro: makes it easier to experiment with new file systems & caching strategies (like @jomi-se 's LRU cache)
> con: super easy to break dc's performance (or entire operation) by passing the wrong file systems (e.g. an async one, or one using no cache ...)
> ***=>*** keep the specific pass-through. We can experiment by other means
> - [x] Another dillema: 
>  - wait for enhanced-resolve 5 to come out to publish this feature
>  - publish it as a beta until ehr release 5, or just 
>  - ***=>*** trust ehr's beta branch and put it in dc 9.9.3

## Motivation and Context

Fixes #332 
## How Has This Been Tested?

- [x] automated non-regression tests
- [x] manual performance tests (with hyperfine: `npm run test:load` and `npm run test:load:short`)
- [x] manual memory utilisation tests (@jomi-se 's instructions in #332 were rather helpful with that...)
- [x] green ci

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
