### PR TITLE
refactor(enrich|validate): sanitize validate interface

### DIFF
--- a/src/enrich/add-validations.js
+++ b/src/enrich/add-validations.js
@@ -1,23 +1,29 @@
 const validate = require("../validate");
 
+function addDependencyViolations(pModule, pDependency, pRuleSet, pValidate) {
+  return {
+    ...pDependency,
+    ...(pValidate
+      ? validate.dependency(pRuleSet, pModule, pDependency)
+      : { valid: true }),
+  };
+}
 /**
  * Runs through all dependencies, validates them
  * - when there's a transgression: adds it
  * - when everything is hunky-dory: adds the dependency is valid
  *
  * @param  {Object} pModules [description]
- * @param  {Object} pValidate [description]
  * @param  {Object} pRuleSet [description]
  * @return {Object}               the same dependencies, but for each
  *                                of them added whether or not it is
  *                                part of
  */
-module.exports = (pModules, pValidate, pRuleSet) =>
+module.exports = (pModules, pRuleSet, pValidate) =>
   pModules.map((pModule) => ({
     ...pModule,
-    ...validate.module(pValidate, pRuleSet, pModule),
-    dependencies: pModule.dependencies.map((pDependency) => ({
-      ...pDependency,
-      ...validate.dependency(pValidate, pRuleSet, pModule, pDependency),
-    })),
+    ...(pValidate ? validate.module(pRuleSet, pModule) : { valid: true }),
+    dependencies: pModule.dependencies.map((pDependency) =>
+      addDependencyViolations(pModule, pDependency, pRuleSet, pValidate)
+    ),
   }));

--- a/src/enrich/enrich-modules.js
+++ b/src/enrich/enrich-modules.js
@@ -10,6 +10,11 @@ module.exports = function enrichModules(pModules, pOptions) {
   lModules = deriveOrphans(lModules);
   lModules = deriveReachable(lModules, pOptions.ruleSet);
   lModules = addFocus(lModules, _get(pOptions, "focus"));
-  lModules = addValidations(lModules, pOptions.validate, pOptions.ruleSet);
+
+  // when validate === false we might want to skip the addValidations.
+  // We don't at this time, however, as "valid" is a mandatory
+  // attribute (to simplify reporter logic)
+  lModules = addValidations(lModules, pOptions.ruleSet, pOptions.validate);
+
   return lModules;
 };

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -84,7 +84,6 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
  * If pValidate equals true, validates the pFrom and pTo
  * dependency pair against the given ruleset pRuleSet
  *
- * @param  {Boolean} pValidate whether or not to validate at all
  * @param  {object} pRuleSet  a ruleset (adhering to
  *                            [the ruleset schema](jsonschema.json))
  * @param  {object} pFrom     The from part of the dependency
@@ -102,16 +101,8 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
  *                                  the ruleset
  */
 module.exports = {
-  module: (pValidate, pRuleSet, pModule) => {
-    if (!pValidate) {
-      return { valid: true };
-    }
-    return validateAgainstRules(pRuleSet, pModule, {}, matchModuleRule);
-  },
-  dependency: (pValidate, pRuleSet, pFrom, pTo) => {
-    if (!pValidate) {
-      return { valid: true };
-    }
-    return validateAgainstRules(pRuleSet, pFrom, pTo, matchDependencyRule);
-  },
+  module: (pRuleSet, pModule) =>
+    validateAgainstRules(pRuleSet, pModule, {}, matchModuleRule),
+  dependency: (pRuleSet, pFrom, pTo) =>
+    validateAgainstRules(pRuleSet, pFrom, pTo, matchDependencyRule),
 };

