### PR TITLE
feature(enrich): de-duplicate cyclic violations in the summary

### DIFF
--- a/src/enrich/de-duplicate-violations.js
+++ b/src/enrich/de-duplicate-violations.js
@@ -1,0 +1,18 @@
+const _difference = require("lodash/difference");
+const _uniqWith = require("lodash/uniqWith");
+
+function violationIsEqual(pLeftViolation, pRightViolation) {
+  if (
+    pLeftViolation.rule.name === pRightViolation.rule.name &&
+    pLeftViolation.cycle
+  ) {
+    return (
+      _difference(pLeftViolation.cycle, pRightViolation.cycle).length === 0
+    );
+  }
+  return false;
+}
+
+module.exports = function deDuplicateViolations(pViolations) {
+  return _uniqWith(pViolations, violationIsEqual);
+};

--- a/src/enrich/summarize-modules.js
+++ b/src/enrich/summarize-modules.js
@@ -2,6 +2,7 @@ const _flattenDeep = require("lodash/flattenDeep");
 const _get = require("lodash/get");
 const findRuleByName = require("../utl/find-rule-by-name");
 const compare = require("../utl/compare");
+const deDuplicateViolations = require("./de-duplicate-violations");
 
 function cutNonTransgressions(pSourceEntry) {
   return {
@@ -127,9 +128,11 @@ function extractModuleViolations(pModules, pRuleSet) {
 }
 
 module.exports = (pModules, pRuleSet) => {
-  const lViolations = extractDependencyViolations(pModules, pRuleSet)
-    .concat(extractModuleViolations(pModules, pRuleSet))
-    .sort(compare.violations);
+  const lViolations = deDuplicateViolations(
+    extractDependencyViolations(pModules, pRuleSet).concat(
+      extractModuleViolations(pModules, pRuleSet)
+    )
+  ).sort(compare.violations);
 
   return {
     violations: lViolations,

--- a/src/report/error-html/index.js
+++ b/src/report/error-html/index.js
@@ -31,16 +31,23 @@ function aggregateViolations(pViolations, pRuleSetUsed) {
     );
 }
 
-function report(pResults) {
-  return Handlebars.templates["error-html.template.hbs"]({
+function massageSummaryIntoSomethingUsable(pResults) {
+  const lSummary = formatSummaryForReport(pResults.summary);
+  return {
     summary: {
-      ...formatSummaryForReport(pResults.summary),
+      ...lSummary,
       agggregateViolations: aggregateViolations(
-        pResults.summary.violations,
-        pResults.summary.ruleSetUsed
+        lSummary.violations,
+        lSummary.ruleSetUsed
       ),
     },
-  });
+  };
+}
+
+function report(pResults) {
+  return Handlebars.templates["error-html.template.hbs"](
+    massageSummaryIntoSomethingUsable(pResults)
+  );
 }
 
 /**

--- a/test/enrich/de-duplicate-violations.spec.js
+++ b/test/enrich/de-duplicate-violations.spec.js
@@ -1,0 +1,167 @@
+const { expect } = require("chai");
+const deDuplicateViolations = require("~/src/enrich/de-duplicate-violations");
+
+describe("enrich/de-duplicate-violations", () => {
+  it("no violations => no violations", () => {
+    expect(deDuplicateViolations([])).to.deep.equal([]);
+  });
+  it("non-cyclic violations => same non-cyclic violations", () => {
+    const lViolations = [
+      {
+        from: "somewhere.js",
+        to: "somewhere-else.js",
+        rule: {
+          severity: "error",
+          name: "no-thi-ng-else",
+        },
+      },
+      {
+        from: "call.js",
+        to: "kthulu.js",
+        rule: {
+          severity: "warn",
+          name: "matters",
+        },
+      },
+    ];
+    expect(deDuplicateViolations(lViolations)).to.deep.equal(lViolations);
+  });
+
+  it("2 violations from different cycles => the 2 same violations", () => {
+    const lViolations = [
+      {
+        from: "src/report/not/index.js",
+        to: "src/report/not/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/not/module-utl.js", "src/report/not/index.js"],
+      },
+      {
+        from: "src/report/dot/module-utl.js",
+        to: "src/report/dot/index.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/index.js", "src/report/dot/module-utl.js"],
+      },
+    ];
+    expect(deDuplicateViolations(lViolations)).to.deep.equal(lViolations);
+  });
+
+  it("2 violations from the same cycle => 1 violation", () => {
+    const lViolations = [
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
+      },
+      {
+        from: "src/report/dot/module-utl.js",
+        to: "src/report/dot/index.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/index.js", "src/report/dot/module-utl.js"],
+      },
+    ];
+    const lDeDuplicatedViolations = [
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
+      },
+    ];
+    expect(deDuplicateViolations(lViolations)).to.deep.equal(
+      lDeDuplicatedViolations
+    );
+  });
+
+  it("2 violations from the same cycle, but of different name => no changes", () => {
+    const lViolations = [
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-ride-the-lightning",
+        },
+        cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
+      },
+      {
+        from: "src/report/dot/module-utl.js",
+        to: "src/report/dot/index.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/index.js", "src/report/dot/module-utl.js"],
+      },
+    ];
+    expect(deDuplicateViolations(lViolations)).to.deep.equal(lViolations);
+  });
+
+  it("does not mix up cyclic & non-cyclic violations when de-duplicating", () => {
+    const lViolations = [
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-fade-to-black",
+        },
+      },
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
+      },
+      {
+        from: "src/report/dot/module-utl.js",
+        to: "src/report/dot/index.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/index.js", "src/report/dot/module-utl.js"],
+      },
+    ];
+    const lDeDuplicatedViolations = [
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-fade-to-black",
+        },
+      },
+      {
+        from: "src/report/dot/index.js",
+        to: "src/report/dot/module-utl.js",
+        rule: {
+          severity: "error",
+          name: "no-circular",
+        },
+        cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
+      },
+    ];
+    expect(deDuplicateViolations(lViolations)).to.deep.equal(
+      lDeDuplicatedViolations
+    );
+  });
+});

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -98,21 +98,11 @@
           "src/dynamic-to-circular.js",
           "src/circular.js"
         ]
-      },
-      {
-        "from": "src/index.js",
-        "to": "src/dynamic-to-circular.js",
-        "rule": { "severity": "info", "name": "no-circular" },
-        "cycle": [
-          "src/dynamic-to-circular.js",
-          "src/circular.js",
-          "src/index.js"
-        ]
       }
     ],
     "error": 0,
     "warn": 1,
-    "info": 2,
+    "info": 1,
     "totalCruised": 3,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -98,21 +98,11 @@
           "src/dynamic-to-circular.ts",
           "src/circular.ts"
         ]
-      },
-      {
-        "from": "src/index.ts",
-        "to": "src/dynamic-to-circular.ts",
-        "rule": { "severity": "info", "name": "no-circular" },
-        "cycle": [
-          "src/dynamic-to-circular.ts",
-          "src/circular.ts",
-          "src/index.ts"
-        ]
       }
     ],
     "error": 0,
     "warn": 1,
-    "info": 2,
+    "info": 1,
     "totalCruised": 3,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -98,21 +98,11 @@
           "src/dynamic-to-circular.ts",
           "src/circular.ts"
         ]
-      },
-      {
-        "from": "src/index.ts",
-        "to": "src/dynamic-to-circular.ts",
-        "rule": { "severity": "info", "name": "no-circular" },
-        "cycle": [
-          "src/dynamic-to-circular.ts",
-          "src/circular.ts",
-          "src/index.ts"
-        ]
       }
     ],
     "error": 0,
     "warn": 1,
-    "info": 2,
+    "info": 1,
     "totalCruised": 3,
     "totalDependenciesCruised": 3,
     "optionsUsed": {


### PR DESCRIPTION
## Description, Motivation and Context

The reporters that use the summarised errors for or in their output (err, err-html, teamcity, json, anon and the api only 'identity') currently report each dependency in a cycle separately. This is correct and in line with other dependency violations. It's slightly impractical, though as each module in the cycle will show up once, whereas it's just one cycle. E.g this one cycle ...

<img width="244" alt="Screenshot 2020-08-05 at 19 37 42" src="https://user-images.githubusercontent.com/4822597/89445322-464e1080-d753-11ea-9550-d9978fad2122.png">

would (correctly, but verbosely) yield:

```
  error no-circular: src/report/anon/random-string.js → 
      src/report/anon/index.js →
      src/report/anon/anonymize-path.js →
      src/report/anon/anonymize-path-element.js →
      src/report/anon/random-string.js
  error no-circular: src/report/anon/index.js → 
      src/report/anon/anonymize-path.js →
      src/report/anon/anonymize-path-element.js →
      src/report/anon/random-string.js →
      src/report/anon/index.js
  error no-circular: src/report/anon/anonymize-path.js → 
      src/report/anon/anonymize-path-element.js →
      src/report/anon/random-string.js →
      src/report/anon/index.js →
      src/report/anon/anonymize-path.js
  error no-circular: src/report/anon/anonymize-path-element.js → 
      src/report/anon/random-string.js →
      src/report/anon/index.js →
      src/report/anon/anonymize-path.js →
      src/report/anon/anonymize-path-element.js

✖ 4 dependency violations (4 errors, 0 warnings). 8 modules, 8 dependencies cruised.
```

With this change, the reporters will show this cycle more concisely only once, like so:
```
  error no-circular: src/report/anon/anonymize-path-element.js → 
      src/report/anon/random-string.js →
      src/report/anon/index.js →
      src/report/anon/anonymize-path.js →
      src/report/anon/anonymize-path-element.js

✖ 1 dependency violations (1 errors, 0 warnings). 8 modules, 8 dependencies cruised.
```

... which will make the output of these reporters more readable and usable, while retaining the same information.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] additional unit tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
