### PR TITLE
bugfix(resolve): try other extensions even when importing with explicit extension

### DIFF
--- a/test/extract/resolve/fixtures/donot-resolve-to-non-ts/there-is-a-cjs-variant-of-me-but-you-will-not-find-it.cjs
+++ b/test/extract/resolve/fixtures/donot-resolve-to-non-ts/there-is-a-cjs-variant-of-me-but-you-will-not-find-it.cjs
@@ -1,0 +1,1 @@
+module.exports = "beep boop";

--- a/test/extract/resolve/fixtures/resolve-to-ts-even-when-imported-as-js/i-am-secretly-typescript.ts
+++ b/test/extract/resolve/fixtures/resolve-to-ts-even-when-imported-as-js/i-am-secretly-typescript.ts
@@ -1,0 +1,1 @@
+export const peekABoo = 42;

--- a/test/extract/resolve/index.spec.js
+++ b/test/extract/resolve/index.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 const path = require("path");
 const { expect } = require("chai");
 const parseTSConfig = require("~/src/cli/parse-ts-config");
@@ -489,6 +490,88 @@ describe("extract/resolve/index", () => {
       dependencyTypes: ["npm-no-pkg"],
       followable: true,
       resolved: "node_modules/export-testinga/feature.cjs",
+    });
+  });
+
+  it("Resolves the .ts even when the import includes a (non-existing) .js with explicit extension", () => {
+    process.chdir(
+      "test/extract/resolve/fixtures/resolve-to-ts-even-when-imported-as-js"
+    );
+    expect(
+      resolve(
+        {
+          module: "./i-am-secretly-typescript.js",
+          moduleSystem: "es6",
+        },
+        process.cwd(),
+        process.cwd(),
+        normalizeResolveOptions(
+          {
+            bustTheCache: true,
+          },
+          {}
+        )
+      )
+    ).to.deep.equal({
+      coreModule: false,
+      couldNotResolve: false,
+      dependencyTypes: ["local"],
+      followable: true,
+      resolved: "i-am-secretly-typescript.ts",
+    });
+  });
+
+  it("Does NOT resolve the .ts when the import includes a (non-existing) .cjs with explicit extension", () => {
+    process.chdir(
+      "test/extract/resolve/fixtures/resolve-to-ts-even-when-imported-as-js"
+    );
+    expect(
+      resolve(
+        {
+          module: "./i-am-secretly-typescript.cjs",
+          moduleSystem: "es6",
+        },
+        process.cwd(),
+        process.cwd(),
+        normalizeResolveOptions(
+          {
+            bustTheCache: true,
+          },
+          {}
+        )
+      )
+    ).to.deep.equal({
+      coreModule: false,
+      couldNotResolve: true,
+      dependencyTypes: ["unknown"],
+      followable: false,
+      resolved: "./i-am-secretly-typescript.cjs",
+    });
+  });
+
+  it("Does NOT resolve to something non-typescriptish when the import includes a (non-existing) .js with explicit extension", () => {
+    process.chdir("test/extract/resolve/fixtures/donot-resolve-to-non-ts");
+    expect(
+      resolve(
+        {
+          module: "./there-is-a-cjs-variant-of-me-but-you-will-not-find-it.js",
+          moduleSystem: "es6",
+        },
+        process.cwd(),
+        process.cwd(),
+        normalizeResolveOptions(
+          {
+            bustTheCache: true,
+          },
+          {}
+        )
+      )
+    ).to.deep.equal({
+      coreModule: false,
+      couldNotResolve: true,
+      dependencyTypes: ["unknown"],
+      followable: false,
+      resolved: "./there-is-a-cjs-variant-of-me-but-you-will-not-find-it.js",
     });
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

This is currently the typescript compiler's default behavior, so we follow suit. 

Fixes #364 

TODO

- [x] _mull this over a night - we wanna feature switch this?_ => Not necessary.
  - some research shows that this only applies to typescript and only for Microsoft's typescript compiler and only for .js/.jsx => .ts/ .tsx/ .d.ts. It's really deliberate (explicitly including .ts makes the compiler relapse in horror) so it's going to be made more specific in order to not induce any breaking changes.
  - feature switch is not necessary if we narrow it down to only js/jsx going in and something typescript-ish coming out of the retry (extensions ts and tsx). That way it won't start to all-of-a-sudden start to do weird resolves in any non-ts environment.
  - the solution should _actually_ be in enhanced_resolve (either by default or by way of a plugin).


## How Has This Been Tested?

- [x] automated non-regression, green ci
- [x] additional unit test

## Screenshots

see issue

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
