### PR TITLE
bugfix(enrich): adds support for capturing groups on 'reachable' rules

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -178,6 +178,17 @@
       "severity": "error",
       "from": { "path": "\\.spec\\.js$" },
       "to": { "path": "^src", "reachable": false }
+    },
+    {
+      "name": "not-reachable-from-folder-index",
+      "severity": "info",
+      "from": {
+        "path": "^src/([^/]+)/index\\.js$"
+      },
+      "to": {
+        "path": "^src/$1/",
+        "reachable": false
+      }
     }
   ],
   "options": {

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -85,7 +85,7 @@
     },
     "ReachableType": {
       "type": "object",
-      "required": ["value", "asDefinedInRule"],
+      "required": ["value", "asDefinedInRule", "matchedFrom"],
       "additionalProperties": false,
       "properties": {
         "value": {
@@ -95,6 +95,10 @@
         "asDefinedInRule": {
           "type": "string",
           "description": "The name of the rule where the reachability was defined"
+        },
+        "matchedFrom": {
+          "type": "string",
+          "description": "Sometimes the 'asDefinedInRule' is not specific enough - e.g. when the from part can be many modules and/ or contains capturing groups used in the to part of the rule. The matchedFrom attribute shows what the 'from' module that causes the 'reachable' information to be what it is."
         }
       }
     },

--- a/test/cli/fixtures/result-has-a-dependency-violation.json
+++ b/test/cli/fixtures/result-has-a-dependency-violation.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../src/cli/format",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -24,9 +22,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../src/cli/validate-node-environment",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -47,9 +43,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../main",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -63,9 +57,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./normalize-options",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -79,9 +71,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/io",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -95,9 +85,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/validate-file-existence",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -111,6 +99,8 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/depcruise-fmt.js",
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -124,9 +114,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../extract",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -140,9 +128,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../extract/transpile/meta",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -156,9 +142,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../report",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -172,9 +156,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../schema/cruise-result.schema.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -188,9 +170,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./files-and-dirs/normalize",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -204,9 +184,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./options/normalize",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -220,9 +198,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./options/validate",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -236,9 +212,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve-options/normalize",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -252,9 +226,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./rule-set/normalize",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -268,9 +240,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./rule-set/validate",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -284,6 +254,8 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -295,14 +267,14 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -316,9 +288,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./add-focus",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -332,9 +302,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./add-validations",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -348,9 +316,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./clear-caches",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -364,9 +330,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./derive/circular",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -380,9 +344,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./derive/orphan",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -396,9 +358,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./derive/reachable",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -412,9 +372,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./gather-initial-sources",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -428,9 +386,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-dependencies",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -444,9 +400,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./summarize",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -460,9 +414,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/path-to-posix",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -476,6 +428,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -489,9 +442,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/filename-matches-pattern",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -505,6 +456,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -517,6 +469,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -530,9 +483,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../validate",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -546,6 +497,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -559,9 +511,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./match-dependency-rule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -575,9 +525,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./match-module-rule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -591,6 +539,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -604,9 +553,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-module-only-rule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -620,9 +567,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./matchers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -636,6 +581,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -648,6 +594,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -661,9 +608,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/array-util",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -677,6 +622,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -689,6 +635,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -702,9 +649,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-module-only-rule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -718,9 +663,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./matchers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -734,6 +677,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -747,9 +691,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./parse/to-javascript-ast",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -763,9 +705,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./parse/to-typescript-ast",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -779,9 +719,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve/get-manifest-dependencies",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -795,9 +733,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve/local-npm-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -811,9 +747,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve/resolve",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -827,9 +761,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve/resolve-amd",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -843,6 +775,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -856,9 +789,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../transpile",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -872,9 +803,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/get-extension",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -888,6 +817,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -901,9 +831,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./meta",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -917,6 +845,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -930,9 +859,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./coffeescript-wrap",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -946,9 +873,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./javascript-wrap",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -962,9 +887,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./livescript-wrap",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -978,9 +901,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./typescript-wrap",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -994,9 +915,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./vue-template-wrap",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1010,6 +929,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1022,6 +942,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1034,6 +955,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1046,6 +968,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1058,6 +981,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1070,6 +994,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1082,6 +1007,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1094,6 +1020,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1107,9 +1034,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./merge-manifests",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1123,6 +1048,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1135,6 +1061,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1148,9 +1075,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-relative-module-name",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1164,9 +1089,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "license": "MIT",
           "module": "./resolve",
           "moduleSystem": "cjs",
@@ -1181,6 +1104,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1193,6 +1117,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1206,9 +1131,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/path-to-posix",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1222,9 +1145,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/strip-query-parameters",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1238,6 +1159,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1250,6 +1172,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1262,6 +1185,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1275,9 +1199,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/path-to-posix",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1291,9 +1213,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./determine-dependency-types",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1307,9 +1227,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-manifest-dependencies",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1323,9 +1241,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-core",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1339,9 +1255,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1355,6 +1269,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1368,9 +1283,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-core",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1384,9 +1297,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-relative-module-name",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1400,9 +1311,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./local-npm-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1416,6 +1325,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1428,6 +1338,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1441,9 +1352,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./local-npm-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1457,6 +1366,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1470,9 +1380,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-cycle",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1486,6 +1394,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1498,6 +1407,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1511,9 +1421,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-orphan",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1527,6 +1435,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1539,6 +1448,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1552,9 +1462,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1568,6 +1476,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1580,6 +1489,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1593,9 +1503,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./transpile/meta",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1609,9 +1517,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/filename-matches-pattern",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1625,9 +1531,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/path-to-posix",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1641,6 +1545,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1654,9 +1559,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/array-util",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1670,9 +1573,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./ast-extractors/extract-amd-deps",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1686,9 +1587,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./ast-extractors/extract-cjs-deps",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1702,9 +1601,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./ast-extractors/extract-es6-deps",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1718,9 +1615,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./ast-extractors/extract-typescript-deps",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1734,9 +1629,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./parse/to-javascript-ast",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1750,9 +1643,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./parse/to-typescript-ast",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1766,9 +1657,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "license": "MIT",
           "module": "./resolve",
           "moduleSystem": "cjs",
@@ -1783,9 +1672,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/detect-pre-compilation-ness",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1799,6 +1686,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1812,9 +1700,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./estree-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1828,9 +1714,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./extract-cjs-deps",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1844,6 +1728,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1856,6 +1741,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1869,9 +1755,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./estree-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1885,6 +1769,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1898,9 +1783,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./estree-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1914,6 +1797,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1926,6 +1810,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -1939,9 +1824,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/path-to-posix",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1955,9 +1838,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-relative-module-name",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1971,9 +1852,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve-amd",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -1987,9 +1866,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve-cjs",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2003,6 +1880,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2016,9 +1894,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/path-to-posix",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2032,9 +1908,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./determine-dependency-types",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2048,9 +1922,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-manifest-dependencies",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2064,9 +1936,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-core",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2080,9 +1950,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./is-followable",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2096,9 +1964,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "license": "MIT",
           "module": "./resolve",
           "moduleSystem": "cjs",
@@ -2113,9 +1979,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./resolve-helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2129,6 +1993,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2142,9 +2007,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/get-extension",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2158,6 +2021,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2171,9 +2035,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./compare",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2187,6 +2049,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2199,6 +2062,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2212,9 +2076,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/find-rule-by-name",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2228,9 +2090,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/compare",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2244,6 +2104,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2256,6 +2117,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2269,9 +2131,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./anon",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2285,9 +2145,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./csv",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2301,9 +2159,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./dot",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2317,9 +2173,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./error",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2333,9 +2187,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./error-html",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2349,9 +2201,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./html",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2365,9 +2215,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./identity",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2381,9 +2229,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2397,9 +2243,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./teamcity",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2413,9 +2257,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./text",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2429,6 +2271,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2442,9 +2285,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./anonymize-path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2458,6 +2299,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2471,9 +2313,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./anonymize-path-element",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2487,6 +2327,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2500,9 +2341,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./random-string",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2516,6 +2355,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2528,6 +2368,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2541,9 +2382,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/dependency-to-incidence-transformer",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2557,6 +2396,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2569,6 +2409,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2582,9 +2423,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./dot.template",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2598,9 +2437,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./module-utl",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2614,9 +2451,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./prepare-custom-level",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2630,9 +2465,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./prepare-folder-level",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2646,9 +2479,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./theming",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2662,6 +2493,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2674,6 +2506,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2687,9 +2520,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./theming",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2703,6 +2534,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2716,9 +2548,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./default-theme.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2732,6 +2562,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2743,14 +2574,13 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2764,9 +2594,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/consolidate-to-pattern",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2780,9 +2608,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./module-utl",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2796,6 +2622,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2809,9 +2636,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./consolidate-module-dependencies",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2825,9 +2650,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./consolidate-modules",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2841,6 +2664,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2854,9 +2678,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./compare-rules",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2870,6 +2692,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2882,6 +2705,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2895,9 +2719,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./compare-rules",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2911,6 +2733,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2924,9 +2747,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/consolidate-to-folder",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2940,9 +2761,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./module-utl",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2956,6 +2775,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -2969,9 +2789,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./consolidate-module-dependencies",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -2985,9 +2803,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./consolidate-modules",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3001,6 +2817,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3014,9 +2831,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/find-rule-by-name",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3030,6 +2845,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3043,9 +2859,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./error-html.template",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3059,9 +2873,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3075,6 +2887,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3087,6 +2900,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3099,6 +2913,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3112,9 +2927,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../utl/dependency-to-incidence-transformer",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3128,9 +2941,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./html.template",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3144,6 +2955,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3156,6 +2968,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3168,6 +2981,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3180,6 +2994,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3192,6 +3007,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3204,6 +3020,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3216,6 +3033,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3229,9 +3047,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./defaults.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3245,6 +3061,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3256,14 +3073,13 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3277,9 +3093,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../../report",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3293,6 +3107,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3306,9 +3121,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../../extract/transpile/meta",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3322,6 +3135,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3334,6 +3148,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3347,9 +3162,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../../schema/configuration.schema.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3363,9 +3176,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../options/validate",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3379,6 +3190,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3390,14 +3202,13 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3411,9 +3222,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./compile-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3427,9 +3236,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./defaults.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3443,6 +3250,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3454,14 +3262,13 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3475,9 +3282,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../../extract/resolve/resolve",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3497,9 +3302,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../../main/resolve-options/normalize",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3513,9 +3316,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./merge-configs",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3529,9 +3330,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./read-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3545,6 +3344,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3557,6 +3357,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3569,6 +3370,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3581,6 +3383,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3593,6 +3396,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3605,6 +3409,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3618,9 +3423,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../src/cli",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3634,9 +3437,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../src/cli/validate-node-environment",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3657,9 +3458,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../main",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3673,9 +3472,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./format-meta-info",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3689,9 +3486,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-resolve-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3705,9 +3500,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./init-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3721,9 +3514,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./normalize-options",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3737,9 +3528,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./parse-ts-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3753,9 +3542,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/io",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3769,9 +3556,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/validate-file-existence",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3785,6 +3570,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3798,9 +3584,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../main",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3814,6 +3598,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3827,9 +3612,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./utl/make-absolute",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3843,6 +3626,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3855,6 +3639,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3868,9 +3653,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../defaults.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3884,9 +3667,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./build-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3900,9 +3681,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./get-user-input",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3916,9 +3695,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3932,9 +3709,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./normalize-init-options",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3948,9 +3723,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./write-config",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3964,6 +3737,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -3977,9 +3751,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./config.js.template",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -3993,9 +3765,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -4009,6 +3779,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4021,6 +3792,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4033,6 +3805,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4046,9 +3819,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../defaults.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -4062,9 +3833,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -4078,6 +3847,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4091,9 +3861,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -4107,6 +3875,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4120,9 +3889,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./helpers",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -4136,6 +3903,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4148,6 +3916,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4161,9 +3930,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../src/cli/tools/wrap-stream-in-html",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -4183,6 +3950,7 @@
       "reachable": [
         {
           "value": true,
+          "matchedFrom": "bin/dependency-cruise.js",
           "asDefinedInRule": "not-unreachable-from-cli"
         }
       ],
@@ -4222,21 +3990,14 @@
       },
       "externalModuleResolutionStrategy": "node_modules",
       "includeOnly": "^(src|bin)",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "tmp_graph_deps.json",
       "outputType": "json",
       "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/",
       "preserveSymlinks": false,
       "rulesFile": ".dependency-cruiser.json",
       "tsPreCompilationDeps": true,
