### PR TITLE
Add knownViolations option to the optionsUsed section in the summary

### DIFF
--- a/src/enrich/summarize/summarize-options.js
+++ b/src/enrich/summarize/summarize-options.js
@@ -8,6 +8,7 @@ const SHAREABLE_OPTIONS = [
   "externalModuleResolutionStrategy",
   "focus",
   "includeOnly",
+  "knownViolations",
   "maxDepth",
   "moduleSystems",
   "outputTo",
@@ -38,6 +39,10 @@ function makeOptionsPresentable(pOptions) {
     .filter(
       (pOption) =>
         pOption !== "exclude" || Object.keys(pOptions.exclude).length > 0
+    )
+    .filter(
+      (pOption) =>
+        pOption !== "knownViolations" || pOptions.knownViolations.length > 0
     )
     .reduce((pAll, pOption) => {
       pAll[pOption] = pOptions[pOption];

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -128,4 +128,55 @@ describe("enrich/summarize", () => {
     const lResult = summarize(cycleFest, lOptions, ["src"]);
     expect(lResult).to.deep.equal(lExpected);
   });
+
+  it("includes known violations in the summary", () => {
+    const lKnownViolations = [
+      {
+        from: "src/schema/baseline-violations.schema.js",
+        to: "src/schema/baseline-violations.schema.js",
+        rule: {
+          severity: "error",
+          name: "not-unreachable-from-cli",
+        },
+      },
+      {
+        from: "src/cli/format.js",
+        to: "src/cli/format.js",
+        rule: {
+          severity: "info",
+          name: "not-reachable-from-folder-index",
+        },
+      },
+    ];
+    expect(
+      summarize([], { knownViolations: lKnownViolations }, [])
+    ).to.deep.equal({
+      error: 0,
+      info: 0,
+      ignore: 0,
+      optionsUsed: {
+        args: "",
+        knownViolations: lKnownViolations,
+      },
+      totalCruised: 0,
+      totalDependenciesCruised: 0,
+      violations: [],
+      warn: 0,
+    });
+  });
+
+  it("doesn't include known violations key when none exist", () => {
+    expect(summarize([], { knownViolations: [] }, [])).to.deep.equal({
+      error: 0,
+      info: 0,
+      ignore: 0,
+      optionsUsed: {
+        args: "",
+      },
+      totalCruised: 0,
+      totalDependenciesCruised: 0,
+      violations: [],
+      warn: 0,
+    });
+  });
 });


### PR DESCRIPTION
## Description

Adds the `knownViolations` key to the optionsUsed section in the summary when the `--ignore-known` flag is passed on the command line.

## Motivation and Context

Fixes #508 

## How Has This Been Tested?

Tested changes locally. Also ran `test/enrich/summarize.spec.mjs`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
