### PR TITLE
buid(npm): :arrow_down: enhanced-resolve to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "ajv": "7.0.3",
     "chalk": "4.1.0",
     "commander": "6.2.1",
-    "enhanced-resolve": "5.4.1",
+    "enhanced-resolve": "5.1.0",
     "figures": "3.2.0",
     "get-stream": "6.0.0",
     "glob": "7.1.6",
@@ -186,6 +186,10 @@
       {
         "package": "husky",
         "because": "https://github.com/typicode/husky/issues/822"
+      },
+      {
+        "package": "enhanced-resolve",
+        "because": "version 5.1.0 is dramatically faster than any later version"
       }
     ]
   },


### PR DESCRIPTION
## Description, Motivation and Context

:arrow_down: enhanced-resolve to 5.1.0 as 5.2.0 and up seem to have a performance regression.
- Brings down the execution time on dependency-cruiser itself down from ~5.3s to ~3.4s (windows) and ~2.9s to ~2.1s (linux)
- ehr is now pinned to 5.1.0 as long as the performance regression is in (or when functionality in 5.4 and up becomes more important than performance regression).

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] elaborate performance testing

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
