### PR TITLE
refactor(extract): excludes excludable file name patterns earlier

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -226,7 +226,8 @@
     // },
     "enhancedResolveOptions": {
       "exportsFields": ["exports"],
-      "conditionNames": ["require"]
+      "conditionNames": ["require"],
+      "extensions": [".js", ".ts", ".d.ts"]
     },
     "exoticRequireStrings": ["tryRequire"],
     "reporterOptions": {

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -18,7 +18,7 @@ module.exports = {
   ],
   options: {
     doNotFollow: {
-      // path: "node_modules",
+      path: "node_modules",
       dependencyTypes: [
         "npm",
         "npm-dev",

--- a/src/cli/format-meta-info.js
+++ b/src/cli/format-meta-info.js
@@ -26,7 +26,8 @@ function formatExtensions(pExtensions) {
   );
 }
 
-module.exports = () => `
+module.exports = function formatMetaInfo() {
+  return `
   Supported:
 
     If you need a supported, but not enabled transpiler ('${chalk.red(
@@ -42,5 +43,6 @@ ${formatTranspilers()}
 
 ${formatExtensions(main.allExtensions)}
 `;
+};
 
 /* eslint security/detect-object-injection : 0 */

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -107,7 +107,7 @@ function runCruise(pFileDirectoryArray, pCruiseOptions) {
   return lReportingResult.exitCode;
 }
 
-module.exports = (pFileDirectoryArray, pCruiseOptions) => {
+module.exports = function executeCli(pFileDirectoryArray, pCruiseOptions) {
   pCruiseOptions = pCruiseOptions || {};
   let lExitCode = 0;
 

--- a/src/cli/utl/validate-file-existence.js
+++ b/src/cli/utl/validate-file-existence.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 
-module.exports = (pDirectoryOrFile) => {
+module.exports = function validateFileExistence(pDirectoryOrFile) {
   try {
     fs.accessSync(pDirectoryOrFile, fs.R_OK);
   } catch (pError) {

--- a/src/extract/ast-extractors/extract-amd-deps.js
+++ b/src/extract/ast-extractors/extract-amd-deps.js
@@ -44,7 +44,11 @@ function extractCommonJSWrappers(pNode, pDependencies, pExoticRequireStrings) {
   }
 }
 
-module.exports = (pAST, pDependencies, pExoticRequireStrings) => {
+module.exports = function extractAMDDependencies(
+  pAST,
+  pDependencies,
+  pExoticRequireStrings
+) {
   walk.simple(
     pAST,
     {

--- a/src/extract/ast-extractors/extract-cjs-deps.js
+++ b/src/extract/ast-extractors/extract-cjs-deps.js
@@ -37,12 +37,12 @@ function pushRequireCallsToDependencies(
   };
 }
 
-module.exports = (
+module.exports = function extractCommonJSDependencies(
   pAST,
   pDependencies,
   pModuleSystem,
   pExoticRequireStrings
-) => {
+) {
   // var/const lalala = require('./lalala');
   // require('./lalala');
   // require('./lalala').doFunkyStuff();

--- a/src/extract/ast-extractors/extract-es6-deps.js
+++ b/src/extract/ast-extractors/extract-es6-deps.js
@@ -24,7 +24,7 @@ function pushImportNodeValue(pDependencies) {
   };
 }
 
-module.exports = (pAST, pDependencies) => {
+module.exports = function extractES6Dependencies(pAST, pDependencies) {
   function pushSourceValue(pNode) {
     if (pNode.source && pNode.source.value) {
       pDependencies.push({

--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -232,8 +232,11 @@ function extractNestedDependencies(pAST, pExoticRequireStrings) {
  *
  * @type {(pTypeScriptAST: (import("typescript").Node), pExoticRequireStrings: string[]) => {module: string, moduleSystem: string, dynamic: boolean}[]}
  */
-module.exports = (pTypeScriptAST, pExoticRequireStrings) =>
-  Boolean(typescript)
+module.exports = function extractTypeScriptDependencies(
+  pTypeScriptAST,
+  pExoticRequireStrings
+) {
+  return Boolean(typescript)
     ? extractImportsAndExports(pTypeScriptAST)
         .concat(extractImportEquals(pTypeScriptAST))
         .concat(extractTrippleSlashDirectives(pTypeScriptAST))
@@ -242,3 +245,4 @@ module.exports = (pTypeScriptAST, pExoticRequireStrings) =>
         )
         .map((pModule) => ({ dynamic: false, ...pModule }))
     : [];
+};

--- a/src/extract/gather-initial-sources.js
+++ b/src/extract/gather-initial-sources.js
@@ -9,12 +9,17 @@ const transpileMeta = require("./transpile/meta");
 
 const SUPPORTED_EXTENSIONS = transpileMeta.scannableExtensions;
 
-function keepNonExcluded(pFullPathToFile, pOptions) {
+function shouldBeIncluded(pFullPathToFile, pOptions) {
+  return (
+    !_get(pOptions, "includeOnly.path") ||
+    filenameMatchesPattern(pFullPathToFile, pOptions.includeOnly.path)
+  );
+}
+
+function shouldNotBeExcluded(pFullPathToFile, pOptions) {
   return (
     (!_get(pOptions, "exclude.path") ||
       !filenameMatchesPattern(pFullPathToFile, pOptions.exclude.path)) &&
-    (!_get(pOptions, "includeOnly.path") ||
-      filenameMatchesPattern(pFullPathToFile, pOptions.includeOnly.path)) &&
     (!_get(pOptions, "doNotFollow.path") ||
       !filenameMatchesPattern(pFullPathToFile, pOptions.doNotFollow.path))
   );
@@ -23,32 +28,33 @@ function keepNonExcluded(pFullPathToFile, pOptions) {
 function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
   return fs
     .readdirSync(pDirectoryName)
-    .reduce((pSum, pFileName) => {
+    .map((pFileName) => path.join(pDirectoryName, pFileName))
+    .filter((pFullPathToFile) =>
+      shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions)
+    )
+    .reduce((pSum, pFullPathToFile) => {
       let lStat = {};
       try {
-        lStat = fs.statSync(path.join(pDirectoryName, pFileName));
+        lStat = fs.statSync(pFullPathToFile);
       } catch (pError) {
         return pSum;
       }
       if (lStat.isDirectory()) {
         return pSum.concat(
-          gatherScannableFilesFromDirectory(
-            path.join(pDirectoryName, pFileName),
-            pOptions
-          )
+          gatherScannableFilesFromDirectory(pFullPathToFile, pOptions)
         );
       }
       if (
         SUPPORTED_EXTENSIONS.some((pExtension) =>
-          pFileName.endsWith(pExtension)
+          pFullPathToFile.endsWith(pExtension)
         )
       ) {
-        return pSum.concat(path.join(pDirectoryName, pFileName));
+        return pSum.concat(pFullPathToFile);
       }
       return pSum;
     }, [])
     .map((pFullPathToFile) => pathToPosix(pFullPathToFile))
-    .filter((pFullPathToFile) => keepNonExcluded(pFullPathToFile, pOptions));
+    .filter((pFullPathToFile) => shouldBeIncluded(pFullPathToFile, pOptions));
 }
 
 /**

--- a/src/extract/get-dependencies.js
+++ b/src/extract/get-dependencies.js
@@ -91,7 +91,7 @@ function matchesDoNotFollow(pResolved, pDoNotFollow) {
 }
 
 function addResolutionAttributes(pOptions, pFileName, pResolveOptions) {
-  return (pDependency) => {
+  return function addAttributes(pDependency) {
     const lResolved = resolve(
       pDependency,
       pOptions.baseDir,
@@ -155,12 +155,12 @@ function compareDeps(pLeft, pRight) {
  *                               'extends' option in there)
  * @return {array}           an array of dependency objects (see above)
  */
-module.exports = (
+module.exports = function getDependencies(
   pFileName,
   pCruiseOptions,
   pResolveOptions,
   pTranspileOptions
-) => {
+) {
   try {
     return _uniqBy(
       extractDependencies(pCruiseOptions, pFileName, pTranspileOptions),

--- a/src/extract/transpile/coffeescript-wrap.js
+++ b/src/extract/transpile/coffeescript-wrap.js
@@ -24,11 +24,13 @@ function getCoffeeScriptModule() {
 
 const coffeeScript = getCoffeeScriptModule();
 
-module.exports = (pLiterate) => ({
-  isAvailable: () => coffeeScript !== false,
-  transpile: (pSource) => {
-    const lOptions = pLiterate ? { literate: true } : {};
+module.exports = function coffeeScriptWrap(pLiterate) {
+  return {
+    isAvailable: () => coffeeScript !== false,
+    transpile: (pSource) => {
+      const lOptions = pLiterate ? { literate: true } : {};
 
-    return coffeeScript.compile(pSource, lOptions);
-  },
-});
+      return coffeeScript.compile(pSource, lOptions);
+    },
+  };
+};

--- a/src/extract/transpile/index.js
+++ b/src/extract/transpile/index.js
@@ -19,7 +19,7 @@ const meta = require("./meta");
  *                                itself when the function could not find a
  *                                transpiler matching pExtension
  */
-module.exports = (pExtension, pSource, pTranspilerOptions) => {
+module.exports = function transpile(pExtension, pSource, pTranspilerOptions) {
   const lWrapper = meta.getWrapper(pExtension, pTranspilerOptions);
 
   if (lWrapper.isAvailable()) {

--- a/src/extract/transpile/svelte-wrap.js
+++ b/src/extract/transpile/svelte-wrap.js
@@ -16,7 +16,9 @@ function getTranspiler(pTranspilerWrapper) {
   };
 }
 
-module.exports = (pTranspilerWrapper) => ({
-  isAvailable: () => svelteCompiler !== false,
-  transpile: getTranspiler(pTranspilerWrapper),
-});
+module.exports = function svelteWrap(pTranspilerWrapper) {
+  return {
+    isAvailable: () => svelteCompiler !== false,
+    transpile: getTranspiler(pTranspilerWrapper),
+  };
+};

--- a/src/extract/transpile/typescript-wrap.js
+++ b/src/extract/transpile/typescript-wrap.js
@@ -19,15 +19,17 @@ function getCompilerOptions(pTsx, pTSConfig) {
   };
 }
 
-module.exports = (pTsx) => ({
-  isAvailable: () => typescript !== false,
+module.exports = function typescriptWrap(pTsx) {
+  return {
+    isAvailable: () => typescript !== false,
 
-  transpile: (pSource, pTranspileOptions = {}) =>
-    typescript.transpileModule(pSource, {
-      ...(pTranspileOptions.tsConfig || {}),
-      compilerOptions: getCompilerOptions(
-        pTsx,
-        pTranspileOptions.tsConfig || {}
-      ),
-    }).outputText,
-});
+    transpile: (pSource, pTranspileOptions = {}) =>
+      typescript.transpileModule(pSource, {
+        ...(pTranspileOptions.tsConfig || {}),
+        compilerOptions: getCompilerOptions(
+          pTsx,
+          pTranspileOptions.tsConfig || {}
+        ),
+      }).outputText,
+  };
+};

--- a/src/extract/utl/detect-pre-compilation-ness.js
+++ b/src/extract/utl/detect-pre-compilation-ness.js
@@ -1,8 +1,12 @@
 const compare = require("./compare");
 
-module.exports = (pTSDependencies, pJSDependencies) =>
-  pTSDependencies.map((pTSDependency) =>
+module.exports = function detectPreCompilationNess(
+  pTSDependencies,
+  pJSDependencies
+) {
+  return pTSDependencies.map((pTSDependency) =>
     pJSDependencies.some(compare.dependenciesEqual(pTSDependency))
       ? { ...pTSDependency, preCompilationOnly: false }
       : { ...pTSDependency, preCompilationOnly: true }
   );
+};

--- a/src/extract/utl/get-extension.js
+++ b/src/extract/utl/get-extension.js
@@ -10,7 +10,7 @@ const path = require("path");
  * @param {string} pFileName path to the file to be parsed
  * @return {string}          extension
  */
-module.exports = (pFileName) => {
+module.exports = function getExtensions(pFileName) {
   let lReturnValue = path.extname(pFileName);
 
   if (lReturnValue === ".md") {

--- a/src/main/files-and-dirs/normalize.js
+++ b/src/main/files-and-dirs/normalize.js
@@ -9,5 +9,8 @@ function relativize(pFileDirectory) {
     : pFileDirectory;
 }
 
-module.exports = (pFileAndDirectoryArray) =>
-  pFileAndDirectoryArray.map(relativize);
+module.exports = function normalizeFileAndDirectoryArray(
+  pFileAndDirectoryArray
+) {
+  return pFileAndDirectoryArray.map(relativize);
+};

--- a/src/main/resolve-options/normalize.js
+++ b/src/main/resolve-options/normalize.js
@@ -106,8 +106,12 @@ function compileResolveOptions(
   };
 }
 
-module.exports = (pResolveOptions, pOptions, pTSConfig) =>
-  compileResolveOptions(
+module.exports = function normalizeResolveOptions(
+  pResolveOptions,
+  pOptions,
+  pTSConfig
+) {
+  return compileResolveOptions(
     {
       /*
         for later: check semantics of enhanced-resolve symlinks and
@@ -131,3 +135,4 @@ module.exports = (pResolveOptions, pOptions, pTSConfig) =>
     pTSConfig || {},
     _get(pOptions, "enhancedResolveOptions", {})
   );
+};

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -37,7 +37,7 @@ function normalizeRule(pRule) {
  * @param  {object} pRuleSet [description]
  * @return {object}          [description]
  */
-module.exports = (pRuleSet) => {
+module.exports = function normalizeRuleSet(pRuleSet) {
   if (_has(pRuleSet, "allowed")) {
     pRuleSet.allowedSeverity = normalizeSeverity(pRuleSet.allowedSeverity);
     if (pRuleSet.allowedSeverity === "ignore") {

--- a/src/main/rule-set/validate.js
+++ b/src/main/rule-set/validate.js
@@ -58,12 +58,12 @@ function checkRuleSafety(pRule) {
  * - the ruleset adheres to the [config json schema](../../schema/configuration.schema.json)
  * - any regular expression in the rule set is 'safe' (~= won't be too slow)
  *
- * @param  {object} pConfiguration The configuration to validate
- * @return {object}                The configuration as passed
+ * @param  {any} pConfiguration The configuration to validate
+ * @return {import("../../../types/configuration").IConfiguration}  The configuration as passed
  * @throws {Error}                 An error with the reason for the error as
  *                                 a message
  */
-module.exports = (pConfiguration) => {
+module.exports = function validateConfiguration(pConfiguration) {
   validateAgainstSchema(configurationSchema, pConfiguration);
   (pConfiguration.allowed || []).forEach(checkRuleSafety);
   (pConfiguration.forbidden || []).forEach(checkRuleSafety);
@@ -75,3 +75,4 @@ module.exports = (pConfiguration) => {
 
 /* think we can ignore object injection here because it's not a public function */
 /* eslint security/detect-object-injection: 0 */
+// file deepcode ignore valid-jsdoc: seems deepcode's jsdoc parser can't handle type imports yet


### PR DESCRIPTION
## Description, Motivation and Context

- Closes #409 
- Also makes named functions of module exports that were still anonymous - so they;re easier to identify in profiling tools.
- ... and simplifies some of the extract code 

## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] manual test on a windows machine

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
