### PR TITLE
feature(extract): adds basic support for ESM urls (a.o. the node: protocol)

### DIFF
--- a/src/extract/get-dependencies.js
+++ b/src/extract/get-dependencies.js
@@ -12,6 +12,7 @@ const toJavascriptAST = require("./parse/to-javascript-ast");
 const toTypescriptAST = require("./parse/to-typescript-ast");
 const toSwcAST = require("./parse/to-swc-ast");
 const detectPreCompilationNess = require("./utl/detect-pre-compilation-ness");
+const extractModuleAttributes = require("./utl/extract-module-attributes");
 
 function extractFromSwcAST(pOptions, pFileName) {
   return extractSwcDeps(
@@ -101,7 +102,10 @@ function extractDependencies(pCruiseOptions, pFileName, pTranspileOptions) {
     );
   }
 
-  return lDependencies;
+  return lDependencies.map((pDependency) => ({
+    ...pDependency,
+    ...extractModuleAttributes(pDependency.module),
+  }));
 }
 
 function matchesDoNotFollow(pResolved, pDoNotFollow) {

--- a/src/extract/utl/extract-module-attributes.js
+++ b/src/extract/utl/extract-module-attributes.js
@@ -1,0 +1,37 @@
+/* eslint-disable security/detect-object-injection */
+
+/**
+ * Given a module string returns in an object
+ * - the module name
+ * - the protocol (when encoded in the string)
+ * - the mimeType (when encoded in the string)
+ *
+ * See https://nodejs.org/api/esm.html#esm_urls
+ *
+ * would've loved to use url.URL here, but that doesn't extract the mime type
+ * (if there's a default node API that does this I'm all ears)
+ *
+ * @param {string} pString
+ * @returns {any}
+ */
+module.exports = function extractModuleAttributes(pString) {
+  let lReturnValue = { module: pString };
+  const lModuleAttributes = pString.match(
+    // eslint-disable-next-line security/detect-unsafe-regex, unicorn/no-unsafe-regex
+    /^(node:|file:|data:)?(([^,]+),)?(.+)$/
+  );
+  const lProtocolPosition = 1;
+  const lMimeTypePosition = 3;
+  const lModulePosition = 4;
+
+  if (lModuleAttributes) {
+    lReturnValue.module = lModuleAttributes[lModulePosition];
+    if (lModuleAttributes[lProtocolPosition]) {
+      lReturnValue.protocol = lModuleAttributes[lProtocolPosition];
+    }
+    if (lModuleAttributes[lMimeTypePosition]) {
+      lReturnValue.mimeType = lModuleAttributes[lMimeTypePosition];
+    }
+  }
+  return lReturnValue;
+};

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -163,6 +163,15 @@
           "type": "string",
           "description": "The name of the module as it appeared in the source code, e.g. './main'"
         },
