### PR TITLE
feature(validate): adds via restrictions for cycles

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -678,6 +678,55 @@ up at itself.
 }
 ```
 
+### `via` and `viaNot` - restricting what cycles to match
+
+Some codebases include a lot of circular dependencies, sometimes with a few 'knots'
+(typically barrel files) that partake in most of them. Fixing these cycles might
+take a spell, so you might want to (temporarily :-) ) exclude them from breaking
+the build. At the same time you might want to prevent any new violation going
+unnoticed because of this.
+
+One solution to this is to use dependency-cruiser's `ignore-known` mechanism, but
+for this specific case it's also possible to exclude everything passing through
+these knots from breaking the build, but still flagging any other cycle.
+
+In this example `app/javascript/tables/index.ts` and `app/javascript/tables/index.ts`
+are the known 'knots':
+
+```javascript
+// log an error for all circular dependencies except when they are via one of the
+// known 'knots'
+{
+  name: 'no-circular',
+  severity: 'error',
+  from: {
+  },
+  to: {
+    circular: true,
+    viaNot: [
+      '^app/javascript/tables/index.ts',
+      '^app/javascript/ui/index.tsx',
+    ]
+  }
+},
+
+// for circular dependencies that pass through one of the knots, still generate
+// a warning
+{
+  name: 'no-circular (exception for known barrels)',
+  severity: 'warn',
+  from: {
+  },
+  to: {
+    circular: true,
+    via: [
+      '^app/javascript/tables/index.ts',
+      '^app/javascript/ui/index.tsx',
+    ]
+  }
+}
+```
+
 ### `license` and `licenseNot`
 
 You can flag dependent modules that have licenses that are e.g. not

--- a/src/main/utl/normalize-re-properties.js
+++ b/src/main/utl/normalize-re-properties.js
@@ -10,6 +10,8 @@ const RE_PROPERTIES = [
   "licenseNot",
   "exoticRequire",
   "exoticRequireNot",
+  "via",
+  "viaNot",
 ];
 
 module.exports = function normalizeREProperties(

--- a/src/schema/configuration.schema.js
+++ b/src/schema/configuration.schema.js
@@ -162,6 +162,8 @@ module.exports = {
         moreThanOneDependencyType: { type: "boolean" },
         license: { $ref: "#/definitions/REAsStringsType" },
         licenseNot: { $ref: "#/definitions/REAsStringsType" },
+        via: { $ref: "#/definitions/REAsStringsType" },
+        viaNot: { $ref: "#/definitions/REAsStringsType" },
       },
     },
     DependentsModuleRestrictionType: {

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -233,6 +233,14 @@
         "licenseNot": {
           "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here",
           "$ref": "#/definitions/REAsStringsType"
+        },
+        "via": {
+          "description": "For circular dependencies - whether or not to match cycles that include include modules with this regular expression. E.g. to allow all cycles, except when they go through one specific module. Typically to temporarily disallow some cycles with a lower severity - setting up a rule with a viaNot that ignores them.",
+          "$ref": "#/definitions/REAsStringsType"
+        },
+        "viaNot": {
+          "description": "For circular dependencies - whether or not to match cycles that do NOT include modules with this regular expression. E.g. to disallow all cycles, except when they go through one specific module. Typically to temporarily allow some cycles until they're removed.",
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },

--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -334,6 +334,8 @@ module.exports = {
         moreThanOneDependencyType: { type: "boolean" },
         license: { $ref: "#/definitions/REAsStringsType" },
         licenseNot: { $ref: "#/definitions/REAsStringsType" },
+        via: { $ref: "#/definitions/REAsStringsType" },
+        viaNot: { $ref: "#/definitions/REAsStringsType" },
       },
     },
     DependentsModuleRestrictionType: {

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -554,6 +554,14 @@
         "licenseNot": {
           "description": "Whether or not to match modules that were NOT released under one of the mentioned licenses. E.g. to flag everyting non MIT use \"MIT\" here",
           "$ref": "#/definitions/REAsStringsType"
+        },
+        "via": {
+          "description": "For circular dependencies - whether or not to match cycles that include include modules with this regular expression. E.g. to allow all cycles, except when they go through one specific module. Typically to temporarily disallow some cycles with a lower severity - setting up a rule with a viaNot that ignores them.",
+          "$ref": "#/definitions/REAsStringsType"
+        },
+        "viaNot": {
+          "description": "For circular dependencies - whether or not to match cycles that do NOT include modules with this regular expression. E.g. to disallow all cycles, except when they go through one specific module. Typically to temporarily allow some cycles until they're removed.",
+          "$ref": "#/definitions/REAsStringsType"
         }
       }
     },

--- a/src/validate/match-dependency-rule.js
+++ b/src/validate/match-dependency-rule.js
@@ -37,6 +37,8 @@ function match(pFrom, pTo) {
       matchers.toLicenseNot(pRule, pTo) &&
       matchers.toExoticRequire(pRule, pTo) &&
       matchers.toExoticRequireNot(pRule, pTo) &&
+      matchers.toVia(pRule, pTo) &&
+      matchers.toViaNot(pRule, pTo) &&
       // preCompilationOnly is not a mandatory attribute, but if the attribute
       // is in the rule but not in the dependency there won't be a match
       // anyway, so we can use the default propertyEquals method regardless

--- a/src/validate/matchers.js
+++ b/src/validate/matchers.js
@@ -100,6 +100,22 @@ function toExoticRequireNot(pRule, pDependency) {
   );
 }
 
+function toViaNot(pRule, pDependency) {
+  return Boolean(
+    !pRule.to.viaNot ||
+      (pDependency.cycle &&
+        !pDependency.cycle.some((pVia) => pVia.match(pRule.to.viaNot)))
+  );
+}
+
+function toVia(pRule, pDependency) {
+  return Boolean(
+    !pRule.to.via ||
+      (pDependency.cycle &&
+        pDependency.cycle.some((pVia) => pVia.match(pRule.to.via)))
+  );
+}
+
 module.exports = {
   _replaceGroupPlaceholders,
   fromPath,
@@ -115,4 +131,6 @@ module.exports = {
   toLicenseNot,
   toExoticRequire,
   toExoticRequireNot,
+  toVia,
+  toViaNot,
 };

--- a/test/validate/fixtures/rules.cycle.via-not.json
+++ b/test/validate/fixtures/rules.cycle.via-not.json
@@ -1,0 +1,11 @@
+{
+  "forbidden": [
+    {
+      "from": {},
+      "to": {
+        "circular": true,
+        "viaNot": "^tmp/ab\\.js$"
+      }
+    }
+  ]
+}

--- a/test/validate/fixtures/rules.cycle.via.json
+++ b/test/validate/fixtures/rules.cycle.via.json
@@ -1,0 +1,11 @@
+{
+  "forbidden": [
+    {
+      "from": {},
+      "to": {
+        "circular": true,
+        "via": "^tmp/ab\\.js$"
+      }
+    }
+  ]
+}

--- a/test/validate/index.cycle-vias.spec.mjs
+++ b/test/validate/index.cycle-vias.spec.mjs
@@ -1,0 +1,74 @@
+/* eslint-disable max-statements */
+import { expect } from "chai";
+import validate from "../../src/validate/index.js";
+import readRuleSet from "./readruleset.utl.mjs";
+
+describe("validate/index dependency - cycle viaNot", () => {
+  it("a => ba => bb => bc => a get flagged when none of them is in a viaNot", () => {
+    expect(
+      validate.dependency(
+        readRuleSet("./test/validate/fixtures/rules.cycle.via-not.json"),
+        { source: "tmp/a.js" },
+        {
+          resolved: "tmp/ba.js",
+          circular: true,
+          cycle: ["tmp/ba.js", "tmp/bb.js", "tmp/bc.js", "tmp/a.js"],
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "unnamed", severity: "warn" }],
+    });
+  });
+
+  it("a => aa => ab => ac => a doesn't get flagged when one of them is in a viaNot", () => {
+    expect(
+      validate.dependency(
+        readRuleSet("./test/validate/fixtures/rules.cycle.via-not.json"),
+        { source: "tmp/a.js" },
+        {
+          resolved: "tmp/aa.js",
+          circular: true,
+          cycle: ["tmp/aa.js", "tmp/ab.js", "tmp/ac.js", "tmp/a.js"],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+});
+
+describe("validate/index dependency - cycle via", () => {
+  it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via", () => {
+    expect(
+      validate.dependency(
+        readRuleSet("./test/validate/fixtures/rules.cycle.via.json"),
+        { source: "tmp/a.js" },
+        {
+          resolved: "tmp/ba.js",
+          circular: true,
+          cycle: ["tmp/ba.js", "tmp/bb.js", "tmp/bc.js", "tmp/a.js"],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+
+  it("a => aa => ab => ac => a get flagged when one of them is in a via", () => {
+    expect(
+      validate.dependency(
+        readRuleSet("./test/validate/fixtures/rules.cycle.via.json"),
+        { source: "tmp/a.js" },
+        {
+          resolved: "tmp/aa.js",
+          circular: true,
+          cycle: ["tmp/aa.js", "tmp/ab.js", "tmp/ac.js", "tmp/a.js"],
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "unnamed", severity: "warn" }],
+    });
+  });
+});

--- a/test/validate/matchers.spec.mjs
+++ b/test/validate/matchers.spec.mjs
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import matchers from "../../src/validate/matchers.js";
 
-describe("validate/matches", () => {
+describe("validate/matchers", () => {
   it("_replaceGroupPlaceholders - leaves re alone if passed empty match result", () => {
     expect(matchers._replaceGroupPlaceholders("$1/aap|noot", [])).to.equal(
       "$1/aap|noot"

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -122,6 +122,23 @@ export default {
             'the mentioned licenses. E.g. to flag everyting non MIT use "MIT" here',
           $ref: "#/definitions/REAsStringsType",
         },
+        via: {
+          description:
+            "For circular dependencies - whether or not to match cycles that include " +
+            "include modules with this regular expression. E.g. to allow all cycles, " +
+            "except when they go through one specific module. Typically to temporarily " +
+            "disallow some cycles with a lower severity - setting up a rule with a viaNot " +
+            "that ignores them.",
+          $ref: "#/definitions/REAsStringsType",
+        },
+        viaNot: {
+          description:
+            "For circular dependencies - whether or not to match cycles that do NOT " +
+            "include modules with this regular expression. E.g. to disallow all cycles, " +
+            "except when they go through one specific module. Typically to temporarily " +
+            "allow some cycles until they're removed.",
+          $ref: "#/definitions/REAsStringsType",
+        },
       },
     },
     DependentsModuleRestrictionType: {

--- a/types/restrictions.d.ts
+++ b/types/restrictions.d.ts
@@ -34,11 +34,18 @@ export interface IToRestriction extends IBaseRestrictionType {
    */
   circular?: boolean;
   /**
-   * If following this dependency will ultimately return to the source
-   * (circular === true), this attribute will contain an (ordered) array of module
-   * names that shows (one of the) circular path(s)
+   * For circular dependencies - whether or not to match cycles that include include modules
+   * with this regular expression. E.g. to allow all cycles, except when they go through one
+   * specific module. Typically to temporarily disallow some cycles with a lower severity -
+   * setting up a rule with a viaNot that ignores them.
    */
-  cycle?: string[];
+  via?: string | string[];
+  /**
+   * For circular dependencies - whether or not to match cycles that do NOT include modules
+   * with this regular expression. E.g. to disallow all cycles, except when they go through
+   * one specific module. Typically to temporarily allow some cycles until they're removed.
+   */
+  viaNot?: string | string[];
   /**
    * Whether or not to match when the dependency is a dynamic one.
    */


### PR DESCRIPTION
## Description

- adds `via` and `viaNot` attributes to rules so you can use them in conjunction with rules that flag circular dependencies

E.g.
```javascript
// log an error for all circular dependencies except when they are via one of the barrels
{
  name: 'no-circular',
  severity:  'error',
  from: {
  },
  to: {
    circular: true,
    viaNot: [
      '^(app/javascript/tables/index.ts)',
      '^(app/javascript/ui/index.tsx)',
    ]
  }
},

// for circular dependencies that pass through one of the barrels generate a warning
{
  name: 'no-circular (exception for known barrels)',
  severity: 'warn',
  from: {
  },
  to: {
    circular: true,
    via: [
      '^(app/javascript/tables/index.ts)',
      '^(app/javascript/ui/index.tsx)',
    ]
  }
}
```

## Motivation and Context

fixes #505 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests
- [x] manual sanity check


## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
