### PR TITLE
fix bug where baseDir is ignored when calling programmatically

### DIFF
--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -653,6 +653,13 @@ favourite editor. Here's an example for visual studio code:
 
 > :bulb: Make sure the prefix ends on a `/`.
 
+### `baseDir`: specify a directory to cruise from
+
+> :shell: there is no command line equivalent for this at the moment
+
+By default dependency-cruiser will take the current working directory to start
+a cruise from. If you want to alter that you can pass it in this attribute.
+
 ## reporterOptions
 
 In the `reporterOptions` attribute you can pass things to reporters to influence

--- a/src/extract/gather-initial-sources.js
+++ b/src/extract/gather-initial-sources.js
@@ -27,7 +27,7 @@ function shouldNotBeExcluded(pFullPathToFile, pOptions) {
 
 function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
   return fs
-    .readdirSync(pDirectoryName)
+    .readdirSync(path.join(pOptions.baseDir, pDirectoryName))
     .map((pFileName) => path.join(pDirectoryName, pFileName))
     .filter((pFullPathToFile) =>
       shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions)
@@ -35,7 +35,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
     .reduce((pSum, pFullPathToFile) => {
       let lStat = {};
       try {
-        lStat = fs.statSync(pFullPathToFile);
+        lStat = fs.statSync(path.join(pOptions.baseDir, pFullPathToFile));
       } catch (pError) {
         return pSum;
       }

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -461,6 +461,10 @@
               "enum": ["cli-feedback", "performance-log", "none"]
             }
           }
+        },
+        "baseDir": {
+          "type": "string",
+          "description": "The directory dependency-cruiser should run its cruise from. Defaults to the current working directory."
         }
       }
     },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -705,6 +705,10 @@
             }
           }
         },
+        "baseDir": {
+          "type": "string",
+          "description": "The directory dependency-cruiser should run its cruise from. Defaults to the current working directory."
+        },
         "args": {
           "type": "string",
           "description": "arguments passed on the command line"

--- a/test/extract/gather-initial-sources.spec.js
+++ b/test/extract/gather-initial-sources.spec.js
@@ -213,6 +213,24 @@ describe("extract/gatherInitialSources", () => {
     ]);
   });
 
