### PR TITLE
bugfix(schema|types): adds metrics flag to options schema

### DIFF
--- a/src/schema/configuration.schema.js
+++ b/src/schema/configuration.schema.js
@@ -348,6 +348,7 @@ module.exports = {
             },
           },
         },
+        metrics: { type: "boolean" },
         baseDir: { type: "string" },
       },
     },

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -551,6 +551,10 @@
             }
           }
         },
+        "metrics": {
+          "type": "boolean",
+          "description": "When this flag is set to true, dependency-cruiser will calculate (stability) metrics for all modules and folders. Defaults to false."
+        },
         "baseDir": {
           "type": "string",
           "description": "The directory dependency-cruiser should run its cruise from. Defaults to the current working directory."

--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -496,6 +496,7 @@ module.exports = {
             },
           },
         },
+        metrics: { type: "boolean" },
         baseDir: { type: "string" },
         args: { type: "string" },
         rulesFile: { type: "string" },

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -876,6 +876,10 @@
             }
           }
         },
+        "metrics": {
+          "type": "boolean",
+          "description": "When this flag is set to true, dependency-cruiser will calculate (stability) metrics for all modules and folders. Defaults to false."
+        },
         "baseDir": {
           "type": "string",
           "description": "The directory dependency-cruiser should run its cruise from. Defaults to the current working directory."

--- a/tools/schema/options.mjs
+++ b/tools/schema/options.mjs
@@ -315,6 +315,12 @@ export default {
             },
           },
         },
+        metrics: {
+          type: "boolean",
+          description:
+            "When this flag is set to true, dependency-cruiser will calculate (stability) metrics " +
+            "for all modules and folders. Defaults to false.",
+        },
         baseDir: {
           type: "string",
           description:

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -239,4 +239,9 @@ export interface ICruiseOptions {
      */
     type: ProgressType;
   };
+  /**
+   * When this flag is set to true, dependency-cruiser will calculate (stability) metrics
+   * for all modules and folders. Defaults to false.
+   */
+  metrics?: boolean;
 }


### PR DESCRIPTION
## Description, Motivation and Context

they were missing

## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] manual: autocomplete in editor

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
