### PR TITLE
bugfix(extract): use acorn-jsx for parsing jsx (instead of acorn + acorn-loose)

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -205,7 +205,50 @@ necessary compilers at its disposal.
 ### Q: I'm developing in React and use jsx/ tsx/ csx/ cjsx. How do I get that to work?
 
 **A**: jsx and its TypeScript and CoffeeScript variants work
-out of the box as well.
+out of the box as well. For jsx there is a little caveat, though.
+
+### Q: I hear there is a little caveat with jsx. What is that?
+
+**A**: Under the hood dependency-cruiser currently uses `acorn` and `acorn-jsx`
+which (for at least some time) have been the official jsx transpilers and are
+still used by other tools (source: acorn-jsx github page). Some constructs in
+jsx it does not support however. In the lion's share of the cases you will not
+notice, and acorn will still pick out the correct dependencies (more nor
+less than are in the source code) because it will fall back on the acorn-loose
+parser, which will pick up the pieces. _except_, that is when you happen to use
+_import_, _export_ or _require_ in jsx fragments in one special flavor of jsx
+
+<details>
+<summary>Sample of jsx the default parser doesn't parse</summary>
+
+```jsx
+import React from "react";
+
+export class ReplicateIssueComponent extends React.Component {
+  renderSomethingElse = () => {
+    return (
+      <>The word import here results is picked up as an import statement.</>
+    );
+  };
+
+  render = () => (
+    <>
+      {this.renderSomethingElse()}
+      Here import is confused with an import statement as well.
+    </>
+  );
+}
+```
+
+</details>
+
+In [this comment](https://github.com/sverweij/dependency-cruiser/issues/395#issuecomment-730295987)
+on the orignal issue [@audunsol](https://github.com/audunsol) offers a few
+ways to work around the issue you might find helpful when you have similar
+jsx.
+
+(As a future feature dependency-cruiser will include ways to handle even these
+situations without workarounds).
 
 ### Q: Does this work with Vue as well?
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
   },
   "dependencies": {
     "acorn": "8.0.4",
+    "acorn-jsx": "5.3.1",
+    "acorn-jsx-walk": "2.0.0",
     "acorn-loose": "8.0.1",
     "acorn-walk": "8.0.0",
     "ajv": "6.12.6",

--- a/src/extract/ast-extractors/extract-es6-deps.js
+++ b/src/extract/ast-extractors/extract-es6-deps.js
@@ -1,5 +1,8 @@
 const walk = require("acorn-walk");
+const { extend } = require("acorn-jsx-walk");
 const estreeHelpers = require("./estree-helpers");
+
+extend(walk.base);
 
 function pushImportNodeValue(pDependencies) {
   return (pNode) => {

--- a/src/extract/parse/to-javascript-ast.js
+++ b/src/extract/parse/to-javascript-ast.js
@@ -1,25 +1,34 @@
 const fs = require("fs");
 const acorn = require("acorn");
 const acornLoose = require("acorn-loose");
+const acornJsx = require("acorn-jsx");
 const _memoize = require("lodash/memoize");
 const transpile = require("../transpile");
 const getExtension = require("../utl/get-extension");
+
+const ACORN_OPTIONS = {
+  sourceType: "module",
+  ecmaVersion: 11,
+};
+
+const acornJsxParser = acorn.Parser.extend(acornJsx());
 
 function getASTFromSource(pSource, pExtension, pTranspileOptions) {
   const lJavaScriptSource = transpile(pExtension, pSource, pTranspileOptions);
 
   try {
+    if (pExtension === ".jsx") {
+      return acornJsxParser.parse(lJavaScriptSource, {
+        ...ACORN_OPTIONS,
+        allowNamespacedObjects: true,
+      });
+    }
+
     // ecmaVersion 11 necessary for acorn to understand dynamic imports
     // explicitly passing ecmaVersion is recommended from acorn 8
-    return acorn.parse(lJavaScriptSource, {
-      sourceType: "module",
-      ecmaVersion: 11,
-    });
+    return acorn.parse(lJavaScriptSource, ACORN_OPTIONS);
   } catch (pError) {
-    return acornLoose.parse(lJavaScriptSource, {
-      sourceType: "module",
-      ecmaVersion: 11,
-    });
+    return acornLoose.parse(lJavaScriptSource, ACORN_OPTIONS);
   }
 }
 

--- a/src/extract/transpile/jsx-implementation-rationale.md
+++ b/src/extract/transpile/jsx-implementation-rationale.md
@@ -27,16 +27,15 @@ More react research:
     - do the various options have a common denominator (e.g. `babel-plugin-jsx` - maybe another one?)
   - `babel-plugin-transform-react-jsx` seems to be a reasonable common denominator. It just doesn't work on its own in most react project I've used it on.
 
-## Alternative: acorn with acorn-jsx (not chosen)
+## Alternative: acorn with acorn-jsx (chosen)
 
 - For this I introduced acorn-jsx in the extraction step. It's a relatively elegant solution; .js is correctly parsed without hitches, as is .jsx. In the latter case abstract syntax tree contains JSXxxx nodes. Also acorn-jsx is the 'official' jsx parser used by facebook. And babel. However ...
 - ... for extracting dependencies from the syntax tree I use the tree-walker included in acorn. This - understandably - chokes on the new-fangled JSXxxx nodes acorn-jsx uses. There's some solutions available for this
-  - use the `acorn-jsx-walk` package. It isn't updated for quite a long time, and doesn't seem to have a lot of traction (in downloads, stars or otherwise). It also uses quite a lot of dependencies (biggish) and the code base didn't seem as one I'd like to adopt.
+
+  - use the `acorn-jsx-walk` package. ~~It isn't updated for quite a long time, and doesn't seem to have a lot of traction (in downloads, stars or otherwise). It also uses quite a lot of dependencies (biggish) and the code base didn't seem as one I'd like to adopt.~~ _update 2020-11-16_: acorn-jsx-walk is dependency-less (now - or was it always?), and super straightforward, small piece code to boot, so it makes sense that it doesn't need a whole lot of updates => totally legit to pull in.
   - filter/ transform the parsed tree so it doesn't contain JSXxxx nodes anymore - I'm not interested in those anyway. My estimation is that this will be non-trivial to do right.
 
-**=> not a viable option for the short term**
-
-## Alternative: acorn_loose
+## Alternative: acorn_loose (not chosen)
 
 Observing
 
@@ -48,7 +47,7 @@ Observing
   - fast & stable
 - ... implementing & testing this is a doddle ...
 
-**=> acorn_loose it is for now** ; maybe later an elegant solution for one of the above (plugin? passing babelrc?)
+**this was used until dependency-cruiser 9.17.0** when it started using acorn-jsx + acorn-jsx-walk
 
 # Vue
 

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -10,17 +10,6 @@ const litCoffeeWrap = require("./coffeescript-wrap")(true);
 const vueWrap = require("./vue-template-wrap");
 const babelWrap = require("./babel-wrap");
 
-/*
-  jsx - acorn_loose will handle this correctly when imports
-        etc are on top, which is the most likely use case.
-        Alternatives (making a jsxWrap with babel-core & a bunch
-        of plugins or using acorn-jsx) might be more correct in
-        edge cases but are either much harder to implement or
-        likely to fail in basic use cases.
-
-        See ./jsx-implementation-rationale.md for an implementation
-        rationale on jsx ...
- */
 const EXTENSION2WRAPPER = {
   ".js": javaScriptWrap,
   ".cjs": javaScriptWrap,

--- a/test/extract/ast-extractors/extract-es6-deps.spec.js
+++ b/test/extract/ast-extractors/extract-es6-deps.spec.js
@@ -3,8 +3,11 @@ const extractES6Deps = require("../../../src/extract/ast-extractors/extract-es6-
 const getASTFromSource = require("../../../src/extract/parse/to-javascript-ast")
   .getASTFromSource;
 
-const extractES6 = (pJavaScriptSource, pDependencies) =>
-  extractES6Deps(getASTFromSource(pJavaScriptSource, "js"), pDependencies);
+const extractES6 = (pJavaScriptSource, pDependencies, pExtension = ".js") =>
+  extractES6Deps(
+    getASTFromSource(pJavaScriptSource, pExtension),
+    pDependencies
+  );
 
 describe("ast-extractors/extract-ES6-deps", () => {
   it("dynamic imports of strings", () => {
@@ -81,5 +84,70 @@ describe("ast-extractors/extract-ES6-deps", () => {
       lDeps
     );
     expect(lDeps).to.deep.equal([]);
+  });
+
+  it("doesn't get confused about import keywords in jsx components", () => {
+    let lDependencies = [];
+    const INPUT = `import React from 'react';
+
+    export const ReplicateIssueComponent = props => {
+      return (
+        <>
+        This usage of the word import doesn't get detected as dependency
+        </>
+      );
+    }`;
+
+    extractES6(INPUT, lDependencies, ".jsx");
+    expect(lDependencies).to.deep.equal([
+      {
+        module: "react",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
+  });
+
+  it("does a.t.m. NOT handle certain ways of jsx notation correctly", () => {
+    let lDependencies = [];
+    const INPUT = `import React from 'react';
+
+export class ReplicateIssueComponent extends React.Component {
+  renderSomethingElse = () => {
+    return (
+      <>The word import here still triggers the not-to-unresolvable error</>
+    );
+  };
+
+  render = () => (
+    <>
+      {this.renderSomethingElse()}
+      This usage of the word import in this string does no longer trigger the
+      not-to-unresolvable error (at version 9.17.1-beta-1)
+    </>
+  );
+}`;
+    extractES6(INPUT, lDependencies, ".jsx");
+    expect(lDependencies).to.deep.equal([
+      {
+        module: "react",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+      {
+        module: "✖",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+      {
+        module: "✖",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Description

dependency-cruiser shirked back from using acorn-jsx + acorn-jsx-walk because it didn't look like a stable solution and straight acorn + acorn-loose worked correctly in all jsx cases thrown at them. Today @audunsol raised #395, showing a counter example.  acorn-jsx-walk's code today (and with today's eyes) looks totally simple and solid to use, so this PR can use it to ensure dependency-cruiser parse jsx with the official acorn-jsx plugin.

## Motivation and Context

fixes #395 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit test(s)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
