### PR TITLE
refactor: replaces Object.property.hasOwnProperty.call with _.has

### DIFF
--- a/src/cli/compile-config/index.js
+++ b/src/cli/compile-config/index.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const _has = require("lodash/has");
 const resolve = require("../../extract/resolve/resolve");
 const normalizeResolveOptions = require("../../main/resolve-options/normalize");
 const readConfig = require("./read-config");
@@ -68,7 +69,7 @@ function compileConfig(
 
   let lReturnValue = readConfig(lResolvedFileName, pBaseDirectory);
 
-  if (Object.prototype.hasOwnProperty.call(lReturnValue, "extends")) {
+  if (_has(lReturnValue, "extends")) {
     lReturnValue = processExtends(
       lReturnValue,
       pAlreadyVisited,

--- a/src/cli/init-config/environment-helpers.js
+++ b/src/cli/init-config/environment-helpers.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const _get = require("lodash/get");
+const _has = require("lodash/has");
 
 const LIKELY_SOURCE_FOLDERS = ["src", "lib", "app", "bin"];
 const LIKELY_TEST_FOLDERS = ["test", "spec", "tests", "specs", "bdd"];
@@ -48,10 +49,7 @@ function babelIsConfiguredInManifest() {
   let lReturnValue = false;
 
   try {
-    lReturnValue = Object.prototype.hasOwnProperty.call(
-      readManifest(),
-      "babel"
-    );
+    lReturnValue = _has(readManifest(), "babel");
   } catch (pError) {
     // silently ignore - we'll return false anyway then
   }

--- a/src/cli/init-config/normalize-init-options.js
+++ b/src/cli/init-config/normalize-init-options.js
@@ -1,3 +1,4 @@
+const _has = require("lodash/has");
 const $dependencyCruiserManifest = require("../../../package.json");
 const {
   getSourceFolderCandidates,
@@ -32,9 +33,7 @@ module.exports = function normalizeInitOptions(pInitOptions) {
   if (lReturnValue.useYarnPnP) {
     lReturnValue.externalModuleResolutionStrategy = "yarn-pnp";
   }
-  if (
-    !Object.prototype.hasOwnProperty.call(lReturnValue, "hasTestsOutsideSource")
-  ) {
+  if (!_has(lReturnValue, "hasTestsOutsideSource")) {
     lReturnValue.hasTestsOutsideSource =
       !pInitOptions.isMonoRepo &&
       !hasTestsWithinSource(

--- a/src/cli/parse-babel-config.js
+++ b/src/cli/parse-babel-config.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const json5 = require("json5");
 const _get = require("lodash/get");
+const _has = require("lodash/has");
 const tryRequire = require("semver-try-require");
 const $package = require("../../package.json");
 const makeAbsolute = require("./utl/make-absolute");
@@ -62,9 +63,7 @@ function getConfig(pBabelConfigFileName) {
   };
   const lExtension = path.extname(pBabelConfigFileName);
 
-  if (
-    !Object.prototype.hasOwnProperty.call(EXTENSION_TO_PARSE_FN, lExtension)
-  ) {
+  if (!_has(EXTENSION_TO_PARSE_FN, lExtension)) {
     throw new Error(
       `The babel config '${pBabelConfigFileName}' is in a format ('${lExtension}')\n` +
         "         dependency-cruiser doesn't support yet.\n"

--- a/src/enrich/derive/reachable/index.js
+++ b/src/enrich/derive/reachable/index.js
@@ -2,16 +2,15 @@
 
 const _clone = require("lodash/clone");
 const _get = require("lodash/get");
+const _has = require("lodash/has");
 const getPath = require("./get-path");
 
 function getReachableRules(pRuleSet) {
   return _get(pRuleSet, "forbidden", [])
-    .filter((pRule) =>
-      Object.prototype.hasOwnProperty.call(pRule.to, "reachable")
-    )
+    .filter((pRule) => _has(pRule.to, "reachable"))
     .concat(
       _get(pRuleSet, "allowed", []).filter((pRule) =>
-        Object.prototype.hasOwnProperty.call(pRule.to, "reachable")
+        _has(pRule.to, "reachable")
       )
     );
 }

--- a/src/enrich/summarize-options.js
+++ b/src/enrich/summarize-options.js
@@ -1,4 +1,5 @@
 const _get = require("lodash/get");
+const _has = require("lodash/has");
 const pathToPosix = require("../utl/path-to-posix");
 
 const SHAREABLE_OPTIONS = [
@@ -27,9 +28,7 @@ const SHAREABLE_OPTIONS = [
 
 function makeOptionsPresentable(pOptions) {
   return SHAREABLE_OPTIONS.filter(
-    (pOption) =>
-      Object.prototype.hasOwnProperty.call(pOptions, pOption) &&
-      pOptions[pOption] !== 0
+    (pOption) => _has(pOptions, pOption) && pOptions[pOption] !== 0
   )
     .filter(
       (pOption) =>

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -1,6 +1,7 @@
 const _uniqBy = require("lodash/uniqBy");
 const _spread = require("lodash/spread");
 const _concat = require("lodash/concat");
+const _has = require("lodash/has");
 const pathToPosix = require("../utl/path-to-posix");
 const getDependencies = require("./get-dependencies");
 const gatherInitialSources = require("./gather-initial-sources");
@@ -126,8 +127,7 @@ function filterExcludedDynamicDependencies(pModule, pExclude) {
     ...pModule,
     dependencies: pModule.dependencies.filter(
       (pDependency) =>
-        !Object.prototype.hasOwnProperty.call(pExclude, "dynamic") ||
-        pExclude.dynamic !== pDependency.dynamic
+        !_has(pExclude, "dynamic") || pExclude.dynamic !== pDependency.dynamic
     ),
   };
 }

--- a/src/extract/resolve/determine-dependency-types.js
+++ b/src/extract/resolve/determine-dependency-types.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const _has = require("lodash/has");
 const isCore = require("./is-core");
 const isRelativeModuleName = require("./is-relative-module-name");
 const localNpmHelpers = require("./local-npm-helpers");
@@ -17,7 +18,7 @@ function dependencyKeyHasModuleName(
   return (pKey) =>
     pKey.includes("ependencies") &&
     pExternalModuleResolvePaths.some((pResolvePath) =>
-      Object.prototype.hasOwnProperty.call(
+      _has(
         pPackageDependencies[pKey],
         path.posix.join(pResolvePath, pModuleName)
       )

--- a/src/extract/resolve/local-npm-helpers.js
+++ b/src/extract/resolve/local-npm-helpers.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const _memoize = require("lodash/memoize");
+const _has = require("lodash/has");
 const resolve = require("./resolve");
 const isRelativeModuleName = require("./is-relative-module-name");
 
@@ -121,9 +122,7 @@ function dependencyIsDeprecated(pModule, pBaseDirectory, pResolveOptions) {
   let lPackageJson = getPackageJson(pModule, pBaseDirectory, pResolveOptions);
 
   if (Boolean(lPackageJson)) {
-    lReturnValue =
-      Object.prototype.hasOwnProperty.call(lPackageJson, "deprecated") &&
-      lPackageJson.deprecated;
+    lReturnValue = _has(lPackageJson, "deprecated") && lPackageJson.deprecated;
   }
   return lReturnValue;
 }
@@ -143,7 +142,7 @@ function getLicense(pModule, pBaseDirectory, pResolveOptions) {
 
   if (
     Boolean(lPackageJson) &&
-    Object.prototype.hasOwnProperty.call(lPackageJson, "license") &&
+    _has(lPackageJson, "license") &&
     typeof lPackageJson.license === "string"
   ) {
     lReturnValue = lPackageJson.license;

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -1,3 +1,4 @@
+const _has = require("lodash/has");
 const normalizeREProperties = require("../utl/normalize-re-properties");
 
 const VALID_SEVERITIES = /^(error|warn|info|ignore)$/;
@@ -37,7 +38,7 @@ function normalizeRule(pRule) {
  * @return {object}          [description]
  */
 module.exports = (pRuleSet) => {
-  if (Object.prototype.hasOwnProperty.call(pRuleSet, "allowed")) {
+  if (_has(pRuleSet, "allowed")) {
     pRuleSet.allowedSeverity = normalizeSeverity(pRuleSet.allowedSeverity);
     if (pRuleSet.allowedSeverity === "ignore") {
       Reflect.deleteProperty(pRuleSet, "allowed");
@@ -52,13 +53,13 @@ module.exports = (pRuleSet) => {
     }
   }
 
-  if (Object.prototype.hasOwnProperty.call(pRuleSet, "forbidden")) {
+  if (_has(pRuleSet, "forbidden")) {
     pRuleSet.forbidden = pRuleSet.forbidden
       .map(normalizeRule)
       .filter((pRule) => pRule.severity !== "ignore");
   }
 
-  if (Object.prototype.hasOwnProperty.call(pRuleSet, "required")) {
+  if (_has(pRuleSet, "required")) {
     pRuleSet.required = pRuleSet.required
       .map(normalizeRule)
       .filter((pRule) => pRule.severity !== "ignore");

--- a/src/main/rule-set/validate.js
+++ b/src/main/rule-set/validate.js
@@ -1,5 +1,6 @@
 const Ajv = require("ajv");
 const safeRegex = require("safe-regex");
+const _has = require("lodash/has");
 const validateOptions = require("../options/validate");
 const configurationSchema = require("../../schema/configuration.schema.json");
 
@@ -12,10 +13,7 @@ function validateAgainstSchema(pSchema, pConfiguration) {
 }
 
 function hasPath(pObject, pSection, pCondition) {
-  return (
-    Object.prototype.hasOwnProperty.call(pObject, pSection) &&
-    Object.prototype.hasOwnProperty.call(pObject[pSection], pCondition)
-  );
+  return _has(pObject, pSection) && _has(pObject[pSection], pCondition);
 }
 
 function safeRule(pRule, pSection, pCondition) {
@@ -67,7 +65,7 @@ module.exports = (pConfiguration) => {
   validateAgainstSchema(configurationSchema, pConfiguration);
   (pConfiguration.allowed || []).forEach(checkRuleSafety);
   (pConfiguration.forbidden || []).forEach(checkRuleSafety);
-  if (Object.prototype.hasOwnProperty.call(pConfiguration, "options")) {
+  if (_has(pConfiguration, "options")) {
     validateOptions(pConfiguration.options);
   }
   return pConfiguration;

--- a/src/report/dot/theming.js
+++ b/src/report/dot/theming.js
@@ -1,4 +1,5 @@
 const _get = require("lodash/get");
+const _has = require("lodash/has");
 const DEFAULT_THEME = require("./default-theme.json");
 
 function matchesRE(pValue, pRE) {
@@ -10,8 +11,7 @@ function matchesRE(pValue, pRE) {
 function moduleMatchesCriteria(pSchemeEntry, pModule) {
   return Object.keys(pSchemeEntry.criteria).every(
     (pKey) =>
-      (_get(pModule, pKey) ||
-        Object.prototype.hasOwnProperty.call(pModule, pKey)) &&
+      (_get(pModule, pKey) || _has(pModule, pKey)) &&
       (_get(pModule, pKey) === _get(pSchemeEntry.criteria, pKey) ||
         matchesRE(_get(pModule, pKey), _get(pSchemeEntry.criteria, pKey)))
   );

--- a/src/report/error-html/utl.js
+++ b/src/report/error-html/utl.js
@@ -1,11 +1,10 @@
 const _get = require("lodash/get");
+const _has = require("lodash/has");
 const { version } = require("../../../package.json");
 
 function getFormattedAllowedRule(pRuleSetUsed) {
   const lAllowed = _get(pRuleSetUsed, "allowed", []);
-  const lCommentedRule = lAllowed.find((pRule) =>
-    Object.prototype.hasOwnProperty.call(pRule, "comment")
-  );
+  const lCommentedRule = lAllowed.find((pRule) => _has(pRule, "comment"));
   const lComment = lCommentedRule ? lCommentedRule.comment : "-";
 
   return lAllowed.length > 0

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -1,3 +1,4 @@
+const _has = require("lodash/has");
 const matchModuleRule = require("./match-module-rule");
 const matchDependencyRule = require("./match-dependency-rule");
 const violatesRequiredRule = require("./violates-required-rule");
@@ -48,7 +49,7 @@ function validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo) {
 function validateAgainstRequiredRules(pRuleSet, pModule, pMatchModule) {
   let lFoundRequiredRuleViolations = [];
 
-  if (Object.prototype.hasOwnProperty.call(pRuleSet, "required")) {
+  if (_has(pRuleSet, "required")) {
     lFoundRequiredRuleViolations = pRuleSet.required
       .filter(pMatchModule.isInteresting)
       .filter((pRule) => violatesRequiredRule(pRule, pModule))

--- a/src/validate/is-module-only-rule.js
+++ b/src/validate/is-module-only-rule.js
@@ -1,13 +1,15 @@
+const _has = require("lodash/has");
+
 /**
  * @param {any} pRule a dependency-cruiser rule
  * @returns {boolean} whether or not the rule is 'module only'
  */
 function isModuleOnlyRule(pRule) {
   return (
-    Object.prototype.hasOwnProperty.call(pRule.from || {}, "orphan") ||
+    _has(pRule.from || {}, "orphan") ||
     // note: the to might become optional for required rules
-    Object.prototype.hasOwnProperty.call(pRule.to, "reachable") ||
-    Object.prototype.hasOwnProperty.call(pRule, "module")
+    _has(pRule.to, "reachable") ||
+    _has(pRule, "module")
   );
 }
 

--- a/src/validate/match-dependency-rule.js
+++ b/src/validate/match-dependency-rule.js
@@ -1,3 +1,4 @@
+const _has = require("lodash/has");
 const isModuleOnlyRule = require("./is-module-only-rule");
 const matchers = require("./matchers");
 const { extractGroups } = require("./utl");
@@ -6,7 +7,7 @@ function propertyEquals(pTo, pRule, pProperty) {
   // ignore security/detect-object-injection because:
   // - we only use it from within the module with two fixed values
   // - the propertyEquals function is not exposed externaly
-  return Object.prototype.hasOwnProperty.call(pRule.to, pProperty)
+  return _has(pRule.to, pProperty)
     ? // eslint-disable-next-line security/detect-object-injection
       pTo[pProperty] === pRule.to[pProperty]
     : true;
@@ -23,10 +24,7 @@ function match(pFrom, pTo) {
       matchers.toPath(pRule, pTo, lGroups) &&
       matchers.toPathNot(pRule, pTo, lGroups) &&
       matchers.toDependencyTypes(pRule, pTo) &&
-      (!Object.prototype.hasOwnProperty.call(
-        pRule.to,
-        "moreThanOneDependencyType"
-      ) ||
+      (!_has(pRule.to, "moreThanOneDependencyType") ||
         pTo.dependencyTypes.length > 1) &&
       matchers.toLicense(pRule, pTo) &&
       matchers.toLicenseNot(pRule, pTo) &&

--- a/src/validate/match-module-rule.js
+++ b/src/validate/match-module-rule.js
@@ -1,9 +1,10 @@
+const _has = require("lodash/has");
 const isModuleOnlyRule = require("./is-module-only-rule");
 const matchers = require("./matchers");
 
 function matchesOrphanRule(pRule, pModule) {
   return (
-    Object.prototype.hasOwnProperty.call(pRule.from, "orphan") &&
+    _has(pRule.from, "orphan") &&
     pModule.orphan === pRule.from.orphan &&
     matchers.fromPath(pRule, pModule) &&
     matchers.fromPathNot(pRule, pModule)
@@ -12,8 +13,8 @@ function matchesOrphanRule(pRule, pModule) {
 
 function matchesReachableRule(pRule, pModule) {
   return (
-    Object.prototype.hasOwnProperty.call(pRule.to, "reachable") &&
-    Object.prototype.hasOwnProperty.call(pModule, "reachable") &&
+    _has(pRule.to, "reachable") &&
+    _has(pModule, "reachable") &&
     pModule.reachable.some(
       (pReachable) =>
         pReachable.asDefinedInRule === pRule.name &&
@@ -26,8 +27,8 @@ function matchesReachableRule(pRule, pModule) {
 
 function matchesReachesRule(pRule, pModule) {
   return (
-    Object.prototype.hasOwnProperty.call(pRule.to, "reachable") &&
-    Object.prototype.hasOwnProperty.call(pModule, "reaches") &&
+    _has(pRule.to, "reachable") &&
+    _has(pModule, "reaches") &&
     pModule.reaches.some(
       (pReaches) =>
         pReaches.asDefinedInRule === pRule.name &&

--- a/test/extract/resolve/local-npm-helpers.spec.js
+++ b/test/extract/resolve/local-npm-helpers.spec.js
@@ -1,4 +1,5 @@
 const { expect } = require("chai");
+const _has = require("lodash/has");
 const clearCaches = require("~/src/extract/clear-caches");
 const localNpmHelpers = require("~/src/extract/resolve/local-npm-helpers");
 const normalizeResolveOptions = require("~/src/main/resolve-options/normalize");
@@ -51,8 +52,7 @@ describe("extract/resolve/localNpmHelpers.getPackageJson", () => {
     );
 
     expect(lPackageJson).to.be.not.null;
-    expect(Object.prototype.hasOwnProperty.call(lPackageJson, "name")).to.be
-      .true;
+    expect(_has(lPackageJson, "name")).to.be.true;
     expect(lPackageJson.name).to.equal("chai");
   });
 
@@ -64,8 +64,7 @@ describe("extract/resolve/localNpmHelpers.getPackageJson", () => {
     );
 
     expect(lPackageJson).to.be.not.null;
-    expect(Object.prototype.hasOwnProperty.call(lPackageJson, "name")).to.be
-      .true;
+    expect(_has(lPackageJson, "name")).to.be.true;
     expect(lPackageJson.name).to.equal(
       "deprecated-at-the-start-for-test-purposes"
     );
@@ -79,8 +78,7 @@ describe("extract/resolve/localNpmHelpers.getPackageJson", () => {
     );
 
     expect(lPackageJson).to.be.not.null;
-    expect(Object.prototype.hasOwnProperty.call(lPackageJson, "name")).to.be
-      .true;
+    expect(_has(lPackageJson, "name")).to.be.true;
     expect(lPackageJson.description).to.equal("testinga 2");
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

See title. Improves readability

## How Has This Been Tested?

- [x] automated non-regression + green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
