### PR TITLE
bugfix(wrap-stream-in-html): de-buffer so it can handle larger streams

### DIFF
--- a/bin/wrap-stream-in-html.js
+++ b/bin/wrap-stream-in-html.js
@@ -2,8 +2,4 @@
 
 const wrapStreamInHtml = require("../src/cli/tools/wrap-stream-in-html");
 
-wrapStreamInHtml(process.stdin)
-  .then((pOutput) => process.stdout.write(pOutput))
-  .catch((pError) => {
-    process.stderr.write(`${pError}\n`);
-  });
+wrapStreamInHtml(process.stdin, process.stdout);

--- a/test/cli/tools/wrap-stream-in-html.spec.js
+++ b/test/cli/tools/wrap-stream-in-html.spec.js
@@ -1,18 +1,32 @@
 const fs = require("fs");
+const { Writable } = require("stream");
 const chai = require("chai");
 const wrapStreamInHTML = require("../../../src/cli/tools/wrap-stream-in-html");
 
 const expect = chai.expect;
 
+class WriteableExpectStream extends Writable {
+  _write(pThing) {
+    this.buffer += pThing.toString();
+  }
+
+  write(pThing) {
+    this._write(pThing);
+  }
+
+  end() {
+    expect(this.buffer).to.contain("<html");
+    expect(this.buffer).to.contain("<style>");
+    expect(this.buffer).to.contain('"name": "dependency-cruiser"');
+    expect(this.buffer).to.contain("</html");
+  }
+}
+
 describe("wrap-stream-in-html", () => {
-  const lStream = fs.createReadStream("package.json");
+  const lInStream = fs.createReadStream("package.json");
+  const lOutStream = new WriteableExpectStream();
 
-  it("Wraps the contens of a stream in html with some preloaded css", async () => {
-    const lResultHTML = await wrapStreamInHTML(lStream);
-
-    expect(lResultHTML).to.contain("<html");
-    expect(lResultHTML).to.contain("<style>");
-    expect(lResultHTML).to.contain('"name": "dependency-cruiser"');
-    expect(lResultHTML).to.contain("</html");
+  it("Wraps the contens of a stream in html with some preloaded css", () => {
+    wrapStreamInHTML(lInStream, lOutStream);
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

If the size of svg wrapped in the stream passes a certain threshold,  the buffer in `get-stream` can get bigger than memory allows, and the string to construct the output will be bigger than allowed. By removing these buffers from the equation, these problems will go away.

## How Has This Been Tested?

- [x] automated non-regression tests, green ci
- [x] adapted unit test(s)
- [x] manual tests


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
