### PR TITLE
feature(cli): adds showing % complete in cli-feedback

### DIFF
--- a/src/cli/listeners/cli-feedback/index.js
+++ b/src/cli/listeners/cli-feedback/index.js
@@ -2,11 +2,40 @@ const chalk = require("chalk");
 const figures = require("figures");
 const busLogLevels = require("../../../utl/bus-log-levels");
 
-function getProgressMessageWriter(pStream, pMaxLogLevel) {
-  return (pMessage, pLevel = busLogLevels.SUMMARY) => {
-    if (pStream.isTTY && pLevel <= pMaxLogLevel) {
+const FULL_ON = 100;
+
+function normalizeParameters(pParameters) {
+  return {
+    barSize: 10,
+    block: figures.squareSmallFilled,
+    blank: figures.squareSmall,
+    ...(pParameters || {}),
+  };
+}
+function getPercBar(pPercentage, pParameters) {
+  const lParameters = normalizeParameters(pParameters);
+  const lPercentage = Math.min(pPercentage || 0, 1);
+  const lBlocks = Math.floor(lParameters.barSize * lPercentage);
+  const lBlanks = lParameters.barSize - lBlocks;
+
+  return `${chalk.green(lParameters.block.repeat(lBlocks))}${chalk.green(
+    lParameters.blank.repeat(lBlanks)
+  )} ${Math.round(FULL_ON * lPercentage)}%`;
+}
+
+function getProgressMessageWriter(pStream, pState, pMaxLogLevel) {
+  return (pMessage, pOptions) => {
+    const lOptions = {
+      level: busLogLevels.SUMMARY,
+      complete: pState.complete,
+      ...(pOptions || {}),
+    };
+
+    pState.complete = lOptions.complete;
+
+    if (pStream.isTTY && lOptions.level <= pMaxLogLevel) {
       pStream.clearLine(1);
-      pStream.write(`  ${chalk.greenBright(figures.play)} ${pMessage} ...\n`);
+      pStream.write(`  ${getPercBar(lOptions.complete)} ${pMessage} ...\n`);
       pStream.moveCursor(0, -1);
     }
   };
@@ -28,7 +57,13 @@ module.exports = function setUpCliFeedbackListener(
   pMaxLogLevel = busLogLevels.SUMMARY,
   pStream = process.stderr
 ) {
-  pEventEmitter.on("progress", getProgressMessageWriter(pStream, pMaxLogLevel));
+  const lState = {
+    complete: 0,
+  };
+  pEventEmitter.on(
+    "progress",
+    getProgressMessageWriter(pStream, lState, pMaxLogLevel)
+  );
 
   pEventEmitter.on("write-start", getStartWriter(pStream));
 

--- a/src/cli/listeners/performance-log/index.js
+++ b/src/cli/listeners/performance-log/index.js
@@ -2,14 +2,18 @@ const busLogLevels = require("../../../utl/bus-log-levels");
 const { getHeader, getProgressLine, getEndText } = require("./handlers");
 
 function getHeaderWriter(pStream, pMaxLevel) {
-  return (_pMessage, pLevel = busLogLevels.SUMMARY) => {
-    pStream.write(getHeader(pLevel, pMaxLevel));
+  return (_pMessage, pOptions) => {
+    const lOptions = { level: busLogLevels.SUMMARY, ...(pOptions || {}) };
+
+    pStream.write(getHeader(lOptions.level, pMaxLevel));
   };
 }
 
 function getProgressWriter(pStream, pState, pMaxLevel) {
-  return (pMessage, pLevel = busLogLevels.SUMMARY) => {
-    pStream.write(getProgressLine(pMessage, pState, pLevel, pMaxLevel));
+  return (pMessage, pOptions) => {
+    const lOptions = { level: busLogLevels.SUMMARY, ...(pOptions || {}) };
+
+    pStream.write(getProgressLine(pMessage, pState, lOptions.level, pMaxLevel));
   };
 }
 

--- a/src/enrich/enrich-modules.js
+++ b/src/enrich/enrich-modules.js
@@ -8,19 +8,21 @@ const deriveReachable = require("./derive/reachable");
 const addValidations = require("./add-validations");
 
 module.exports = function enrichModules(pModules, pOptions) {
-  bus.emit("progress", "analyzing: cycles", busLogLevels.INFO);
+  bus.emit("progress", "analyzing: cycles", { level: busLogLevels.INFO });
   let lModules = deriveCirculars(pModules);
-  bus.emit("progress", "analyzing: orphans", busLogLevels.INFO);
+  bus.emit("progress", "analyzing: orphans", { level: busLogLevels.INFO });
   lModules = deriveOrphans(lModules);
-  bus.emit("progress", "analyzing: reachables", busLogLevels.INFO);
+  bus.emit("progress", "analyzing: reachables", { level: busLogLevels.INFO });
   lModules = deriveReachable(lModules, pOptions.ruleSet);
-  bus.emit("progress", "analyzing: add focus (if any)", busLogLevels.INFO);
+  bus.emit("progress", "analyzing: add focus (if any)", {
+    level: busLogLevels.INFO,
+  });
   lModules = addFocus(lModules, _get(pOptions, "focus"));
 
   // when validate === false we might want to skip the addValidations.
   // We don't at this time, however, as "valid" is a mandatory
   // attribute (to simplify reporter logic)
-  bus.emit("progress", "analyzing: validations", busLogLevels.INFO);
+  bus.emit("progress", "analyzing: validations", { level: busLogLevels.INFO });
   lModules = addValidations(lModules, pOptions.ruleSet, pOptions.validate);
 
   return lModules;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 /* eslint-disable import/max-dependencies */
 const Ajv = require("ajv");
 const extract = require("../extract");
@@ -38,37 +39,42 @@ function format(pResult, pFormatOptions = {}) {
   return reportWrap(pResult, lFormatOptions);
 }
 
+const TOTAL_STEPS = 8;
+
+function c(pComplete, pTotal = TOTAL_STEPS) {
+  return { complete: pComplete / pTotal };
+}
 function futureCruise(
   pFileAndDirectoryArray,
   pCruiseOptions,
   pResolveOptions,
   pTranspileOptions
 ) {
-  bus.emit("progress", "parsing options");
+  bus.emit("progress", "parsing options", c(1));
   let lCruiseOptions = normalizeCruiseOptions(
     validateCruiseOptions(pCruiseOptions)
   );
 
   if (Boolean(lCruiseOptions.ruleSet)) {
-    bus.emit("progress", "parsing rule set");
+    bus.emit("progress", "parsing rule set", c(2));
     lCruiseOptions.ruleSet = normalizeRuleSet(
       validateRuleSet(lCruiseOptions.ruleSet)
     );
   }
 
-  bus.emit("progress", "making sense of files and directories");
+  bus.emit("progress", "making sense of files and directories", c(3));
   const lNormalizedFileAndDirectoryArray = normalizeFilesAndDirectories(
     pFileAndDirectoryArray
   );
 
-  bus.emit("progress", "determining how to resolve");
+  bus.emit("progress", "determining how to resolve", c(4));
   const lNormalizedResolveOptions = normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
     pTranspileOptions.tsConfig
   );
 
-  bus.emit("progress", "reading files");
+  bus.emit("progress", "reading files", c(5));
   const lExtractionResult = extract(
     lNormalizedFileAndDirectoryArray,
     lCruiseOptions,
@@ -76,14 +82,14 @@ function futureCruise(
     pTranspileOptions
   );
 
-  bus.emit("progress", "analyzing");
+  bus.emit("progress", "analyzing", c(6));
   const lCruiseResult = enrich(
     lExtractionResult,
     lCruiseOptions,
     lNormalizedFileAndDirectoryArray
   );
 
-  bus.emit("progress", "reporting");
+  bus.emit("progress", "reporting", c(7));
   return reportWrap(lCruiseResult, lCruiseOptions);
 }
 


### PR DESCRIPTION
## Description

Adds a % complete to the `cli-feedback` --progress option


## Motivation and Context

Shows more information

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci

## Screenshots

Before: 
```
▶ reading files ...
```

After:
```
◼◼◼◼◼◼◻◻◻◻ 63% reading files ...
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
