### PR TITLE
feature(validate): adds a dependencyTypesNot restriction

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -38,7 +38,7 @@
    - [rules on dependents - `numberOfDependentsMoreThan`](#rules-on-dependents---numberOfDependentsMoreThan)
    - [`circular`](#circular)
    - [`license` and `licenseNot`](#license-and-licensenot)
-   - [`dependencyTypes`](#dependencytypes)
+   - [`dependencyTypes` and `dependencyTypesNot`](#dependencytypes-and-dependencytypesnot)
    - [`dynamic`](#dynamic)
    - [`moreThanOneDependencyType`](#more-than-one-dependencytype-per-dependency-morethanonedependencytype)
    - [`exoticRequire` and `exoticRequireNot`](#exoticallyrequired-exoticrequire-and-exoticrequirenot)
@@ -778,7 +778,7 @@ for managing your own legal stuff. To re-iterate what is in the
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
-### `dependencyTypes`
+### `dependencyTypes` and `dependencyTypesNot`
 
 You might have spent some time wondering why something works on your machine,
 but not on other's. Only to discover you _did_ install a dependency, but
@@ -786,7 +786,7 @@ _did not_ save it to package.json. Or you already had it in your devDependencies
 and started using it in a production source.
 
 To save you from embarrassing moments like this, you can make rules with the
-`dependencyTypes` verb. E.g. to prevent you accidentally depend on a
+`dependencyTypes` restrction. E.g. to prevent you accidentally depend on a
 `devDependency` from anything in `src` add this to your
 .dependency-cruiser.js's "forbidden" section:
 
@@ -814,8 +814,25 @@ Or to detect stuff you npm i'd without putting it in your package.json:
 }
 ```
 
-If you don't specify dependencyTypes in a rule, dependency-cruiser will ignore
-them in the evaluation of that rule.
+Likewise you can use the inverse `dependencyTypesNot` restriction. E.g. to ensure
+type-only imports (e.g. `import type { IYadda } from "./types"`) are used from
+`.d.ts` modules and/ or modules called `types.ts`:
+
+```json
+{
+  "name": "only-type-only",
+  "comment": "use explicit 'type' imports to import from type declaration modules",
+  "severity": "error",
+  "from": {},
+  "to": {
+    "path": ["types\\.ts$", "\\.d\\.ts$"],
+    "dependencyTypesNot": ["type-only"]
+  }
+}
+```
+
+If you don't specify dependencyTypes (or dependencyTypesNot) in a rule, dependency-cruiser
+will ignore them in the evaluation of that rule.
 
 #### OK - `unknown`, `npm-unknown`, `undetermined` - I'm officially weirded out - what's that about?
 
@@ -831,7 +848,7 @@ This is a list of dependency types dependency-cruiser currently detects.
 | npm-peer        | it's a module in package.json's `peerDependencies` - note: deprecated in npm 3                                                                                                | "thing-i-am-a-plugin-for" |
 | npm-bundled     | it's a module that occurs in package.json's `bundle(d)Dependencies` array                                                                                                     | "iwillgetbundled"         |
 | npm-no-pkg      | it's an npm module - but it's nowhere in your package.json                                                                                                                    | "forgetmenot"             |
-| npm-unknown     | it's an npm module - but there is no (parseable/ valid) package.json in your package                                                                                          |
+| npm-unknown     | it's an npm module - but there is no (parseable/ valid) package.json in your package                                                                                          |                           |
 | deprecated      | it's an npm module, but the version you're using or the module itself is officially deprecated                                                                                | "some-deprecated-package" |
 | core            | it's a core module                                                                                                                                                            | "fs"                      |
 | aliased         | it's a module that's linked through an aliased (webpack)                                                                                                                      | "~/hello.ts"              |

--- a/src/schema/configuration.schema.js
+++ b/src/schema/configuration.schema.js
@@ -159,6 +159,10 @@ module.exports = {
           type: "array",
           items: { $ref: "#/definitions/DependencyTypeType" },
         },
+        dependencyTypesNot: {
+          type: "array",
+          items: { $ref: "#/definitions/DependencyTypeType" },
+        },
         moreThanOneDependencyType: { type: "boolean" },
         license: { $ref: "#/definitions/REAsStringsType" },
         licenseNot: { $ref: "#/definitions/REAsStringsType" },

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -222,6 +222,11 @@
           "description": "Whether or not to match modules of any of these types (leaving out matches any of them)",
           "items": { "$ref": "#/definitions/DependencyTypeType" }
         },
+        "dependencyTypesNot": {
+          "type": "array",
+          "description": "Whether or not to match modules NOT of any of these types (leaving out matches none of them)",
+          "items": { "$ref": "#/definitions/DependencyTypeType" }
+        },
         "moreThanOneDependencyType": {
           "type": "boolean",
           "description": "If true matches dependencies with more than one dependency type (e.g. defined in _both_ npm and npm-dev)"

--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -331,6 +331,10 @@ module.exports = {
           type: "array",
           items: { $ref: "#/definitions/DependencyTypeType" },
         },
+        dependencyTypesNot: {
+          type: "array",
+          items: { $ref: "#/definitions/DependencyTypeType" },
+        },
         moreThanOneDependencyType: { type: "boolean" },
         license: { $ref: "#/definitions/REAsStringsType" },
         licenseNot: { $ref: "#/definitions/REAsStringsType" },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -543,6 +543,11 @@
           "description": "Whether or not to match modules of any of these types (leaving out matches any of them)",
           "items": { "$ref": "#/definitions/DependencyTypeType" }
         },
+        "dependencyTypesNot": {
+          "type": "array",
+          "description": "Whether or not to match modules NOT of any of these types (leaving out matches none of them)",
+          "items": { "$ref": "#/definitions/DependencyTypeType" }
+        },
         "moreThanOneDependencyType": {
           "type": "boolean",
           "description": "If true matches dependencies with more than one dependency type (e.g. defined in _both_ npm and npm-dev)"

--- a/src/validate/match-dependency-rule.js
+++ b/src/validate/match-dependency-rule.js
@@ -32,6 +32,7 @@ function match(pFrom, pTo) {
       matchers.toPath(pRule, pTo, lGroups) &&
       matchers.toPathNot(pRule, pTo, lGroups) &&
       matchers.toDependencyTypes(pRule, pTo) &&
+      matchers.toDependencyTypesNot(pRule, pTo) &&
       matchesMoreThanOneDependencyType(pRule.to, pTo) &&
       matchers.toLicense(pRule, pTo) &&
       matchers.toLicenseNot(pRule, pTo) &&

--- a/src/validate/matchers.js
+++ b/src/validate/matchers.js
@@ -70,6 +70,13 @@ function toDependencyTypes(pRule, pDependency) {
   );
 }
 
+function toDependencyTypesNot(pRule, pDependency) {
+  return Boolean(
+    !pRule.to.dependencyTypesNot ||
+      !intersects(pDependency.dependencyTypes, pRule.to.dependencyTypesNot)
+  );
+}
+
 function toLicense(pRule, pDependency) {
   return Boolean(
     !pRule.to.license ||
@@ -127,6 +134,7 @@ module.exports = {
   toPathNot,
   toModulePathNot,
   toDependencyTypes,
+  toDependencyTypesNot,
   toLicense,
   toLicenseNot,
   toExoticRequire,

--- a/test/validate/fixtures/rules.only-to-core.allowed-with-forbidden.json
+++ b/test/validate/fixtures/rules.only-to-core.allowed-with-forbidden.json
@@ -1,0 +1,12 @@
+{
+  "forbidden": [
+    {
+      "name": "only-to-core",
+      "severity": "error",
+      "from": {},
+      "to": {
+        "dependencyTypesNot": ["core"]
+      }
+    }
+  ]
+}

--- a/test/validate/fixtures/rules.only-to-type-only.allowed-with-forbidden.json
+++ b/test/validate/fixtures/rules.only-to-type-only.allowed-with-forbidden.json
@@ -1,0 +1,12 @@
+{
+  "forbidden": [
+    {
+      "name": "only-to-type-only",
+      "severity": "error",
+      "from": {},
+      "to": {
+        "dependencyTypesNot": ["type-only"]
+      }
+    }
+  ]
+}

--- a/test/validate/index.spec.mjs
+++ b/test/validate/index.spec.mjs
@@ -206,6 +206,73 @@ describe("validate/index - specific tests", () => {
     ).to.deep.equal({ valid: true });
   });
 
+  it("only to core - with dependencyTypesNot in forbidden - ok", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.only-to-core.allowed-with-forbidden.json"
+        ),
+        { source: "koos koets" },
+        { resolved: "os", dependencyTypes: ["core"] }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("only to core - with dependencyTypesNot in forbidden - nok", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.only-to-core.allowed-with-forbidden.json"
+        ),
+        { source: "koos koets" },
+        { resolved: "robbie kerkhof", dependencyTypes: ["local"] }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [
+        {
+          name: "only-to-core",
+          severity: "error",
+        },
+      ],
+    });
+  });
+
+  it("only to type-only - with dependencyTypesNot in forbidden, multiple types - ok", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.only-to-type-only.allowed-with-forbidden.json"
+        ),
+        { source: "src/koos-koets.ts" },
+        {
+          resolved: "src/robbie-kerkhof.ts",
+          dependencyTypes: ["type-only", "local"],
+        }
+      )
+    ).to.deep.equal({ valid: true });
+  });
+
+  it("only to type-only - with dependencyTypesNot in forbidden, multiple types - nok", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.only-to-type-only.allowed-with-forbidden.json"
+        ),
+        { source: "src/koos-koets.ts" },
+        { resolved: "src/ger-hekking.ts", dependencyTypes: ["local"] }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [
+        {
+          name: "only-to-type-only",
+          severity: "error",
+        },
+      ],
+    });
+  });
+
   it("only to core - via 'allowed' - violation", () => {
     expect(
       validate.dependency(

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -103,6 +103,15 @@ export default {
             $ref: "#/definitions/DependencyTypeType",
           },
         },
+        dependencyTypesNot: {
+          type: "array",
+          description:
+            "Whether or not to match modules NOT of any of these types (leaving out " +
+            "matches none of them)",
+          items: {
+            $ref: "#/definitions/DependencyTypeType",
+          },
+        },
         moreThanOneDependencyType: {
           type: "boolean",
           description:

--- a/types/restrictions.d.ts
+++ b/types/restrictions.d.ts
@@ -72,6 +72,11 @@ export interface IToRestriction extends IBaseRestrictionType {
    */
   dependencyTypes?: DependencyType[];
   /**
+   * Whether or not to match modules NOT of any of these types (leaving out
+   * matches none of them)"
+   */
+  dependencyTypesNot?: DependencyType[];
+  /**
    * If true matches dependencies with more than one dependency type (e.g. defined in
    * _both_ npm and npm-dev)
    */


### PR DESCRIPTION
## Description

- Adds a dependencyTypesNot restriction (counterpart of the dependencyTypes restriction)


E.g. if you want to only allow dependencies to node core modules, you could use a rule like this:

```javascript
{
  forbidden: [
    {
      "name": "only-to-core",
      "severity": "error",
      "from": {},
      "to": {
        "dependencyTypesNot": ["core"]
      }
    }
  ]
}
```

This was already possible with a rule in the section of `allowed` rules ...

```javascript
{
  allowed: [
    {
      "name": "only-to-core",
      "from": {},
      "to": {
        "dependencyTypes": ["core"]
      }
    }
  ],
  allowedSeverity: "error"
}
```

... but 'allowed' rules are a bit tricky to work with when you're used to the 'forbidden' pattern that most linters use. Moreover  dependencyTypesNot restrictions can be useful in 'allowed' rules too.

## Motivation and Context

Fixes #516 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests
- [x] manual sanity check

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
