### PR TITLE
chore(ci): adds a workflow for running under yarn/berry

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -34,6 +34,7 @@
         "pathNot": [
           "^src/(main|utl|config-utl)/",
           "^node_modules",
+          "^\\.yarn/cache",
           "^fs$",
           "^path$",
           "$1",
@@ -52,6 +53,7 @@
         "pathNot": [
           "$1",
           "^node_modules",
+          "^\\.yarn/cache",
           "^path$",
           "^src/meta\\.js$",
           "^src/graph-utl",
@@ -70,6 +72,7 @@
         "pathNot": [
           "$1",
           "^node_modules",
+          "^\\.yarn/cache",
           "^(path|fs|module)$",
           "^src/meta\\.js$",
           "^src/graph-utl",
@@ -91,7 +94,14 @@
       "comment": "This module in the bin/ folder depends on something not in the cli interface. This means it either contains code that doesn't belong in bin/, or the thing it depends upon should be put in the cli interface. ",
       "severity": "error",
       "from": { "path": "(^bin/)" },
-      "to": { "pathNot": ["^src/cli", "^node_modules", "^src/meta\\.js$"] }
+      "to": {
+        "pathNot": [
+          "^src/cli",
+          "^node_modules",
+          "^\\.yarn/cache",
+          "^src/meta\\.js$"
+        ]
+      }
     },
     {
       "name": "restrict-fs-access",
@@ -291,7 +301,7 @@
     "exoticRequireStrings": ["tryRequire"],
     "reporterOptions": {
       "archi": {
-        "collapsePattern": ["^(node_modules|src|test)/[^/]+", "^bin/"]
+        "collapsePattern": ["^(src|test)/[^/]+", "^bin/", "node_modules/[^/]+"]
       },
       "dot": {
         "filters": {

--- a/.github/workflows/berry-integration-workflow.yml
+++ b/.github/workflows/berry-integration-workflow.yml
@@ -1,0 +1,59 @@
+name: yarn berry test - linux
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 16.x
+        platform:
+          - ubuntu-latest
+
+    runs-on: ${{matrix.platform}}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+      - name: cache external modules for ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/cache@v1
+        with:
+          path: .yarn/cache
+          key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+          restore-keys: |
+            ${{matrix.node-version}}@${{matrix.platform}}-build-
+      - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.node-version}}
+      - name: install & build
+        run: |
+          node --version
+          yarn set version berry
+          yarn
+        shell: bash
+        env:
+          CI: true
+      - name: forbidden dependency check
+        run: |
+          node --version
+          yarn --version
+          yarn depcruise
+        shell: bash
+        env:
+          CI: true
+      - name: test coverage
+        run: |
+          node --version
+          yarn --version
+          yarn test:cover
+        shell: bash
+        env:
+          CI: true

--- a/.github/workflows/berry-integration-workflow.yml
+++ b/.github/workflows/berry-integration-workflow.yml
@@ -40,7 +40,7 @@ jobs:
           node --version
           rm -f .npmrc
           yarn set version berry
-          yarn
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
         shell: bash
         env:
           CI: true

--- a/.github/workflows/berry-integration-workflow.yml
+++ b/.github/workflows/berry-integration-workflow.yml
@@ -52,11 +52,13 @@ jobs:
         shell: bash
         env:
           CI: true
-      - name: test coverage
-        run: |
-          node --version
-          yarn --version
-          yarn test:cover
-        shell: bash
-        env:
-          CI: true
+      # testing doesn't work as the tests are esm and berry, with pnp enabled,
+      # doesn't support esm yet.
+      # - name: test coverage
+      #   run: |
+      #     node --version
+      #     yarn --version
+      #     yarn test:cover
+      #   shell: bash
+      #   env:
+      #     CI: true

--- a/.github/workflows/berry-integration-workflow.yml
+++ b/.github/workflows/berry-integration-workflow.yml
@@ -23,12 +23,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
       - name: cache external modules for ${{matrix.node-version}}@${{matrix.platform}}
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: .yarn/cache
+          path: |
+            .yarn
+            .yarnrc.yml
+            .pnp.js
+            yarn.lock
           key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
-          restore-keys: |
-            ${{matrix.node-version}}@${{matrix.platform}}-build-
       - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
         uses: actions/setup-node@v1
         with:
@@ -36,6 +38,7 @@ jobs:
       - name: install & build
         run: |
           node --version
+          rm -f .npmrc
           yarn set version berry
           yarn
         shell: bash

--- a/.github/workflows/berry-integration-workflow.yml
+++ b/.github/workflows/berry-integration-workflow.yml
@@ -31,6 +31,8 @@ jobs:
             .pnp.js
             yarn.lock
           key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+          restore-keys: |
+            ${{matrix.node-version}}@${{matrix.platform}}-build-
       - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
         uses: actions/setup-node@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,15 @@ dependency-violations.html
 /node_modules/
 isolate-*-v8.log
 npm-debug.log
-yarn-error.log
 package-lock.json
-.pnp*
 dependency-cruiser-*.tgz
+
+# we're not actively on yarn but occasionally test stuff - shouldn't get committed accidentally
+.pnp*
+.yarn/
+.yarnrc.yml
+yarn-error.log
+yarn.lock
 
 # integration test intermediate files
 test/integration/*.testing-ground

--- a/package.json
+++ b/package.json
@@ -208,6 +208,8 @@
     ]
   },
   "eslintIgnore": [
+    ".pnp.cjs",
+    ".yarn",
     "node_modules",
     "coverage",
     "tmp",


### PR DESCRIPTION
## Description

- adds a workflow for checking whether dependency-cruiser generally works under yarn berry
- updates .dependency-cruiser config to deal with some of the differences between npm based package management and yarn's plug'n play

## Motivation and Context

yarn/ berry is used in the wild & we want to ensure dependency-cruiser works ok with it.

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
