### PR TITLE
bugfix(resolve): don't count regular and @types in package.json as two separate things

### DIFF
--- a/test/extract/resolve/determine-dependency-types.spec.js
+++ b/test/extract/resolve/determine-dependency-types.spec.js
@@ -117,25 +117,25 @@ describe("extract/resolve/determineDependencyTypes - determine dependencyTypes",
     ).to.deep.equal(["npm-dev"]);
   });
 
-  // it("Only picks the 'npm' dependency-type when it's in the manifest as a regular dependency and a devDependencies @types dependency ", () => {
-  //   expect(
-  //     determineDependencyTypes(
-  //       {
-  //         couldNotResolve: false,
-  //         resolved: "node_modules/snodash/index.js",
-  //       },
-  //       "snodash",
-  //       {
-  //         dependencies: {
-  //           snodash: "1.2.3",
-  //         },
-  //         devDependencies: {
-  //           "@types/snodash": "1.2.3",
-  //         },
-  //       }
-  //     )
-  //   ).to.deep.equal(["npm"]);
-  // });
+  it("Only picks the 'npm' dependency-type when it's in the manifest as a regular dependency and a devDependencies @types dependency ", () => {
+    expect(
+      determineDependencyTypes(
+        {
+          couldNotResolve: false,
+          resolved: "node_modules/snodash/index.js",
+        },
+        "snodash",
+        {
+          dependencies: {
+            snodash: "1.2.3",
+          },
+          devDependencies: {
+            "@types/snodash": "1.2.3",
+          },
+        }
+      )
+    ).to.deep.equal(["npm"]);
+  });
 
   it("sorts node_modules into 'npm-no-pkg' when they're in the supplied package devDependencies with an @types scope, but the resolve modules don't include 'node_modules/@types'", () => {
     expect(


### PR DESCRIPTION
## Description

See title

## Motivation and Context

So when you have e.g. a `hodash` dependency and a ~@types/hodash~ devDependency they're not (1) flagged as duplicate dependencies (2) the @types devDependency isn't flagged in a not-to-dev rule. Which both would be false positives.


## How Has This Been Tested?

- [x] additional unit test
- [x] automated non-regression tests/ green ci


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
