### PR TITLE
refactor(extract): call path-to-posix less often

### DIFF
--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -25,13 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v1
-      # - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: node_modules
-      #     key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
-      #     restore-keys: |
-      #       ${{matrix.node-version}}@${{matrix.platform}}-build-
+      - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+          restore-keys: |
+            ${{matrix.node-version}}@${{matrix.platform}}-build-
       - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test-workflow-windows-only.yml
+++ b/.github/workflows/test-workflow-windows-only.yml
@@ -22,24 +22,21 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v1
-      # - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: node_modules
-      #     key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
-      #     restore-keys: |
-      #       ${{matrix.node-version}}@${{matrix.platform}}-build-
+      - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+          restore-keys: |
+            ${{matrix.node-version}}@${{matrix.platform}}-build-
       - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
         uses: actions/setup-node@v1
         with:
           node-version: ${{matrix.node-version}}
-      # the rimraf node_modules appears to be necessary as there's a wyrd
-      # renaming thing occurring on windows with npm:
-      # npm ERR! enoent ENOENT: no such file or directory, rename 'd:\a\dependency-cruiser\dependency-cruiser\node_modules\.staging\rxjs-76baa905' -> 'd:\a\dependency-cruiser\dependency-cruiser\node_modules\inquirer\node_modules\rxjs'
       - name: install & build
         run: |
           node --version
-          rm -rf node_modules
+          # rm -rf node_modules
           npm install
           npm run build
         shell: bash

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "check:full": "npm-run-all check test:glob test:yarn-pnp",
     "depcruise": "node ./bin/dependency-cruise.js src bin test configs types tools --config",
     "depcruise:explain": "node ./bin/dependency-cruise.js src bin test configs types tools --output-type err-long --config --progress none",
+    "depcruise:graph:dev": "node ./bin/dependency-cruise.js bin src --prefix vscode://file/$(pwd)/ --config --output-type dot --progress cli-feedback | dot -T svg | node ./bin/wrap-stream-in-html.js | browser",
     "depcruise:graph:doc": "npm-run-all depcruise:graph:doc:json --parallel depcruise:graph:doc:fmt-* depcruise:graph:doc:samples",
     "depcruise:graph:doc:json": "node ./bin/dependency-cruise.js bin src test --config --output-type json --output-to tmp_graph_deps.json --progress",
     "depcruise:graph:doc:fmt-detail": "./bin/depcruise-fmt.js -T dot -f - tmp_graph_deps.json | dot -T svg | tee doc/real-world-samples/dependency-cruiser-without-node_modules.svg | node bin/wrap-stream-in-html.js > docs/dependency-cruiser-dependency-graph.html",

--- a/src/enrich/summarize-options.js
+++ b/src/enrich/summarize-options.js
@@ -1,6 +1,5 @@
 const _get = require("lodash/get");
 const _has = require("lodash/has");