-      "exoticRequireStrings": [
-        "tryRequire"
-      ],
+      "exoticRequireStrings": ["tryRequire"],
       "reporterOptions": {
         "archi": {
           "collapsePattern": "^(node_modules|src|test)/[^/]+|^bin/"
@@ -4556,9 +4317,7 @@
             "path": "^(bin|src)"
           },
           "to": {
-            "dependencyTypes": [
-              "npm-dev"
-            ],
+            "dependencyTypes": ["npm-dev"],
             "exoticallyRequired": false
           }
         },
@@ -4578,9 +4337,7 @@
           "comment": "This module uses an external dependency that in package.json shows up as an optional dependency. In dependency-cruiser optional dependencies donot make sense - and are hence forbidden. Either make it a regular dependency (if it's production code) or a dev one (if it's for development only)",
           "from": {},
           "to": {
-            "dependencyTypes": [
-              "npm-optional"
-            ]
+            "dependencyTypes": ["npm-optional"]
           }
         },
         {
@@ -4589,9 +4346,7 @@
           "severity": "error",
           "from": {},
           "to": {
-            "dependencyTypes": [
-              "npm-peer"
-            ]
+            "dependencyTypes": ["npm-peer"]
           }
         },
         {
@@ -4652,9 +4407,7 @@
           "severity": "error",
           "from": {},
           "to": {
-            "dependencyTypes": [
-              "core"
-            ],
+            "dependencyTypes": ["core"],
             "path": [
               "^(v8/tools/codemap)$",
               "^(v8/tools/consarray)$",
@@ -4695,10 +4448,7 @@
           "comment": "This module depends on an npm package that isn't in the 'dependencies' section of your package.json. That's problematic as the package either (1) won't be available on live (2 - worse) will be available on live with an non-guaranteed version. Fix it by adding the package to the dependencies in your package.json.",
           "from": {},
           "to": {
-            "dependencyTypes": [
-              "npm-no-pkg",
-              "npm-unknown"
-            ]
+            "dependencyTypes": ["npm-no-pkg", "npm-unknown"]
           }
         },
         {
@@ -4707,9 +4457,7 @@
           "severity": "error",
           "from": {},
           "to": {
-            "dependencyTypes": [
-              "deprecated"
-            ]
+            "dependencyTypes": ["deprecated"]
           }
         }
       ],

--- a/test/enrich/derive/reachable/index.spec.js
+++ b/test/enrich/derive/reachable/index.spec.js
@@ -68,6 +68,7 @@ const ANOTATED_GRAPH_FOR_HAJOO = [
     reachable: [
       {
         asDefinedInRule: "unnamed",
+        matchedFrom: "./src/hajoo.js",
         value: false,
       },
     ],
@@ -82,6 +83,7 @@ const ANOTATED_GRAPH_FOR_HAJOO = [
     reachable: [
       {
         asDefinedInRule: "unnamed",
+        matchedFrom: "./src/hajoo.js",
         value: false,
       },
     ],
@@ -189,6 +191,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             value: true,
+            matchedFrom: "./src/index.js",
             asDefinedInRule: "not-in-allowed",
           },
         ],
@@ -260,6 +263,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             value: true,
+            matchedFrom: "./src/index.js",
             asDefinedInRule: "not-in-allowed",
           },
         ],
