### PR TITLE
bugfix(resolve): by default don't let enhanced-resolve look at 'exports' fields in package.json manifests just yet

### DIFF
--- a/src/main/resolve-options/normalize.js
+++ b/src/main/resolve-options/normalize.js
@@ -29,6 +29,12 @@ const DEFAULT_RESOLVE_OPTIONS = {
   //   to look for modules (in addition to "node_modules" which
   //   is the default for enhanced-resolve)
   modules: ["node_modules", "node_modules/@types"],
+  // this overrides the default exports fields enhanced-resolve uses
+  // (being ["exports"]) to keep backwards compatibility between enhanced-resolve
+  // 4 and 5 (4 didn't heed them at all and the empty array has the same
+  // effect).
+  // Also see https://github.com/sverweij/dependency-cruiser/issues/338
+  exportsFields: [],
 };
 
 function getNonOverridableResolveOptions(pCacheDuration) {

--- a/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/feature.cjs
+++ b/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/feature.cjs
@@ -1,0 +1,3 @@
+module.exports.getStuff = function getStuff() {
+  return "hello from commonjs module";
+};

--- a/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/feature.mjs
+++ b/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/feature.mjs
@@ -1,0 +1,3 @@
+export function getStuff() {
+  return "hello from es module";
+}

--- a/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/main.cjs
+++ b/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/main.cjs
@@ -1,0 +1,3 @@
+const {getStuff} = require('package-json-with-weird-exports/conditionalExports')
+
+console.log(getStuff())

--- a/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/main.mjs
+++ b/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/main.mjs
@@ -1,0 +1,3 @@
+import { getStuff } from 'package-json-with-weird-exports/conditionalExports'
+
+console.log(getStuff())

--- a/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/package.json
+++ b/test/extract/resolve/fixtures/package-json-with-exports/node_modules/export-testinga/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "export-testinga",
+  "version": "1.0.0",
+  "description": "testinga",
+  "main": "main.cjs",
+  "exports": {
+    ".": "./main.cjs",
+    "./conditionalExports": {
+      "require": "./feature.cjs",
+      "import": "./feature.mjs"
+    }
+  }
+}

--- a/test/extract/resolve/fixtures/package-json-with-exports/yolo.cjs
+++ b/test/extract/resolve/fixtures/package-json-with-exports/yolo.cjs
@@ -1,0 +1,3 @@
+const { getStuff } = require("export-testinga/conditionalExports");
+
+console.log(getStuff());

--- a/test/extract/resolve/fixtures/package-json-with-exports/yolo.mjs
+++ b/test/extract/resolve/fixtures/package-json-with-exports/yolo.mjs
@@ -1,0 +1,3 @@
+import { getStuff } from "export-testinga/conditionalExports";
+
+console.log(getStuff());

--- a/test/main/resolve-options/normalize.spec.js
+++ b/test/main/resolve-options/normalize.spec.js
@@ -4,7 +4,7 @@ const normalizeOptions = require("~/src/main/options/normalize");
 const normalizeResolveOptions = require("~/src/main/resolve-options/normalize");
 
 describe("main/resolve-options/normalize", () => {
-  const DEFAULT_NO_OF_RESOLVE_OPTIONS = 8;
+  const DEFAULT_NO_OF_RESOLVE_OPTIONS = 9;
   const TEST_TSCONFIG = path.join(
     __dirname,
     "..",


### PR DESCRIPTION
## Description

See title. For an explanation - see the 2nd response in the linked issue.

## Motivation and Context

fixes #338 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] manual tests against the sample laid out in the issue
- [x] additional unit tests

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
