### PR TITLE
bugfix(depcruise-fmt): only override dot collapse when it's provided

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -58,9 +58,12 @@ function format(pResult, pFormatOptions = {}) {
 
   const lReportFn = report.getReporter(lFormatOptions.outputType);
 
-  return lReportFn(reSummarizeResults(pResult, lFormatOptions), {
-    collapsePattern: lFormatOptions.collapse,
-  });
+  return lReportFn(
+    reSummarizeResults(pResult, lFormatOptions),
+    _has(lFormatOptions, "collapse")
+      ? { collapsePattern: lFormatOptions.collapse }
+      : {}
+  );
 }
 
 function futureCruise(


### PR DESCRIPTION
## Description, Motivation and Context

On a `depcruise-fmt output.json -T archi` depcruise-fmt didn't heed the collapsePattern defined for the archi reporter. This PR makes sure it does.

## How Has This Been Tested?

- [x] automated non-regression tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
