### PR TITLE
bugfix(report): make the err-long reporter print comments again

### DIFF
--- a/src/report/error-long.js
+++ b/src/report/error-long.js
@@ -1,0 +1,5 @@
+const error = require("./error");
+
+module.exports = function errorLong(pResults, pOptions) {
+  return error(pResults, { ...pOptions, long: true });
+};

--- a/src/report/index.js
+++ b/src/report/index.js
@@ -1,12 +1,11 @@
-const curryRight = require("lodash/curryRight");
 const anon = require("./anon");
 const csv = require("./csv");
 const dot = require("./dot")("module");
 const ddot = require("./dot")("folder");
 const cdot = require("./dot")("custom");
 const errorHtml = require("./error-html");
-const errorLong = curryRight(require("./error"))({ long: true });
 const error = require("./error");
+const errorLong = require("./error-long");
 const html = require("./html");
 const identity = require("./identity");
 const json = require("./json");

--- a/test/main/main.format.spec.js
+++ b/test/main/main.format.spec.js
@@ -71,4 +71,23 @@ describe("main.format - format", () => {
     expect(lCollapsedResult.summary.totalCruised).to.equal(19);
     expect(lCollapsedResult.summary.totalDependenciesCruised).to.equal(18);
   });
+
+  it("returns string with error explanations when asked for the err-long report", () => {
+    const lErrorLongResult = main.format(cruiseResult, {
+      outputType: "err-long",
+    }).output;
+    expect(lErrorLongResult).to.contain("cli-to-main-only-warn:");
+    expect(lErrorLongResult).to.contain(
+      "This cli module depends on something not in the public interface"
+    );
+  });
+  it("returns string without error explanations when asked for the err report", () => {
+    const lErrorResult = main.format(cruiseResult, {
+      outputType: "err",
+    }).output;
+    expect(lErrorResult).to.contain("cli-to-main-only-warn:");
+    expect(lErrorResult).to.not.contain(
+      "This cli module depends on something not in the public interface"
+    );
+  });
 });

--- a/test/report/error/error-long.spec.js
+++ b/test/report/error/error-long.spec.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-magic-numbers */
-const curryRight = require("lodash/curryRight");
 const { expect } = require("chai");
 const chalk = require("chalk");
 const okdeps = require("./mocks/everything-fine.json");
@@ -7,7 +6,7 @@ const deps = require("./mocks/cjs-no-dependency-valid.json");
 const warndeps = require("./mocks/err-only-warnings.json");
 const erradds = require("./mocks/err-with-additional-information.json");
 const orphanerrs = require("./mocks/orphan-deps.json");
-const render = curryRight(require("~/src/report/error"))({ long: true });
+const render = require("~/src/report/error-long");
 
 describe("report/error-long", () => {
   let chalkLevel = chalk.level;


### PR DESCRIPTION
## Description

- Makes the error-long reporter invocation un-fancy, so it prints comments/ explanations again

Since the moment reporter invocation in `main` was made more generic parameters weren't passed correctly anymore to the error-long reporter (which in itself still worked fine :-/)

## Motivation and Context

Fixes a bug (error-long is expected to print the comments)

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] additional integration test


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
