### PR TITLE
bugfix(schema|types): adds denormalized 'instability' to the schema & types

### DIFF
--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -127,6 +127,7 @@ module.exports = {
           type: "array",
           items: { $ref: "#/definitions/RuleSummaryType" },
         },
+        instability: { type: "number" },
       },
     },
     DependencyTypeType: {

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -244,6 +244,10 @@
           "type": "array",
           "items": { "$ref": "#/definitions/RuleSummaryType" },
           "description": "an array of rules violated by this dependency - left out if the dependency is valid"
+        },
+        "instability": {
+          "type": "number",
+          "description": "the (de-normalized) instability of the dependency - also available in the module on the 'to' side of this dependency"
         }
       }
     },

--- a/test/main/fixtures/cruise-reporterless/metrics.json
+++ b/test/main/fixtures/cruise-reporterless/metrics.json
@@ -1,0 +1,282 @@
+[
+  {
+    "title": "metrics",
+    "input": {
+      "fileName": "test/main/fixtures/cruise-reporterless/metrics/root.js",
+      "options": {
+        "forceDeriveDependents": false,
+        "metrics": true
+      }
+    },
+    "expected": [
+      {
+        "source": "test/main/fixtures/cruise-reporterless/metrics/root.js",
+        "dependencies": [
+          {
+            "module": "./format-output",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "test/main/fixtures/cruise-reporterless/metrics/format-output/index.js",
+            "coreModule": false,
+            "followable": true,
+            "couldNotResolve": false,
+            "dependencyTypes": ["local"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0.5,
+            "valid": true
+          },
+          {
+            "module": "./mangle-entry",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/index.js",
+            "coreModule": false,
+            "followable": true,
+            "couldNotResolve": false,
+            "dependencyTypes": ["local"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0.6666666666666666,
+            "valid": true
+          },
+          {
+            "module": "./parse-input",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "test/main/fixtures/cruise-reporterless/metrics/parse-input/index.js",
+            "coreModule": false,
+            "followable": true,
+            "couldNotResolve": false,
+            "dependencyTypes": ["local"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0,
+            "valid": true
+          },
+          {
+            "module": "ndjson",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "ndjson",
+            "coreModule": false,
+            "followable": false,
+            "couldNotResolve": true,
+            "dependencyTypes": ["unknown"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0,
+            "valid": true
+          }
+        ],
+        "dependents": [],
+        "orphan": false,
+        "instability": 1,
+        "valid": true
+      },
+      {
+        "source": "ndjson",
+        "followable": false,
+        "coreModule": false,
+        "couldNotResolve": true,
+        "matchesDoNotFollow": false,
+        "dependencyTypes": ["unknown"],
+        "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/root.js"
+        ],
+        "orphan": false,
+        "valid": true
+      },
+      {
+        "source": "test/main/fixtures/cruise-reporterless/metrics/format-output/index.js",
+        "dependencies": [
+          {
+            "module": "os",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "os",
+            "coreModule": true,
+            "followable": false,
+            "couldNotResolve": false,
+            "dependencyTypes": ["core"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0,
+            "valid": true
+          }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/root.js"
+        ],
+        "orphan": false,
+        "instability": 0.5,
+        "valid": true
+      },
+      {
+        "source": "os",
+        "followable": false,
+        "coreModule": true,
+        "couldNotResolve": false,
+        "matchesDoNotFollow": false,
+        "dependencyTypes": ["core"],
+        "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/format-output/index.js"
+        ],
+        "orphan": false,
+        "valid": true
+      },
+      {
+        "source": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/index.js",
+        "dependencies": [
+          {
+            "module": "./do-something-else.js",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something-else.js",
+            "coreModule": false,
+            "followable": true,
+            "couldNotResolve": false,
+            "dependencyTypes": ["local"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0,
+            "valid": true
+          },
+          {
+            "module": "./do-something.js",
+            "moduleSystem": "es6",
+            "dynamic": false,
+            "exoticallyRequired": false,
+            "resolved": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something.js",
+            "coreModule": false,
+            "followable": true,
+            "couldNotResolve": false,
+            "dependencyTypes": ["local"],
+            "matchesDoNotFollow": false,
+            "circular": false,
+            "instability": 0,
+            "valid": true
+          }
+        ],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/root.js"
+        ],
+        "orphan": false,
+        "instability": 0.6666666666666666,
+        "valid": true
+      },
+      {
+        "source": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something-else.js",
+        "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/index.js"
+        ],
+        "orphan": false,
+        "instability": 0,
+        "valid": true
+      },
+      {
+        "source": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something.js",
+        "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/mangle-entry/index.js"
+        ],
+        "orphan": false,
+        "instability": 0,
+        "valid": true
+      },
+      {
+        "source": "test/main/fixtures/cruise-reporterless/metrics/parse-input/index.js",
+        "dependencies": [],
+        "dependents": [
+          "test/main/fixtures/cruise-reporterless/metrics/root.js"
+        ],
+        "orphan": false,
+        "instability": 0,
+        "valid": true
+      }
+    ],
+    "expectedFolders": [
+      {
+        "name": "test",
+        "dependencies": ["ndjson", "os"],
+        "dependents": [],
+        "moduleCount": 6,
+        "afferentCouplings": 0,
+        "efferentCouplings": 2,
+        "instability": 1
+      },
+      {
+        "name": "test/main",
+        "dependencies": ["ndjson", "os"],
+        "dependents": [],
+        "moduleCount": 6,
+        "afferentCouplings": 0,
+        "efferentCouplings": 2,
+        "instability": 1
+      },
+      {
+        "name": "test/main/fixtures",
+        "dependencies": ["ndjson", "os"],
+        "dependents": [],
+        "moduleCount": 6,
+        "afferentCouplings": 0,
+        "efferentCouplings": 2,
+        "instability": 1
+      },
+      {
+        "name": "test/main/fixtures/cruise-reporterless",
+        "dependencies": ["ndjson", "os"],
+        "dependents": [],
+        "moduleCount": 6,
+        "afferentCouplings": 0,
+        "efferentCouplings": 2,
+        "instability": 1
+      },
+      {
+        "name": "test/main/fixtures/cruise-reporterless/metrics",
+        "dependencies": ["ndjson", "os"],
+        "dependents": [],
+        "moduleCount": 6,
+        "afferentCouplings": 0,
+        "efferentCouplings": 2,
+        "instability": 1
+      },
+      {
+        "name": "test/main/fixtures/cruise-reporterless/metrics/format-output",
+        "dependencies": ["os"],
+        "dependents": ["test/main/fixtures/cruise-reporterless/metrics"],
+        "moduleCount": 1,
+        "afferentCouplings": 1,
+        "efferentCouplings": 1,
+        "instability": 0.5
+      },
+      {
+        "name": "test/main/fixtures/cruise-reporterless/metrics/mangle-entry",
+        "dependencies": [],
+        "dependents": ["test/main/fixtures/cruise-reporterless/metrics"],
+        "moduleCount": 3,
+        "afferentCouplings": 1,
+        "efferentCouplings": 0,
+        "instability": 0
+      },
+      {
+        "name": "test/main/fixtures/cruise-reporterless/metrics/parse-input",
+        "dependencies": [],
+        "dependents": ["test/main/fixtures/cruise-reporterless/metrics"],
+        "moduleCount": 1,
+        "afferentCouplings": 1,
+        "efferentCouplings": 0,
+        "instability": 0
+      }
+    ]
+  }
+]

--- a/test/main/fixtures/cruise-reporterless/metrics/format-output/index.js
+++ b/test/main/fixtures/cruise-reporterless/metrics/format-output/index.js
@@ -1,0 +1,3 @@
+import { EOL } from "os";
+
+export default (pInput) => pInput.padStart(40).concat(EOL);

--- a/test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something-else.js
+++ b/test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something-else.js
@@ -1,0 +1,1 @@
+export default (pInput) => pInput;

--- a/test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something.js
+++ b/test/main/fixtures/cruise-reporterless/metrics/mangle-entry/do-something.js
@@ -1,0 +1,1 @@
+export default (pInput) => pInput;

--- a/test/main/fixtures/cruise-reporterless/metrics/mangle-entry/index.js
+++ b/test/main/fixtures/cruise-reporterless/metrics/mangle-entry/index.js
@@ -1,0 +1,4 @@
+import doSomething from "./do-something.js";
+import doSomethingElse from "./do-something-else.js";
+
+export default (pEntry) => doSomething(doSomethingElse(pEntry));

--- a/test/main/fixtures/cruise-reporterless/metrics/parse-input/index.js
+++ b/test/main/fixtures/cruise-reporterless/metrics/parse-input/index.js
@@ -1,0 +1,1 @@
+export default (pInput) => [pInput];

--- a/test/main/fixtures/cruise-reporterless/metrics/root.js
+++ b/test/main/fixtures/cruise-reporterless/metrics/root.js
@@ -1,0 +1,18 @@
+import ndjson from "ndjson";
+import parseInput from "./parse-input";
+import mangleEntry from "./mangle-entry";
+import formatOutput from "./format-output";
+
+process.stdin
+  .pipe(ndjson.parse())
+  .on("data", (pEntry) => {
+    console.log(parseInput(pEntry).map(mangleEntry).map(formatOutput));
+  })
+  .on("error", (pError) => {
+    console.error(pError);
+    process.exitCode = 1;
+    process.exit();
+  })
+  .on("end", () => {
+    console.log(TerseAdvisoryLog2Table(lAdvisaryLog.get()));
+  });

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -23,6 +23,9 @@ const vueFixtures = requireJSON("./fixtures/cruise-reporterless/vue.json");
 const coffeeFixtures = requireJSON(
   "./fixtures/cruise-reporterless/coffee.json"
 );
+const metricsFixtures = requireJSON(
+  "./fixtures/cruise-reporterless/metrics.json"
+);
 
 use(chaiJSONSchema);
 
@@ -31,7 +34,7 @@ function runRecursiveFixture(pFixture) {
     it(pFixture.title, () => {
       let lResult = cruise(
         [pFixture.input.fileName],
-        { ...pFixture.input.options, forceDeriveDependents: true },
+        { forceDeriveDependents: true, ...pFixture.input.options },
         {
           bustTheCache: true,
           resolveLicenses: true,
@@ -41,6 +44,9 @@ function runRecursiveFixture(pFixture) {
 
       expect(lResult).to.be.jsonSchema(cruiseResultSchema);
       expect(lResult.modules).to.deep.equal(pFixture.expected);
+      if (lResult.folders) {
+        expect(lResult.folders).to.deep.equal(pFixture.expectedFolders);
+      }
     });
   }
 }
@@ -59,3 +65,5 @@ describe("main.cruise - reporterless - Deprecation - ", () =>
   deprecationFixtures.forEach(runRecursiveFixture));
 describe("main.cruise - reporterless - Bundled - ", () =>
   bundledFixtures.forEach(runRecursiveFixture));
+describe("main.cruise - reporterless - metrics - ", () =>
+  metricsFixtures.forEach(runRecursiveFixture));

--- a/tools/schema/dependencies.mjs
+++ b/tools/schema/dependencies.mjs
@@ -157,6 +157,12 @@ export default {
             "an array of rules violated by this dependency - left out if the dependency " +
             "is valid",
         },
+        instability: {
+          type: "number",
+          description:
+            "the (de-normalized) instability of the dependency - also available in " +
+            "the module on the 'to' side of this dependency",
+        },
       },
     },
     ...dependencyType.definitions,

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -221,6 +221,11 @@ export interface IDependency {
    * will be in the 'rule' object at the same level.
    */
   valid: boolean;
+  /**
+   * the (de-normalized) instability of the dependency - also available in
+   * the module on the 'to' side of this dependency
+   */
+  instability: number;
 }
 
 export interface IReachable {


### PR DESCRIPTION
## Description

- see title

## Motivation and Context

- they were missing

## How Has This Been Tested?

- [x] automated non-regression tests & green ci
- [x] additional automated integration test
- [x] manual check

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
