### PR TITLE
fix: allow highlighting to work after formatting the html

### DIFF
--- a/src/cli/tools/svg-in-html-snippets/footer.snippet.html
+++ b/src/cli/tools/svg-in-html-snippets/footer.snippet.html
@@ -10,7 +10,7 @@ nodes.forEach(function (n) {
   var title = n.querySelector('title');
   var titleText = title && title.textContent;
   if (titleText) {
-    nodeMap[titleText] = n;
+    nodeMap[titleText.trim()] = n;
   }
 });
 /** @type {{[key: string]: SVGGElement[]}} */
@@ -20,7 +20,8 @@ edges.forEach(function (e) {
   var title = e.querySelector('title');
   var titleText = title && title.textContent;
   if (titleText) {
-    var nodeNames = titleText.split('->');
+    titleText = titleText.trim();
+    var nodeNames = titleText.split(/\s*->\s*/);
     edgeMap[titleText] = [nodeMap[nodeNames[0]], nodeMap[nodeNames[1]]];
     (edgeMap[nodeNames[0]] || (edgeMap[nodeNames[0]] = [])).push(e);
     (edgeMap[nodeNames[1]] || (edgeMap[nodeNames[1]] = [])).push(e);
@@ -40,6 +41,9 @@ function onmouseover(ev) {
   /** @type {SVGTitleElement} */
   var title = nodeOrEdge && nodeOrEdge.querySelector('title');
   var titleText = title && title.textContent;
+  if (titleText) {
+    titleText = titleText.trim();
+  }
   if (current === titleText) {
     return;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description + Motivation and Context

I was playing around with making a dark theme, and the output html got formatted and this broke my highlighting code, since it introduced whitespace. This is a small tweak to fix that.

### The dark theme, for context

in `.dependency-cruiser.js`
```js
const darkTheme = {
  graph: {
    bgcolor: 'black',
    fontcolor: 'white',
    fillcolor: '#000000',
  },
  node: {
    color: 'gray',
    // fillcolor: '#000033',
    // fontcolor: 'white'
  },
  edge: {
    color: '#FFFFFF33',
  },
};

module.exports = {
  // ...
  options: { reporterOptions: { dot: { theme: darkTheme } } }
};
```

in `svg-in-html-snippets/header.snippet.html`
```html
<html lang="en" dir="ltr">
  <head>
    <meta charset="utf-8" />
    <title>dependency graph</title>
    <style>
      html,
      body {
        background-color: black;
        scrollbar-color: DimGray black;
      }
      .cluster:active path,
      .cluster:hover path {
        fill: #33330011;
      }
      .cluster > path[stroke='black'] {
        stroke: lightgray;
      }
      /* ... */
```

![Screen Shot 2020-09-04 at 1 33 09 PM](https://user-images.githubusercontent.com/760204/92282796-3725c400-eeb3-11ea-9d74-00cfa475c0de.png)

## How Has This Been Tested?

Just in my browser.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
