### PR TITLE
bugfix(ts-config): pass an absolute path to tsconfig.json so typescripts config parsing still works under yarn 3

### DIFF
--- a/src/config-utl/extract-ts-config.js
+++ b/src/config-utl/extract-ts-config.js
@@ -53,7 +53,7 @@ module.exports = function extractTSConfig(pTSConfigFileName) {
     lReturnValue = typescript.parseJsonConfigFileContent(
       lConfig.config,
       typescript.sys,
-      path.dirname(pTSConfigFileName),
+      path.dirname(path.resolve(pTSConfigFileName)),
       {},
       pTSConfigFileName
     );


### PR DESCRIPTION
## Description

- see title
- released on npmjs as `dependency-cruiser@10.0.8-beta-1`

TODO:
- ~additional automated regression test against yarn 3 (and 2 f.t.m.)~ will be part of the fix for #471 

## Motivation and Context

fixes #480 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] manually against a local version of https://github.com/sverweij/dependency-cruiser-repro-repo/tree/main/480


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
