### PR TITLE
perf: restricts requiring init-config (/ inquirer) to when it's necessary

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -8,7 +8,6 @@ const extractBabelConfig = require("../config-utl/extract-babel-config");
 const extractWebpackResolveConfig = require("../config-utl/extract-webpack-resolve-config");
 const validateFileExistence = require("./utl/validate-file-existence");
 const normalizeOptions = require("./normalize-options");
-const initConfig = require("./init-config");
 const io = require("./utl/io");
 const formatMetaInfo = require("./format-meta-info");
 const setUpCliFeedbackListener = require("./listeners/cli-feedback");
@@ -115,6 +114,11 @@ module.exports = function executeCli(pFileDirectoryArray, pCruiseOptions) {
     if (pCruiseOptions.info === true) {
       process.stdout.write(formatMetaInfo());
     } else if (pCruiseOptions.init) {
+      // requiring init-config takes ~100ms (most of it taken up by requiring
+      // inquirer, measured on a 2.6GHz quad core i7 with flash storage on
+      // macOS 10.15.7). Only requiring it when '--init' is necessary speeds up
+      // (the start-up) of cruises by that same amount.
+      const initConfig = require("./init-config");
       initConfig(pCruiseOptions.init);
     } else {
       lExitCode = runCruise(pFileDirectoryArray, pCruiseOptions);


### PR DESCRIPTION
## Description, Motivation and Context

requiring init-config takes ~100ms (most of it taken up by requiring inquirer, measured on a 2.6GHz quad core i7 with flash storage on macOS 10.15.7). Only requiring it when --init is necessary speeds up (the start-up) of cruises by that same amount.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
