### PR TITLE
bugfix(summary): fix ignore count in the model's schema + add it to the schema for the summary

### DIFF
--- a/src/enrich/summarize/summarize-modules.js
+++ b/src/enrich/summarize/summarize-modules.js
@@ -23,6 +23,7 @@ function extractMetaData(pViolations) {
       error: 0,
       warn: 0,
       info: 0,
+      ignore: 0,
     }
   );
 }

--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -172,6 +172,7 @@ module.exports = {
         error: { type: "number" },
         warn: { type: "number" },
         info: { type: "number" },
+        ignore: { type: "number" },
         totalCruised: { type: "number" },
         totalDependenciesCruised: { type: "number" },
         ruleSetUsed: { $ref: "#/definitions/RuleSetType" },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -305,6 +305,10 @@
           "type": "number",
           "description": "the number of informational level notices in the dependencies"
         },
+        "ignore": {
+          "type": "number",
+          "description": "the number of ignored notices in the dependencies"
+        },
         "totalCruised": {
           "type": "number",
           "description": "the number of modules cruised"

--- a/test/cli/fixtures/babel/babel-es6-result.json
+++ b/test/cli/fixtures/babel/babel-es6-result.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -37,9 +35,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -58,17 +54,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 2,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/babel-es6-result.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/babel/babel-ts-result.json
+++ b/test/cli/fixtures/babel/babel-ts-result.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -37,9 +35,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "../shared",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -60,9 +56,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "module": "react",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -81,9 +75,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -102,9 +94,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./home",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -118,9 +108,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./routes-config",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -134,9 +122,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "module": "react",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -150,9 +136,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "module": "react-router-dom",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -171,9 +155,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -184,17 +166,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 8,
     "totalDependenciesCruised": 7,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/babel-ts-result.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/cjs.dir.filtered.json
+++ b/test/cli/fixtures/cjs.dir.filtered.json
@@ -8,9 +8,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -29,9 +27,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -44,9 +40,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -67,9 +61,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./one_only_one",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -83,9 +75,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./one_only_two",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -99,9 +89,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -115,9 +103,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./sub/dir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -131,9 +117,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "fs",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -152,9 +136,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -167,9 +149,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -190,9 +170,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./depindir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -206,9 +184,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -229,9 +205,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -252,9 +226,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -268,9 +240,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./somedata.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -284,9 +254,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./two_only_one",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -300,9 +268,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "http",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -321,9 +287,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -334,9 +298,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -349,9 +311,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./sub/dir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -370,6 +330,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 12,
     "totalDependenciesCruised": 16,
     "optionsUsed": {
@@ -378,12 +339,7 @@
         "path": "node_modules"
       },
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/cjs.dir.filtered.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/cjs.dir.json
+++ b/test/cli/fixtures/cjs.dir.json
@@ -20,9 +20,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./moar-javascript",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -36,9 +34,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "module": "someothermodule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -59,9 +55,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -80,9 +74,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -95,9 +87,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -118,9 +108,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./one_only_one",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -134,9 +122,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./one_only_two",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -150,9 +136,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -166,9 +150,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./sub/dir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -182,9 +164,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "fs",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -198,9 +178,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "module": "somemodule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -219,9 +197,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -234,9 +210,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -257,9 +231,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./depindir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -273,9 +245,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -296,9 +266,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -319,9 +287,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -335,9 +301,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./somedata.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -351,9 +315,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./two_only_one",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -367,9 +329,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "http",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -388,9 +348,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -401,9 +359,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -416,9 +372,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./sub/dir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -437,17 +391,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 15,
     "totalDependenciesCruised": 19,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/cjs.dir.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/cjs.dir.stdout.json
+++ b/test/cli/fixtures/cjs.dir.stdout.json
@@ -372,6 +372,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 15,
     "totalDependenciesCruised": 19,
     "optionsUsed": {

--- a/test/cli/fixtures/cjs.file.json
+++ b/test/cli/fixtures/cjs.file.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./one_only_one",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -24,9 +22,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./one_only_two",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -40,9 +36,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -56,9 +50,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./sub/dir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -72,9 +64,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "fs",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -88,9 +78,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "module": "somemodule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -109,9 +97,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -124,9 +110,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -145,9 +129,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -160,9 +142,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -183,9 +163,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -206,9 +184,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./depindir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -222,9 +198,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -245,9 +219,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -268,9 +240,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./moar-javascript",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -284,9 +254,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "module": "someothermodule",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -317,17 +285,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 11,
     "totalDependenciesCruised": 14,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/cjs.file.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/dynamic-import-nok.json
+++ b/test/cli/fixtures/dynamic-import-nok.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./import_this",
           "moduleSystem": "es6",
           "dynamic": true,
@@ -35,17 +33,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 2,
     "totalDependenciesCruised": 1,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/dynamic-import-nok.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/dynamic-import-ok.json
+++ b/test/cli/fixtures/dynamic-import-ok.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./import_this",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -35,17 +33,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 2,
     "totalDependenciesCruised": 1,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/dynamic-import-ok.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/empty.json
+++ b/test/cli/fixtures/empty.json
@@ -1,26 +1,22 @@
 {
-    "modules": [
-    ],
-    "summary": {
-        "violations": [],
-        "error": 0,
-        "warn": 0,
-        "info": 0,
-        "totalCruised": 0,
-        "totalDependenciesCruised": 0,
-        "optionsUsed": {
-            "args": "whatever",
-            "outputTo": "empty.json",
-            "moduleSystems": [
-                "amd",
-                "cjs",
-                "es6"
-            ],
-            "outputType": "json",
-            "tsPreCompilationDeps": false,
-            "combinedDependencies": false,
-            "preserveSymlinks": false,
-            "externalModuleResolutionStrategy": "node_modules"
-        }
+  "modules": [],
+  "summary": {
+    "violations": [],
+    "error": 0,
+    "warn": 0,
+    "info": 0,
+    "ignore": 0,
+    "totalCruised": 0,
+    "totalDependenciesCruised": 0,
+    "optionsUsed": {
+      "args": "whatever",
+      "outputTo": "empty.json",
+      "moduleSystems": ["amd", "cjs", "es6"],
+      "outputType": "json",
+      "tsPreCompilationDeps": false,
+      "combinedDependencies": false,
+      "preserveSymlinks": false,
+      "externalModuleResolutionStrategy": "node_modules"
     }
+  }
 }

--- a/test/cli/fixtures/multiple-in-one-go.json
+++ b/test/cli/fixtures/multiple-in-one-go.json
@@ -8,9 +8,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -29,9 +27,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -44,9 +40,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "module": "./depindir",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -60,9 +54,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "module": "path",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -89,9 +81,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "module": "./not-at-home",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -105,9 +95,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "module": "./this/path/does/not/exist",
           "moduleSystem": "es6",
           "dynamic": false,
@@ -126,9 +114,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -139,9 +125,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -152,17 +136,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 7,
     "totalDependenciesCruised": 5,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/multiple-in-one-go.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/result-has-a-dependency-violation.json
+++ b/test/cli/fixtures/result-has-a-dependency-violation.json
@@ -3971,6 +3971,7 @@
     "warn": 0,
     "error": 1,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 116,
     "totalDependenciesCruised": 169,
     "optionsUsed": {

--- a/test/cli/fixtures/typescript-path-resolution.json
+++ b/test/cli/fixtures/typescript-path-resolution.json
@@ -8,9 +8,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "module": "shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -37,9 +35,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "module": "shared",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -58,17 +54,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 2,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/typescript-path-resolution.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/webpack-config-alias-cruiser-config.json
+++ b/test/cli/fixtures/webpack-config-alias-cruiser-config.json
@@ -14,9 +14,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "module": "configSpullenAlias",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -30,9 +28,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "module": "configSpullenAlias/someconfig.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -51,9 +47,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "aliased"
-      ],
+      "dependencyTypes": ["aliased"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -64,17 +58,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 2,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/webpack-config-alias-cruiser-config.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/fixtures/webpack-config-alias.json
+++ b/test/cli/fixtures/webpack-config-alias.json
@@ -14,9 +14,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "module": "configSpullenAlias",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -30,9 +28,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "module": "configSpullenAlias/someconfig.json",
           "moduleSystem": "cjs",
           "dynamic": false,
@@ -51,9 +47,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "aliased"
-      ],
+      "dependencyTypes": ["aliased"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -64,17 +58,13 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 2,
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
       "outputTo": "test/cli/output/webpack-config-alias.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/enrich/summarize-modules.spec.mjs
+++ b/test/enrich/summarize-modules.spec.mjs
@@ -10,6 +10,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       info: 0,
       warn: 0,
       error: 0,
+      ignore: 0,
       totalDependenciesCruised: 0,
       totalCruised: 0,
     });
@@ -29,6 +30,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       info: 0,
       warn: 0,
       error: 0,
+      ignore: 0,
       totalDependenciesCruised: 0,
       totalCruised: 1,
     });
