### PR TITLE
bugfix(doc): consistently use .dependency-cruiser.js as config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Sample rule:
 #### Report them
 
 ```sh
-depcruise --config .dependency-cruiser.json src
+depcruise --config .dependency-cruiser.js src
 ```
 
 This will validate against your rules and shows any violations in an eslint-like format:

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -94,7 +94,8 @@ dependency-cruise --config my-depcruise-rules.json src
 This will:
 
 - ... print nothing and exit with code 0 if dependency-cruiser didn't
-  find any violations of the rules in .dependency-cruiser.json.
+  find any violations of the rules in the configuration file (e.g.
+  .dependency-cruiser.js or .dependency-cruiser.json).
 - ... print the violating dependencies if there is any. Moreover it
   will exit with exit code _number of violations with severity `error` found_
   in the same fashion linters and test tools do.

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -433,7 +433,7 @@ in your dependency graph), but it is something to
 keep in mind.
 
 To detect orphan guys you can add e.g. this snippet to your
-.dependency-cruiser.json's `forbidden` section:
+.dependency-cruiser.js's `forbidden` section:
 
 ```json
 {
@@ -590,7 +590,7 @@ where you started (a.k.a. circular dependencies). Leaving this out => you don't
 care either way.
 
 For example, adding this rule to the "forbidden" section in your
-.dependency-cruiser.json will issue a warning for each dependency that ends
+.dependency-cruiser.js will issue a warning for each dependency that ends
 up at itself.
 
 ```json
@@ -663,7 +663,7 @@ and started using it in a production source.
 To save you from embarrassing moments like this, you can make rules with the
 `dependencyTypes` verb. E.g. to prevent you accidentally depend on a
 `devDependency` from anything in `src` add this to your
-.dependency-cruiser.json's "forbidden" section:
+.dependency-cruiser.js's "forbidden" section:
 
 ```json
 {

--- a/src/cli/init-config/write-run-scripts-to-manifest.js
+++ b/src/cli/init-config/write-run-scripts-to-manifest.js
@@ -72,7 +72,7 @@ function getSuccessMessage(pDestinationManifestFileName) {
     )} Run scripts added to '${pDestinationManifestFileName}':` +
     `\n    ${chalk.green(figures.play)} npm run depcruise` +
     `\n${wrapAndIndent(
-      "validates against the rules in .dependency-cruiser.json and writes the outcome to stdout",
+      "validates against the rules in .dependency-cruiser.js and writes the outcome to stdout",
       lExplanationIndent
     )}` +
     `\n\n    ${chalk.green(figures.play)} npm run depcruise:html` +


### PR DESCRIPTION
and only mention the alternate .json when really relevant

## Description

- Updates documentation as in title

## Motivation and Context

fixes #383 

## How Has This Been Tested?

- [x] automated non-regression tests + green ci 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
