### PR TITLE
bugfix(cli): print errors normally also when handling progress feedback

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -115,8 +115,8 @@ module.exports = (pFileDirectoryArray, pCruiseOptions) => {
       lExitCode = runCruise(pFileDirectoryArray, pCruiseOptions);
     }
   } catch (pError) {
-    bus.emit("end", "error");
     process.stderr.write(`\n  ERROR: ${pError.message}\n`);
+    bus.emit("end");
     lExitCode = 1;
   }
 


### PR DESCRIPTION
## Description, motivation and context

When the `progress` option is on (undocumented yet - experimental), and dc encountered an error situation it emitted an `end` event. The listeners typically write some close remarks and then close the stream.

```javascript
bus.emit('end');

// errors when there's a listener on the bus that just closed the stream on stderr
process.stderr.write(`something went wrong yadda\n`);
```

When we use `process.stderr` as the stream the listener writes to, after bus.emit, `stderr` is already closed, resulting in an erroring error message about trying to write after the stream is closed.

This fix fixes that bug.

> The problem does not occur when not using the `progress` option (which you probably don't do in the first
> place as it's still experimental).

## How Has This Been Tested?

- [x] automated non-regression testing
- [x] green ci


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
