### PR TITLE
Adding Vue3 @vue/compiler-sfc support

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -298,9 +298,11 @@ situations without workarounds).
 
 **A**: Yes.
 
-For `.vue` single file components it uses the `vue-template-compiler` (which will
-be in your module dependencies if you're developing with Vue - just make sure
-you install dependency-cruiser in the same spot).
+For `.vue` single file components it uses _either_ the `vue-template-compiler` (Vue2) or `@vue/compiler-sfc` (Vue3).
+
+`vue-template-compiler` should be in your module dependencies already if you are developing with Vue2 - just make sure you install dependency-cruiser in the same place.
+
+`@vue/compiler-sfc` is [included by default in Vue 3 projects since version 3.2.13](https://github.com/vuejs/vue-next/tree/master/packages/compiler-sfc#vuecompiler-sfc). If you are using an older version of Vue 3, you may have to add `@vue/compiler-sfc` manually.
 
 ### Q: Does this work with Svelte as well?
 

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@swc/core": "1.2.98",
     "@typescript-eslint/eslint-plugin": "5.0.0",
     "@typescript-eslint/parser": "5.0.0",
+    "@vue/compiler-sfc": "3.2.20",
     "c8": "7.10.0",
     "chai": "4.3.4",
     "chai-json-schema": "1.5.1",
@@ -179,9 +180,10 @@
     "intercept-stdout": "0.1.2",
     "lint-staged": "11.2.3",
     "mocha": "9.1.3",
-    "normalize-newline": "4.1.0",
+    "normalize-newline": "^3.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.4.1",
+    "proxyquire": "2.1.3",
     "shx": "0.3.3",
     "svelte": "3.43.2",
     "symlink-dir": "5.0.1",
@@ -246,7 +248,8 @@
     "svelte": ">=3.0.0 <4.0.0",
     "swc": ">=1.0.0 <2.0.0",
     "typescript": ">=2.0.0 <5.0.0",
-    "vue-template-compiler": ">=2.0.0 <3.0.0"
+    "vue-template-compiler": ">=2.0.0 <3.0.0",
+    "@vue/compiler-sfc": ">=3.0.0 <4.0.0"
   },
   "husky": {
     "hooks": {

--- a/src/extract/transpile/jsx-implementation-rationale.md
+++ b/src/extract/transpile/jsx-implementation-rationale.md
@@ -60,6 +60,6 @@ seems to perform pretty ok, but a more elegant solution is welcome.
 
 ## Single File Components (SFC)
 
-For these we can use the vue-template-compiler - which seems to do a clean and consistent job -
+For these we can use the vue-template-compiler (Vue2) or @vue/compiler-sfc (Vue3) - which seems to do a clean and consistent job -
 it splits the _template_, _script_, _style_ etc parts in an object, and these can be parsed
 individually. Implementation in `vue-template-wrap.js`

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -39,6 +39,7 @@ const TRANSPILER2WRAPPER = {
   swc,
   typescript: typeScriptWrap,
   "vue-template-compiler": vueWrap,
+  "@vue/compiler-sfc": vueWrap,
 };
 
 const BABELEABLE_EXTENSIONS = [

--- a/src/extract/transpile/vue-template-wrap.js
+++ b/src/extract/transpile/vue-template-wrap.js
@@ -1,15 +1,58 @@
+const isEmpty = require("lodash/isEmpty");
 const _get = require("lodash/get");
 const tryRequire = require("semver-try-require");
 const { supportedTranspilers } = require("../../../src/meta.js");
 
-const vueTemplateCompiler = tryRequire(
-  "vue-template-compiler",
-  supportedTranspilers["vue-template-compiler"]
-);
+/*
+ * vue-template-compiler was replaced by @vue/compiler-sfc for Vue3.
+ *
+ * if your project uses Vue3, then trying to require vue-template-compiler will
+ * cause an incompatibility error - so try @vue/compiler-sfc (which is Vue3's
+ * version of vue-template-compiler) if the first one fails
+ */
+function getVueTemplateCompiler() {
+  let lIsVue3 = false;
+
+  let lCompiler = tryRequire(
+    "vue-template-compiler",
+    supportedTranspilers["vue-template-compiler"]
+  );
+
+  if (lCompiler === false) {
+    lCompiler = tryRequire(
+      "@vue/compiler-sfc",
+      supportedTranspilers["@vue/compiler-sfc"]
+    );
+    lIsVue3 = true;
+  }
+
+  return { lCompiler, lIsVue3 };
+}
+
+const { lCompiler: vueTemplateCompiler, lIsVue3: isVue3 } =
+  getVueTemplateCompiler();
+
+function vue3Transpile(pSource) {
+  const parsedComponent = vueTemplateCompiler.parse(pSource);
+  const errors = _get(parsedComponent, "errors");
+
+  if (!isEmpty(errors)) {
+    return "";
+  }
+
+  return _get(parsedComponent, "descriptor.script.content", "");
+}
+
+function vue2Transpile(pSource) {
+  return _get(
+    vueTemplateCompiler.parseComponent(pSource),
+    "script.content",
+    ""
+  );
+}
 
 module.exports = {
   isAvailable: () => vueTemplateCompiler !== false,
-
   transpile: (pSource) =>
-    _get(vueTemplateCompiler.parseComponent(pSource), "script.content", ""),
+    isVue3 ? vue3Transpile(pSource) : vue2Transpile(pSource),
 };

--- a/src/meta.js
+++ b/src/meta.js
@@ -14,5 +14,6 @@ module.exports = {
     swc: ">=1.0.0 <2.0.0",
     typescript: ">=2.0.0 <5.0.0",
     "vue-template-compiler": ">=2.0.0 <3.0.0",
+    "@vue/compiler-sfc": ">=3.0.0 <4.0.0",
   },
 };

--- a/test/extract/transpile/meta.spec.mjs
+++ b/test/extract/transpile/meta.spec.mjs
@@ -113,6 +113,11 @@ describe("extract/transpile/meta", () => {
         version: ">=2.0.0 <3.0.0",
         available: true,
       },
+      {
+        name: "@vue/compiler-sfc",
+        version: ">=3.0.0 <4.0.0",
+        available: true,
+      },
     ]);
   });
 });

