### PR TITLE
feature(validate): adds a dependents count > check

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -34,7 +34,8 @@
    - [`orphan`](#orphans)
    - [`reachable`](#reachable---detecting-dead-wood-and-transient-dependencies)
    - [`couldNotResolve`](#couldnotresolve)
-     [rules on dependents - `numberOfDependentsLessThan`](#rules-on-dependents---numberOfDependentsLessThan)
+   - [rules on dependents - `numberOfDependentsLessThan`](#rules-on-dependents---numberOfDependentsLessThan)
+   - [rules on dependents - `numberOfDependentsMoreThan`](#rules-on-dependents---numberOfDependentsMoreThan)
    - [`circular`](#circular)
    - [`license` and `licenseNot`](#license-and-licensenot)
    - [`dependencyTypes`](#dependencytypes)
@@ -607,6 +608,38 @@ E.g. to flag modules in the `shared` folder that are only used from the
   one thing `$1` means - making use in e.g. `to.path` ambiguous.
 
   </details>
+
+### rules on dependents - `numberOfDependentsMoreThan`
+
+Matches when the number of dependents of a module is more than the provided number.
+Useful to
+
+- detect whether modules are 'shared' enough to your liking, or whether
+  they're actually used in the first place, but you want or need to enforce that
+  in an allowed rule
+- put a maximum number on the number of dependents a module can have (not sure
+  it's like super useful or anything, it's just a side-effect of the previous
+  use)
+
+E.g. to flag modules in the `shared` folder that are only used from the
+`features` folder once (or not a all), you can use a rule like this in the
+`allowed` section
+
+```javascript
+{
+  name: "no-unshared-in-shared",
+  from: {
+    path: "^features/"
+  },
+  module: {
+    path: "^shared/",
+    numberOfDependentsMoreThan: 1
+  }
+}
+```
+
+The same usage notes and caveats apply as do for the numberOfDependentsLessThan
+attribute.
 
 ### `couldNotResolve`
 

--- a/src/enrich/derive/dependents/index.js
+++ b/src/enrich/derive/dependents/index.js
@@ -3,8 +3,10 @@ const getDependents = require("./get-dependents");
 
 function hasDependentsRule(pOptions) {
   // TODO: might want to enable this in required and allowed rules as well
-  return get(pOptions, "ruleSet.forbidden", []).some((pRule) =>
-    get(pRule, "module.numberOfDependentsLessThan")
+  return get(pOptions, "ruleSet.forbidden", []).some(
+    (pRule) =>
+      get(pRule, "module.numberOfDependentsLessThan") ||
+      get(pRule, "module.numberOfDependentsMoreThan")
   );
 }
 

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -255,6 +255,12 @@
           "description": "Matches when the number of times the 'to' module is used falls below (<) this number. Caveat: only works in concert with path and pathNot restrictions in the from and to parts of the rule; other conditions will be ignored.(somewhat experimental; - syntax can change over time without a major bump)E.g. to flag modules that are used only once or not at all, use 2 here.",
           "minimum": 0,
           "maximum": 100
+        },
+        "numberOfDependentsMoreThan": {
+          "type": "integer",
+          "description": "Matches when the number of times the 'to' module is used raises above (>) this number. Caveat: only works in concert with path and pathNot restrictions in the from and to parts of the rule; other conditions will be ignored.(somewhat experimental; - syntax can change over time without a major bump)E.g. to flag modules that are used more than 10 times, use 10 here.",
+          "minimum": 0,
+          "maximum": 100
         }
       }
     },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -558,6 +558,12 @@
           "description": "Matches when the number of times the 'to' module is used falls below (<) this number. Caveat: only works in concert with path and pathNot restrictions in the from and to parts of the rule; other conditions will be ignored.(somewhat experimental; - syntax can change over time without a major bump)E.g. to flag modules that are used only once or not at all, use 2 here.",
           "minimum": 0,
           "maximum": 100
+        },
+        "numberOfDependentsMoreThan": {
+          "type": "integer",
+          "description": "Matches when the number of times the 'to' module is used raises above (>) this number. Caveat: only works in concert with path and pathNot restrictions in the from and to parts of the rule; other conditions will be ignored.(somewhat experimental; - syntax can change over time without a major bump)E.g. to flag modules that are used more than 10 times, use 10 here.",
+          "minimum": 0,
+          "maximum": 100
         }
       }
     },

--- a/src/validate/match-module-rule.js
+++ b/src/validate/match-module-rule.js
@@ -47,10 +47,25 @@ function matchesReachesRule(pRule, pModule) {
   );
 }
 
+function dependentsCountsMatch(pRule, pDependents) {
+  const lMatchingDependentsCount = pDependents.filter(
+    (pDependent) =>
+      Boolean(!pRule.from.path || pDependent.match(pRule.from.path)) &&
+      Boolean(!pRule.from.pathNot || pDependent.match(pRule.from.pathNot))
+  ).length;
+  return (
+    (!pRule.module.numberOfDependentsLessThan ||
+      lMatchingDependentsCount < pRule.module.numberOfDependentsLessThan) &&
+    (!pRule.module.numberOfDependentsMoreThan ||
+      lMatchingDependentsCount > pRule.module.numberOfDependentsMoreThan)
+  );
+}
+
 function matchesDependentsRule(pRule, pModule) {
   if (
-    _has(pModule, "dependents") &&
-    _has(pRule, "module.numberOfDependentsLessThan")
+    (_has(pModule, "dependents") &&
+      _has(pRule, "module.numberOfDependentsLessThan")) ||
+    _has(pRule, "module.numberOfDependentsMoreThan")
   ) {
     return (
       // group matching seems like a nice idea, however, the 'from' part of the
@@ -61,11 +76,7 @@ function matchesDependentsRule(pRule, pModule) {
       // matchers.toModulePath together.
       matchers.modulePath(pRule, pModule) &&
       matchers.modulePathNot(pRule, pModule) &&
-      pModule.dependents.filter(
-        (pDependent) =>
-          Boolean(!pRule.from.path || pDependent.match(pRule.from.path)) &&
-          Boolean(!pRule.from.pathNot || pDependent.match(pRule.from.pathNot))
-      ).length < pRule.module.numberOfDependentsLessThan
+      dependentsCountsMatch(pRule, pModule.dependents)
     );
   }
   return false;

--- a/test/validate/match-module-rule.dependents.spec.js
+++ b/test/validate/match-module-rule.dependents.spec.js
@@ -33,6 +33,28 @@ const MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR = {
     numberOfDependentsLessThan: 2,
   },
 };
+
+const CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES = {
+  from: {
+    pathNot: "^src/snackbar",
+  },
+  module: {
+    path: "^src/utensils",
+    numberOfDependentsMoreThan: 3,
+  },
+};
+
+const USED_FROM_SNACKBAR_BETWEEN = {
+  from: {
+    pathNot: "^src/snackbar",
+  },
+  module: {
+    path: "^src/utensils",
+    numberOfDependentsMoreThan: 3,
+    numberOfDependentsLessThan: 5,
+  },
+};
+
 describe("validate/match-module-rule - dependents", () => {
   it("rule without dependents restriction doesn't flag (implicit)", () => {
     expect(matchesDependentsRule(EMPTY_RULE, {})).to.equal(false);
@@ -131,11 +153,64 @@ describe("validate/match-module-rule - dependents", () => {
       })
     ).to.equal(true);
   });
+
   it("must-share (>=2 dependents) with a from pathNot when there's 0 dependents from that from pathNot", () => {
     expect(
       matchesDependentsRule(MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
+      })
+    ).to.equal(false);
+  });
+
+  it("must not be used more than 3 times from snackbar - happy scenario", () => {
+    expect(
+      matchesDependentsRule(CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES, {
+        source: "src/utensils/frieten.ts",
+        dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
+      })
+    ).to.equal(false);
+  });
+
+  it("must not be used more than 3 times from snackbar - fail scenario", () => {
+    expect(
+      matchesDependentsRule(CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES, {
+        source: "src/utensils/frieten.ts",
+        dependents: [
+          "src/snackbar/kapsalon.ts",
+          "src/snackbar/zijspan.ts",
+          "src/snackbar/dooierat.ts",
+          "src/snackbar/kipcorn.ts",
+        ],
+      })
+    ).to.equal(true);
+  });
+
+  it("combo breaker (3 < x < 5) - happy scenario", () => {
+    expect(
+      matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
+        source: "src/utensils/frieten.ts",
+        dependents: [
+          "src/snackbar/kapsalon.ts",
+          "src/snackbar/zijspan.ts",
+          "src/snackbar/dooierat.ts",
+          "src/snackbar/kipcorn.ts",
+        ],
+      })
+    ).to.equal(true);
+  });
+
+  it("combo breaker (3 < x < 5) - fail scenario", () => {
+    expect(
+      matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
+        source: "src/utensils/frieten.ts",
+        dependents: [
+          "src/snackbar/kapsalon.ts",
+          "src/snackbar/zijspan.ts",
+          "src/snackbar/dooierat.ts",
+          "src/snackbar/kipcorn.ts",
+          "src/snackbar/bereklauw.ts",
+        ],
       })
     ).to.equal(false);
   });

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -143,6 +143,17 @@ export default {
           minimum: 0,
           maximum: 100,
         },
