### PR TITLE
refactor(transpile): also pass a filename to the transpilers

### DIFF
--- a/src/extract/parse/to-javascript-ast.js
+++ b/src/extract/parse/to-javascript-ast.js
@@ -13,11 +13,11 @@ const ACORN_OPTIONS = {
 
 const acornJsxParser = acorn.Parser.extend(acornJsx());
 
-function getASTFromSource(pSource, pExtension, pTranspileOptions) {
-  const lJavaScriptSource = transpile(pExtension, pSource, pTranspileOptions);
+function getASTFromSource(pFileRecord, pTranspileOptions) {
+  const lJavaScriptSource = transpile(pFileRecord, pTranspileOptions);
 
   try {
-    if (pExtension === ".jsx") {
+    if (pFileRecord.extension === ".jsx") {
       return acornJsxParser.parse(lJavaScriptSource, {
         ...ACORN_OPTIONS,
         allowNamespacedObjects: true,
@@ -46,8 +46,11 @@ function getASTFromSource(pSource, pExtension, pTranspileOptions) {
  */
 function getAST(pFileName, pTranspileOptions) {
   return getASTFromSource(
-    fs.readFileSync(pFileName, "utf8"),
-    getExtension(pFileName),
+    {
+      source: fs.readFileSync(pFileName, "utf8"),
+      extension: getExtension(pFileName),
+      filename: pFileName,
+    },
     pTranspileOptions
   );
 }

--- a/src/extract/transpile/babel-wrap.js
+++ b/src/extract/transpile/babel-wrap.js
@@ -5,11 +5,11 @@ const babel = tryRequire("@babel/core", $package.supportedTranspilers.babel);
 
 module.exports = {
   isAvailable: () => babel !== false,
-  transpile: (pSource, pTranspileOptions = {}) =>
+  transpile: (pSource, pFileName, pTranspileOptions = {}) =>
     babel.transformSync(pSource, {
       ...(pTranspileOptions.babelConfig || {}),
       // Some babel plugins assume a piece of source to have a filename.
       // See https://github.com/sverweij/dependency-cruiser/issues/410
-      filename: "dummy-filename.js",
+      filename: pFileName,
     }).code,
 };

--- a/src/extract/transpile/index.js
+++ b/src/extract/transpile/index.js
@@ -19,12 +19,15 @@ const meta = require("./meta");
  *                                itself when the function could not find a
  *                                transpiler matching pExtension
  */
-module.exports = function transpile(pExtension, pSource, pTranspilerOptions) {
-  const lWrapper = meta.getWrapper(pExtension, pTranspilerOptions);
+module.exports = function transpile(
+  { extension, source, filename },
+  pTranspilerOptions
+) {
+  const lWrapper = meta.getWrapper(extension, pTranspilerOptions);
 
   if (lWrapper.isAvailable()) {
-    return lWrapper.transpile(pSource, pTranspilerOptions);
+    return lWrapper.transpile(source, filename, pTranspilerOptions);
   } else {
-    return pSource;
+    return source;
   }
 };

--- a/src/extract/transpile/index.js
+++ b/src/extract/transpile/index.js
@@ -11,8 +11,7 @@ const meta = require("./meta");
  *      for supported versions of transpilers
  * @see [meta.js](meta.js) for the extension -> transpiler mapping
  *
- * @param  {string} pExtension    extension of the file to transpile
- * @param  {string} pSource       the contents of the file to transpile
+ * @param  {any} pFileRecord      Record with source code, an extension and a filename
  * @param  {any} pTranspilerOptions (optional) object with options influencing
  *                                the underlying transpiler behavior.
  * @return {string}               the transpiled version of the file (or the file

--- a/src/extract/transpile/svelte-preprocess.js
+++ b/src/extract/transpile/svelte-preprocess.js
@@ -53,6 +53,7 @@ function getSourceReplacer(pTranspiler, pTranspilerOptions) {
     if (lParsedAttributes.lang === "ts") {
       return `<script${lAttributes}>${pTranspiler(
         pSource,
+        "dummy-filename",
         composeTranspilerOptions(pTranspilerOptions)
       )}</script>`;
     } else {

--- a/src/extract/transpile/svelte-wrap.js
+++ b/src/extract/transpile/svelte-wrap.js
@@ -6,7 +6,7 @@ const svelteCompiler = tryRequire(
 const preProcess = require("./svelte-preprocess");
 
 function getTranspiler(pTranspilerWrapper) {
-  return (pSource, pTranspilerOptions) => {
+  return (pSource, _pFileName, pTranspilerOptions) => {
     const lPreProcessedSource = preProcess(
       pSource,
       pTranspilerWrapper,

--- a/src/extract/transpile/typescript-wrap.js
+++ b/src/extract/transpile/typescript-wrap.js
@@ -23,7 +23,7 @@ module.exports = function typescriptWrap(pTsx) {
   return {
     isAvailable: () => typescript !== false,
 
-    transpile: (pSource, pTranspileOptions = {}) =>
+    transpile: (pSource, _pFileName, pTranspileOptions = {}) =>
       typescript.transpileModule(pSource, {
         ...(pTranspileOptions.tsConfig || {}),
         compilerOptions: getCompilerOptions(

--- a/test/extract/ast-extractors/extract-amd-deps.spec.js
+++ b/test/extract/ast-extractors/extract-amd-deps.spec.js
@@ -9,7 +9,7 @@ const extractAMD = (
   pExoticRequireStrings = []
 ) =>
   extractAMDDeps(
-    getASTFromSource(pJavaScriptSource, "js"),
+    getASTFromSource({ source: pJavaScriptSource, extension: ".js" }),
     pDependencies,
     pExoticRequireStrings
   );

--- a/test/extract/ast-extractors/extract-cjs-deps.spec.js
+++ b/test/extract/ast-extractors/extract-cjs-deps.spec.js
@@ -9,7 +9,7 @@ const extractcommonJS = (
   pExoticRequireStrings = []
 ) =>
   extractcommonJSDeps(
-    getASTFromSource(pJavaScriptSource, "js"),
+    getASTFromSource({ source: pJavaScriptSource, extension: ".js" }),
     pDependencies,
     "cjs",
     pExoticRequireStrings

--- a/test/extract/ast-extractors/extract-es6-deps.spec.js
+++ b/test/extract/ast-extractors/extract-es6-deps.spec.js
@@ -5,7 +5,7 @@ const getASTFromSource = require("../../../src/extract/parse/to-javascript-ast")
 
 const extractES6 = (pJavaScriptSource, pDependencies, pExtension = ".js") =>
   extractES6Deps(
-    getASTFromSource(pJavaScriptSource, pExtension),
+    getASTFromSource({ source: pJavaScriptSource, extension: pExtension }),
     pDependencies
   );
 

--- a/test/extract/transpile/babel-wrap.spec.js
+++ b/test/extract/transpile/babel-wrap.spec.js
@@ -38,7 +38,11 @@ describe("extract/transpile/babel-wrap", () => {
       },
     };
     const lOutput = normalizeSource(
-      wrap.transpile(lInputFileContents, lBabelOptions)
+      wrap.transpile(
+        lInputFileContents,
+        "/test/extract/transpile/fixtures/babel-in.js",
+        lBabelOptions
+      )
     );
     const lExpected = fs.readFileSync(
       "./test/extract/transpile/fixtures/babel-out-es-old.js",

--- a/test/extract/transpile/index.spec.js
+++ b/test/extract/transpile/index.spec.js
@@ -6,9 +6,18 @@ const normalizeSource = require("../normalize-source.utl");
 
 describe("transpiler", () => {
   it("As the 'livescript' transpiler is not available, returns the original source", () => {
-    expect(transpile(".ls", "whatever the bever")).to.equal(
-      "whatever the bever"
-    );
+    expect(
+      transpile({ extension: ".ls", source: "whatever the bever" })
+    ).to.equal("whatever the bever");
+  });
+
+  it("As the 'bf-script' transpiler is not supported at all, returns the original source", () => {
+    expect(
+      transpile({
+        extension: ".bfs",
+        source: "'brane-fuchs-skrybd'|#$'nicht unterstutzt'|^^^",
+      })
+    ).to.equal("'brane-fuchs-skrybd'|#$'nicht unterstutzt'|^^^");
   });
 
   it("Returns svelte compiled down to js", () => {
@@ -20,9 +29,9 @@ describe("transpiler", () => {
       fs.readFileSync(path.join(__dirname, "fixtures", "svelte.js"), "utf8")
     );
 
-    expect(normalizeSource(transpile(".svelte", lInput))).to.equal(
-      lExpectedOoutput
-    );
+    expect(
+      normalizeSource(transpile({ extension: ".svelte", source: lInput }))
+    ).to.equal(lExpectedOoutput);
   });
 
   it("Does not confuse .ts for .tsx", () => {
@@ -41,9 +50,9 @@ describe("transpiler", () => {
       "utf8"
     );
 
-    expect(normalizeSource(transpile(".ts", lInputFixture))).to.equal(
-      normalizeSource(lTranspiledFixture)
-    );
+    expect(
+      normalizeSource(transpile({ extension: ".ts", source: lInputFixture }))
+    ).to.equal(normalizeSource(lTranspiledFixture));
   });
 
   it("Takes a tsconfig and takes that into account on transpilation", () => {
@@ -72,7 +81,12 @@ describe("transpiler", () => {
       types: ["foo", "bar", "baz"],
     };
     expect(
-      normalizeSource(transpile(".ts", lInputFixture, lTranspilerOptions))
+      normalizeSource(
+        transpile(
+          { extension: ".ts", source: lInputFixture },
+          lTranspilerOptions
+        )
+      )
     ).to.equal(lTranspiledFixture);
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

- Adds a _filename_ parameter to all transpiler wrapper functions so underlying transpilers can have fun with it.

Some of the transpilers use the file name them for decorative purposes, some (e.g. babel with some plugins) really use the filename to determine how to transpile things. This is one step in the direction of fixing interesting behavior of the babel api uncovered in #421.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
