### PR TITLE
bugfix(init): explicitly pass no params to ts config detector

### DIFF
--- a/src/cli/init-config/get-user-input.js
+++ b/src/cli/init-config/get-user-input.js
@@ -72,7 +72,7 @@ const INQUIRER_QUESTIONS = [
     type: "confirm",
     message: "Looks like you're using TypeScript. Use a 'tsconfig.json'?",
     default: true,
-    when: hasTSConfigCandidates,
+    when: () => hasTSConfigCandidates(),
   },
   {
     name: "tsConfig",
@@ -93,7 +93,7 @@ const INQUIRER_QUESTIONS = [
     type: "confirm",
     message: "Looks like you're using Babel. Use a babel config?",
     default: true,
-    when: hasBabelConfigCandidates,
+    when: () => hasBabelConfigCandidates(),
   },
   {
     name: "babelConfig",
@@ -107,7 +107,7 @@ const INQUIRER_QUESTIONS = [
     type: "confirm",
     message: "Looks like you're using webpack - specify a webpack config?",
     default: true,
-    when: hasWebpackConfigCandidates,
+    when: () => hasWebpackConfigCandidates(),
   },
   {
     name: "webpackConfig",


### PR DESCRIPTION
## Description

see title

## Motivation and Context

fixes #416 (which was introduced in release 9.21.2, commit 090e6774)

## How Has This Been Tested?

- [x] automated non-regression test + green ci
- [x] manual tests on all paths in --init


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