@@ -346,6 +350,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             value: true,
+            matchedFrom: "./src/index.js",
             asDefinedInRule: "not-in-allowed",
           },
         ],
@@ -356,6 +361,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             value: true,
+            matchedFrom: "./src/index.js",
             asDefinedInRule: "not-in-allowed",
           },
         ],
@@ -397,6 +403,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "unnamed",
+            matchedFrom: "./src/hajoo.js",
             value: false,
           },
         ],
@@ -451,6 +458,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "unnamed",
+            matchedFrom: "./src/hajoo.js",
             value: false,
           },
         ],
@@ -536,6 +544,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "not-unreachable-by-test",
+            matchedFrom: "./test/hajoo.spec.js",
             value: true,
           },
         ],
@@ -550,6 +559,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "not-unreachable-by-test",
+            matchedFrom: "./test/hajoo.spec.js",
             value: true,
           },
         ],
@@ -567,6 +577,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "not-unreachable-by-test",
+            matchedFrom: "./test/hajoo.spec.js",
             value: true,
           },
         ],
@@ -667,6 +678,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "not-unreachable-by-test",
+            matchedFrom: "./test/hajoo.spec.js",
             value: true,
           },
         ],
@@ -681,6 +693,7 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "not-unreachable-by-test",
+            matchedFrom: "./test/hajoo.spec.js",
             value: true,
           },
         ],
