### PR TITLE
feature(depcruise-fmt): add filter options

### DIFF
--- a/bin/depcruise-fmt.js
+++ b/bin/depcruise-fmt.js
@@ -32,6 +32,15 @@ try {
       "err"
     )
     .option(
+      "-I, --include-only <regex>",
+      "only include modules matching the regex"
+    )
+    .option(
+      "-F, --focus <regex>",
+      "only include modules matching the regex + their direct neighbours"
+    )
+    .option("-x, --exclude <regex>", "exclude all modules matching the regex")
+    .option(
       "-e, --exit-code",
       "exit with a non-zero exit code when the input json contains error level " +
         "dependency violations. Works for err, err-long and teamcity output types"

--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -33,9 +33,12 @@ try {
       "file to write output to; - for stdout",
       "-"
     )
-    .option("--include-only <regex>", "only include modules matching the regex")
     .option(
-      "--focus <regex>",
+      "-I, --include-only <regex>",
+      "only include modules matching the regex"
+    )
+    .option(
+      "-F, --focus <regex>",
       "only include modules matching the regex + their direct neighbours"
     )
     .option("-x, --exclude <regex>", "exclude all modules matching the regex")

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -681,6 +681,21 @@ depcruise-fmt -T err-html -f violation-report.html cruise_result.json
 depcruise-fmt -T dot cruise_result.json | dot -T svg > dependency-graph.svg
 ```
 
+You can also use the filters --focus, --include-only and --exclude to peruse
+parts of the dependency-graph. This could be useful for chopping up humoungous
+graphs efficiently, or to quickly find the uses of a module.
+
+```sh
+depcruise -v -T json src -f cruise_result.json
+depcruise-fmt -T dot --focus "^src/main" cruise_result.json | dot -T svg > main.svg
+depcruise-fmt -T dot --focus "^src/juggle" cruise_result.json | dot -T svg > juggle.svg
+depcruise-fmt -T dot --include-only "^src/the-law" cruise_result.json | dot -T svg > the-law.svg
+
+## or to find dependencies going into or departing from the spelunkme module
+## and emitting them to stdout:
+depcruise-fmt -T text --focus "^src/main/spelunkme\\.ts$" cruise_result.json
+```
+
 If you want to see non-zero exit codes when there's error level dependency
 violations, you can use the `--exit-code` (short: `-e`). This only works for
 the output types that support non-zero exit codes (_err_, _err-long_ and
@@ -697,15 +712,16 @@ Format dependency-cruiser output json.
 Details: https://github.com/sverweij/dependency-cruiser
 
 Options:
-  -f, --output-to <file>    file to write output to; - for stdout (default:
-                            "-")
-  -T, --output-type <type>  output type; e.g. err, err-html, dot, ddot, archi
-                            or json (default: "err")
-  -e, --exit-code           exit with a non-zero exit code when the input json
-                            contains error level dependency violations. Works
-                            for err, err-long and teamcity output types
-  -V, --version             output the version number
-  -h, --help                display help for command
+  -f, --output-to <file>      file to write output to; - for stdout (default:
+                              "-")
+  -T, --output-type <type>    output type; e.g. err, err-html, dot, ddot, archi
+                              or json (default: "err")
+  -I, --include-only <regex>  only include modules matching the regex
+  -F, --focus <regex>         only include modules matching the regex + their
+                              direct neighbours
+  -x, --exclude <regex>       exclude all modules matching the regex
+  -V, --version               output the version number
+  -h, --help                  display help for command
 ```
 
 ## depcruise-wrap-stream-in-html

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -1558,6 +1558,16 @@ depcruise-fmt -T archi results.json | dot -T svg > high-level-graph.svg
 depcruise-fmt -e -T err results.json
 ```
 
+> Note: as of version 9.12.0 depcruise-fmt has [filters](cli.md#depcruise-fmt)
+> as command line options that have the same effect, work on all reporters and might
+> give you more flexibility.
+
+> ```sh
+> depcruise-fmt -T dot results.json --include-only "^packages/search" | dot -T svg > search.svg
+> depcruise-fmt -T dot results.json --include-only "^packages/ancillaries" | dot -T svg > ancillaries.svg
+> depcruise-fmt -T dot results.json --include-only "^packages/checkout" | dot -T svg > checkout.svg
+> ```
+
 ##### theming
 
 Most representational aspects of the 'dot' reporter are customizable:

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -14,10 +14,7 @@ module.exports = async (pResultFile, pOptions) => {
 
   const lResult = await getStream(io.getInStream(pResultFile));
 
-  const lReportingResult = main.format(
-    JSON.parse(lResult),
-    lOptions.outputType
-  );
+  const lReportingResult = main.format(JSON.parse(lResult), lOptions);
 
   io.write(lOptions.outputTo, lReportingResult.output);
   return lReportingResult.exitCode;

--- a/src/enrich/summarize-modules.js
+++ b/src/enrich/summarize-modules.js
@@ -127,7 +127,7 @@ function extractModuleViolations(pModules, pRuleSet) {
     );
 }
 
-module.exports = (pModules, pRuleSet) => {
+module.exports = function summarizeModules(pModules, pRuleSet) {
   const lViolations = deDuplicateViolations(
     extractDependencyViolations(pModules, pRuleSet).concat(
       extractModuleViolations(pModules, pRuleSet)

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-object-injection */
 const normalizeREProperties = require("../utl/normalize-re-properties");
 const defaults = require("./defaults.json");
 
@@ -24,7 +25,7 @@ function normalizeReporterOptions(pReporterOptions) {
     "archi.filters.exclude.path",
     "dot.collapsePattern",
     "dot.filters.includeOnly.path",
-    "dot.filters.focus",
+    "dot.filters.focus.path",
     "dot.filters.exclude.path",
     "ddot.collapsePattern",
     "ddot.filters.includeOnly.path",
@@ -35,7 +36,20 @@ function normalizeReporterOptions(pReporterOptions) {
   return normalizeREProperties(pReporterOptions, lNormalizeableOptions);
 }
 
-module.exports = (pOptions) => {
+function normalizeFilterOptions(pOptions, pFilterOptionKeys) {
+  let lReturnValue = { ...pOptions };
+
+  for (let pFilterOptionKey of pFilterOptionKeys) {
+    if (pOptions[pFilterOptionKey]) {
+      lReturnValue[pFilterOptionKey] = normalizeFilterOption(
+        lReturnValue[pFilterOptionKey]
+      );
+    }
+  }
+  return lReturnValue;
+}
+
+module.exports = function normalizeCruiseOptions(pOptions) {
   let lReturnValue = {
     baseDir: process.cwd(),
     ...defaults,
@@ -44,14 +58,13 @@ module.exports = (pOptions) => {
 
   lReturnValue.maxDepth = Number.parseInt(lReturnValue.maxDepth, 10);
   lReturnValue.moduleSystems = uniq(lReturnValue.moduleSystems.sort());
+  // TODO: further down the execution path code still relies on .doNotFollow
+  //       and .exclude existing. We should treat them the same as the
+  //       other two filters (so either make all exist always or only
+  //       when they're actually defined)
   lReturnValue.doNotFollow = normalizeFilterOption(lReturnValue.doNotFollow);
   lReturnValue.exclude = normalizeFilterOption(lReturnValue.exclude);
-  if (lReturnValue.includeOnly) {
-    lReturnValue.includeOnly = normalizeFilterOption(lReturnValue.includeOnly);
-  }
-  if (lReturnValue.focus) {
-    lReturnValue.focus = normalizeFilterOption(lReturnValue.focus);
-  }
+  lReturnValue = normalizeFilterOptions(lReturnValue, ["focus", "includeOnly"]);
   lReturnValue.exoticRequireStrings = uniq(
     lReturnValue.exoticRequireStrings.sort()
   );
@@ -62,4 +75,14 @@ module.exports = (pOptions) => {
   }
 
   return lReturnValue;
+};
+
+module.exports.normalizeFormatOptions = function normalizeFormatOptions(
+  pFormatOptions
+) {
+  return normalizeFilterOptions(pFormatOptions, [
+    "exclude",
+    "focus",
+    "includeOnly",
+  ]);
 };

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -82,4 +82,11 @@ function validate(pOptions) {
 
 module.exports = validate;
 
-module.exports.validateOutputType = validateOutputType;
+module.exports.validateFormatOptions = function validateFormatOptions(
+  pFormatOptions
+) {
+  validatePathsSafety(pFormatOptions.exclude);
+  validatePathsSafety(pFormatOptions.focus);
+  validatePathsSafety(pFormatOptions.includeOnly);
+  validateOutputType(pFormatOptions.outputType);
+};

--- a/test/cli/format.spec.js
+++ b/test/cli/format.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 const fs = require("fs");
 const path = require("path");
 const { expect } = require("chai");
@@ -24,7 +25,45 @@ describe("cli/format", () => {
     deleteDammit(lOutFile);
   });
 
-  it("returns a non-zero exit code when there's error level dependency violations in the output and ", async () => {
+  it("formats a cruise result, --focus filter works and writes it to a file", async () => {
+    const lOutFile = "thing.json";
+
+    deleteDammit(lOutFile);
+
+    const lExitCode = await format(
+      path.join(
+        __dirname,
+        "fixtures",
+        "result-has-a-dependency-violation.json"
+      ),
+      {
+        outputTo: lOutFile,
+        outputType: "json",
+        focus: "^src/main",
+      }
+    );
+    const lResult = JSON.parse(fs.readFileSync(lOutFile, "utf8"));
+    expect(lResult.summary.error).to.equal(0);
+    expect(lResult.summary.totalCruised).to.be.lessThan(116);
+    expect(lResult.summary.totalDependenciesCruised).to.be.lessThan(169);
+    expect(lResult.summary.violations.length).to.equal(0);
+    expect(lResult.modules.map((pModule) => pModule.source)).to.not.include(
+      "bin/depcruise-fmt.js"
+    );
+    expect(lResult.modules.map((pModule) => pModule.source)).to.include(
+      "src/main/index.js"
+    );
+    expect(lResult.modules.map((pModule) => pModule.source)).to.include(
+      "src/cli/index.js"
+    );
+    expect(lResult.modules.map((pModule) => pModule.source)).to.not.include(
+      "src/cli/init-config/index.js"
+    );
+    expect(lExitCode).to.equal(0);
+    deleteDammit(lOutFile);
+  });
+
+  it("returns a non-zero exit code when there's error level dependency violations in the output (regardless the value of exitCode)", async () => {
     const lOutFile = "otherthing";
 
     deleteDammit(lOutFile);

--- a/test/main/main.format.spec.js
+++ b/test/main/main.format.spec.js
@@ -19,7 +19,7 @@ const MINIMAL_RESULT = {
 describe("main.format - format", () => {
   it("barfs when it gets an invalid output type", () => {
     expect(() => {
-      main.format({}, "not-a-valid-reporter");
+      main.format({}, { outputType: "not-a-valid-reporter" });
     }).to.throw("'not-a-valid-reporter' is not a valid output type.");
   });
 
@@ -38,14 +38,16 @@ describe("main.format - format", () => {
   });
 
   it("returns an error reporter formatted report when presented with a legal result", () => {
-    expect(main.format(MINIMAL_RESULT, "err").output).to.contain(
+    expect(
+      main.format(MINIMAL_RESULT, { outputType: "err" }).output
+    ).to.contain(
       "no dependency violations found (0 modules, 0 dependencies cruised)"
     );
   });
 
   it("returns an json reporter formatted report when presented with a legal result", () => {
     expect(
-      JSON.parse(main.format(MINIMAL_RESULT, "json").output)
+      JSON.parse(main.format(MINIMAL_RESULT, { outputType: "json" }).output)
     ).to.deep.equal(MINIMAL_RESULT);
   });
 });


### PR DESCRIPTION
## Description

- Adds three command line filtering options to depcruise-fmt (--include-only, --focus, --exclude) that work the same as the ones on the depcruise command.
- Also adds short versions for the filter commands to the `depcruise` command (-I and -F respectively) to be consistent with depcruise-fmt and to make it easier to use if you're using the cli to interrogate.
- On the fly fixes an as of yet undetected bug where a reportOptions.dot/archi/ddot.filters.focus wasn't taken into account.

## Motivation and Context

`depcruise-fmt` is useful if you want to display the results of the same cruise in different ways, without having to run the cruise repeatedly. Especially on bigger code bases this can save time. Cruising all code can sometimes take more than a minute, while formatting usually takes well below a second.

Adding filter options increases the usefulness of the `depcruise-fmt` command. 

Cruise your humongous code base once (~30 - 60s?) and save it to a json (e.g. results.json):
- run depcruise-fmt several times against result.json to produce overviews of parts of the code base
- run depcruise-fmt with `--focus` to quickly find everything going into and coming out of packages/old-utils/spelunk-this.js
- run depcruise-fmt without any filters to find all violations
- run depcruise-fmt with submodules as filter to find violations for only that submodule

depcruise-fmt typically takes ~1s for each of this runs, so if you have a lot of things like this going on it could be big win™️. 

## How Has This Been Tested?

- [x] additional automated tests
- [x] automated non-regression tests
- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
