### PR TITLE
feature(validate): adds moreUnstable attribute to enforce stable dependencies

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -72,6 +72,366 @@
     }
   },
   {
+    "from": "src/config-utl/extract-depcruise-config/index.js",
+    "to": "src/config-utl/extract-depcruise-config/merge-configs.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/enrich/derive/metrics/folder.js",
+    "to": "src/enrich/derive/metrics/get-stability-metrics.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/enrich/index.js",
+    "to": "src/enrich/enrich-modules.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/enrich/summarize/index.js",
+    "to": "src/enrich/summarize/add-rule-set-used.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/enrich/summarize/index.js",
+    "to": "src/enrich/summarize/summarize-modules.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/enrich/summarize/index.js",
+    "to": "src/enrich/summarize/summarize-options.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/ast-extractors/extract-swc-deps.js",
+    "to": "src/extract/ast-extractors/swc-dependency-visitor.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/clear-caches.js",
+    "to": "src/extract/resolve/resolve-amd.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/index.js",
+    "to": "src/extract/clear-caches.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/index.js",
+    "to": "src/extract/gather-initial-sources.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/index.js",
+    "to": "src/extract/get-dependencies.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/resolve/get-manifest/index.js",
+    "to": "src/extract/resolve/get-manifest/merge-manifests.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/resolve/resolve-helpers.js",
+    "to": "src/extract/resolve/external-module-helpers.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/extract/transpile/index.js",
+    "to": "src/extract/transpile/meta.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/graph-utl/consolidate-to-folder.js",
+    "to": "src/graph-utl/consolidate-module-dependencies.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/graph-utl/consolidate-to-folder.js",
+    "to": "src/graph-utl/consolidate-modules.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/graph-utl/consolidate-to-pattern.js",
+    "to": "src/graph-utl/consolidate-module-dependencies.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/graph-utl/consolidate-to-pattern.js",
+    "to": "src/graph-utl/consolidate-modules.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/index.js",
+    "to": "src/enrich/index.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/index.js",
+    "to": "src/extract/index.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/index.js",
+    "to": "src/extract/transpile/meta.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/index.js",
+    "to": "src/main/options/validate.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/index.js",
+    "to": "src/main/report-wrap.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/index.js",
+    "to": "src/main/rule-set/validate.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/options/normalize.js",
+    "to": "src/main/utl/normalize-re-properties.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/options/validate.js",
+    "to": "src/report/index.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/resolve-options/normalize.js",
+    "to": "src/extract/transpile/meta.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/main/rule-set/normalize.js",
+    "to": "src/main/utl/normalize-re-properties.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/report/dot/index.js",
+    "to": "src/report/dot/prepare-custom-level.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/report/dot/index.js",
+    "to": "src/report/dot/prepare-flat-level.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/report/dot/index.js",
+    "to": "src/report/dot/prepare-folder-level.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/report/dot/module-utl.js",
+    "to": "src/report/dot/theming.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/report/error-long.js",
+    "to": "src/report/error.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/validate/index.js",
+    "to": "src/validate/match-dependency-rule.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/validate/index.js",
+    "to": "src/validate/match-module-rule.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "src/validate/index.js",
+    "to": "src/validate/violates-required-rule.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "test/extract/ast-extractors/extract-typescript.utl.mjs",
+    "to": "src/extract/ast-extractors/extract-typescript-deps.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "test/extract/ast-extractors/extract-typescript.utl.mjs",
+    "to": "src/extract/parse/to-typescript-ast.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "test/extract/ast-extractors/extract-with-swc.utl.mjs",
+    "to": "src/extract/ast-extractors/extract-swc-deps.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "test/extract/ast-extractors/extract-with-swc.utl.mjs",
+    "to": "src/extract/parse/to-swc-ast.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "test/validate/readruleset.utl.mjs",
+    "to": "src/main/rule-set/normalize.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "test/validate/readruleset.utl.mjs",
+    "to": "src/main/rule-set/validate.js",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "tools/schema/rule-set.mjs",
+    "to": "tools/schema/restrictions.mjs",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "tools/schema/summary.mjs",
+    "to": "tools/schema/options-used.mjs",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
+    "from": "types/rule-set.d.ts",
+    "to": "types/restrictions.d.ts",
+    "rule": {
+      "severity": "info",
+      "name": "SDP"
+    }
+  },
+  {
     "from": "src/utl/array-util.js",
     "to": "src/utl/array-util.js",
     "rule": {

--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -228,6 +228,17 @@
       "severity": "info",
       "from": { "path": "^src" },
       "module": { "path": "^src/utl", "numberOfDependentsLessThan": 3 }
+    },
+    {
+      "name": "SDP",
+      "severity": "info",
+      "comment": "This module violates the 'stable dependencies' principle; it depends on a module that is likely to be more prone to changes than it is itself. Consider refactoring. ",
+      "from": {
+        "pathNot": "^test/"
+      },
+      "to": {
+        "moreUnstable": true
+      }
     }
   ],
   "options": {
@@ -435,8 +446,9 @@
         }
       },
       "metrics": {
-        "orderBy": "instability",
-        "hideModules": true
+        "orderBy": "name",
+        "hideModules": false,
+        "hideFolders": true
       },
       "anon": {
         "wordlist": [

--- a/configs/.dependency-cruiser-show-metrics-config.json
+++ b/configs/.dependency-cruiser-show-metrics-config.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "../src/schema/configuration.schema.json",
+  "extends": "../.dependency-cruiser.json",
+  "options": {
+    "reporterOptions": {
+      "dot": {
+        "collapsePattern": ["^src/report/[^/]+"],
+        "filters": {
+          "includeOnly": { "path": "^(src|bin)" },
+          "exclude": { "path": ["^src/meta\\.js$", "^src/utl/bus.+"] }
+        },
+        "showMetrics": true,
+        "theme": {
+          "replace": false,
+          "graph": {
+            "splines": "ortho"
+          },
+          "modules": [
+            {
+              "criteria": { "source": "^src/cli" },
+              "attributes": { "fillcolor": "#ccccff" }
+            },
+            {
+              "criteria": { "source": "^src/config-utl" },
+              "attributes": { "fillcolor": "#99ffff" }
+            },
+            {
+              "criteria": { "source": "^src/report" },
+              "attributes": { "fillcolor": "#ffccff" }
+            },
+            {
+              "criteria": { "source": "^src/extract" },
+              "attributes": { "fillcolor": "#ccffcc" }
+            },
+            {
+              "criteria": { "source": "^src/enrich" },
+              "attributes": { "fillcolor": "#77eeaa" }
+            },
+            {
+              "criteria": { "source": "^src/validate" },
+              "attributes": { "fillcolor": "#ccccff" }
+            },
+            {
+              "criteria": { "source": "^src/main" },
+              "attributes": { "fillcolor": "#ffcccc" }
+            },
+            {
+              "criteria": { "source": "^src/utl" },
+              "attributes": { "fillcolor": "#cccccc" }
+            },
+            {
+              "criteria": { "source": "^src/graph-utl" },
+              "attributes": { "fillcolor": "#ffcccc" }
+            },
+            {
+              "criteria": {
+                "source": "^src/meta\\.js$|\\.template\\.js$|\\.schema\\.js$"
+              },
+              "attributes": { "style": "filled" }
+            },
+            {
+              "criteria": { "source": "\\.json$" },
+              "attributes": { "shape": "cylinder" }
+            }
+          ],
+          "dependencies": [
+            {
+              "criteria": { "rules[0].severity": "error" },
+              "attributes": { "fontcolor": "red", "color": "red" }
+            },
+            {
+              "criteria": { "rules[0].severity": "warn" },
+              "attributes": {
+                "fontcolor": "orange",
+                "color": "orange"
+              }
+            },
+            {
+              "criteria": { "rules[0].severity": "info" },
+              "attributes": { "fontcolor": "blue", "color": "blue" }
+            },
+            {
+              "criteria": { "valid": false },
+              "attributes": { "fontcolor": "red", "color": "red" }
+            },
+            {
+              "criteria": { "resolved": "^src/cli" },
+              "attributes": { "color": "#0000ff77" }
+            },
+            {
+              "criteria": { "resolved": "^src/config-utl" },
+              "attributes": { "color": "#22999977" }
+            },
+            {
+              "criteria": { "resolved": "^src/report" },
+              "attributes": { "color": "#ff00ff77" }
+            },
+            {
+              "criteria": { "resolved": "^src/extract" },
+              "attributes": { "color": "#00770077" }
+            },
+            {
+              "criteria": { "resolved": "^src/enrich" },
+              "attributes": { "color": "#00776677" }
+            },
+            {
+              "criteria": { "resolved": "^src/validate" },
+              "attributes": { "color": "#0000ff77" }
+            },
+            {
+              "criteria": { "resolved": "^src/main" },
+              "attributes": { "color": "#77000077" }
+            },
+            {
+              "criteria": { "resolved": "^src/utl" },
+              "attributes": { "color": "#aaaaaa77" }
+            },
+            {
+              "criteria": { "resolved": "^src/graph-utl" },
+              "attributes": { "color": "#77000077" }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -43,6 +43,7 @@
    - [`moreThanOneDependencyType`](#more-than-one-dependencytype-per-dependency-morethanonedependencytype)
    - [`exoticRequire` and `exoticRequireNot`](#exoticallyrequired-exoticrequire-and-exoticrequirenot)
    - [`preCompilationOnly`](#precompilationonly)
+   - [`moreUnstable`](#moreunstable)
 4. [Configurations in JavaScript](#configurations-in-javascript)
 
 ## The structure of a dependency cruiser configuration
@@ -1001,6 +1002,52 @@ make it beyond the pre-compilation step:
 
 :warning: This attribute only works for TypeScript sources, and only when
 [`tsPreCompilationDeps`](#tsprecompilationdeps) option is set to `"specify"`.
+
+### `moreUnstable`
+
+When set to true moreUnstable matches for any dependency that has a higher
+Instability than the module that depends on it. When set to false it matches
+when the opposite is true; the dependency has an equal or lower Instability.
+
+This attribute is useful when you want to check against Robert C. Martin's
+stable dependencies principle: "depend in the direction of stability". Martin
+defines Instability as a function of the number of dependents and dependencies
+a component has: Instability = #dependencies/ (#dependents + #dependencies).
+
+E.g. a module with no dependencies and one or more dependents has a Instability
+of 0%; as stable as it can get. Conversely a module with no dependents, but
+a one or more dependencies is 100% Instable.
+
+Instability has a bit of an unusual connotation here - it's not 'bad' to be
+an 100% Instable module - it's just the nature of the module. A CLI or GUI
+component typically only depends on other modules and is 100% Instable. This is
+not a bad thing
+
+Another way to look at Instability is how hard it is to change a module without
+consequences to other modules. Changing a 0% Instable module will typically have
+consequences for all its dependents. Making changes to a 100% Instable module
+will have consequences for itself only.
+
+To enforce/ find all modules that violate the stable dependencies principle
+(SDP) you can include a rule like this in the _forbidden_ section
+
+```javascript
+module.exports = {
+  forbidden: [
+    {
+      name: "SDP",
+      description:
+        "This module violates the 'stable dependencies' principle; it depends " +
+        "on a module that is likely to be more prone to changes than it is " +
+        "itself. Consider refactoring.",
+      from: {},
+      to: {
+        moreUnstable: true,
+      },
+    },
+  ],
+};
+```
 
 ## Configurations in JavaScript
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "depcruise:all": "node ./bin/dependency-cruise.js src bin test configs types tools --config",
     "depcruise:baseline": "node ./bin/depcruise-baseline.js src bin test configs types tools",
     "depcruise:explain": "node ./bin/dependency-cruise.js src bin test configs types tools --output-type err-long --config --progress none",
-    "depcruise:graph:dev": "node ./bin/dependency-cruise.js bin src --metrics --prefix vscode://file/$(pwd)/ --config --output-type dot --progress cli-feedback | dot -T svg | node ./bin/wrap-stream-in-html.js | browser",
+    "depcruise:graph:dev": "node ./bin/dependency-cruise.js bin src --prefix vscode://file/$(pwd)/ --config configs/.dependency-cruiser-show-metrics-config.json --output-type dot --progress cli-feedback | dot -T svg | node ./bin/wrap-stream-in-html.js | browser",
     "depcruise:graph:doc": "npm-run-all depcruise:graph:doc:json --parallel depcruise:graph:doc:fmt-* depcruise:graph:doc:samples",
     "depcruise:graph:doc:json": "node ./bin/dependency-cruise.js bin src test --config --output-type json --output-to tmp_graph_deps.json --progress",
     "depcruise:graph:doc:fmt-detail": "./bin/depcruise-fmt.js -T dot -f - tmp_graph_deps.json | dot -T svg | tee doc/real-world-samples/dependency-cruiser-without-node_modules.svg | node bin/wrap-stream-in-html.js > docs/dependency-cruiser-dependency-graph.html",

--- a/src/enrich/derive/metrics/module.js
+++ b/src/enrich/derive/metrics/module.js
@@ -1,9 +1,9 @@
-// const { findModuleByName, clearCache } = require("../utl");
+const { findModuleByName, clearCache } = require("../utl");
 const { metricsAreCalculable } = require("./module-utl");
 
 module.exports = function deriveModuleMetrics(pModules, pOptions) {
   if (pOptions.metrics) {
-    return pModules.map((pModule) => ({
+    const lModules = pModules.map((pModule) => ({
       ...pModule,
       ...(metricsAreCalculable(pModule)
         ? {
@@ -13,16 +13,16 @@ module.exports = function deriveModuleMetrics(pModules, pOptions) {
           }
         : {}),
     }));
-    // clearCache();
-    // return lModules.map((pModule) => ({
-    //   ...pModule,
-    //   dependencies: pModule.dependencies.map((pDependency) => ({
-    //     ...pDependency,
-    //     instability:
-    //       (findModuleByName(lModules, pDependency.resolved) || {})
-    //         .instability || 0,
-    //   })),
-    // }));
+    clearCache();
+    return lModules.map((pModule) => ({
+      ...pModule,
+      dependencies: pModule.dependencies.map((pDependency) => ({
+        ...pDependency,
+        instability:
+          (findModuleByName(lModules, pDependency.resolved) || {})
+            .instability || 0,
+      })),
+    }));
   }
   return pModules;
 };

--- a/src/enrich/enrich-modules.js
+++ b/src/enrich/enrich-modules.js
@@ -19,7 +19,7 @@ module.exports = function enrichModules(pModules, pOptions) {
   lModules = deriveOrphans(lModules);
   bus.emit("progress", "analyzing: reachables", { level: busLogLevels.INFO });
   lModules = deriveReachable(lModules, pOptions.ruleSet);
-  bus.emit("progress", "analyzing: calculating module metrics", {
+  bus.emit("progress", "analyzing: module metrics", {
     level: busLogLevels.INFO,
   });
   lModules = deriveModuleMetrics(lModules, pOptions);

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -66,6 +66,32 @@ function normalizeCollapse(pCollapse) {
   return lReturnValue;
 }
 
+function hasMetricsRule(pRule) {
+  return _has(pRule, "to.moreUnstable");
+}
+
+function ruleSetHasMetricsRule(pRuleSet) {
+  const lRuleSet = pRuleSet || {};
+  return (
+    (lRuleSet.forbidden || []).some(hasMetricsRule) ||
+    (lRuleSet.allowed || []).some(hasMetricsRule)
+  );
+}
+
+/**
+ * Determines whether (instability) metrics should be calculated
+ *
+ * @param {import('../../../types/options').ICruiseOptions pOptions
+ * @returns Boolean
+ */
+function shouldCalculateMetrics(pOptions) {
+  return (
+    pOptions.metrics ||
+    pOptions.outputType === "metrics" ||
+    ruleSetHasMetricsRule(pOptions.ruleSet)
+  );
+}
+
 /**
  *
  * @param {Partial <import('../../../types/options').ICruiseOptions>} pOptions
@@ -101,7 +127,7 @@ function normalizeCruiseOptions(pOptions) {
       lReturnValue.reporterOptions
     );
   }
-  lReturnValue.metrics = pOptions.metrics || pOptions.outputType === "metrics";
+  lReturnValue.metrics = shouldCalculateMetrics(pOptions);
 
   return lReturnValue;
 }

--- a/src/schema/configuration.schema.js
+++ b/src/schema/configuration.schema.js
@@ -168,6 +168,7 @@ module.exports = {
         licenseNot: { $ref: "#/definitions/REAsStringsType" },
         via: { $ref: "#/definitions/REAsStringsType" },
         viaNot: { $ref: "#/definitions/REAsStringsType" },
+        moreUnstable: { type: "boolean" },
       },
     },
     DependentsModuleRestrictionType: {

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -246,6 +246,10 @@
         "viaNot": {
           "description": "For circular dependencies - whether or not to match cycles that do NOT include modules with this regular expression. E.g. to disallow all cycles, except when they go through one specific module. Typically to temporarily allow some cycles until they're removed.",
           "$ref": "#/definitions/REAsStringsType"
+        },
+        "moreUnstable": {
+          "type": "boolean",
+          "description": "When set to true moreUnstable matches for any dependency that has a higherInstability than the module that depends on it. When set to false it matcheswhen the opposite is true; the dependency has an equal or lower Instability.This attribute is useful when you want to check against Robert C. Martin'sstable dependency principle. See online documentation for examples and details.Leave this out when you don't care either way."
         }
       }
     },

--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -357,6 +357,7 @@ module.exports = {
         licenseNot: { $ref: "#/definitions/REAsStringsType" },
         via: { $ref: "#/definitions/REAsStringsType" },
         viaNot: { $ref: "#/definitions/REAsStringsType" },
+        moreUnstable: { type: "boolean" },
       },
     },
     DependentsModuleRestrictionType: {

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -620,6 +620,10 @@
         "viaNot": {
           "description": "For circular dependencies - whether or not to match cycles that do NOT include modules with this regular expression. E.g. to disallow all cycles, except when they go through one specific module. Typically to temporarily allow some cycles until they're removed.",
           "$ref": "#/definitions/REAsStringsType"
+        },
+        "moreUnstable": {
+          "type": "boolean",
+          "description": "When set to true moreUnstable matches for any dependency that has a higherInstability than the module that depends on it. When set to false it matcheswhen the opposite is true; the dependency has an equal or lower Instability.This attribute is useful when you want to check against Robert C. Martin'sstable dependency principle. See online documentation for examples and details.Leave this out when you don't care either way."
         }
       }
     },

--- a/src/validate/match-dependency-rule.js
+++ b/src/validate/match-dependency-rule.js
@@ -40,6 +40,7 @@ function match(pFrom, pTo) {
       matchers.toExoticRequireNot(pRule, pTo) &&
       matchers.toVia(pRule, pTo) &&
       matchers.toViaNot(pRule, pTo) &&
+      matchers.toIsMoreUnstable(pRule, pFrom, pTo) &&
       // preCompilationOnly is not a mandatory attribute, but if the attribute
       // is in the rule but not in the dependency there won't be a match
       // anyway, so we can use the default propertyEquals method regardless

--- a/src/validate/matchers.js
+++ b/src/validate/matchers.js
@@ -1,3 +1,4 @@
+const _has = require("lodash/has");
 const { intersects } = require("../utl/array-util");
 
 function fromPath(pRule, pModule) {
@@ -123,6 +124,16 @@ function toVia(pRule, pDependency) {
   );
 }
 
+function toIsMoreUnstable(pRule, pFrom, pTo) {
+  if (_has(pRule, "to.moreUnstable")) {
+    return (
+      (pRule.to.moreUnstable && pFrom.instability < pTo.instability) ||
+      (!pRule.to.moreUnstable && pFrom.instability >= pTo.instability)
+    );
+  }
+  return true;
+}
+
 module.exports = {
   _replaceGroupPlaceholders,
   fromPath,
@@ -141,4 +152,5 @@ module.exports = {
   toExoticRequireNot,
   toVia,
   toViaNot,
+  toIsMoreUnstable,
 };

--- a/test/enrich/derive/metrics/module.spec.mjs
+++ b/test/enrich/derive/metrics/module.spec.mjs
@@ -84,15 +84,8 @@ describe("enrich/derive/metrics/module - module stability metrics derivation", (
           },
         ],
         { metrics: true }
-      )
-    ).to.deep.equal([
-      {
-        source: "src/hello.js",
-        dependencies: ["for", "this", "only", "array-length", "matters"],
-        dependents: [],
-        instability: 1,
-      },
-    ]);
+      )[0].instability
+    ).to.equal(1);
   });
 
   it("emits an instability metric when we're asking for metrics (dependents as well as dependencies)", () => {
@@ -106,15 +99,9 @@ describe("enrich/derive/metrics/module - module stability metrics derivation", (
           },
         ],
         { metrics: true }
-      )
-    ).to.deep.equal([
-      {
-        source: "src/hello.js",
-        dependencies: ["for", "this", "only", "array-length", "matters"],
-        dependents: ["three", "eight", "actually"],
-        instability: 0.625,
-      },
-    ]);
+      )[0].instability
+      // eslint-disable-next-line no-magic-numbers
+    ).to.equal(0.625);
   });
 
   it("doesn't emit an instability metric when we're asking for metrics on something we don't want to calc them on", () => {

--- a/test/validate/fixtures/rules.stable-dependencies-only-allowed.json
+++ b/test/validate/fixtures/rules.stable-dependencies-only-allowed.json
@@ -1,0 +1,11 @@
+{
+  "allowedSeverity": "info",
+  "allowed": [
+    {
+      "from": {},
+      "to": {
+        "moreUnstable": false
+      }
+    }
+  ]
+}

--- a/test/validate/fixtures/rules.stable-dependencies-only-forbidden.json
+++ b/test/validate/fixtures/rules.stable-dependencies-only-forbidden.json
@@ -1,0 +1,12 @@
+{
+  "forbidden": [
+    {
+      "name": "SDP",
+      "severity": "info",
+      "from": {},
+      "to": {
+        "moreUnstable": true
+      }
+    }
+  ]
+}

--- a/test/validate/index.spec.mjs
+++ b/test/validate/index.spec.mjs
@@ -470,4 +470,74 @@ describe("validate/index - specific tests", () => {
       ],
     });
   });
+
+  it("moreUnstable: flags when depending on a module that is more unstable (moreUnstable=true, forbidden)", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.stable-dependencies-only-forbidden.json"
+        ),
+        { source: "something", instability: 0 },
+        {
+          resolved: "src/some/thing/else.js",
+          instability: 1,
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "SDP", severity: "info" }],
+    });
+  });
+
+  it("moreUnstable: does not flag when depending on a module that is more stable (moreUnstable=true, forbidden)", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.stable-dependencies-only-forbidden.json"
+        ),
+        { source: "something", instability: 1 },
+        {
+          resolved: "src/some/thing/else.js",
+          instability: 0.1,
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+
+  it("moreUnstable: flags when depending on a module that is more unstable (moreUnstable=false, allowed)", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.stable-dependencies-only-allowed.json"
+        ),
+        { source: "something", instability: 0 },
+        {
+          resolved: "src/some/thing/else.js",
+          instability: 1,
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "not-in-allowed", severity: "info" }],
+    });
+  });
+
+  it("moreUnstable: does not flag when depending on a module that is more stable (moreUnstable=false, allowed)", () => {
+    expect(
+      validate.dependency(
+        readRuleSet(
+          "./test/validate/fixtures/rules.stable-dependencies-only-allowed.json"
+        ),
+        { source: "something", instability: 1 },
+        {
+          resolved: "src/some/thing/else.js",
+          instability: 0.1,
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
 });

--- a/tools/schema/restrictions.mjs
+++ b/tools/schema/restrictions.mjs
@@ -148,6 +148,16 @@ export default {
             "allow some cycles until they're removed.",
           $ref: "#/definitions/REAsStringsType",
         },
+        moreUnstable: {
+          type: "boolean",
+          description:
+            "When set to true moreUnstable matches for any dependency that has a higher" +
+            "Instability than the module that depends on it. When set to false it matches" +
+            "when the opposite is true; the dependency has an equal or lower Instability." +
+            "This attribute is useful when you want to check against Robert C. Martin's" +
+            "stable dependency principle. See online documentation for examples and details." +
+            "Leave this out when you don't care either way.",
+        },
       },
     },
     DependentsModuleRestrictionType: {

--- a/types/restrictions.d.ts
+++ b/types/restrictions.d.ts
@@ -92,6 +92,18 @@ export interface IToRestriction extends IBaseRestrictionType {
    * licenses. E.g. to flag everyting non MIT use "MIT" here
    */
   licenseNot?: string | string[];
+  /**
+   * When set to true moreUnstable matches for any dependency that has a higher
+   * Instability than the module that depends on it. When set to false it matches
+   * when the opposite is true; the dependency has an equal or lower Instability.
+   *
+   * This attribute is useful when you want to check against Robert C. Martin's
+   * stable dependency * principle. See online documentation for examples and
+   * details.
+   *
+   * Leave this out when you don't care either way.
+   */
+  moreUnstable?: boolean;
 }
 
 export interface IReachabilityToRestrictionType extends IBaseRestrictionType {


### PR DESCRIPTION
## Description

- adds a moreUnstable boolean attribute to violations
- the presence this attribute will imply dependency-cruiser calculates instability metrics (so there's no need to pass --metrics on the cli or metrics:true in the api)

## Motivation and Context

Enables enforcing the SDP (stable dependencies principle) & highlighting any violations of the principle - as announced in #523. See documentation within the commit for details.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional automated tests
- [x] manual checks (+ incorporated in the dependency-cruiser's self-cruise)

## Screenshots

With the earlier PR that adapts the dot reporter you can see what dependencies violate the principle and you can verify why so:

<img width="657" alt="dependency graph showing the two violations of the stable dependencies principle within dependency-cruiser's source code" src="https://user-images.githubusercontent.com/4822597/146087169-2d6e08dc-09c1-4208-9e00-123dd59aa9d5.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