@@ -63,6 +65,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       info: 0,
       warn: 1,
       error: 0,
+      ignore: 0,
       totalDependenciesCruised: 0,
       totalCruised: 1,
     });
@@ -129,6 +132,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       info: 0,
       warn: 2,
       error: 0,
+      ignore: 0,
       totalDependenciesCruised: 1,
       totalCruised: 1,
     });
@@ -171,6 +175,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       info: 0,
       warn: 0,
       error: 0,
+      ignore: 0,
       totalDependenciesCruised: 1,
       totalCruised: 2,
     });
@@ -243,6 +248,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       info: 1,
       warn: 0,
       error: 1,
+      ignore: 0,
       totalDependenciesCruised: 1,
       totalCruised: 2,
     });

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -8,6 +8,7 @@ describe("enrich/summarize", () => {
     expect(summarize([], {}, [])).to.deep.equal({
       error: 0,
       info: 0,
+      ignore: 0,
       optionsUsed: {
         args: "",
       },
@@ -21,6 +22,7 @@ describe("enrich/summarize", () => {
     expect(summarize([], { ruleSet: { required: [] } }, [])).to.deep.equal({
       error: 0,
       info: 0,
+      ignore: 0,
       optionsUsed: {
         args: "",
       },

--- a/test/main/fixtures/collapse-after-cruise/expected-result.json
+++ b/test/main/fixtures/collapse-after-cruise/expected-result.json
@@ -159,6 +159,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 7,
     "totalDependenciesCruised": 6,
     "optionsUsed": {

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -103,6 +103,7 @@
     "error": 0,
     "warn": 1,
     "info": 1,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -103,6 +103,7 @@
     "error": 0,
     "warn": 1,
     "info": 1,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -103,6 +103,7 @@
     "error": 0,
     "warn": 1,
     "info": 1,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/jsx-as-object.json
+++ b/test/main/fixtures/jsx-as-object.json
@@ -184,6 +184,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 8,
     "totalDependenciesCruised": 7,
     "optionsUsed": {

--- a/test/main/fixtures/jsx.json
+++ b/test/main/fixtures/jsx.json
@@ -184,6 +184,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 8,
     "totalDependenciesCruised": 7,
     "optionsUsed": {

--- a/test/main/fixtures/ts-no-precomp-cjs.json
+++ b/test/main/fixtures/ts-no-precomp-cjs.json
@@ -59,6 +59,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 4,
     "totalDependenciesCruised": 2,
     "optionsUsed": {

--- a/test/main/fixtures/ts-no-precomp-es.json
+++ b/test/main/fixtures/ts-no-precomp-es.json
@@ -59,6 +59,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 4,
     "totalDependenciesCruised": 2,
     "optionsUsed": {

--- a/test/main/fixtures/ts-precomp-cjs.json
+++ b/test/main/fixtures/ts-precomp-cjs.json
@@ -73,6 +73,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 4,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/ts-precomp-es.json
+++ b/test/main/fixtures/ts-precomp-es.json
@@ -73,6 +73,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 4,
     "totalDependenciesCruised": 3,
     "optionsUsed": {

--- a/test/main/fixtures/ts.json
+++ b/test/main/fixtures/ts.json
@@ -133,6 +133,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 6,
     "totalDependenciesCruised": 6,
     "optionsUsed": {

--- a/test/main/fixtures/tsx.json
+++ b/test/main/fixtures/tsx.json
@@ -59,6 +59,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 3,
     "totalDependenciesCruised": 2,
     "optionsUsed": {

--- a/test/main/fixtures/type-only-module-references/output-no-ts.json
+++ b/test/main/fixtures/type-only-module-references/output-no-ts.json
@@ -12,6 +12,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 1,
     "totalDependenciesCruised": 0,
     "optionsUsed": {

--- a/test/main/fixtures/type-only-module-references/output.json
+++ b/test/main/fixtures/type-only-module-references/output.json
@@ -34,6 +34,7 @@
     "error": 0,
     "warn": 0,
     "info": 0,
+    "ignore": 0,
     "totalCruised": 2,
     "totalDependenciesCruised": 1,
     "optionsUsed": {

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -15,6 +15,7 @@ const MINIMAL_RESULT = {
     error: 0,
     warn: 0,
     info: 0,
+    ignore: 0,
     totalCruised: 0,
     totalDependenciesCruised: 0,
     optionsUsed: {},

--- a/tools/schema/summary.mjs
+++ b/tools/schema/summary.mjs
@@ -31,6 +31,10 @@ export default {
           description:
             "the number of informational level notices in the dependencies",
         },
+        ignore: {
+          type: "number",
+          description: "the number of ignored notices in the dependencies",
+        },
         totalCruised: {
           type: "number",
           description: "the number of modules cruised",

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -272,6 +272,10 @@ export interface ISummary {
    */
   error: number;
   /**
+   * the number of ignored notices in the dependencies
+   */
+  ignore: number;
+  /**
    * the number of informational level notices in the dependencies
    */
   info: number;


### PR DESCRIPTION
## Description

See title

## Motivation and Context

Ignore count _was_ added but incorrectly + it wasn't part of the json schema so depcruise-fmt refused to run on input that contained ignored errors.

## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] manual testing

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
