### PR TITLE
feature(enrich): adds dependents to each module

### DIFF
--- a/configs/plugins/stats-reporter-plugin.js
+++ b/configs/plugins/stats-reporter-plugin.js
@@ -2,6 +2,33 @@ const MEDIAN = 0.5;
 const P75 = 0.75;
 const DEFAULT_JSON_INDENT = 2;
 
+function doMagic(pCruiseResult) {
+  let lReturnValue = {};
+
+  if (pCruiseResult.modules.some((pModule) => pModule.dependents)) {
+    const lDependentCounts = pCruiseResult.modules
+      .map((pModule) => pModule.dependents.length)
+      .sort();
+
+    lReturnValue = {
+      minDependentsPerModule: lDependentCounts[0] || 0,
+      maxDependentsPerModule:
+        lDependentCounts[Math.max(lDependentCounts.length - 1, 0)] || 0,
+      meanDependentsPerModule:
+        lDependentCounts.reduce((pAll, pCurrent) => pAll + pCurrent, 0) /
+        pCruiseResult.summary.totalCruised,
+      medianDependentsPerModule:
+        lDependentCounts[
+          Math.max(0, Math.floor(lDependentCounts.length * MEDIAN))
+        ],
+      p75DependentsPerModule:
+        lDependentCounts[
+          Math.max(0, Math.floor(lDependentCounts.length * P75))
+        ],
+    };
+  }
+  return lReturnValue;
+}
 /**
  * returns an object with some stats from the ICruiseResult pCruiseResult it
  * got passed
@@ -21,8 +48,8 @@ function samplePluginReporter(pCruiseResult) {
     maxDependenciesPerModule:
       lDependencyCounts[Math.max(lDependencyCounts.length - 1, 0)] || 0,
     meanDependenciesPerModule:
-      pCruiseResult.summary.totalCruised /
-      pCruiseResult.summary.totalDependenciesCruised,
+      pCruiseResult.summary.totalDependenciesCruised /
+      pCruiseResult.summary.totalCruised,
     medianDependenciesPerModule:
       lDependencyCounts[
         Math.max(0, Math.floor(lDependencyCounts.length * MEDIAN))
@@ -31,6 +58,7 @@ function samplePluginReporter(pCruiseResult) {
       lDependencyCounts[
         Math.max(0, Math.floor(lDependencyCounts.length * P75))
       ],
+    ...doMagic(pCruiseResult),
   };
 }
 

--- a/src/enrich/derive/dependents/get-dependents.js
+++ b/src/enrich/derive/dependents/get-dependents.js
@@ -1,0 +1,13 @@
+// TODO: duplicate of the function of the same nature in is-orphan
+function isDependent(pResolvedName) {
+  return (pModule) =>
+    pModule.dependencies.some(
+      (pDependency) => pDependency.resolved === pResolvedName
+    );
+}
+module.exports = function getDependents(pModule, pModules) {
+  // TODO: perf - O(n^2)
+  return pModules
+    .filter(isDependent(pModule.source))
+    .map((pDependantModule) => pDependantModule.source);
+};

--- a/src/enrich/derive/dependents/index.js
+++ b/src/enrich/derive/dependents/index.js
@@ -1,0 +1,20 @@
+const getDependents = require("./get-dependents");
+
+function shouldAddDependents(pOptions) {
+  return Boolean(pOptions.forceDeriveDependents);
+}
+
+module.exports = function addDependents(pModules, pOptions) {
+  if (shouldAddDependents(pOptions)) {
+    return pModules.map((pModule) => {
+      return {
+        ...pModule,
+        dependents: getDependents(pModule, pModules),
+        // TODO: observation:
+        // an orphan is a module for which module.dependents === 0 && module.dependencies === 0
+        // orphan: lDependents.length + pModule.dependencies.length === 0,
+      };
+    });
+  }
+  return pModules;
+};

--- a/src/enrich/derive/orphan/index.js
+++ b/src/enrich/derive/orphan/index.js
@@ -1,7 +1,7 @@
 const isOrphan = require("./is-orphan");
 
 module.exports = (pModules) =>
-  pModules.map((pNode) => ({
-    ...pNode,
-    orphan: isOrphan(pNode, pModules),
+  pModules.map((pModule) => ({
+    ...pModule,
+    orphan: isOrphan(pModule, pModules),
   }));

--- a/src/enrich/enrich-modules.js
+++ b/src/enrich/enrich-modules.js
@@ -4,6 +4,7 @@ const busLogLevels = require("../utl/bus-log-levels");
 const addFocus = require("../../src/graph-utl/add-focus");
 const deriveCirculars = require("./derive/circular");
 const deriveOrphans = require("./derive/orphan");
+const addDependents = require("./derive/dependents");
 const deriveReachable = require("./derive/reachable");
 const addValidations = require("./add-validations");
 
@@ -12,6 +13,8 @@ module.exports = function enrichModules(pModules, pOptions) {
   let lModules = deriveCirculars(pModules);
   bus.emit("progress", "analyzing: orphans", { level: busLogLevels.INFO });
   lModules = deriveOrphans(lModules);
+  bus.emit("progress", "analyzing: dependents", { level: busLogLevels.INFO });
+  lModules = addDependents(lModules, pOptions);
   bus.emit("progress", "analyzing: reachables", { level: busLogLevels.INFO });
   lModules = deriveReachable(lModules, pOptions.ruleSet);
   bus.emit("progress", "analyzing: add focus (if any)", {

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -380,6 +380,10 @@
           "description": "What external module resolution strategy to use. Defaults to 'node_modules' (not used anymore - module resolution strategy determination is automatic now)",
           "enum": ["node_modules", "yarn-pnp"]
         },
+        "forceDeriveDependents": {
+          "type": "boolean",
+          "description": "When true includes denormalized dependents in the cruise-result, even though there's no rule in the rule set that requires them. Defaults to false."
+        },
         "webpackConfig": {
           "type": "object",
           "additionalProperties": false,

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -29,6 +29,14 @@
           "description": "'true' if this module violated a rule; 'false' in all other cases. The violated rule will be in the 'rule' object at the same level."
         },
         "dependencies": { "$ref": "#/definitions/DependenciesType" },
+        "dependents": {
+          "type": "array",
+          "description": "list of modules depending on this module",
+          "items": {
+            "type": "string",
+            "description": "the (resolved) name of the dependant"
+          }
+        },
         "followable": {
           "type": "boolean",
           "description": "Whether or not this is a dependency that can be followed any further. This will be 'false' for for core modules, json, modules that could not be resolved to a file and modules that weren't followed because it matches the doNotFollow expression."
@@ -626,6 +634,10 @@
           "type": "string",
           "description": "What external module resolution strategy to use. Defaults to 'node_modules' (not used anymore - module resolution strategy determination is automatic now)",
           "enum": ["node_modules", "yarn-pnp"]
+        },
+        "forceDeriveDependents": {
+          "type": "boolean",
+          "description": "When true includes denormalized dependents in the cruise-result, even though there's no rule in the rule set that requires them. Defaults to false."
         },
         "webpackConfig": {
           "type": "object",

--- a/test/enrich/derive/dependents/get-dependents.spec.js
+++ b/test/enrich/derive/dependents/get-dependents.spec.js
@@ -1,0 +1,66 @@
+const { expect } = require("chai");
+
+const getDependents = require("../../../../src/enrich/derive/dependents/get-dependents");
+
+describe("enrich/derive/dependents/get-dependents", () => {
+  it("empty module without a source name & no modules yield no modules", () => {
+    expect(getDependents({}, [])).to.deep.equal([]);
+  });
+
+  it("module & no modules yield no modules", () => {
+    expect(getDependents({ source: "itsme" }, [])).to.deep.equal([]);
+  });
+
+  it("module & modules without any dependencies yield no modules", () => {
+    expect(
+      getDependents({ source: "itsme" }, [
+        {
+          source: "someoneelse",
+          dependencies: [],
+        },
+      ])
+    ).to.deep.equal([]);
+  });
+
+  it("module & modules with non-matching dependencies yield no modules", () => {
+    expect(
+      getDependents({ source: "itsme" }, [
+        {
+          source: "someoneelse",
+          dependencies: [{ resolved: "itsnotme" }],
+        },
+      ])
+    ).to.deep.equal([]);
+  });
+
+  it("module & module that's dependent yields that other module", () => {
+    expect(
+      getDependents({ source: "itsme" }, [
+        {
+          source: "someoneelse",
+          dependencies: [{ resolved: "itsnotme" }, { resolved: "itsme" }],
+        },
+      ])
+    ).to.deep.equal(["someoneelse"]);
+  });
+
+  it("module & modules that are dependent yields those other modules", () => {
+    expect(
+      getDependents({ source: "itsme" }, [
+        {
+          source: "someoneelse",
+          dependencies: [{ resolved: "itsnotme" }, { resolved: "itsme" }],
+        },
+        {
+          source: "someoneelse-again",
+          dependencies: [
+            { resolved: "notme" },
+            { resolved: "notmeagain" },
+            { resolved: "itsme" },
+            { resolved: "itsnotmeeither" },
+          ],
+        },
+      ])
+    ).to.deep.equal(["someoneelse", "someoneelse-again"]);
+  });
+});

--- a/test/main/fixtures/collapse-after-cruise/expected-result.json
+++ b/test/main/fixtures/collapse-after-cruise/expected-result.json
@@ -9,18 +9,14 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "orphan": false,
       "consolidated": false
     },
     {
       "dependencies": [
         {
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "rules": [],
           "valid": true,
           "resolved": "test/main/fixtures/collapse-after-cruise/src/input",
@@ -35,9 +31,7 @@
           "circular": false
         },
         {
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "rules": [],
           "valid": true,
           "resolved": "test/main/fixtures/collapse-after-cruise/src/output",
@@ -52,9 +46,7 @@
           "circular": false
         },
         {
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "rules": [],
           "valid": true,
           "resolved": "test/main/fixtures/collapse-after-cruise/src/post-processing",
@@ -69,9 +61,7 @@
           "circular": false
         },
         {
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "rules": [],
           "valid": true,
           "resolved": "test/main/fixtures/collapse-after-cruise/src/pre-processing",
@@ -86,9 +76,7 @@
           "circular": false
         },
         {
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "rules": [],
           "valid": true,
           "resolved": "./processing",
@@ -112,9 +100,7 @@
     {
       "dependencies": [
         {
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "rules": [],
           "valid": true,
           "resolved": "test/main/fixtures/collapse-after-cruise/src/utl",
@@ -178,12 +164,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/fixtures/cruise-reporterless/amd.json
+++ b/test/main/fixtures/cruise-reporterless/amd.json
@@ -52,6 +52,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -63,6 +64,9 @@
         "dependencyTypes": ["unknown"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/amd/requires-non-relative-module.js"
+        ],
         "valid": true
       },
       {
@@ -74,12 +78,18 @@
         "dependencyTypes": ["unknown"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/amd/requires-non-relative-module.js"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/amd/sub/local-module-in-drag.js",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/amd/requires-non-relative-module.js"
+        ],
         "valid": true
       }
     ]

--- a/test/main/fixtures/cruise-reporterless/bundled-dependencies.json
+++ b/test/main/fixtures/cruise-reporterless/bundled-dependencies.json
@@ -44,18 +44,21 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
         "source": "node_modules/idontgetbundled/index.js",
         "orphan": false,
         "dependencies": [],
+        "dependents": ["index.js"],
         "valid": true
       },
       {
         "source": "node_modules/igetbundled/index.js",
         "orphan": false,
         "dependencies": [],
+        "dependents": ["index.js"],
         "valid": true
       }
     ]

--- a/test/main/fixtures/cruise-reporterless/coffee.json
+++ b/test/main/fixtures/cruise-reporterless/coffee.json
@@ -80,6 +80,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -91,12 +92,18 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/coffee/index.coffee"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/coffee/javascriptThing.js",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/coffee/index.coffee"
+        ],
         "valid": true
       },
       {
@@ -118,18 +125,28 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/coffee/index.coffee"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/coffee/sub/willBeReExported.coffee.md",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/coffee/index.coffee",
+          "test/main/fixtures/cruise-reporterless/coffee/sub/index.coffee"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/coffee/sub/kaching.litcoffee",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/coffee/index.coffee"
+        ],
         "valid": true
       }
     ]

--- a/test/main/fixtures/cruise-reporterless/commonjs.json
+++ b/test/main/fixtures/cruise-reporterless/commonjs.json
@@ -9,6 +9,7 @@
         "source": "test/main/fixtures/cruise-reporterless/commonjs/empty.js",
         "orphan": true,
         "dependencies": [],
+        "dependents": [],
         "valid": true
       }
     ]
@@ -80,6 +81,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -91,6 +93,9 @@
         "dependencyTypes": ["local"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_two.js"
+        ],
         "valid": true
       },
       {
@@ -102,6 +107,9 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_two.js"
+        ],
         "valid": true
       },
       {
@@ -123,6 +131,9 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_two.js"
+        ],
         "valid": true
       },
       {
@@ -134,6 +145,11 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/shared.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/sub/dir.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/sub/depindir.js"
+        ],
         "valid": true
       },
       {
@@ -154,6 +170,9 @@
             "couldNotResolve": false,
             "valid": true
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_two.js"
         ],
         "valid": true
       },
@@ -190,6 +209,9 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/two_only_one.js"
+        ],
         "valid": true
       },
       {
@@ -210,6 +232,9 @@
             "couldNotResolve": false,
             "valid": true
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/sub/dir.js"
         ],
         "valid": true
       }
@@ -299,6 +324,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -310,6 +336,9 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_one.js"
+        ],
         "valid": true
       },
       {
@@ -331,6 +360,9 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_one.js"
+        ],
         "valid": true
       },
       {
@@ -342,6 +374,13 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/one_only_one.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/one_only_two.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/shared.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/sub/dir.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/sub/depindir.js"
+        ],
         "valid": true
       },
       {
@@ -363,6 +402,9 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_one.js"
+        ],
         "valid": true
       },
       {
@@ -383,6 +425,9 @@
             "couldNotResolve": false,
             "valid": true
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_one.js"
         ],
         "valid": true
       },
@@ -419,6 +464,9 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/root_one.js"
+        ],
         "valid": true
       },
       {
@@ -439,6 +487,9 @@
             "couldNotResolve": false,
             "valid": true
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/sub/dir.js"
         ],
         "valid": true
       }
@@ -514,6 +565,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -525,6 +577,7 @@
         "dependencyTypes": ["local"],
         "orphan": false,
         "dependencies": [],
+        "dependents": ["root_two.js"],
         "valid": true
       },
       {
@@ -536,6 +589,7 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": ["root_two.js"],
         "valid": true
       },
       {
@@ -557,6 +611,7 @@
             "valid": true
           }
         ],
+        "dependents": ["root_two.js"],
         "valid": true
       },
       {
@@ -568,6 +623,7 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": ["shared.js", "sub/dir.js", "sub/depindir.js"],
         "valid": true
       },
       {
@@ -589,6 +645,7 @@
             "valid": true
           }
         ],
+        "dependents": ["root_two.js"],
         "valid": true
       },
       {
@@ -624,6 +681,7 @@
             "valid": true
           }
         ],
+        "dependents": ["two_only_one.js"],
         "valid": true
       },
       {
@@ -645,6 +703,7 @@
             "valid": true
           }
         ],
+        "dependents": ["sub/dir.js"],
         "valid": true
       }
     ]
@@ -711,12 +770,18 @@
             ]
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/ralucric.js"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/commonjs/pointed-to-by-circular.js",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/circular.js"
+        ],
         "valid": true
       },
       {
@@ -748,6 +813,9 @@
             ]
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/circular.js"
+        ],
         "valid": true
       }
     ]
@@ -777,6 +845,7 @@
             "circular": false
           }
         ],
+        "dependents": [],
         "orphan": false,
         "valid": true
       },
@@ -802,6 +871,10 @@
               "test/main/fixtures/cruise-reporterless/commonjs/circle-one.js"
             ]
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/points-to-circle-one.js",
+          "test/main/fixtures/cruise-reporterless/commonjs/circle-three.js"
         ],
         "orphan": false,
         "valid": true
@@ -830,6 +903,9 @@
             ]
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/circle-one.js"
+        ],
         "valid": true
       },
       {
@@ -855,6 +931,9 @@
               "test/main/fixtures/cruise-reporterless/commonjs/circle-three.js"
             ]
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/commonjs/circle-two.js"
         ],
         "valid": true
       }

--- a/test/main/fixtures/cruise-reporterless/deprecated-node-module.json
+++ b/test/main/fixtures/cruise-reporterless/deprecated-node-module.json
@@ -26,6 +26,7 @@
             "license": "GPL"
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -47,6 +48,9 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/deprecated-node-module/require-something-deprecated.js"
+        ],
         "valid": true
       },
       {
@@ -58,6 +62,9 @@
         "dependencyTypes": ["local"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/deprecated-node-module/node_modules/deprecated-at-the-start-for-test-purposes/index.js"
+        ],
         "valid": true
       }
     ]

--- a/test/main/fixtures/cruise-reporterless/typescript.json
+++ b/test/main/fixtures/cruise-reporterless/typescript.json
@@ -97,6 +97,7 @@
             "circular": false
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -108,6 +109,9 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript/index.ts"
+        ],
         "valid": true
       },
       {
@@ -119,12 +123,18 @@
         "dependencyTypes": ["core"],
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript/index.ts"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/typescript/javascriptThing.js",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript/index.ts"
+        ],
         "valid": true
       },
       {
@@ -146,18 +156,28 @@
             "circular": false
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript/index.ts"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/typescript/sub/willBeReExported.ts",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript/index.ts",
+          "test/main/fixtures/cruise-reporterless/typescript/sub/index.ts"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/typescript/sub/kaching.ts",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript/index.ts"
+        ],
         "valid": true
       }
     ]
@@ -194,6 +214,9 @@
             ]
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript-circular-with-types/B.ts"
+        ],
         "valid": true
       },
       {
@@ -218,6 +241,9 @@
               "test/main/fixtures/cruise-reporterless/typescript-circular-with-types/B.ts"
             ]
           }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript-circular-with-types/A.ts"
         ],
         "valid": true
       }
@@ -265,6 +291,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -286,12 +313,19 @@
             "valid": true
           }
         ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript-unused-dependencies/a.ts"
+        ],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/typescript-unused-dependencies/c.ts",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript-unused-dependencies/a.ts",
+          "test/main/fixtures/cruise-reporterless/typescript-unused-dependencies/b.ts"
+        ],
         "valid": true
       }
     ]
@@ -322,12 +356,16 @@
             "circular": false
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/typescript-circular-with-types/B.ts",
         "orphan": false,
         "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/typescript-circular-with-types/A.ts"
+        ],
         "valid": true
       }
     ]
@@ -342,6 +380,7 @@
         "source": "test/main/fixtures/cruise-reporterless/typescript-unused-dependencies/a.ts",
         "orphan": true,
         "dependencies": [],
+        "dependents": [],
         "valid": true
       }
     ]

--- a/test/main/fixtures/cruise-reporterless/vue.json
+++ b/test/main/fixtures/cruise-reporterless/vue.json
@@ -38,6 +38,7 @@
             "valid": true
           }
         ],
+        "dependents": [],
         "valid": true
       },
       {
@@ -49,6 +50,7 @@
         "dependencyTypes": ["unknown"],
         "orphan": false,
         "dependencies": [],
+        "dependents": ["test/main/fixtures/cruise-reporterless/vue/main.js"],
         "valid": true
       },
       {
@@ -70,12 +72,14 @@
             "valid": true
           }
         ],
+        "dependents": ["test/main/fixtures/cruise-reporterless/vue/main.js"],
         "valid": true
       },
       {
         "source": "test/main/fixtures/cruise-reporterless/vue/components/HelloWorld.vue",
         "orphan": false,
         "dependencies": [],
+        "dependents": ["test/main/fixtures/cruise-reporterless/vue/App.vue"],
         "valid": true
       }
     ]

--- a/test/main/main.cruise-reporterless.spec.js
+++ b/test/main/main.cruise-reporterless.spec.js
@@ -16,11 +16,15 @@ chai.use(require("chai-json-schema"));
 function runRecursiveFixture(pFixture) {
   if (!Boolean(pFixture.ignore)) {
     it(pFixture.title, () => {
-      let lResult = cruise([pFixture.input.fileName], pFixture.input.options, {
-        bustTheCache: true,
-        resolveLicenses: true,
-        resolveDeprecations: true,
-      }).output;
+      let lResult = cruise(
+        [pFixture.input.fileName],
+        { ...pFixture.input.options, forceDeriveDependents: true },
+        {
+          bustTheCache: true,
+          resolveLicenses: true,
+          resolveDeprecations: true,
+        }
+      ).output;
 
       expect(lResult).to.be.jsonSchema(cruiseResultSchema);
       expect(lResult.modules).to.deep.equal(pFixture.expected);

--- a/tools/regenerate-main-fixtures.utl.js
+++ b/tools/regenerate-main-fixtures.utl.js
@@ -43,6 +43,17 @@ barfTheJSON(
     { bustTheCache: true }
   )
 );
+barfTheJSON(
+  "collapse-after-cruise/expected-result.json",
+  main.cruise(
+    ["test/main/fixtures/collapse-after-cruise"],
+    {
+      ruleSet: {},
+      collapse: "^test/main/fixtures/collapse-after-cruise/src/[^/]+",
+    },
+    { bustTheCache: true }
+  )
+);
 
 // main.cruise - tsPreCompilationDeps
 barfTheJSON(
@@ -181,7 +192,11 @@ process.chdir(WORKING_DIR);
 process.chdir("test/main/fixtures/type-only-module-references");
 barfTheJSON(
   "type-only-module-references/output.json",
-  main.cruise(["src"], { tsPreCompilationDeps: true }, { bustTheCache: true })
+  main.cruise(
+    ["src"],
+    { tsPreCompilationDeps: true },
+    { bustTheCache: true, resolveLicenses: true }
+  )
 );
 process.chdir(WORKING_DIR);
 

--- a/tools/schema/modules.mjs
+++ b/tools/schema/modules.mjs
@@ -27,6 +27,14 @@ export default {
             "The violated rule will be in the 'rule' object at the same level.",
         },
         dependencies: { $ref: "#/definitions/DependenciesType" },
+        dependents: {
+          type: "array",
+          description: "list of modules depending on this module",
+          items: {
+            type: "string",
+            description: "the (resolved) name of the dependant",
+          },
+        },
         followable: {
           type: "boolean",
           description:

--- a/tools/schema/options.mjs
+++ b/tools/schema/options.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import REAsStringsType from "./re-as-strings-type.mjs";
 import compoundDoNotFollowType from "./compound-donot-follow-type.mjs";
 import compoundExcludeType from "./compound-exclude-type.mjs";
@@ -124,6 +125,12 @@ export default {
             "What external module resolution strategy to use. Defaults to 'node_modules' " +
             "(not used anymore - module resolution strategy determination is automatic now)",
           enum: ["node_modules", "yarn-pnp"],
+        },
+        forceDeriveDependents: {
+          type: "boolean",
+          description:
+            "When true includes denormalized dependents in the cruise-result, even " +
+            "though there's no rule in the rule set that requires them. Defaults to false.",
         },
         webpackConfig: {
           type: "object",

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -23,7 +23,15 @@ export interface IModule {
    * be in the 'rule' object at the same level.
    */
   valid: boolean;