+  it("heeds the baseDir", () => {
+    expect(
+      gather(
+        ["**/src/**/*.js"],
+        normalizeCruiseOptions({
+          baseDir: "test/extract/fixtures/gather-globbing",
+        })
+      ).map(pathToPosix)
+    ).to.deep.equal([
+      "packages/baldr/src/bow.js",
+      "packages/baldr/src/index.js",
+      "packages/odin/src/deep/ly.js",
+      "packages/odin/src/deep/ly.spec.js",
+      "packages/odin/src/deep/ly/index.js",
+      "packages/odin/src/deep/ly/nested.js",
+    ]);
+  });
+
   it("filters invalid symlinks", () => {
     expect(
       fs

--- a/test/main/fixtures/cruise-reporterless/commonjs.json
+++ b/test/main/fixtures/cruise-reporterless/commonjs.json
@@ -445,6 +445,211 @@
     ]
   },
   {
+    "title": "root_one unfiltered - with a baseDir",
+    "input": {
+      "fileName": "root_two.js",
+      "options": {
+        "baseDir": "test/main/fixtures/cruise-reporterless/commonjs"
+      }
+    },
+    "expected": [
+      {
+        "source": "root_two.js",
+        "orphan": false,
+        "dependencies": [
+          {
+            "module": "./shared",
+            "resolved": "shared.js",
+            "moduleSystem": "cjs",
+            "coreModule": false,
+            "dependencyTypes": ["local"],
+            "dynamic": false,
+            "circular": false,
+            "followable": true,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          },
+          {
+            "module": "./somedata.json",
+            "resolved": "somedata.json",
+            "moduleSystem": "cjs",
+            "coreModule": false,
+            "dependencyTypes": ["local"],
+            "dynamic": false,
+            "circular": false,
+            "followable": false,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          },
+          {
+            "module": "./two_only_one",
+            "resolved": "two_only_one.js",
+            "moduleSystem": "cjs",
+            "coreModule": false,
+            "dependencyTypes": ["local"],
+            "dynamic": false,
+            "circular": false,
+            "followable": true,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          },
+          {
+            "module": "http",
+            "resolved": "http",
+            "moduleSystem": "cjs",
+            "coreModule": true,
+            "dependencyTypes": ["core"],
+            "dynamic": false,
+            "circular": false,
+            "followable": false,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          }
+        ],
+        "valid": true
+      },
+      {
+        "source": "somedata.json",
+        "followable": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false,
+        "coreModule": false,
+        "dependencyTypes": ["local"],
+        "orphan": false,
+        "dependencies": [],
+        "valid": true
+      },
+      {
+        "source": "http",
+        "followable": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false,
+        "coreModule": true,
+        "dependencyTypes": ["core"],
+        "orphan": false,
+        "dependencies": [],
+        "valid": true
+      },
+      {
+        "source": "shared.js",
+        "orphan": false,
+        "dependencies": [
+          {
+            "module": "path",
+            "resolved": "path",
+            "moduleSystem": "cjs",
+            "coreModule": true,
+            "dependencyTypes": ["core"],
+            "dynamic": false,
+            "circular": false,
+            "followable": false,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          }
+        ],
+        "valid": true
+      },
+      {
+        "source": "path",
+        "followable": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false,
+        "coreModule": true,
+        "dependencyTypes": ["core"],
+        "orphan": false,
+        "dependencies": [],
+        "valid": true
+      },
+      {
+        "source": "two_only_one.js",
+        "orphan": false,
+        "dependencies": [
+          {
+            "module": "./sub/dir",
+            "resolved": "sub/dir.js",
+            "moduleSystem": "cjs",
+            "coreModule": false,
+            "dependencyTypes": ["local"],
+            "dynamic": false,
+            "circular": false,
+            "followable": true,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          }
+        ],
+        "valid": true
+      },
+      {
+        "source": "sub/dir.js",
+        "orphan": false,
+        "dependencies": [
+          {
+            "module": "./depindir",
+            "resolved": "sub/depindir.js",
+            "moduleSystem": "cjs",
+            "coreModule": false,
+            "dependencyTypes": ["local"],
+            "dynamic": false,
+            "circular": false,
+            "followable": true,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          },
+          {
+            "module": "path",
+            "resolved": "path",
+            "moduleSystem": "cjs",
+            "coreModule": true,
+            "dependencyTypes": ["core"],
+            "dynamic": false,
+            "circular": false,
+            "followable": false,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          }
+        ],
+        "valid": true
+      },
+      {
+        "source": "sub/depindir.js",
+        "orphan": false,
+        "dependencies": [
+          {
+            "module": "path",
+            "resolved": "path",
+            "moduleSystem": "cjs",
+            "coreModule": true,
+            "dependencyTypes": ["core"],
+            "dynamic": false,
+            "circular": false,
+            "followable": false,
+            "exoticallyRequired": false,
+            "matchesDoNotFollow": false,
+            "couldNotResolve": false,
+            "valid": true
+          }
+        ],
+        "valid": true
+      }
+    ]
+  },
+  {
     "title": "circular dependency (one step)",
     "input": {
       "fileName": "test/main/fixtures/cruise-reporterless/commonjs/circular.js",

--- a/tools/schema/options.mjs
+++ b/tools/schema/options.mjs
@@ -280,6 +280,12 @@ export default {
             },
           },
         },
+        baseDir: {
+          type: "string",
+          description:
+            "The directory dependency-cruiser should run its cruise from. Defaults to the current " +
+            "working directory.",
+        },
       },
     },
     ...moduleSystemsType.definitions,

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -99,6 +99,11 @@ export interface ICruiseOptions {
    */
   args?: string;
   /**
+   * The directory dependency-cruiser should run its cruise from. Defaults
+   * to the current working directory.
+   */
+  baseDir?: string;
+  /**
    * a string to insert before links (in dot/ svg output) so with
    * cruising local dependencies it is possible to point to sources
    * elsewhere (e.g. in an online repository)


### PR DESCRIPTION
Running a scan with cruiseOptions `baseDir` set almost works, but actually results in various errors and bad scenarios because the run always sees `fileDirectoryArray` as relative to `process.cwd()` instead of the path specified in `baseDir`.

## Description

When calling dependency cruiser programmatically my understanding is specifying `baseDir` in cruiseOptions should be as if I ran `depcruise` in the shell from that folder. But `gatherScannableFilesFromDirectory` breaks that because it calls `readdirSync(pDirectoryName)` which *implicitly* relies on cwd when passed a relative path. If we instead join `pOptions.baseDir` into that path then `pDirectoryName` gets resolved according to `baseDir`.

By default `baseDir` is cwd so this doesn't change existing functionality, but allows the caller to override baseDir via options.

The same problem exists on L38 where stats are called.

With this fix in place I can now call this:
```js
futureCruise(
  ['.'],
  { outputType: 'dot', baseDir: dirOfMyChoosing },
)
```
Which generates the same output as if I run:
```bash
dirOfMyChoosing $ depcruise --output-type dot .
```

### Possible more work to do

I noticed Typescript definition for `ICruiseOptions` doesn't include `baseDir` so it may be I'm violating the intentions of the API. In that case I'd love to hear if there's anything I can do to salvage the intention of my PR which is to have `futureCruise` generate output relative to a specified folder.

## Motivation and Context

API caller can now specify `baseDir` and have the `fileDirectoryArray` be resolved relative to that.

## How Has This Been Tested?

I've only verified my own output now works, and have run the shell command and API call under debugger side-by-side to compare the function calls and variables resolve identically.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
