### PR TITLE
bugfix(main): relax the check to load tsconfig-paths-plugin

### DIFF
--- a/src/main/resolve-options/normalize.js
+++ b/src/main/resolve-options/normalize.js
@@ -58,11 +58,8 @@ function pushPlugin(pPlugins, pPluginToPush) {
   return (pPlugins || []).concat(pPluginToPush);
 }
 
-function hasTsConfigPaths(pTSConfig) {
-  return (
-    _has(pTSConfig, "options.baseUrl") &&
-    Object.keys(_get(pTSConfig, "options.paths", {})).length > 0
-  );
+function isTsConfigPathsEligible(pTSConfig) {
+  return _has(pTSConfig, "options.baseUrl");
 }
 
 function compileResolveOptions(
@@ -83,7 +80,7 @@ function compileResolveOptions(
   // will be a win.
   // Also: requiring the plugin only when it's necessary will save some
   // startup time (especially on a cold require cache)
-  if (pResolveOptions.tsConfig && hasTsConfigPaths(pTSConfig)) {
+  if (pResolveOptions.tsConfig && isTsConfigPathsEligible(pTSConfig)) {
     // eslint-disable-next-line node/global-require
     const TsConfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
     lResolveOptions.plugins = pushPlugin(

--- a/test/main/resolve-options/normalize.spec.js
+++ b/test/main/resolve-options/normalize.spec.js
@@ -14,9 +14,6 @@ describe("main/resolve-options/normalize", () => {
     "tsconfig.test.json"
   );
   const lTsconfigContents = {};
-  const lTsconfigContentsWithBaseURL = {
-    options: { baseUrl: "" },
-  };
   const lTsconfigContentsWithBaseURLAndPaths = {
     options: { baseUrl: "", paths: { "*": ["lalala/*"] } },
   };
@@ -45,27 +42,6 @@ describe("main/resolve-options/normalize", () => {
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
       }),
       lTsconfigContents
-    );
-
-    expect(Object.keys(lNormalizedOptions).length).to.equal(
-      lDefaultNoOfResolveOptions
-    );
-    expect(lNormalizedOptions.symlinks).to.equal(false);
-    expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
-    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
-    expect(lNormalizedOptions).to.ownProperty("extensions");
-    expect(lNormalizedOptions).to.ownProperty("fileSystem");
-    expect((lNormalizedOptions.plugins || []).length).to.equal(0);
-    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
-  });
-
-  it("does not add the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and no actual paths", () => {
-    const lNormalizedOptions = normalizeResolveOptions(
-      {},
-      normalizeCruiseOptions({
-        ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
-      }),
-      lTsconfigContentsWithBaseURL
     );
 
     expect(Object.keys(lNormalizedOptions).length).to.equal(


### PR DESCRIPTION
## Description

Rolls back #419 

Dependency-cruiser used to check for a non-empty 'paths' object in the tsconfig (PR #419, commit 60eea5a7353dd721f87f2abb41592e851a53cdb6, as that's the primary goal of the plugin) before enabling the ts-config-paths plugin. As it turns out tsconfig-paths also resolves `fixed/path/jadda.js` to `${baseDir}/fixed/path/jadda.js` if the 'fixed' module or alias doesn't exist otherwise. Also at least 2 (but likely a lot more)  consumers rely on that behaviour.

## Motivation and Context

Fixes #426, fixes #422 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [ ] additional unit test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
