### PR TITLE
refactor(swc): adds typeAnnotation detection, refactors

### DIFF
--- a/src/extract/ast-extractors/extract-swc-deps.js
+++ b/src/extract/ast-extractors/extract-swc-deps.js
@@ -3,39 +3,9 @@ const SwcDependencyVisitor = require("./swc-dependency-visitor");
 /**
  *
  * @param {import('@swc/core').ModuleItem[]} pAST
+ * @param {string[]} pExoticRequireStrings
  * @returns {{module: string, moduleSystem: string, dynamic: boolean}[]}
  */
-function extractImportsAndExports(pAST) {
-  return pAST.body
-    .filter(
-      (pNode) =>
-        [
-          "ImportDeclaration",
-          "ExportAllDeclaration",
-          "ExportNamedDeclaration",
-        ].includes(pNode.type) && Boolean(pNode.source)
-    )
-    .map((pNode) => ({
-      module: pNode.source.value,
-      moduleSystem: "es6",
-      exoticallyRequired: false,
-    }));
-}
-
-function extractImportEquals(pAST) {
-  return pAST.body
-    .filter(
-      (pNode) =>
-        pNode.type === "TsImportEqualsDeclaration" &&
-        pNode.moduleRef.type === "TsExternalModuleReference"
-    )
-    .map((pNode) => ({
-      module: pNode.moduleRef.expression.value,
-      moduleSystem: "cjs",
-      exoticallyRequired: false,
-    }));
-}
-
 function extractNestedDependencies(pAST, pExoticRequireStrings) {
   const visitor = new SwcDependencyVisitor(pExoticRequireStrings);
   return visitor.getDependencies(pAST);
@@ -44,7 +14,7 @@ function extractNestedDependencies(pAST, pExoticRequireStrings) {
 /**
  *
  * @param {import('@swc/core').ModuleItem[]} pSwcAST
- * @param {*} pExoticRequireStrings
+ * @param {string[]} pExoticRequireStrings
  * @returns {{module: string, moduleSystem: string, dynamic: boolean}[]}
  */
 module.exports = function extractSwcDependencies(
@@ -52,11 +22,9 @@ module.exports = function extractSwcDependencies(
   pExoticRequireStrings
 ) {
   return (
-    extractImportsAndExports(pSwcAST)
-      .concat(extractImportEquals(pSwcAST))
+    extractNestedDependencies(pSwcAST, pExoticRequireStrings)
       // as far as I can tell swc doesn't do tripple slash directives
       // .concat(extractTrippleSlashDirectives(pSwcAST))
-      .concat(extractNestedDependencies(pSwcAST, pExoticRequireStrings))
       .map((pModule) => ({ dynamic: false, ...pModule }))
   );
 };

--- a/test/extract/ast-extractors/extract-with-swc-type-imports.spec.js
+++ b/test/extract/ast-extractors/extract-with-swc-type-imports.spec.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const extractWithSwc = require("./extract-with-swc.utl");
 
 describe("ast-extractors/extract-swc - type imports", () => {
-  // normal fail
+  // normal fail, but Visitor.visitTsTypeAnnotation doesn't seem to get called
   // it("extracts type imports in const declarations", () => {
   //   expect(
   //     extractWithSwc("const tiepetjes: import('./types').T;")
@@ -30,7 +30,7 @@ describe("ast-extractors/extract-swc - type imports", () => {
   //   ]);
   // });
 
-  // normal fail
+  // normal fail, but pNode in Visitor.visitTsTypeAnnotation(pNode) equals null
   // it("extracts type imports in parameter declarations", () => {
   //   expect(
   //     extractWithSwc(
@@ -46,21 +46,20 @@ describe("ast-extractors/extract-swc - type imports", () => {
   //   ]);
   // });
 
-  // normal fail
-  // it("extracts type imports in class members", () => {
-  //   expect(
-  //     extractWithSwc(
-  //       "class Klass{ private membert: import('./wypes').T; constructor() { membert = 'x'}}"
-  //     )
-  //   ).to.deep.equal([
-  //     {
-  //       module: "./wypes",
-  //       moduleSystem: "es6",
-  //       dynamic: false,
-  //       exoticallyRequired: false,
-  //     },
-  //   ]);
-  // });
+  it("extracts type imports in class members", () => {
+    expect(
+      extractWithSwc(
+        "class Klass{ private membert: import('./wypes').T; constructor() { membert = 'x'}}"
+      )
+    ).to.deep.equal([
+      {
+        module: "./wypes",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
+  });
 
   // swc fails with: "Error: internal error: entered unreachable code: parse_lit should not be called"
   // it("leaves type imports with template literals with placeholders alone", () => {


### PR DESCRIPTION
## Description, Motivation and Context

- the type annotations (that is to say: only a subset of the typescript spec) swc supports are now detected as ell.
- all AST traversal now happens within the Visitor, which makes it easier to maintain (and should be a little bit better for performant as we now do less).

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