+        numberOfDependentsMoreThan: {
+          type: "integer",
+          description:
+            "Matches when the number of times the 'to' module is used raises above (>) " +
+            "this number. Caveat: only works in concert with path and pathNot restrictions " +
+            "in the from and to parts of the rule; other conditions will be ignored." +
+            "(somewhat experimental; - syntax can change over time without a major bump)" +
+            "E.g. to flag modules that are used more than 10 times, use 10 here.",
+          minimum: 0,
+          maximum: 100,
+        },
       },
     },
     DependentsFromRestrictionType: {

--- a/types/restrictions.d.ts
+++ b/types/restrictions.d.ts
@@ -106,4 +106,12 @@ export interface IDependentsModuleRestrictionType extends IBaseRestrictionType {
    * E.g. to flag modules that are used only once or not at all, use 2 here.
    */
   numberOfDependentsLessThan?: number;
+  /**
+   * Matches when the number of times the 'to' module is used rises above (<)
+   * this number. Caveat: only works in concert with path and pathNot restrictions
+   * in the from and to parts of the rule; other conditions will be ignored.
+   * (somewhat experimental; - syntax can change over time without a major bump)
+   * E.g. to flag modules that are used more than 10 times, use 10 here.
+   */
+  numberOfDependentsMoreThan?: number;
 }


### PR DESCRIPTION
## Description

Adds a `numberOfDependentsMoreThan` attribute to the schema and enables using it in `forbidden` rules. It was made for `allowed` rules (see below), but that will follow in a separate PR.

## Motivation and Context

TL;DR - so later on 'shared' rules can be enforced in the 'allowed' type of rulesets. And maybe handy for enforcing deprecation.

If you want to enforce a module is shared a minimum number of times, you can currently put a rule like this in the `forbidden` section of your configuration using the `numberOfDependentsLessThan` attribute, e.g.:

```javascript
// ... somewhere in a 'forbidden' rule set
  {
    name: "no-unshared-in-common",
    from: {
      pathNot: "^src/common"
    },
    module: {
      path: "^src/common",
      numberOfDependentsLessThan: 2
    }
  }
// ...
```

However, you currently can't do the same in a `allowed` rules. As the logic is inverted there we'll need an attribute that does the opposite of `numberOfDependentsLessThan` - which is where this new attribute would come in, e.g. with this. hypothetical rule:

```javascript
// ... somewhere in an 'allowed' rule set
  {
    name: "shared-in-common",
    from: {
      pathNot: "^src/common"
    },
    module: {
      path: "^src/common",
      numberOfDependentsMoreThan: 1 // future feature
    }
  }
// ...
```

This PR just prepares the introduction of the attribute and enables it for 'forbidden' rules - integration in 'allowed' rules will follow later. Probably even in 'allowed' rules the `numberOfDependentsMoreThan` has its place. E.g. to ensure that no new dependents are introduced to a deprecated module (which currently has 


```javascript
// ... somewhere in a 'forbidden' rule set
  {
    name: "no-more-dependents-on-deprecated",
    severity: "error"
    from: {
      pathNot: "^src/common"
    },
    module: {
      path: "^src/common/deprecated-thingy",
      numberOfDependentsMoreThan: 4
    }
  },

  // ... this could be paired with a rule to produce a warning for the remaining 4:
    {
    name: "not-to-deprecated-thingy",
    severity: "warn"
    from: {
      pathNot: "^src/common"
    },
    to: {
      path: "^src/common/deprecated-thingy",
    }
  }
// ...
```

## How Has This Been Tested?

- [x] additional unit tests
- [x] automated non-regression tests
- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
