### PR TITLE
bugfix(babel): also pass a filename to babel when parsing a config

### DIFF
--- a/src/config-utl/extract-babel-config.js
+++ b/src/config-utl/extract-babel-config.js
@@ -91,7 +91,14 @@ module.exports = function extractBabelConfig(pBabelConfigFileName) {
 
   /* istanbul ignore else */
   if (babel) {
-    lReturnValue = babel.loadOptions(getConfig(pBabelConfigFileName));
+    const lConfig = {
+      ...getConfig(pBabelConfigFileName),
+      // under some circumstances babel really likes to have a filename to
+      // go with the config we pass it - so we pass it
+      filename: pBabelConfigFileName,
+    };
+
+    lReturnValue = babel.loadOptions(lConfig);
   }
 
   return lReturnValue;

--- a/test/config-utl/extract-babel-config.spec.js
+++ b/test/config-utl/extract-babel-config.spec.js
@@ -1,5 +1,7 @@
 const path = require("path").posix;
+const omit = require("lodash/omit");
 const { expect } = require("chai");
+const pathToPosix = require("../../src/extract/utl/path-to-posix");
 const extractBabelConfig = require("../../src/config-utl/extract-babel-config");
 
 const DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT = {
@@ -47,11 +49,16 @@ describe("config-utl/parseBabelConfig", () => {
   });
 
   it("returns a default options object when an empty config file is passed", () => {
-    expect(
-      extractBabelConfig(
-        path.join(__dirname, "./fixtures/babelconfig/babelrc.empty.json")
-      )
-    ).to.deep.equal(DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT);
+    const lBabelConfig = extractBabelConfig(
+      path.join(__dirname, "./fixtures/babelconfig/babelrc.empty.json")
+    );
+    expect(lBabelConfig).to.have.property("filename");
+    expect(pathToPosix(lBabelConfig.filename)).to.contain(
+      "/fixtures/babelconfig/babelrc.empty.json"
+    );
+    expect(omit(lBabelConfig, "filename")).to.deep.equal(
+      DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT
+    );
   });
 
   it("reads the 'babel' key when a package.json is passed", () => {
@@ -63,14 +70,19 @@ describe("config-utl/parseBabelConfig", () => {
   });
 
   it("returns an empty (/ default) options object when package.json without a babel key is passed", () => {
-    expect(
-      extractBabelConfig(
-        path.join(
-          __dirname,
-          "./fixtures/babelconfig/no-babel-config-in-this-package.json"
-        )
+    const lBabelConfig = extractBabelConfig(
+      path.join(
+        __dirname,
+        "./fixtures/babelconfig/no-babel-config-in-this-package.json"
       )
-    ).to.deep.equal(DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT);
+    );
+    expect(lBabelConfig).to.have.property("filename");
+    expect(pathToPosix(lBabelConfig.filename)).to.contain(
+      "/fixtures/babelconfig/no-babel-config-in-this-package.json"
+    );
+    expect(omit(lBabelConfig, "filename")).to.deep.equal(
+      DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT
+    );
   });
 
   it("returns a babel config when a javascript file with a regular object export is passed", () => {


### PR DESCRIPTION
## Description

Under certain circumstances babel expects a filename together with the contents of the babel config. This PR makes sure babel always has a filename to use.

## Motivation and Context

Adresses #421 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] updated unit test(s)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
