### PR TITLE
feature(extract): makes it possible to use tsc as the primary parser

### DIFF
--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -1189,8 +1189,12 @@ to `true`.
 
 ### `parser`
 
-This _EXPERIMENTAL_ feature enables you to specify whether to use the `acorn`
-parser dependency-cruiser uses by default or the faster and smaller (but slightly
-less) feature rich `swc` parser. This only works when `@core/swc` is installed
-in the same spot as dependency-cruiser is (it's not (yet?) bundled as a
-dependency).
+With this _EXPERIMENTAL_ feature you can specify which parser you want to use
+as the primary parser: the `acorn` one, which handles all things javascript
+(commonjs, es-modules, jsx), or one of two parser that can in addition parse
+typescript; microsoft's `tsc` or the faster and smaller (but slightly less
+feature rich) `swc`.
+
+`swc` and `tsc` only work when the compilers (respectivley `@core/swc` and
+`typescript`) are installed in the same spot as dependency-cruiser is. They're
+not bundled with dependency-cruiser.

--- a/src/extract/get-dependencies.js
+++ b/src/extract/get-dependencies.js
@@ -28,21 +28,25 @@ function extractFromTypeScriptAST(pOptions, pFileName) {
   );
 }
 
-function shouldUseTSC(pOptions, pFileName) {
-  return (
-    toTypescriptAST.isAvailable() &&
-    path.extname(pFileName).startsWith(".ts") &&
-    pOptions.tsPreCompilationDeps
+function isTypeScriptCompatible(pFileName) {
+  return [".ts", ".tsx", ".js", ".mjs", ".cjs"].includes(
+    path.extname(pFileName)
   );
 }
 
-function isSwcAble(pFileName) {
-  return [".ts", ".js", ".mjs", ".cjs"].includes(path.extname(pFileName));
+function shouldUseTsc(pOptions, pFileName) {
+  return (
+    (pOptions.tsPreCompilationDeps || pOptions.parser === "tsc") &&
+    toTypescriptAST.isAvailable() &&
+    isTypeScriptCompatible(pFileName)
+  );
 }
 
 function shouldUseSwc(pOptions, pFileName) {
   return (
-    pOptions.parser === "swc" && toSwcAST.isAvailable() && isSwcAble(pFileName)
+    pOptions.parser === "swc" &&
+    toSwcAST.isAvailable() &&
+    isTypeScriptCompatible(pFileName)
   );
 }
 
@@ -73,11 +77,12 @@ function extractFromJavaScriptAST(pOptions, pFileName, pTranspileOptions) {
 
 function extractDependencies(pCruiseOptions, pFileName, pTranspileOptions) {
   let lDependencies = [];
+
   if (shouldUseSwc(pCruiseOptions, pFileName)) {
     lDependencies = extractFromSwcAST(pCruiseOptions, pFileName).filter(
       (pDep) => pCruiseOptions.moduleSystems.includes(pDep.moduleSystem)
     );
-  } else if (shouldUseTSC(pCruiseOptions, pFileName)) {
+  } else if (shouldUseTsc(pCruiseOptions, pFileName)) {
     lDependencies = extractFromTypeScriptAST(pCruiseOptions, pFileName).filter(
       (pDep) => pCruiseOptions.moduleSystems.includes(pDep.moduleSystem)
     );

--- a/src/extract/parse/to-typescript-ast.js
+++ b/src/extract/parse/to-typescript-ast.js
@@ -30,7 +30,6 @@ function getASTFromSource(pTypescriptSource, pFileName) {
  * @return {object} - a (typescript) AST
  */
 function getAST(pFileName) {
-  // reading files is kind of the point, so disabled that check here...
   return getASTFromSource(fs.readFileSync(pFileName, "utf8"), pFileName);
 }
 

--- a/test/extract/get-dependencies.spec.mjs
+++ b/test/extract/get-dependencies.spec.mjs
@@ -73,6 +73,7 @@ after(() => {
 describe("extract/getDependencies - CommonJS - ", () => {
   cjsFixtures.forEach((pFixture) => runFixture(pFixture, "acorn"));
   cjsFixtures.forEach((pFixture) => runFixture(pFixture, "swc"));
+  cjsFixtures.forEach((pFixture) => runFixture(pFixture, "tsc"));
 });
 describe("extract/getDependencies - CommonJS - with bangs", () => {
   it("strips the inline loader prefix from the module name when resolving", () => {
@@ -172,10 +173,14 @@ describe("extract/getDependencies - AMD - with bangs", () => {
   });
 });
 
-describe("extract/getDependencies - TypeScript - ", () =>
-  tsFixtures.forEach((pFixture) => runFixture(pFixture)));
-describe("extract/getDependencies - CoffeeScript - ", () =>
-  coffeeFixtures.forEach((pFixture) => runFixture(pFixture)));
+describe("extract/getDependencies - TypeScript - ", () => {
+  tsFixtures.forEach((pFixture) => runFixture(pFixture, "acorn"));
+  tsFixtures.forEach((pFixture) => runFixture(pFixture, "swc"));
+  tsFixtures.forEach((pFixture) => runFixture(pFixture, "tsc"));
+});
+describe("extract/getDependencies - CoffeeScript - ", () => {
+  coffeeFixtures.forEach((pFixture) => runFixture(pFixture));
+});
 
 describe("extract/getDependencies - Error scenarios - ", () => {
   it("Does not raise an exception on syntax errors (because we're on the loose parser)", () => {


### PR DESCRIPTION
## Description

- makes it possible to use tsc as the primary parser in addition to acorn (the default one) and swc

## Motivation and Context

- adds symmetry
- makes it easier to switch transpilers in integration test scenario's


## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] additional automated tests
- [x] manual tests against dependency-cruiser's own code base

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