--- a/test/extract/transpile/vue3-template-wrap.spec.js
+++ b/test/extract/transpile/vue3-template-wrap.spec.js
@@ -1,0 +1,56 @@
+const readFileSync = require("fs").readFileSync;
+const join = require("path").join;
+const expect = require("chai").expect;
+const normalizeNewline = require("normalize-newline");
+
+// declare proxyquire, and ensure it doesn't load modules from cache
+// see https://github.com/thlorenz/proxyquire#forcing-proxyquire-to-reload-modules
+const proxyquire = require("proxyquire").noPreserveCache();
+
+// instead of requiring the module under test, proxyquire it
+const wrap = proxyquire.load(
+  "../../../src/extract/transpile/vue-template-wrap.js",
+  {
+    // Force the tryRequire on "vue-template-compiler" to fail
+    // so that we ensure we are using Vue 3 for this test
+    "semver-try-require": (pModuleName) =>
+      pModuleName === "vue-template-compiler"
+        ? false
+        : // eslint-disable-next-line node/global-require
+          require("@vue/compiler-sfc"),
+  }
+);
+
+describe("vue transpiler", () => {
+  it("extracts the script content from a vue SFC", () => {
+    expect(
+      normalizeNewline(
+        wrap.transpile(
+          readFileSync(join(__dirname, "fixtures/vue.vue"), "utf8")
+        )
+      )
+    ).to.equal(
+      normalizeNewline(readFileSync(join(__dirname, "fixtures/vue.js"), "utf8"))
+    );
+  });
+
+  it("returns the empty string from a vue SFC without a script part", () => {
+    expect(
+      normalizeNewline(
+        wrap.transpile(
+          readFileSync(join(__dirname, "fixtures/vue-noscript.vue"), "utf8")
+        )
+      )
+    ).to.equal(normalizeNewline(""));
+  });
+
+  it("handles invalid vue (silently - for backwards compatibility with Vue 2)", () => {
+    expect(
+      normalizeNewline(
+        wrap.transpile(
+          readFileSync(join(__dirname, "fixtures/vue-invalid.vue"), "utf8")
+        )
+      )
+    ).to.equal(normalizeNewline(""));
+  });
+});


### PR DESCRIPTION
If you are using Vue3, you might include packages that are incompatible with vue-template-compiler, causing the "isAvailable" function for Vue SFCs to return false. Now, if vue-template-compiler fails to load, we go ahead and try @vue/compiler-sfc as well, in case we have that instead..


## Description

Added a different Vue single file component transpiler, following the pattern of what was done with coffeescript modules. 

## Motivation and Context

I want to use dependency-cruiser with my project that includes Vue3 files, but when it checks for available transpilers, `require`ing "vue-template-compiler" errors out because of incompatibility. I added a compatible Vue 3 single file component transpiler that is used if the first one doesn't work.

## How Has This Been Tested?

All existing Vue unit tests still pass. I've also added a new test file, vue3-template-wrap.spec.js, that runs the same tests as the existing file, but it "hides" the "vue-template-compiler" which forces the code to use the Vue3 transpiler. Thanks @sverweij for your help with this!!

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
