### PR TITLE
refactor(swc): consolidate swc call

### DIFF
--- a/src/extract/ast-extractors/extract-swc-deps.js
+++ b/src/extract/ast-extractors/extract-swc-deps.js
@@ -2,17 +2,6 @@ const SwcDependencyVisitor = require("./swc-dependency-visitor");
 
 /**
  *
- * @param {import('@swc/core').ModuleItem[]} pAST
- * @param {string[]} pExoticRequireStrings
- * @returns {{module: string, moduleSystem: string, dynamic: boolean}[]}
- */
-function extractNestedDependencies(pAST, pExoticRequireStrings) {
-  const visitor = new SwcDependencyVisitor(pExoticRequireStrings);
-  return visitor.getDependencies(pAST);
-}
-
-/**
- *
  * @param {import('@swc/core').ModuleItem[]} pSwcAST
  * @param {string[]} pExoticRequireStrings
  * @returns {{module: string, moduleSystem: string, dynamic: boolean}[]}
@@ -21,10 +10,8 @@ module.exports = function extractSwcDependencies(
   pSwcAST,
   pExoticRequireStrings
 ) {
-  return (
-    extractNestedDependencies(pSwcAST, pExoticRequireStrings)
-      // as far as I can tell swc doesn't do tripple slash directives
-      // .concat(extractTrippleSlashDirectives(pSwcAST))
-      .map((pModule) => ({ dynamic: false, ...pModule }))
-  );
+  const visitor = new SwcDependencyVisitor(pExoticRequireStrings);
+  return visitor
+    .getDependencies(pSwcAST)
+    .map((pModule) => ({ dynamic: false, ...pModule }));
 };

--- a/src/extract/ast-extractors/swc-dependency-visitor.js
+++ b/src/extract/ast-extractors/swc-dependency-visitor.js
@@ -188,6 +188,9 @@ if (VisitorModule) {
       return super.visitTsTypeAnnotation(pNode);
     }
 
+    // as far as I can tell swc doesn't do tripple slash directives (yet?)
+    // visitTrippleSlashDirective(pNode)) {}
+
     getDependencies(pAST) {
       this.lResult = [];
       this.visitModule(pAST);


### PR DESCRIPTION
## Description, Motivation and Context

As a remnant of a previous setup running through the swc AST there was an unnecessary extra function call that made the swc extraction function look more complicated than it actually was => this PR remedies that.

## How Has This Been Tested?

- [x] automated non-regression tests + green ci
- [x] performance non-regression test


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
