### PR TITLE
refactor(report): simplify the 'ignored-violations' handling of the err reporters

### DIFF
--- a/src/report/error.js
+++ b/src/report/error.js
@@ -82,14 +82,10 @@ function addExplanation(pRuleSet, pLong) {
     : (pViolation) => pViolation;
 }
 
-function formatIgnoreWarning(pViolations) {
-  const lIgnoredViolations = pViolations.filter(
-    (pViolation) => pViolation.rule.severity === "ignore"
-  );
-
-  if (lIgnoredViolations.length > 0) {
+function formatIgnoreWarning(pNumberOfIgnoredViolations) {
+  if (pNumberOfIgnoredViolations > 0) {
     return chalk.yellow(
-      `${figures.warning} ${lIgnoredViolations.length} known violations ignored. Run without --ignore-known to see them.\n`
+      `${figures.warning} ${pNumberOfIgnoredViolations} known violations ignored. Run without --ignore-known to see them.\n`
     );
   }
   return "";
@@ -106,7 +102,7 @@ function report(pResults, pLong) {
     } modules, ${
       pResults.summary.totalDependenciesCruised
     } dependencies cruised)\n${formatIgnoreWarning(
-      pResults.summary.violations
+      pResults.summary.ignore
     )}\n\n`;
   }
 
@@ -115,7 +111,7 @@ function report(pResults, pLong) {
     .map(addExplanation(pResults.summary.ruleSetUsed, pLong))
     .reduce((pAll, pThis) => `${pAll}  ${formatViolation(pThis)}\n`, "\n")
     .concat(formatSummary(pResults.summary))
-    .concat(formatIgnoreWarning(pResults.summary.violations))
+    .concat(formatIgnoreWarning(pResults.summary.ignore))
     .concat(`\n`);
 }
 

--- a/test/report/error/error.spec.mjs
+++ b/test/report/error/error.spec.mjs
@@ -8,6 +8,8 @@ import onlywarningdependencies from "./mocks/err-only-warnings.mjs";
 import orphanerrs from "./mocks/orphan-deps.mjs";
 import circularerrs from "./mocks/circular-deps.mjs";
 import viaerrs from "./mocks/via-deps.mjs";
+import ignoredviolations from "./mocks/ignored-violations.mjs";
+import ignoredandrealviolations from "./mocks/ignored-and-real-violations.mjs";
 
 describe("report/error", () => {
   let chalkLevel = chalk.level;
@@ -73,5 +75,25 @@ describe("report/error", () => {
     );
     expect(lResult.output).to.contain("      (via via)");
     expect(lResult.exitCode).to.equal(4);
+  });
+  it("emits a warning when there's > 1 ignored violation and no other violations", () => {
+    const lResult = render(ignoredviolations);
+    expect(lResult.output).to.contain("no dependency violations found");
+    expect(lResult.output).to.contain(
+      "11 known violations ignored. Run without --ignore-known to see them."
+    );
+  });
+  it("emits a warning when there's > 1 ignored violation and at least one other violation", () => {
+    const lResult = render(ignoredandrealviolations);
+
+    expect(lResult.output).to.contain(
+      "warn no-orphans: test/extract/ast-extractors/typescript2.8-union-types-ast.json"
+    );
+    expect(lResult.output).to.contain(
+      "1 dependency violations (0 errors, 1 warnings)"
+    );
+    expect(lResult.output).to.contain(
+      "10 known violations ignored. Run without --ignore-known to see them."
+    );
   });
 });

--- a/test/report/error/mocks/ignored-and-real-violations.mjs
+++ b/test/report/error/mocks/ignored-and-real-violations.mjs
@@ -1,0 +1,135 @@
+export default {
+  modules: [],
+  summary: {
+    violations: [
+      {
+        from: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
+        to: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
+        rule: {
+          severity: "warn",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/baseline/baseline-result.json",
+        to: "test/report/baseline/baseline-result.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/baseline/dc-result-no-violations.json",
+        to: "test/report/baseline/dc-result-no-violations.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/baseline/dc-result-with-violations.json",
+        to: "test/report/baseline/dc-result-with-violations.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/dot/module-level/bare-theme.json",
+        to: "test/report/dot/module-level/bare-theme.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "src/cli/format.js",
+        to: "src/cli/format.js",
+        rule: {
+          severity: "ignore",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+      {
+        from: "src/cli/tools/wrap-stream-in-html.js",
+        to: "src/cli/tools/wrap-stream-in-html.js",
+        rule: {
+          severity: "ignore",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+      {
+        from: "src/cli/validate-node-environment.js",
+        to: "src/cli/validate-node-environment.js",
+        rule: {
+          severity: "ignore",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+      {
+        from: "src/schema/baseline-violations.schema.js",
+        to: "src/schema/baseline-violations.schema.js",
+        rule: {
+          severity: "ignore",
+          name: "not-unreachable-from-cli",
+        },
+      },
+      {
+        from: "src/utl/array-util.js",
+        to: "src/utl/array-util.js",
+        rule: {
+          severity: "ignore",
+          name: "utl-module-not-shared-enough",
+        },
+      },
+      {
+        from: "src/utl/wrap-and-indent.js",
+        to: "src/utl/wrap-and-indent.js",
+        rule: {
+          severity: "ignore",
+          name: "utl-module-not-shared-enough",
+        },
+      },
+    ],
+    error: 0,
+    warn: 1,
+    info: 0,
+    ignore: 10,
+    totalCruised: 454,
+    totalDependenciesCruised: 1082,
+    optionsUsed: {
+      combinedDependencies: false,
+      doNotFollow: {
+        path: "node_modules",
+        dependencyTypes: [
+          "npm",
+          "npm-dev",
+          "npm-optional",
+          "npm-peer",
+          "npm-bundled",
+          "npm-no-pkg",
+        ],
+      },
+      exclude: {
+        path: "mocks|fixtures|test/integration|src/cli/tools/svg-in-html-snippets/script.snippet.js",
+      },
+      externalModuleResolutionStrategy: "node_modules",
+      moduleSystems: ["cjs", "es6"],
+      outputTo: "-",
+      outputType: "json",
+      preserveSymlinks: false,
+      rulesFile: ".dependency-cruiser.json",
+      tsPreCompilationDeps: true,
+      exoticRequireStrings: ["tryRequire"],
+      enhancedResolveOptions: {
+        exportsFields: ["exports"],
+        conditionNames: ["require"],
+        extensions: [".js", ".d.ts"],
+      },
+      args: "src bin test configs types tools",
+    },
+    ruleSetUsed: {
+      forbidden: [],
+    },
+  },
+};

--- a/test/report/error/mocks/ignored-violations.mjs
+++ b/test/report/error/mocks/ignored-violations.mjs
@@ -1,0 +1,135 @@
+export default {
+  modules: [],
+  summary: {
+    violations: [
+      {
+        from: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
+        to: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/baseline/baseline-result.json",
+        to: "test/report/baseline/baseline-result.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/baseline/dc-result-no-violations.json",
+        to: "test/report/baseline/dc-result-no-violations.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/baseline/dc-result-with-violations.json",
+        to: "test/report/baseline/dc-result-with-violations.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "test/report/dot/module-level/bare-theme.json",
+        to: "test/report/dot/module-level/bare-theme.json",
+        rule: {
+          severity: "ignore",
+          name: "no-orphans",
+        },
+      },
+      {
+        from: "src/cli/format.js",
+        to: "src/cli/format.js",
+        rule: {
+          severity: "ignore",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+      {
+        from: "src/cli/tools/wrap-stream-in-html.js",
+        to: "src/cli/tools/wrap-stream-in-html.js",
+        rule: {
+          severity: "ignore",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+      {
+        from: "src/cli/validate-node-environment.js",
+        to: "src/cli/validate-node-environment.js",
+        rule: {
+          severity: "ignore",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+      {
+        from: "src/schema/baseline-violations.schema.js",
+        to: "src/schema/baseline-violations.schema.js",
+        rule: {
+          severity: "ignore",
+          name: "not-unreachable-from-cli",
+        },
+      },
+      {
+        from: "src/utl/array-util.js",
+        to: "src/utl/array-util.js",
+        rule: {
+          severity: "ignore",
+          name: "utl-module-not-shared-enough",
+        },
+      },
+      {
+        from: "src/utl/wrap-and-indent.js",
+        to: "src/utl/wrap-and-indent.js",
+        rule: {
+          severity: "ignore",
+          name: "utl-module-not-shared-enough",
+        },
+      },
+    ],
+    error: 0,
+    warn: 0,
+    info: 0,
+    ignore: 11,
+    totalCruised: 454,
+    totalDependenciesCruised: 1082,
+    optionsUsed: {
+      combinedDependencies: false,
+      doNotFollow: {
+        path: "node_modules",
+        dependencyTypes: [
+          "npm",
+          "npm-dev",
+          "npm-optional",
+          "npm-peer",
+          "npm-bundled",
+          "npm-no-pkg",
+        ],
+      },
+      exclude: {
+        path: "mocks|fixtures|test/integration|src/cli/tools/svg-in-html-snippets/script.snippet.js",
+      },
+      externalModuleResolutionStrategy: "node_modules",
+      moduleSystems: ["cjs", "es6"],
+      outputTo: "-",
+      outputType: "json",
+      preserveSymlinks: false,
+      rulesFile: ".dependency-cruiser.json",
+      tsPreCompilationDeps: true,
+      exoticRequireStrings: ["tryRequire"],
+      enhancedResolveOptions: {
+        exportsFields: ["exports"],
+        conditionNames: ["require"],
+        extensions: [".js", ".d.ts"],
+      },
+      args: "src bin test configs types tools",
+    },
+    ruleSetUsed: {
+      forbidden: [],
+    },
+  },
+};


### PR DESCRIPTION
## Description

- The err reporters were iterating over the violations to count the ignored ones. This PR replaces that calculation with the use of summary.ignore - which is available in the same spot and contains the same number.
- Adds unit tests for the violation warning in the err reporter

## Motivation and Context

- Solution is simpler and has the same result as the previous one.
- Less spots to calculate the ignored violation count => less can go wrong.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests
- [x] manual validation

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
