### PR TITLE
bugfix(parse): preserve tsx-ness in the ts-via-acorn route

### DIFF
--- a/test/extract/ast-extractors/extract-typescript.utl.js
+++ b/test/extract/ast-extractors/extract-typescript.utl.js
@@ -1,6 +1,7 @@
 const extractTypescript = require("../../../src/extract/ast-extractors/extract-typescript-deps");
-const getASTFromSource = require("../../../src/extract/parse/to-typescript-ast")
-  .getASTFromSource;
+const {
+  getASTFromSource,
+} = require("../../../src/extract/parse/to-typescript-ast");
 
 module.exports = (pTypesScriptSource, pExoticRequireStrings = []) =>
   extractTypescript(

--- a/test/extract/parse/to-javascript-ast.spec.js
+++ b/test/extract/parse/to-javascript-ast.spec.js
@@ -1,0 +1,97 @@
+const { expect } = require("chai");
+const _get = require("lodash/get");
+const {
+  getASTFromSource,
+} = require("../../../src/extract/parse/to-javascript-ast");
+
+const TSCONFIG_CONSTANTS = {
+  ESNEXT: 99,
+  PRESERVE_JSX: 1,
+  REACT_JSX: 2,
+};
+
+const TSX_SOURCE = `
+    const Index = () => (
+    <div>This has an import keyword in a tag that shall not be recognized as an import</div>
+    );
+
+    export default Index;
+    `;
+describe("extract/parse/to-javascript-ast", () => {
+  it("recogizes 'preserve'd tsx as jsx", () => {
+    const lFoundAST = getASTFromSource(
+      {
+        source: TSX_SOURCE,
+        filename: "./some-page.tsx",
+        extension: ".tsx",
+      },
+      {
+        tsConfig: {
+          options: {
+            module: TSCONFIG_CONSTANTS.ESNEXT,
+            target: TSCONFIG_CONSTANTS.ESNEXT,
+            jsx: TSCONFIG_CONSTANTS.PRESERVE_JSX,
+            baseUrl: ".",
+            skipLibCheck: true,
+            noEmit: true,
+            isolatedModules: true,
+          },
+        },
+      }
+    );
+    expect(
+      _get(
+        lFoundAST,
+        "body[0].declarations[0].init.body.type",
+        "not a jsx element"
+      )
+    ).to.equal("JSXElement");
+  });
+
+  it("doesn't have any weird imports when tsx gets transpiled as non-'preserve' ", () => {
+    const lFoundAST = getASTFromSource(
+      {
+        source: TSX_SOURCE,
+        filename: "./some-page.tsx",
+        extension: ".tsx",
+      },
+      {
+        tsConfig: {
+          options: {
+            module: TSCONFIG_CONSTANTS.ESNEXT,
+            target: TSCONFIG_CONSTANTS.ESNEXT,
+            jsx: TSCONFIG_CONSTANTS.REACT_JSX,
+            baseUrl: ".",
+            skipLibCheck: true,
+            noEmit: true,
+            isolatedModules: true,
+          },
+        },
+      }
+    );
+
+    const likelyTheArrowExpression = _get(
+      lFoundAST,
+      "body[0].declarations.[0].init",
+      {}
+    );
+    expect(likelyTheArrowExpression.type).to.equal("ArrowFunctionExpression");
+    expect(
+      _get(
+        likelyTheArrowExpression,
+        "body.callee.type",
+        "not a member expression"
+      )
+    ).to.equal("MemberExpression");
+    expect(
+      _get(likelyTheArrowExpression, "body.callee.object.name", "not react")
+    ).to.equal("React");
+    expect(
+      _get(
+        likelyTheArrowExpression,
+        "body.callee.property.name",
+        "not createElement"
+      )
+    ).to.equal("createElement");
+  });
+});


### PR DESCRIPTION
## Description, Motivation and Context

When a tsx is compiled down with the tsc option 'preserve' we can pass it to acorn-jsx (who knows how to handle it) instead of to acorn.

This fixes a (corner case) bug:
- Use a .tsx source with import, export or require keywords in a tag
- Use `"jsx": "preserve" in tsconfig.json
- Keep tsPreCompilationDeps on _false_ in the dependency-cruiser config

This way dependency-cruiser would pass a piece of jsx source code to the acorn parser, instead of to acorn-jsx. Acorn would be confused - so dependency-cruiser would pass it to the loose version of the acorn compiler - leading to the side-effects earlier uncovered in #395 for regular jsx.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