+  /**
+   * list of modules this module depends on
+   */
   dependencies: IDependency[];
+  /**
+   * list of modules that depend on this module (values are _resolved_ names of
+   * those modules)
+   */
+  dependents: string[];
   /**
    * Whether or not this is a node.js core module
    */

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -129,6 +129,11 @@ export interface ICruiseOptions {
    */
   externalModuleResolutionStrategy?: ExternalModuleResolutionStrategyType;
   /**
+   * When true includes denormalized dependents in the cruise-result, even
+   * though there's no rule in the rule set that requires them. Defaults to false.
+   */
+  forceDeriveDependents?: boolean;
+  /**
    * if true combines the package.jsons found from the module up to the base
    * folder the cruise is initiated from. Useful for how (some) mono-repos
    * manage dependencies & dependency definitions.


### PR DESCRIPTION
## Description

Adds an array of `dependents` to each module when asked to. As this is potentially an expensive operation, it's feature switched - currently with `forceDeriveDependents` in the `options` object. Later on we'll look whether there's rules (i.e. on how often a module is used) and/ or reporter options (i.e. `focus`) that either need these or will benefit from them.

## Motivation and Context

So we can use them more easily in rules later on - e.g. to create rules based on the amount of dependents a module should have (see #445)

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests
 
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
