### PR TITLE
perf(resolve): only load tsconfig-paths-plugin when there's at least one defined path in tsconfig

### DIFF
--- a/test/main/fixtures/tsconfig.test.json
+++ b/test/main/fixtures/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
-    "compilerOptions": {
-        "baseUrl": "."
-    }
+  "compilerOptions": {
+    "baseUrl": "."
+  }
 }

--- a/test/main/resolve-options/normalize.spec.js
+++ b/test/main/resolve-options/normalize.spec.js
@@ -14,7 +14,12 @@ describe("main/resolve-options/normalize", () => {
     "tsconfig.test.json"
   );
   const lTsconfigContents = {};
-  const lTsconfigContents_WITH_BASEURL = { options: { baseUrl: "" } };
+  const lTsconfigContentsWithBaseURL = {
+    options: { baseUrl: "" },
+  };
+  const lTsconfigContentsWithBaseURLAndPaths = {
+    options: { baseUrl: "", paths: { "*": ["lalala/*"] } },
+  };
 
   it("comes with a set of defaults when passed with no options at all", () => {
     const lNormalizedOptions = normalizeResolveOptions(
@@ -54,13 +59,34 @@ describe("main/resolve-options/normalize", () => {
     expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
   });
 
-  it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl", () => {
+  it("does not add the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and no actual paths", () => {
     const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
       }),
-      lTsconfigContents_WITH_BASEURL
+      lTsconfigContentsWithBaseURL
+    );
+
+    expect(Object.keys(lNormalizedOptions).length).to.equal(
+      lDefaultNoOfResolveOptions
+    );
+    expect(lNormalizedOptions.symlinks).to.equal(false);
+    expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
+    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+    expect(lNormalizedOptions).to.ownProperty("extensions");
+    expect(lNormalizedOptions).to.ownProperty("fileSystem");
+    expect((lNormalizedOptions.plugins || []).length).to.equal(0);
+    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+  });
+
+  it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", () => {
+    const lNormalizedOptions = normalizeResolveOptions(
+      {},
+      normalizeCruiseOptions({
+        ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
+      }),
+      lTsconfigContentsWithBaseURLAndPaths
     );
 
     expect(Object.keys(lNormalizedOptions).length).to.equal(


### PR DESCRIPTION
## Description, Motivation and Context

tsconfig-paths-plugin has a measurable impact (~10ms for 15 resolutions) even when there's no paths in the tsconfig. Hence only loading it when there's _and_ a baseUrl _and_ paths will improve performance for those not using _paths_ in their tsconfig 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