+        "protocol": {
+          "type": "string",
+          "enum": ["data:", "file:", "node:"],
+          "description": "If the module specification is an URI with a protocol in it (e.g. `import * as fs from 'node:fs'` or `import stuff from 'data:application/json,some-thing'`) - this attribute holds the protocol part (e.g. 'node:', 'data:', 'file:'). Also see https://nodejs.org/api/esm.html#esm_urls"
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "If the module specification is an URI and contains a mime type, this attribute holds the mime type (e.g. in `import stuff from 'data:application/json,some-thing'` this would be data:application/json). Also see https://nodejs.org/api/esm.html#esm_urls"
+        },
         "resolved": {
           "type": "string",
           "description": "The (resolved) file name of the module, e.g. 'src/main/index.js'"

--- a/test/extract/utl/extract-module-attributes.spec.js
+++ b/test/extract/utl/extract-module-attributes.spec.js
@@ -1,0 +1,55 @@
+const expect = require("chai").expect;
+const extractModuleAttributes = require("../../../src/extract/utl/extract-module-attributes");
+
+describe("extract/utl/extract-module-attributes", () => {
+  it("leaves regular module specifications alone", () => {
+    expect(extractModuleAttributes("protodash")).to.deep.equal({
+      module: "protodash",
+    });
+  });
+
+  it("extracts the protocol if there is one", () => {
+    expect(extractModuleAttributes("node:fs")).to.deep.equal({
+      module: "fs",
+      protocol: "node:",
+    });
+  });
+
+  it("leaves things alone the protocol is unknown", () => {
+    expect(extractModuleAttributes("nod:fs")).to.deep.equal({
+      module: "nod:fs",
+    });
+  });
+
+  it("manages empty strings gracefully", () => {
+    expect(extractModuleAttributes("")).to.deep.equal({
+      module: "",
+    });
+  });
+
+  it("extracts both protocol and mimeType when they're in the URI", () => {
+    expect(
+      extractModuleAttributes("data:application/json,gegevens.json")
+    ).to.deep.equal({
+      module: "gegevens.json",
+      protocol: "data:",
+      mimeType: "application/json",
+    });
+  });
+
+  it("handles emtpy mimeTypes gracefulley", () => {
+    expect(extractModuleAttributes("data:,gegevens.json")).to.deep.equal({
+      module: ",gegevens.json",
+      protocol: "data:",
+    });
+  });
+
+  it("when protocol separator is mistyped, returns it as part of the module name", () => {
+    expect(
+      extractModuleAttributes("data:application/json;gegevens.json")
+    ).to.deep.equal({
+      module: "application/json;gegevens.json",
+      protocol: "data:",
+    });
+  });
+});

--- a/tools/extract-line-coverage-from-istanbul-json.mjs
+++ b/tools/extract-line-coverage-from-istanbul-json.mjs
@@ -1,3 +1,5 @@
+// eslint-disable-next-line node/no-missing-import, import/no-unresolved
+// import { EOL } from "node:os"; // node 10 still barfs on this
 import { EOL } from "os";
 import getStream from "get-stream";
 

--- a/tools/generate-schemas.utl.mjs
+++ b/tools/generate-schemas.utl.mjs
@@ -1,3 +1,5 @@
+// eslint-disable-next-line node/no-missing-import, import/no-unresolved
+// import fs from "node:fs"; // node 10 barfs on this
 import fs from "fs";
 import prettier from "prettier";
 

--- a/tools/schema/dependencies.mjs
+++ b/tools/schema/dependencies.mjs
@@ -30,6 +30,23 @@ export default {
           description:
             "The name of the module as it appeared in the source code, e.g. './main'",
         },
+        protocol: {
+          type: "string",
+          enum: ["data:", "file:", "node:"],
+          description:
+            "If the module specification is an URI with a protocol in it (e.g. " +
+            "`import * as fs from 'node:fs'` or " +
+            "`import stuff from 'data:application/json,some-thing'`) - this attribute " +
+            "holds the protocol part (e.g. 'node:', 'data:', 'file:'). Also see " +
+            "https://nodejs.org/api/esm.html#esm_urls",
+        },
+        mimeType: {
+          type: "string",
+          description:
+            "If the module specification is an URI and contains a mime type, this " +
+            "attribute holds the mime type (e.g. in `import stuff from 'data:application/json,some-thing'` " +
+            "this would be data:application/json). Also see https://nodejs.org/api/esm.html#esm_urls",
+        },
         resolved: {
           type: "string",
           description:

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -1,6 +1,11 @@
 import { ICruiseOptions } from "./options";
 import { IFlattenedRuleSet } from "./rule-set";
-import { DependencyType, ModuleSystemType, SeverityType } from "./shared-types";
+import {
+  DependencyType,
+  ModuleSystemType,
+  SeverityType,
+  ProtocolType,
+} from "./shared-types";
 
 export interface ICruiseResult {
   /**
@@ -163,6 +168,23 @@ export interface IDependency {
    * The name of the module as it appeared in the source code, e.g. './main'
    */
   module: string;
+  /**
+   * If the module specification is an URI with a protocol in it (e.g.
+   * `import * as fs from 'node:fs'` or
+   * `import stuff from 'data:application/json,some-thing'`) -
+   * this attribute holds the protocol part (e.g. 'node:', 'data:', 'file:').
+   *
+   * Also see https://nodejs.org/api/esm.html#esm_urls
+   */
+  protocol: ProtocolType;
+  /**
+   * If the module specification is an URI and contains a mime type, this
+   * attribute holds the mime type (e.g. in `import stuff from 'data:application/json,some-thing'
+   * `this would be data:application/json)
+   *
+   * Also see https://nodejs.org/api/esm.html#esm_urls
+   */
+  mimeType: string;
   moduleSystem: ModuleSystemType;
   /**
    * The (resolved) file name of the module, e.g. 'src/main//index.js'

--- a/types/shared-types.d.ts
+++ b/types/shared-types.d.ts
@@ -38,3 +38,5 @@ export type DependencyType =
   | "npm-unknown"
   | "undetermined"
   | "unknown";
+
+export type ProtocolType = "data:" | "file:" | "node";


### PR DESCRIPTION
## Description

- Adds recognition of protocol and mime type in module references so things like `import * as fs from 'node:fs'` and `import lalala from 'file:application/json,holadijee.json'` get recognised.
- Adds them to the cruise output model for later use

The new `protocol` and `mimeType` attributes aren't used anywhere yet - this might follow in next PR's

## Motivation and Context

TIL: you can specify a [protocol (and mime type) with ES modules references](https://nodejs.org/api/esm.html#esm_urls). As @sindresorhus is pushing for its use (see [this issue in the nodejs repo](https://github.com/nodejs/node/issues/38343) and the new [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md) rule in eslint-plugin-unicorn) it'll likely become more commonplace.


## How Has This Been Tested?

- [x] automated non-regression tests, green ci
- [x] additional automated unit tests
- [x] manual tests against dependency-cruiser's 'tools' folder


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
