### PR TITLE
bugfix(extract): consistently treat .d.ts as a separate extension (BREAKING CHANGE)

### DIFF
--- a/src/extract/utl/get-extension.js
+++ b/src/extract/utl/get-extension.js
@@ -5,16 +5,20 @@ const path = require("path");
  *
  * Just using path.extname would be fine for most cases,
  * except for coffeescript, where a markdown extension can
- * mean literate coffeescript.
+ * mean literate coffeescript, and for typescript where
+ * .d.ts and .ts are slightly different beasts
  *
  * @param {string} pFileName path to the file to be parsed
  * @return {string}          extension
  */
 module.exports = function getExtensions(pFileName) {
-  let lReturnValue = path.extname(pFileName);
-
-  if (lReturnValue === ".md") {
-    return pFileName.endsWith(".coffee.md") ? ".coffee.md" : lReturnValue;
+  if (pFileName.endsWith(".d.ts")) {
+    return ".d.ts";
   }
-  return lReturnValue;
+
+  if (pFileName.endsWith(".coffee.md")) {
+    return ".coffee.md";
+  }
+
+  return path.extname(pFileName);
 };

--- a/test/extract/utl/get-extension.spec.mjs
+++ b/test/extract/utl/get-extension.spec.mjs
@@ -10,6 +10,14 @@ describe("extract/utl/getExtension", () => {
     expect(getExtension("./aap/noot/mies.tes.md")).to.equal(".md");
   });
 
+  it("types.d.ts classifies as .d.ts", () => {
+    expect(getExtension("./types/types.d.ts")).to.equal(".d.ts");
+  });
+
+  it("any extension (e.g. .ts) classifies as that", () => {
+    expect(getExtension("./types/typed.ts")).to.equal(".ts");
+  });
+
   it("any extension (e.g. .js) classifies as that", () => {
     expect(getExtension("./aap/noot/mies.js")).to.equal(".js");
   });

--- a/types/baseline-violations.d.ts
+++ b/types/baseline-violations.d.ts
@@ -1,3 +1,3 @@
-import { IViolation } from "./cruise-result";
+import { IViolation } from "./violations";
 
 export type IBaselineViolations = IViolation[];

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -1,11 +1,8 @@
 import { ICruiseOptions } from "./options";
 import { IFlattenedRuleSet } from "./rule-set";
-import {
-  DependencyType,
-  ModuleSystemType,
-  SeverityType,
-  ProtocolType,
-} from "./shared-types";
+import { DependencyType, ModuleSystemType, ProtocolType } from "./shared-types";
+import { IViolation } from "./violations";
+import { IRuleSummary } from "./rule-summary";
 
 export interface ICruiseResult {
   /**
@@ -226,27 +223,6 @@ export interface IDependency {
   valid: boolean;
 }
 
-/**
- * If there was a rule violation (valid === false), this object contains the name of the
- * rule and severity of violating it.
- */
-export interface IRuleSummary {
-  /**
-   * The (short, eslint style) name of the violated rule. Typically something like
-   * 'no-core-punycode' or 'no-outside-deps'.
-   */
-  name: string;
-  /**
-   * How severe a violation of a rule is. The 'error' severity will make some reporters return
-   * a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated:
-   * use that. The absence of the 'ignore' severity here is by design; ignored rules don't
-   * show up in the output.
-   *
-   * Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
-   */
-  severity: SeverityType;
-}
-
 export interface IReachable {
   /**
    * The name of the rule where the reachability was defined
@@ -389,29 +365,6 @@ export interface IWebpackConfig {
  */
 export type WebpackEnvType = { [key: string]: any } | string;
 
-export interface IViolation {
-  /**
-   * The violated rule
-   */
-  rule: IRuleSummary;
-  /**
-   * The from part of the dependency this violation is about
-   */
-  from: string;
-  /**
-   * The to part of the dependency this violation is about
-   */
-  to: string;
-  /**
-   * The circular path if the violation is about circularity
-   */
-  cycle?: string[];
-  /**
-   * The path from the from to the to if the violation is transitive
-   */
-  via?: string[];
-}
-
 export interface IFolder {
   /**
    * The name of the folder. FOlder names are normalized to posix (so
@@ -455,3 +408,6 @@ export interface IFolder {
    */
   instability?: number;
 }
+
+export * from "./violations";
+export * from "./rule-summary";

--- a/types/rule-summary.d.ts
+++ b/types/rule-summary.d.ts
@@ -1,0 +1,23 @@
+import { SeverityType } from "./shared-types";
+
+/**
+ * If there was a rule violation (valid === false), this object contains the name of the
+ * rule and severity of violating it.
+ */
+
+export interface IRuleSummary {
+  /**
+   * The (short, eslint style) name of the violated rule. Typically something like
+   * 'no-core-punycode' or 'no-outside-deps'.
+   */
+  name: string;
+  /**
+   * How severe a violation of a rule is. The 'error' severity will make some reporters return
+   * a non-zero exit code, so if you want e.g. a build to stop when there's a rule violated:
+   * use that. The absence of the 'ignore' severity here is by design; ignored rules don't
+   * show up in the output.
+   *
+   * Severity to use when a dependency is not in the 'allowed' set of rules. Defaults to 'warn'
+   */
+  severity: SeverityType;
+}

--- a/types/violations.d.ts
+++ b/types/violations.d.ts
@@ -1,0 +1,24 @@
+import { IRuleSummary } from "./rule-summary";
+
+export interface IViolation {
+  /**
+   * The violated rule
+   */
+  rule: IRuleSummary;
+  /**
+   * The from part of the dependency this violation is about
+   */
+  from: string;
+  /**
+   * The to part of the dependency this violation is about
+   */
+  to: string;
+  /**
+   * The circular path if the violation is about circularity
+   */
+  cycle?: string[];
+  /**
+   * The path from the from to the to if the violation is transitive
+   */
+  via?: string[];
+}


### PR DESCRIPTION
## Motivation/ description
This fixes the following bug:

> ### Steps taken
> - take 2 .d.ts modules where the one includes the other (one.d.ts => two.d.ts)
> - set the options.enhancedResolveOptions.extensions to [".d.ts"] (so DONOT include ".ts")
> - cruise
> 
> ### Expected
> two.d.ts is a dependency of one.d.ts
> two.d.ts' 'followable' attribute equals true
> 
> ### Found
> two.d.ts is a dependency of one.d.ts (OK)
> two.d.ts' 'followable' attribute equals false (KO)
> 
> ### Background
> 
> Before this bugfix the code determining whether an extension was followable looked
> at the extensions array and compared them with the path.extname (except for .coffee.md
> which is simmilarly weird). As ".ts" !== ".d.ts" followable
> 
> A ripple effect was that .d.ts dependencies were 'completed' into the module graph as
> modules without dependencies of themselves. Often they then popped up a second time
> with a bunch of dependencies of their own, so there were _two_ of them in the resulting
> module graph. Which is confusing when you do a modules.find and the first,
> dependency-less .d.ts shows up only.
> 
> ### Severity
> 
> The amount of repo's that (1) define an array of enhancedResolveOptions.extensions and
> (2) _only_ have .d.ts in there and no .ts is likely not too big (dependency-crduiser
> itself was one of them, though) - but it's a breaking change nonetheless, as e.g.
> the cyclic dependency-algorithm now will find more.

## Breaking change

Only when you ...
- .. use the `options. enhancedResolveOptions.extensions` array to determine what dependency-cruiser/ enhanced-resolve should use for extensions AND
- _do_ specify `.d.ts` in that array but _not_ `.ts`


## How Has This Been Tested?

- [x] automated non-regression tests, green ci
- [x] additional unit tests


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
