### PR TITLE
refactor: normalize 'options.metrics' in the normalization step instead of down the line

### DIFF
--- a/src/enrich/derive/metrics/folder.js
+++ b/src/enrich/derive/metrics/folder.js
@@ -1,8 +1,7 @@
 const getStabilityMetrics = require("./get-stability-metrics");
-const { shouldDeriveMetrics } = require("./utl");
 
 module.exports = function deriveMetrics(pModules, pOptions) {
-  if (shouldDeriveMetrics(pOptions)) {
+  if (pOptions.metrics) {
     return { folders: getStabilityMetrics(pModules) };
   }
   return {};

--- a/src/enrich/derive/metrics/get-stability-metrics.js
+++ b/src/enrich/derive/metrics/get-stability-metrics.js
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
 const path = require("path").posix;
-const { foldersObject2folderArray, getParentFolders } = require("./utl");
+const { object2Array, getParentFolders } = require("./utl");
 const {
   getAfferentCouplings,
   getEfferentCouplings,
@@ -63,8 +63,8 @@ function getFolderLevelCouplings(pCouplingArray) {
 }
 
 function calculateFolderMetrics(pFolder) {
-  const lModuleDependents = foldersObject2folderArray(pFolder.dependents);
-  const lModuleDependencies = foldersObject2folderArray(pFolder.dependencies);
+  const lModuleDependents = object2Array(pFolder.dependents);
+  const lModuleDependencies = object2Array(pFolder.dependencies);
   const lAfferentCouplings = lModuleDependents.reduce(sumCounts, 0);
   const lEfferentCouplings = lModuleDependencies.reduce(sumCounts, 0);
 
@@ -83,7 +83,7 @@ function calculateFolderMetrics(pFolder) {
 }
 
 module.exports = function getStabilityMetrics(pModules) {
-  return foldersObject2folderArray(
+  return object2Array(
     pModules.filter(metricsAreCalculable).reduce((pAllFolders, pModule) => {
       getParentFolders(path.dirname(pModule.source)).forEach(
         (pParentDirectory) =>

--- a/src/enrich/derive/metrics/module.js
+++ b/src/enrich/derive/metrics/module.js
@@ -1,9 +1,8 @@
 // const { findModuleByName, clearCache } = require("../utl");
 const { metricsAreCalculable } = require("./module-utl");
-const { shouldDeriveMetrics } = require("./utl");
 
 module.exports = function deriveModuleMetrics(pModules, pOptions) {
-  if (shouldDeriveMetrics(pOptions)) {
+  if (pOptions.metrics) {
     return pModules.map((pModule) => ({
       ...pModule,
       ...(metricsAreCalculable(pModule)

--- a/src/enrich/derive/metrics/utl.js
+++ b/src/enrich/derive/metrics/utl.js
@@ -10,19 +10,14 @@ function getParentFolders(pPath) {
   return lReturnValue.reverse();
 }
 
-function foldersObject2folderArray(pObject) {
+function object2Array(pObject) {
   return Object.keys(pObject).map((pKey) => ({
     name: pKey,
     ...pObject[pKey],
   }));
 }
 
-function shouldDeriveMetrics(pOptions) {
-  return pOptions.metrics || pOptions.outputType === "metrics";
-}
-
 module.exports = {
   getParentFolders,
-  foldersObject2folderArray,
-  shouldDeriveMetrics,
+  object2Array,
 };

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -101,6 +101,8 @@ function normalizeCruiseOptions(pOptions) {
       lReturnValue.reporterOptions
     );
   }
+  lReturnValue.metrics = pOptions.metrics || pOptions.outputType === "metrics";
+
   return lReturnValue;
 }
 

--- a/test/enrich/derive/metrics/folder.spec.mjs
+++ b/test/enrich/derive/metrics/folder.spec.mjs
@@ -10,10 +10,4 @@ describe("enrich/derive/metrics/folder - folder stability metrics derivation", (
   it("emits folders when we're asking for metrics", () => {
     expect(deriveFolders([], { metrics: true })).to.deep.equal({ folders: [] });
   });
-
-  it("emits folders when we're asking for outputType === metrics", () => {
-    expect(deriveFolders([], { outputType: "metrics" })).to.deep.equal({
-      folders: [],
-    });
-  });
 });

--- a/test/enrich/derive/metrics/utl.spec.mjs
+++ b/test/enrich/derive/metrics/utl.spec.mjs
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import {
   getParentFolders,
-  foldersObject2folderArray,
+  object2Array,
 } from "../../../../src/enrich/derive/metrics/utl.js";
 
 describe("enrich/derive/metrics/utl - getParentFolders", () => {
@@ -20,18 +20,16 @@ describe("enrich/derive/metrics/utl - getParentFolders", () => {
 
 describe("enrich/derive/metrics/utl - foldersObject2folderArray", () => {
   it("no folders in object => empty array", () => {
-    expect(foldersObject2folderArray({})).to.deep.equal([]);
+    expect(object2Array({})).to.deep.equal([]);
   });
 
   it("slaps keys into a name attribute in objects", () => {
-    expect(foldersObject2folderArray({ thename: {} })).to.deep.equal([
-      { name: "thename" },
-    ]);
+    expect(object2Array({ thename: {} })).to.deep.equal([{ name: "thename" }]);
   });
 
   it("slaps keys into a name attribute in objects (multiple)", () => {
     expect(
-      foldersObject2folderArray({
+      object2Array({
         "folder/one": {},
         "folder/two": { attribute: "yes" },
       })


### PR DESCRIPTION
## Description, Motivation and Context

Puts normalization where it belongs - freeing all other code from having to do the same


## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] manual run

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