@@ -698,10 +711,12 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
         reachable: [
           {
             asDefinedInRule: "not-unreachable-by-test",
+            matchedFrom: "./test/hajoo.spec.js",
             value: true,
           },
           {
             asDefinedInRule: "not-reachable-from-index",
+            matchedFrom: "./src/index.js",
             value: true,
           },
         ],
@@ -826,5 +841,199 @@ describe("enrich/derive/reachable/index - reachability detection", () => {
     expect(
       addReachability(lSourceGraph, normalize(lTwoDifferentRules))
     ).to.deep.equal(lResultGraph);
+  });
+
+  it("correctly processes capture groups", () => {
+    const lRuleSetWithCaptureGroup = {
+      forbidden: [
+        {
+          name: "with-a-capture-group",
+          from: {
+            path: "^src/([^/]+)/index\\.js$",
+          },
+          to: {
+            path: "^src/$1",
+            reachable: false,
+          },
+        },
+      ],
+    };
+    const lDependencyGraph = [
+      {
+        source: "src/foo/index.js",
+        dependencies: [{ resolved: "src/foo/quux/huey.js" }],
+      },
+      {
+        source: "src/foo/quux/huey.js",
+        dependencies: [{ resolved: "src/foo/quux/louie.js" }],
+      },
+      {
+        source: "src/foo/quux/louie.js",
+        dependencies: [{ resolved: "src/foo/quux/dewey.js" }],
+      },
+      {
+        source: "src/foo/quux/dewey.js",
+        dependencies: [],
+      },
+      {
+        source: "src/foo/quux/not-reachable-from-foo-index.js",
+        dependencies: [],
+      },
+      {
+        source: "src/bar/index.js",
+        dependencies: [{ resolved: "src/bar/ister.js" }],
+      },
+      {
+        source: "src/bar/ister.js",
+        dependencies: [
+          { resolved: "src/bar/stool.js" },
+          { resolved: "src/bar/iton.js" },
+        ],
+      },
+      {
+        source: "src/bar/stool.js",
+        dependencies: [],
+      },
+      {
+        source: "src/bar/iton.js",
+        dependencies: [],
+      },
+      {
+        source: "src/bar/none.js",
+        dependencies: [],
+      },
+      {
+        source: "src/baz/index.js",
+        dependencies: [],
+      },
+    ];
+    const lExpectedGraph = [
+      {
+        source: "src/foo/index.js",
+        dependencies: [
+          {
+            resolved: "src/foo/quux/huey.js",
+          },
+        ],
+      },
+      {
+        source: "src/foo/quux/huey.js",
+        dependencies: [
+          {
+            resolved: "src/foo/quux/louie.js",
+          },
+        ],
+        reachable: [
+          {
+            value: true,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/foo/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/foo/quux/louie.js",
+        dependencies: [
+          {
+            resolved: "src/foo/quux/dewey.js",
+          },
+        ],
+        reachable: [
+          {
+            value: true,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/foo/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/foo/quux/dewey.js",
+        dependencies: [],
+        reachable: [
+          {
+            value: true,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/foo/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/foo/quux/not-reachable-from-foo-index.js",
+        dependencies: [],
+        reachable: [
+          {
+            value: false,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/foo/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/bar/index.js",
+        dependencies: [
+          {
+            resolved: "src/bar/ister.js",
+          },
+        ],
+      },
+      {
+        source: "src/bar/ister.js",
+        dependencies: [
+          {
+            resolved: "src/bar/stool.js",
+          },
+          {
+            resolved: "src/bar/iton.js",
+          },
+        ],
+        reachable: [
+          {
+            value: true,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/bar/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/bar/stool.js",
+        dependencies: [],
+        reachable: [
+          {
+            value: true,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/bar/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/bar/iton.js",
+        dependencies: [],
+        reachable: [
+          {
+            value: true,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/bar/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/bar/none.js",
+        dependencies: [],
+        reachable: [
+          {
+            value: false,
+            asDefinedInRule: "with-a-capture-group",
+            matchedFrom: "src/bar/index.js",
+          },
+        ],
+      },
+      {
+        source: "src/baz/index.js",
+        dependencies: [],
+      },
+    ];
+    expect(
+      addReachability(lDependencyGraph, normalize(lRuleSetWithCaptureGroup))
+    ).to.deep.equal(lExpectedGraph);
   });
 });

--- a/test/validate/fixtures/rules.reachable.capturing-group.json
+++ b/test/validate/fixtures/rules.reachable.capturing-group.json
@@ -1,0 +1,12 @@
+{
+  "forbidden": [
+    {
+      "name": "capt-group",
+      "from": { "path": "^src/([^/]+)/index\\.js$" },
+      "to": {
+        "path": "^src/$1/.+",
+        "reachable": false
+      }
+    }
+  ]
+}

--- a/test/validate/index.reachable.spec.js
+++ b/test/validate/index.reachable.spec.js
@@ -27,7 +27,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         readRuleSet("./test/validate/fixtures/rules.reachable-false.json"),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-unreachable", value: true }],
+          reachable: [
+            {
+              asDefinedInRule: "no-unreachable",
+              matchedFrom: "azazel",
+              value: true,
+            },
+          ],
         }
       )
     ).to.deep.equal({ valid: true });
@@ -39,7 +45,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         readRuleSet("./test/validate/fixtures/rules.reachable-true.json"),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-unreachable", value: true }],
+          reachable: [
+            {
+              asDefinedInRule: "no-unreachable",
+              matchedFrom: "azazel",
+              value: true,
+            },
+          ],
         }
       )
     ).to.deep.equal({ valid: true });
@@ -51,7 +63,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         readRuleSet("./test/validate/fixtures/rules.reachable-false.json"),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-unreachable", value: false }],
+          reachable: [
+            {
+              asDefinedInRule: "no-unreachable",
+              matchedFrom: "azazel",
+              value: false,
+            },
+          ],
         }
       )
     ).to.deep.equal({
@@ -71,7 +89,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         readRuleSet("./test/validate/fixtures/rules.reachable-true.json"),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-reachable", value: true }],
+          reachable: [
+            {
+              asDefinedInRule: "no-reachable",
+              matchedFrom: "azazel",
+              value: true,
+            },
+          ],
         }
       )
     ).to.deep.equal({
@@ -91,7 +115,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         readRuleSet("./test/validate/fixtures/rules.reachable-false.path.json"),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-unreachable", value: false }],
+          reachable: [
+            {
+              asDefinedInRule: "no-unreachable",
+              matchedFrom: "azazel",
+              value: false,
+            },
+          ],
         }
       )
     ).to.deep.equal({
@@ -111,7 +141,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         readRuleSet("./test/validate/fixtures/rules.reachable-true.path.json"),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-reachable", value: true }],
+          reachable: [
+            {
+              asDefinedInRule: "no-reachable",
+              matchedFrom: "azazel",
+              value: true,
+            },
+          ],
         }
       )
     ).to.deep.equal({
@@ -133,7 +169,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         ),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-unreachable", value: false }],
+          reachable: [
+            {
+              asDefinedInRule: "no-unreachable",
+              matchedFrom: "azazel",
+              value: false,
+            },
+          ],
         }
       )
     ).to.deep.equal({ valid: true });