-const pathToPosix = require("../utl/path-to-posix");
 
 const SHAREABLE_OPTIONS = [
   "combinedDependencies",
@@ -59,7 +58,7 @@ module.exports = function summarizeOptions(pFileDirectoryArray, pOptions) {
   return {
     optionsUsed: {
       ...makeOptionsPresentable(makeIncludOnlyBackwardsCompatible(pOptions)),
-      args: pFileDirectoryArray.map(pathToPosix).join(" "),
+      args: pFileDirectoryArray.join(" "),
     },
   };
 };

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -2,7 +2,6 @@ const _uniqBy = require("lodash/uniqBy");
 const _spread = require("lodash/spread");
 const _concat = require("lodash/concat");
 const _has = require("lodash/has");
-const pathToPosix = require("../utl/path-to-posix");
 const getDependencies = require("./get-dependencies");
 const gatherInitialSources = require("./gather-initial-sources");
 const clearCaches = require("./clear-caches");
@@ -49,7 +48,7 @@ function extractRecursive(
       },
       [
         {
-          source: pathToPosix(pFileName),
+          source: pFileName,
           dependencies: lDependencies,
         },
       ]

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const pathToPosix = require("../../utl/path-to-posix");
+const pathToPosix = require("../utl/path-to-posix");
 const { isRelativeModuleName } = require("./module-classifiers");
 const resolveAMD = require("./resolve-amd");
 const resolveCommonJS = require("./resolve-cjs");

--- a/src/extract/resolve/resolve-amd.js
+++ b/src/extract/resolve/resolve-amd.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const memoize = require("lodash/memoize");
-const pathToPosix = require("../../utl/path-to-posix");
+const pathToPosix = require("../utl/path-to-posix");
 const determineDependencyTypes = require("./determine-dependency-types");
 const { isCore } = require("./module-classifiers");
 const getManifest = require("./get-manifest");
@@ -28,7 +28,7 @@ module.exports = function resolveAMD(
   // - [ ] require.config kerfuffle (command line, html, file, ...)
   // - [ ] maybe use mrjoelkemp/module-lookup-amd ?
   // - [ ] or https://github.com/jaredhanson/amd-resolve ?
-  // - [x] funky plugins (json!wappie, ./screeching-cat!sabertooth) -> fixed in 'extract'
+  // - [ ] funky plugins (json!wappie, ./screeching-cat!sabertooth)
   const lProbablePath = pathToPosix(
     path.relative(
       pBaseDirectory,

--- a/src/extract/resolve/resolve-cjs.js
+++ b/src/extract/resolve/resolve-cjs.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const pathToPosix = require("../../utl/path-to-posix");
+const pathToPosix = require("../utl/path-to-posix");
 const determineDependencyTypes = require("./determine-dependency-types");
 const { isCore, isFollowable } = require("./module-classifiers");
 const getManifest = require("./get-manifest");

--- a/src/extract/resolve/resolve.js
+++ b/src/extract/resolve/resolve.js
@@ -1,5 +1,5 @@
 const enhancedResolve = require("enhanced-resolve");
-const pathToPosix = require("../../utl/path-to-posix");
+const pathToPosix = require("../utl/path-to-posix");
 const stripQueryParameters = require("../utl/strip-query-parameters");
 
 let gResolvers = {};

--- a/src/extract/utl/path-to-posix.js
+++ b/src/extract/utl/path-to-posix.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 /**
  * On win32 platforms transform win32 type paths into posix paths
- * (leaves paths on posix platforms alone)ß
+ * (leaves paths on posix platforms alone)
  *
  * This function is just to make dependency-cruiser's internal
  * representation consistent. This is the reason it doesn't have
@@ -19,7 +19,7 @@ const path = require("path");
  *                              this module on posix platforms only; defaults to require('path'))
  * @return {string}             the transformed path
  */
-module.exports = (pFilePath, pPathModule) => {
+module.exports = function pathToPosix(pFilePath, pPathModule) {
   const lPathModule = pPathModule || path;
 
   if (lPathModule.sep !== path.posix.sep) {

--- a/test/cli/parse-ts-config.spec.js
+++ b/test/cli/parse-ts-config.spec.js
@@ -1,7 +1,7 @@
 const path = require("path").posix;
 const { expect } = require("chai");
 const parseTSConfig = require("../../src/cli/parse-ts-config");
-const pathToPosix = require("../../src/utl/path-to-posix");
+const pathToPosix = require("../../src/extract/utl/path-to-posix");
 
 const DIRNAME = pathToPosix(__dirname);
 

--- a/test/extract/gather-initial-sources.spec.js
+++ b/test/extract/gather-initial-sources.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 const gather = require("../../src/extract/gather-initial-sources");
-const p2p = require("../../src/utl/path-to-posix");
+const p2p = require("../../src/extract/utl/path-to-posix");
 const { normalizeCruiseOptions } = require("../../src/main/options/normalize");
 
 // make the import pathToPosix the correct function profile

--- a/test/extract/utl/path-to-posix.spec.js
+++ b/test/extract/utl/path-to-posix.spec.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const { expect } = require("chai");
-const pathToPosix = require("../../src/utl/path-to-posix");
+const pathToPosix = require("../../../src/extract/utl/path-to-posix");
 
 describe("utl/pathToPosix on win32", () => {
   it('transforms win32 style paths to posix ones: ""', () => {

--- a/test/main/main.cruise.spec.js
+++ b/test/main/main.cruise.spec.js
@@ -1,6 +1,7 @@
 const path = require("path").posix;
 const fs = require("fs");
 const chai = require("chai");
+const pathToPosix = require("../../src/extract/utl/path-to-posix");
 const cruiseResultSchema = require("../../src/schema/cruise-result.schema.json");
 const main = require("../../src/main");
 const tsFixture = require("./fixtures/ts.json");
@@ -12,13 +13,22 @@ const expect = chai.expect;
 
 chai.use(require("chai-json-schema"));
 
+function pathPosixify(pOutput) {
+  const lReturnValue = { ...pOutput };
+  lReturnValue.summary.optionsUsed.args = pathToPosix(
+    lReturnValue.summary.optionsUsed.args
+  );
+  return lReturnValue;
+}
+
 describe("main.cruise", () => {
   it("Returns an object when no options are passed", () => {
     const lResult = main.cruise(["test/main/fixtures/ts"]);
 
-    expect(lResult.output).to.deep.equal(tsFixture);
+    expect(pathPosixify(lResult.output)).to.deep.equal(tsFixture);
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
+
   it("Returns an object when no options are passed (absolute path)", () => {
     const lResult = main.cruise(
       [path.join(__dirname, "fixtures", "ts")],
@@ -26,9 +36,10 @@ describe("main.cruise", () => {
       { bustTheCache: true }
     );
 
-    expect(lResult.output).to.deep.equal(tsFixture);
+    expect(pathPosixify(lResult.output)).to.deep.equal(tsFixture);
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
+
   it("Also processes tsx correctly", () => {
     const lResult = main.cruise(
       ["test/main/fixtures/tsx"],
@@ -36,7 +47,7 @@ describe("main.cruise", () => {
       { bustTheCache: true }
     );
 
-    expect(lResult.output).to.deep.equal(tsxFixture);
+    expect(pathPosixify(lResult.output)).to.deep.equal(tsxFixture);
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
   it("And jsx", () => {
@@ -46,7 +57,7 @@ describe("main.cruise", () => {
       { bustTheCache: true }
     );
 
-    expect(lResult.output).to.deep.equal(jsxFixture);
+    expect(pathPosixify(lResult.output)).to.deep.equal(jsxFixture);
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
   it("And rulesets in the form a an object instead of json", () => {
@@ -58,7 +69,7 @@ describe("main.cruise", () => {
       { bustTheCache: true }
     );
 
-    expect(lResult.output).to.deep.equal(jsxAsObjectFixture);
+    expect(pathPosixify(lResult.output)).to.deep.equal(jsxAsObjectFixture);
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
   it("Collapses to a pattern when a collapse pattern is passed", () => {
@@ -71,7 +82,7 @@ describe("main.cruise", () => {
       { bustTheCache: true }
     );
 
-    expect(lResult.output).to.deep.equal(
+    expect(pathPosixify(lResult.output)).to.deep.equal(
       JSON.parse(
         fs.readFileSync(
           "test/main/fixtures/collapse-after-cruise/expected-result.json",


### PR DESCRIPTION
## Description

- Moves converting paths to posix earlier in the process and removes the conversion where the conversion doesn't have any effect anymore.

## Motivation and Context

See #386 - @tvolodimir put me on this trail that path-to-posix has an impact on performance. On msdos derivatives this refactor tends to make a significant difference in performance - on an i5 with win10 dependency-cruiser cruises itself in ~27s instead of in 32s (which is still ~3x as slow as it's on unix derivatives, but it's a start).

## How Has This Been Tested?

- [x] automated non-regression tests + green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
