### PR TITLE
perf(enrich): use different caching strategy for finding modules by name

### DIFF
--- a/src/enrich/derive/utl.js
+++ b/src/enrich/derive/utl.js
@@ -1,13 +1,25 @@
-const _memoize = require("lodash/memoize");
+let gIndexedGraph = null;
 
-function bareFindModuleByName(pGraph, pSource) {
-  return pGraph.find((pNode) => pNode.source === pSource);
+/**
+ * Returns the module with attribute pSource, when it exists in the pModuleGraph.
+ * Returns undefined when it doesn't.
+ *
+ * This function uses an indexed cache for efficiency reasons. If you need to
+ * call this function consecutively for different module graphs, you can clear
+ * this cache with the clearCache function from this module.
+ *
+ * @param {import('../../../types/cruise-result').IModule[]} pModuleGraph
+ * @param {string} pSource
+ * @returns {import('../../../types/cruise-result').IModule | undefined}
+ */
+function findModuleByName(pModuleGraph, pSource) {
+  if (!gIndexedGraph) {
+    gIndexedGraph = new Map(
+      pModuleGraph.map((pModule) => [pModule.source, pModule])
+    );
+  }
+  return gIndexedGraph.get(pSource);
 }
-
-const findModuleByName = _memoize(
-  bareFindModuleByName,
-  (_pGraph, pSource) => pSource
-);
 
 function isDependent(pResolvedName) {
   return (pModule) =>
@@ -17,7 +29,11 @@ function isDependent(pResolvedName) {
 }
 
 function clearCache() {
-  findModuleByName.cache.clear();
+  gIndexedGraph = null;
 }
 
-module.exports = { findModuleByName, clearCache, isDependent };
+module.exports = {
+  findModuleByName,
+  clearCache,
+  isDependent,
+};


### PR DESCRIPTION
## Description, Motivation and Context

Improves performance/ eases code understandability.

### Situation before this PR

On each call to findModuleByName
- it gets the module from the (memoize) cache. If it's not in the cache yet ....
- ... the module is searched with a linear search (Array.find - which is O(N))

This means a lot of O(N) calls before the memoize cache is filled.

### Situation after this PR

- The modulegraph gets cached on the first call (which is O(N))
- All subsequent lookups come from the cache (currently a map with the module name as index)

This should in theory be faster, especially for seriously large dependency-graphs with a memory footprint comparable to the situation before this PR (memoize builds a cache as well and in the end of the run is comparably large as the cache built on the first call).

### What does the non-regression loadtest say?

Just non-regression, surprisingingly. Probably need to run the test with a larger graph (e.g.
lot more than 471 modules, 1123 dependencies - which takes ~2s on a quad core i7 2.6Ghz on which
MacOS is ruining).

## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] performance non-regression test (`npm run test:load`)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