@@ -147,7 +189,13 @@ describe("validate/index - reachable (in forbidden set)", () => {
         ),
         {
           source: "something",
-          reachable: [{ asDefinedInRule: "no-reachable", value: true }],
+          reachable: [
+            {
+              asDefinedInRule: "no-reachable",
+              matchedFrom: "azazel",
+              value: true,
+            },
+          ],
         }
       )
     ).to.deep.equal({ valid: true });
@@ -182,6 +230,7 @@ describe("validate/index - reachable (in allowed set)", () => {
           reachable: [
             {
               value: true,
+              matchedFrom: "azazel",
               asDefinedInRule: "not-in-allowed",
             },
           ],
@@ -211,6 +260,32 @@ describe("validate/index - reachable (in allowed set)", () => {
       rules: [
         {
           name: "not-in-allowed",
+          severity: "warn",
+        },
+      ],
+    });
+  });
+
+  it("Respects capturing groups", () => {
+    const lRuleSet = readRuleSet(
+      "./test/validate/fixtures/rules.reachable.capturing-group.json"
+    );
+    const lModule = {
+      source: "src/hoonk/not-reached.js",
+      reachable: [
+        {
+          value: false,
+          asDefinedInRule: "capt-group",
+          matchedFrom: "src/hoonk/index.js",
+        },
+      ],
+    };
+    const lValidationResult = validate.module(lRuleSet, lModule);
+    expect(lValidationResult).to.deep.equal({
+      valid: false,
+      rules: [
+        {
+          name: "capt-group",
           severity: "warn",
         },
       ],

--- a/tools/schema/modules.mjs
+++ b/tools/schema/modules.mjs
@@ -113,7 +113,7 @@ export default {
     },
     ReachableType: {
       type: "object",
-      required: ["value", "asDefinedInRule"],
+      required: ["value", "asDefinedInRule", "matchedFrom"],
       additionalProperties: false,
       properties: {
         value: {
@@ -127,6 +127,15 @@ export default {
           type: "string",
           description:
             "The name of the rule where the reachability was defined",
+        },
+        matchedFrom: {
+          type: "string",
+          description:
+            "The matchedFrom attribute shows what the 'from' module " +
+            "that causes the 'reachable' information to be what it is. " +
+            "Sometimes the 'asDefinedInRule' is not specific enough - e.g. when the " +
+            "from part can be many modules and/ or contains capturing groups used in the " +
+            "to part of the rule.",
         },
       },
     },

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -198,6 +198,13 @@ export interface IReachable {
    */
   asDefinedInRule: string;
   /**
+   * The matchedFrom attribute shows what the 'from' module that causes the 'reachable'
+   * information to be what it is. Sometimes the 'asDefinedInRule' is not specific enough -
+   * e.g. when the from part can be many modules and/ or contains capturing groups used
+   * in the to part of the rule.
+   */
+  matchedFrom: string;
+  /**
    * 'true' if this module is reachable from any of the modules matched by the from part of a
    * reachability-rule in 'asDefinedInRule', 'false' if not.
    */


### PR DESCRIPTION
## Description, Motivation and Context

- Adds support for capturing groups on rules that have a 'reachable' attribute.
- See #442 for an example rule and an expected output
- Todo:
  - [x] tweak to see if we can make things faster
  - [x] rethink the `reachable: true` logic

Fixes #442 

Published with beta tag as `dependency-cruiser@9.23.1-beta-1`

## How Has This Been Tested?

- [x] passing automated non-regression tests
- [x] green ci
- [x] additional unit tests 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) *
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

*= could be construed as a new feature - but as the documentation doesn't mention it doesn't work you might assume that it does work - so classifying it as a bug nonetheless.

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