--- a/test/validate/index.exotic-require.spec.js
+++ b/test/validate/index.exotic-require.spec.js
@@ -6,7 +6,6 @@ describe("validate/index - exoticallyRequired", () => {
   it("does not flag dependencies that are required with a regular require or import", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotically-required.json"),
         { source: "something" },
         {
@@ -20,7 +19,6 @@ describe("validate/index - exoticallyRequired", () => {
   it("does flag dependencies that are required with any exotic require", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotically-required.json"),
         { source: "something" },
         {
@@ -40,7 +38,6 @@ describe("validate/index - exoticRequire", () => {
   it("does not flag dependencies that are required with a regular require or import", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotic-require.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -51,7 +48,6 @@ describe("validate/index - exoticRequire", () => {
   it("does not flag dependencies that are required with an exotic require not in the forbdidden RE", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotic-require.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts", exoticRequire: "notUse" }
@@ -62,7 +58,6 @@ describe("validate/index - exoticRequire", () => {
   it("flags dependencies that are required with a forbidden exotic require", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotic-require.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts", exoticRequire: "use" }
@@ -78,7 +73,6 @@ describe("validate/index - exoticRequireNot", () => {
   it("does not flag dependencies that are required with a regular require or import", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotic-require-not.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -89,7 +83,6 @@ describe("validate/index - exoticRequireNot", () => {
   it("does not flag dependencies that are required with a sanctioned exotic require", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotic-require-not.json"),
         { source: "something" },
         {
@@ -103,7 +96,6 @@ describe("validate/index - exoticRequireNot", () => {
   it("flags dependencies are required with an unsanctioned exotic require", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.exotic-require-not.json"),
         { source: "something" },
         {

--- a/test/validate/index.groupmatching.spec.js
+++ b/test/validate/index.groupmatching.spec.js
@@ -6,7 +6,6 @@ describe("validate/index group matching - path group matched in a pathnot", () =
   it("group-to-pathnot - Disallows dependencies between peer folders", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/noot/pinda.ts" }
@@ -25,7 +24,6 @@ describe("validate/index group matching - path group matched in a pathnot", () =
   it("group-to-pathnot - Allows dependencies within to peer folder 'shared'", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/shared/bananas.ts" }
@@ -36,7 +34,6 @@ describe("validate/index group matching - path group matched in a pathnot", () =
   it("group-to-pathnot - Allows dependencies within own folder", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/oerangoetang.ts" }
@@ -47,7 +44,6 @@ describe("validate/index group matching - path group matched in a pathnot", () =
   it("group-to-pathnot - Allows dependencies to sub folders of own folder", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -58,7 +54,6 @@ describe("validate/index group matching - path group matched in a pathnot", () =
   it("group-to-pathnot - Allows peer dependencies between sub folders of own folder", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-to-pathnot.json"),
         { source: "src/aap/rekwisieten/touw.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -71,7 +66,6 @@ describe("validate/index group matching - second path group matched in a pathnot
   it("group-two-to-pathnot - Disallows dependencies between peer folders", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/noot/pinda.ts" }
@@ -90,7 +84,6 @@ describe("validate/index group matching - second path group matched in a pathnot
   it("group-two-to-pathnot - Allows dependencies within to peer folder 'shared'", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/shared/bananas.ts" }
@@ -101,7 +94,6 @@ describe("validate/index group matching - second path group matched in a pathnot
   it("group-two-to-pathnot - Allows dependencies within own folder", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/oerangoetang.ts" }
@@ -112,7 +104,6 @@ describe("validate/index group matching - second path group matched in a pathnot
   it("group-two-to-pathnot - Allows dependencies to sub folders of own folder", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -123,7 +114,6 @@ describe("validate/index group matching - second path group matched in a pathnot
   it("group-two-to-pathnot - Allows peer dependencies between sub folders of own folder", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.group-two-to-pathnot.json"),
         { source: "src/aap/rekwisieten/touw.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }

--- a/test/validate/index.license.spec.js
+++ b/test/validate/index.license.spec.js
@@ -6,7 +6,6 @@ describe("validate/index - license", () => {
   it("Skips dependencies that have no license attached", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.license.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -17,7 +16,6 @@ describe("validate/index - license", () => {
   it("does not flag dependencies that do not match the license expression", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.license.json"),
         { source: "something" },
         {
@@ -31,7 +29,6 @@ describe("validate/index - license", () => {
   it("flags dependencies that match the license expression", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.license.json"),
         { source: "something" },
         {
@@ -50,7 +47,6 @@ describe("validate/index - licenseNot", () => {
   it("Skips dependencies that have no license attached", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" }
@@ -61,7 +57,6 @@ describe("validate/index - licenseNot", () => {
   it("does not flag dependencies that do match the license expression", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
         { source: "something" },
         {
@@ -75,7 +70,6 @@ describe("validate/index - licenseNot", () => {
   it("flags dependencies that do not match the license expression", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.licensenot.json"),
         { source: "something" },
         {

--- a/test/validate/index.orphans.spec.js
+++ b/test/validate/index.orphans.spec.js
@@ -6,7 +6,6 @@ describe("validate/index - orphans", () => {
   it("Skips modules that have no orphan attribute", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.json"),
         { source: "something" }
       )
@@ -16,7 +15,6 @@ describe("validate/index - orphans", () => {
   it("Flags modules that are orphans", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.json"),
         {
           source: "something",
@@ -37,7 +35,6 @@ describe("validate/index - orphans", () => {
   it("Flags modules that are orphans if they're in the 'allowed' section", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.allowed.json"),
         {
           source: "something",
@@ -58,7 +55,6 @@ describe("validate/index - orphans", () => {
   it("Leaves modules alone that aren't orphans if there's a rule in the 'allowed' section forbidding them", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.allowed.json"),
         {
           source: "something",
@@ -71,7 +67,6 @@ describe("validate/index - orphans", () => {
   it("Leaves modules that are orphans, but that don't match the rule path", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
         {
           source: "something",
@@ -84,7 +79,6 @@ describe("validate/index - orphans", () => {
   it("Flags modules that are orphans and that match the rule's path", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
         {
           source: "noorphansallowedhere/blah/something.ts",
@@ -105,7 +99,6 @@ describe("validate/index - orphans", () => {
   it("Leaves modules that are orphans, but that do match the rule's pathNot", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.pathnot.json"),
         {
           source: "orphansallowedhere/something",
@@ -118,7 +111,6 @@ describe("validate/index - orphans", () => {
   it("Flags modules that are orphans, but that do not match the rule's pathNot", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.pathnot.json"),
         {
           source: "blah/something.ts",
@@ -139,7 +131,6 @@ describe("validate/index - orphans", () => {
   it("The 'dependency' validation leaves the module only orphan rule alone", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.orphan.path.json"),
         {
           source: "noorphansallowedhere/something.ts",

--- a/test/validate/index.pre-compilation-only.spec.js
+++ b/test/validate/index.pre-compilation-only.spec.js
@@ -6,7 +6,6 @@ describe("validate/index - preCompilationOnly", () => {
   it("Stuff that still exists after compilation - okeleedokelee", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.pre-compilation-only.json"),
         { source: "something" },
         { resolved: "real-stuff-only.ts", preCompilationOnly: false }
@@ -17,7 +16,6 @@ describe("validate/index - preCompilationOnly", () => {
   it("Stuff that only exists before compilation - flaggeleedaggelee", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.pre-compilation-only.json"),
         { source: "something" },
         { resolved: "types.d.ts", preCompilationOnly: true }
@@ -31,7 +29,6 @@ describe("validate/index - preCompilationOnly", () => {
   it("Unknown whether stuff that only exists before compilation - okeleedokelee", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.pre-compilation-only.json"),
         { source: "something" },
         { resolved: "types.d.ts" }

--- a/test/validate/index.reachable.spec.js
+++ b/test/validate/index.reachable.spec.js
@@ -6,7 +6,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Skips modules that have no reachable attribute (reachable false)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-false.json"),
         { source: "something" }
       )
@@ -16,7 +15,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Skips modules that have no reachable attribute (reachable true)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-true.json"),
         { source: "something" }
       )
@@ -26,7 +24,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (non-matching, reachable false)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-false.json"),
         {
           source: "something",
@@ -39,7 +36,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (non-matching, reachable true)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-true.json"),
         {
           source: "something",
@@ -52,7 +48,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (reachable false)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-false.json"),
         {
           source: "something",
@@ -73,7 +68,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (reachable true)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-true.json"),
         {
           source: "something",
@@ -94,7 +88,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (with a path, reachable false)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-false.path.json"),
         {
           source: "something",
@@ -115,7 +108,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (with a path, reachable true)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable-true.path.json"),
         {
           source: "something",
@@ -136,7 +128,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (with a pathNot, reachable false)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.reachable-false.pathnot.json"
         ),
@@ -151,7 +142,6 @@ describe("validate/index - reachable (in forbidden set)", () => {
   it("Triggers on modules that have a reachable attribute (with a pathNot, reachable true)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.reachable-true.pathnot.json"
         ),
@@ -167,7 +157,6 @@ describe("validate/index - reachable (in allowed set)", () => {
   it("Triggers on modules that have no reachable attribute ('allowed' rule set)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
         {
           source: "something",
@@ -187,7 +176,6 @@ describe("validate/index - reachable (in allowed set)", () => {
   it("Skips on modules that have a reachable attribute (match - 'allowed' rule set)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
         {
           source: "something",
@@ -207,7 +195,6 @@ describe("validate/index - reachable (in allowed set)", () => {
   it("Triggers on modules that have a reachable attribute (no match - 'allowed' rule set)", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.reachable.allowed.json"),
         {
           source: "something",

--- a/test/validate/index.required-rules.spec.js
+++ b/test/validate/index.required-rules.spec.js
@@ -6,7 +6,6 @@ describe("validate/index - required rules", () => {
   it("modules not matching the module criteria from the required rule are okeliedokelie", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.required.json"),
         { source: "something" }
       )
@@ -16,7 +15,6 @@ describe("validate/index - required rules", () => {
   it("modules matching the module criteria with no dependencies bork", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.required.json"),
         { source: "grub-controller.ts", dependencies: [] }
       )
@@ -29,7 +27,6 @@ describe("validate/index - required rules", () => {
   it("modules matching the module criteria with no matching dependencies bork", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.required.json"),
         {
           source: "grub-controller.ts",
@@ -52,7 +49,6 @@ describe("validate/index - required rules", () => {
   it("'required' violations don't get flagged as dependency transgressions", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.required.json"),
         {
           source: "grub-controller.ts",
@@ -74,7 +70,6 @@ describe("validate/index - required rules", () => {
   it("modules matching the module criteria with matching dependencies are okeliedokelie", () => {
     expect(
       validate.module(
-        true,
         readRuleSet("./test/validate/fixtures/rules.required.json"),
         {
           source: "grub-controller.ts",

--- a/test/validate/index.spec.js
+++ b/test/validate/index.spec.js
@@ -6,7 +6,6 @@ describe("validate/index dependency - generic tests", () => {
   it("is ok with the empty validation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.empty.json"),
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" }
@@ -17,7 +16,6 @@ describe("validate/index dependency - generic tests", () => {
   it("is ok with the 'everything allowed' validation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.everything-allowed.json"),
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" }
@@ -28,7 +26,6 @@ describe("validate/index dependency - generic tests", () => {
   it("is ok with the 'everything allowed' validation - even when there's a module only rule in 'forbidden'", () => {
     expect(
       validate.module(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.module-only.empty.allowed.json"
         ),
@@ -40,7 +37,6 @@ describe("validate/index dependency - generic tests", () => {
   it("is ok with the 'impossible to match allowed' validation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.impossible-to-match-allowed.json"
         ),
@@ -56,7 +52,6 @@ describe("validate/index dependency - generic tests", () => {
   it("is ok with the 'impossible to match allowed' validation - errors when configured so", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.impossible-to-match-error.allowed.json"
         ),
@@ -72,7 +67,6 @@ describe("validate/index dependency - generic tests", () => {
   it("is ok with the 'nothing allowed' validation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.nothing-allowed.json"),
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" }
@@ -86,7 +80,6 @@ describe("validate/index dependency - generic tests", () => {
   it("if there's more than one violated rule, both are returned", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.not-in-allowed-and-a-forbidden.json"
         ),
@@ -109,7 +102,6 @@ describe("validate/index - specific tests", () => {
   it("node_modules inhibition - ok", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.node_modules-not-allowed.json"
         ),
@@ -122,7 +114,6 @@ describe("validate/index - specific tests", () => {
   it("node_modules inhibition - violation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.node_modules-not-allowed.json"
         ),
@@ -138,7 +129,6 @@ describe("validate/index - specific tests", () => {
   it("not to core - ok", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-core.json"),
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["npm"] }
@@ -149,7 +139,6 @@ describe("validate/index - specific tests", () => {
   it("not to core - violation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-core.json"),
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["core"] }
@@ -163,7 +152,6 @@ describe("validate/index - specific tests", () => {
   it("not to core fs os - ok", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-core-fs-os.json"),
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["core"] }
@@ -174,7 +162,6 @@ describe("validate/index - specific tests", () => {
   it("not to core fs os - violation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-core-fs-os.json"),
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] }
@@ -188,7 +175,6 @@ describe("validate/index - specific tests", () => {
   it("not to unresolvable - ok", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-unresolvable.json"),
         { source: "koos koets" },
         { resolved: "diana charitee", couldNotResolve: false }
@@ -199,7 +185,6 @@ describe("validate/index - specific tests", () => {
   it("not to unresolvable - violation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-unresolvable.json"),
         { source: "koos koets" },
         { resolved: "diana charitee", couldNotResolve: true }
@@ -213,7 +198,6 @@ describe("validate/index - specific tests", () => {
   it("only to core - via 'allowed' - ok", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.only-to-core.allowed.json"),
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] }
@@ -224,7 +208,6 @@ describe("validate/index - specific tests", () => {
   it("only to core - via 'allowed' - violation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.only-to-core.allowed.json"),
         { source: "koos koets" },
         { resolved: "ger hekking", dependencyTypes: ["npm"] }
@@ -238,7 +221,6 @@ describe("validate/index - specific tests", () => {
   it("only to core - via 'forbidden' - ok", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.only-to-core.forbidden.json"
         ),
@@ -251,7 +233,6 @@ describe("validate/index - specific tests", () => {
   it("only to core - via 'forbidden' - violation", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.only-to-core.forbidden.json"
         ),
@@ -267,7 +248,6 @@ describe("validate/index - specific tests", () => {
   it("not to sub except sub itself - ok - sub to sub", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
@@ -280,7 +260,6 @@ describe("validate/index - specific tests", () => {
   it("not to sub except sub itself - ok - not sub to not sub", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
@@ -293,7 +272,6 @@ describe("validate/index - specific tests", () => {
   it("not to sub except sub itself - ok - sub to not sub", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
@@ -306,7 +284,6 @@ describe("validate/index - specific tests", () => {
   it("not to sub except sub itself  - violation - not sub to sub", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.not-to-sub-except-sub.json"
         ),
@@ -322,7 +299,6 @@ describe("validate/index - specific tests", () => {
   it("not to not sub (=> everything must go to 'sub')- ok - sub to sub", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-not-sub.json"),
         { source: "./keek/op/de/sub/week.js" },
         { resolved: "./keek/op/de/sub/maand.js", coreModule: false }
@@ -333,7 +309,6 @@ describe("validate/index - specific tests", () => {
   it("not to not sub (=> everything must go to 'sub')- violation - not sub to not sub", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-not-sub.json"),
         { source: "./amber.js" },
         { resolved: "./jade.js", coreModule: false }
@@ -347,7 +322,6 @@ describe("validate/index - specific tests", () => {
   it("not-to-dev-dep disallows relations to develop dependencies", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-dev-dep.json"),
         { source: "src/aap/zus/jet.js" },
         {
@@ -370,7 +344,6 @@ describe("validate/index - specific tests", () => {
   it("not-to-dev-dep does allow relations to regular dependencies", () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet("./test/validate/fixtures/rules.not-to-dev-dep.json"),
         { source: "src/aap/zus/jet.js" },
         {
@@ -385,7 +358,6 @@ describe("validate/index - specific tests", () => {
   it(`no relations with modules of > 1 dep type (e.g. specified 2x in package.json)`, () => {
     expect(
       validate.dependency(
-        true,
         readRuleSet(
           "./test/validate/fixtures/rules.no-duplicate-dep-types.json"
         ),


### PR DESCRIPTION
## Description, Motivation and Context

Moves the check whether or not to validate to the enrich part, so you don't have to pass a validate boolean to the validate function to get it to validate.



## How Has This Been Tested?

- [x] automated non-regression tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
