### PR TITLE
feature(enrich|report): adds instability metrics to the err reporter

### DIFF
--- a/src/schema/baseline-violations.schema.js
+++ b/src/schema/baseline-violations.schema.js
@@ -17,9 +17,38 @@ module.exports = {
       properties: {
         from: { type: "string" },
         to: { type: "string" },
+        type: {
+          type: "string",
+          enum: [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability",
+          ],
+        },
         rule: { $ref: "#/definitions/RuleSummaryType" },
         cycle: { type: "array", items: { type: "string" } },
         via: { type: "array", items: { type: "string" } },
+        metrics: {
+          type: "object",
+          required: ["from", "to"],
+          additionalProperties: false,
+          properties: {
+            from: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: { instability: { type: "number" } },
+            },
+            to: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: { instability: { type: "number" } },
+            },
+          },
+        },
       },
     },
     RuleSummaryType: {

--- a/src/schema/baseline-violations.schema.json
+++ b/src/schema/baseline-violations.schema.json
@@ -16,6 +16,16 @@
       "properties": {
         "from": { "type": "string" },
         "to": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability"
+          ]
+        },
         "rule": { "$ref": "#/definitions/RuleSummaryType" },
         "cycle": {
           "type": "array",
@@ -26,6 +36,25 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "The path from the from to the to if the violation is transitive"
+        },
+        "metrics": {
+          "type": "object",
+          "required": ["from", "to"],
+          "additionalProperties": false,
+          "properties": {
+            "from": {
+              "type": "object",
+              "required": ["instability"],
+              "additionalProperties": false,
+              "properties": { "instability": { "type": "number" } }
+            },
+            "to": {
+              "type": "object",
+              "required": ["instability"],
+              "additionalProperties": false,
+              "properties": { "instability": { "type": "number" } }
+            }
+          }
         }
       }
     },

--- a/src/schema/configuration.schema.js
+++ b/src/schema/configuration.schema.js
@@ -476,9 +476,38 @@ module.exports = {
       properties: {
         from: { type: "string" },
         to: { type: "string" },
+        type: {
+          type: "string",
+          enum: [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability",
+          ],
+        },
         rule: { $ref: "#/definitions/RuleSummaryType" },
         cycle: { type: "array", items: { type: "string" } },
         via: { type: "array", items: { type: "string" } },
+        metrics: {
+          type: "object",
+          required: ["from", "to"],
+          additionalProperties: false,
+          properties: {
+            from: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: { instability: { type: "number" } },
+            },
+            to: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: { instability: { type: "number" } },
+            },
+          },
+        },
       },
     },
     RuleSummaryType: {

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -760,6 +760,16 @@
       "properties": {
         "from": { "type": "string" },
         "to": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability"
+          ]
+        },
         "rule": { "$ref": "#/definitions/RuleSummaryType" },
         "cycle": {
           "type": "array",
@@ -770,6 +780,25 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "The path from the from to the to if the violation is transitive"
+        },
+        "metrics": {
+          "type": "object",
+          "required": ["from", "to"],
+          "additionalProperties": false,
+          "properties": {
+            "from": {
+              "type": "object",
+              "required": ["instability"],
+              "additionalProperties": false,
+              "properties": { "instability": { "type": "number" } }
+            },
+            "to": {
+              "type": "object",
+              "required": ["instability"],
+              "additionalProperties": false,
+              "properties": { "instability": { "type": "number" } }
+            }
+          }
         }
       }
     },

--- a/src/schema/cruise-result.schema.js
+++ b/src/schema/cruise-result.schema.js
@@ -210,9 +210,38 @@ module.exports = {
       properties: {
         from: { type: "string" },
         to: { type: "string" },
+        type: {
+          type: "string",
+          enum: [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability",
+          ],
+        },
         rule: { $ref: "#/definitions/RuleSummaryType" },
         cycle: { type: "array", items: { type: "string" } },
         via: { type: "array", items: { type: "string" } },
+        metrics: {
+          type: "object",
+          required: ["from", "to"],
+          additionalProperties: false,
+          properties: {
+            from: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: { instability: { type: "number" } },
+            },
+            to: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: { instability: { type: "number" } },
+            },
+          },
+        },
       },
     },
     RuleSetType: {

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -395,6 +395,16 @@
       "properties": {
         "from": { "type": "string" },
         "to": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability"
+          ]
+        },
         "rule": { "$ref": "#/definitions/RuleSummaryType" },
         "cycle": {
           "type": "array",
@@ -405,6 +415,25 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "The path from the from to the to if the violation is transitive"
+        },
+        "metrics": {
+          "type": "object",
+          "required": ["from", "to"],
+          "additionalProperties": false,
+          "properties": {
+            "from": {
+              "type": "object",
+              "required": ["instability"],
+              "additionalProperties": false,
+              "properties": { "instability": { "type": "number" } }
+            },
+            "to": {
+              "type": "object",
+              "required": ["instability"],
+              "additionalProperties": false,
+              "properties": { "instability": { "type": "number" } }
+            }
+          }
         }
       }
     },

--- a/test/enrich/summarize-modules.spec.mjs
+++ b/test/enrich/summarize-modules.spec.mjs
@@ -54,6 +54,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
     expect(lResult).to.deep.equal({
       violations: [
         {
+          type: "module",
           from: "violation.js",
           to: "violation.js",
           rule: {
@@ -111,6 +112,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
     expect(lResult).to.deep.equal({
       violations: [
         {
+          type: "reachability",
           from: "violation.js",
           to: "dont-touch-this.js",
           rule: {
@@ -120,6 +122,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
           via: ["via", "romana"],
         },
         {
+          type: "reachability",
           from: "violation.js",
           to: "mc-hammer.js",
           rule: {
@@ -229,6 +232,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
     expect(lResult).to.deep.equal({
       violations: [
         {
+          type: "dependency",
           from: "violation.js",
           to: "bolderdash",
           rule: {
@@ -237,6 +241,7 @@ describe("enrich/summarize-modules - summarize extraction", () => {
           },
         },
         {
+          type: "module",
           from: "violation.js",
           to: "violation.js",
           rule: {
@@ -251,6 +256,59 @@ describe("enrich/summarize-modules - summarize extraction", () => {
       ignore: 0,
       totalDependenciesCruised: 1,
       totalCruised: 2,
+    });
+  });
+
+  it("violating something with moreUnstable & instabilities", () => {
+    const lResult = summarize(
+      [
+        {
+          source: "violation.js",
+          instability: 0.42,
+          dependencies: [
+            {
+              resolved: "dont-touch-this.js",
+              instability: 1,
+              valid: false,
+              rules: [
+                {
+                  name: "a-rule",
+                  severity: "warn",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      { forbidden: [{ name: "a-rule", from: {}, to: { moreUnstable: true } }] }
+    );
+
+    expect(lResult).to.deep.equal({
+      violations: [
+        {
+          type: "instability",
+          from: "violation.js",
+          to: "dont-touch-this.js",
+          rule: {
+            name: "a-rule",
+            severity: "warn",
+          },
+          metrics: {
+            from: {
+              instability: 0.42,
+            },
+            to: {
+              instability: 1,
+            },
+          },
+        },
+      ],
+      info: 0,
+      warn: 1,
+      error: 0,
+      ignore: 0,
+      totalDependenciesCruised: 1,
+      totalCruised: 1,
     });
   });
 });

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -76,6 +76,7 @@ describe("enrich/summarize", () => {
     const lExpected = {
       violations: [
         {
+          type: "cycle",
           from: "src/brand.js",
           to: "src/domain.js",
           rule: {
@@ -85,6 +86,7 @@ describe("enrich/summarize", () => {
           cycle: ["src/domain.js", "src/market.js", "src/brand.js"],
         },
         {
+          type: "cycle",
           from: "src/brand.js",
           to: "src/market.js",
           rule: {
@@ -94,6 +96,7 @@ describe("enrich/summarize", () => {
           cycle: ["src/market.js", "src/brand.js"],
         },
         {
+          type: "cycle",
           from: "src/domain.js",
           to: "src/market.js",
           rule: {

--- a/test/main/fixtures/dynamic-imports/es/output.json
+++ b/test/main/fixtures/dynamic-imports/es/output.json
@@ -85,11 +85,13 @@
   "summary": {
     "violations": [
       {
+        "type": "dependency",
         "from": "src/dynamic-to-circular.js",
         "to": "src/circular.js",
         "rule": { "severity": "warn", "name": "no-dynamic" }
       },
       {
+        "type": "cycle",
         "from": "src/circular.js",
         "to": "src/index.js",
         "rule": { "severity": "info", "name": "no-circular" },

--- a/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -85,11 +85,13 @@
   "summary": {
     "violations": [
       {
+        "type": "dependency",
         "from": "src/dynamic-to-circular.ts",
         "to": "src/circular.ts",
         "rule": { "severity": "warn", "name": "no-dynamic" }
       },
       {
+        "type": "cycle",
         "from": "src/circular.ts",
         "to": "src/index.ts",
         "rule": { "severity": "info", "name": "no-circular" },

--- a/test/main/fixtures/dynamic-imports/typescript/output.json
+++ b/test/main/fixtures/dynamic-imports/typescript/output.json
@@ -85,11 +85,13 @@
   "summary": {
     "violations": [
       {
+        "type": "dependency",
         "from": "src/dynamic-to-circular.ts",
         "to": "src/circular.ts",
         "rule": { "severity": "warn", "name": "no-dynamic" }
       },
       {
+        "type": "cycle",
         "from": "src/circular.ts",
         "to": "src/index.ts",
         "rule": { "severity": "info", "name": "no-circular" },

--- a/test/main/fixtures/type-only-imports/output-with-rules.json
+++ b/test/main/fixtures/type-only-imports/output-with-rules.json
@@ -43,6 +43,7 @@
     "totalDependenciesCruised": 1,
     "violations": [
       {
+        "type": "dependency",
         "from": "src/bla.ts",
         "rule": {
           "name": "no-type-only",

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -31,6 +31,7 @@ describe("main.cruise - reachable integration", () => {
     );
     expect(lResult.summary.violations).to.deep.equal([
       {
+        type: "reachability",
         from: "src/schema-declarations/naughty.info.js",
         to: "src/db/admin.js",
         rule: {
@@ -44,6 +45,7 @@ describe("main.cruise - reachable integration", () => {
         ],
       },
       {
+        type: "module",
         from: "src/utilities/insula.js",
         to: "src/utilities/insula.js",
         rule: {
@@ -52,6 +54,7 @@ describe("main.cruise - reachable integration", () => {
         },
       },
       {
+        type: "module",
         from: "src/utilities/pen.js",
         to: "src/utilities/pen.js",
         rule: {
@@ -77,6 +80,7 @@ describe("main.cruise - reachable integration", () => {
 
     expect(lResult.summary.violations).to.deep.equal([
       {
+        type: "module",
         from: "src/utilities/insula.js",
         to: "src/utilities/insula.js",
         rule: {
@@ -85,6 +89,7 @@ describe("main.cruise - reachable integration", () => {
         },
       },
       {
+        type: "module",
         from: "src/utilities/pen.js",
         to: "src/utilities/pen.js",
         rule: {
@@ -109,6 +114,7 @@ describe("main.cruise - reachable integration", () => {
 
     expect(lResult.summary.violations).to.deep.equal([
       {
+        type: "module",
         from: "src/db/admin.js",
         to: "src/db/admin.js",
         rule: {

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -64,6 +64,7 @@ describe("main.format - format", () => {
 
     expect(lCollapsedResult.summary.violations).to.deep.equal([
       {
+        type: "dependency",
         from: "src/cli/",
         to: "src/extract/",
         rule: {

--- a/test/report/error/error.spec.mjs
+++ b/test/report/error/error.spec.mjs
@@ -8,8 +8,11 @@ import onlywarningdependencies from "./mocks/err-only-warnings.mjs";
 import orphanerrs from "./mocks/orphan-deps.mjs";
 import circularerrs from "./mocks/circular-deps.mjs";
 import viaerrs from "./mocks/via-deps.mjs";
+import sdperrors from "./mocks/sdp-errors.mjs";
 import ignoredviolations from "./mocks/ignored-violations.mjs";
 import ignoredandrealviolations from "./mocks/ignored-and-real-violations.mjs";
+import missingViolationType from "./mocks/missing-violation-type.mjs";
+import unknownViolationType from "./mocks/unknown-violation-type.mjs";
 
 describe("report/error", () => {
   let chalkLevel = chalk.level;
@@ -75,6 +78,22 @@ describe("report/error", () => {
     );
     expect(lResult.output).to.contain("      (via via)");
     expect(lResult.exitCode).to.equal(4);
+  });
+  it("renders moreUnstable violations with the module & dependents violations", () => {
+    const lResult = render(sdperrors);
+
+    expect(lResult.output).to.contain(
+      "warn sdp: src/more-stable.js → src/less-stable.js\n      instability: 42 → 100\n"
+    );
+  });
+  it("renders a violation as a dependency-violation when the violation.type ain't there", () => {
+    const lResult = render(missingViolationType);
+    expect(lResult.output).to.contain("warn missing-type: a.js → b.js\n");
+  });
+
+  it("renders a violation as a dependency-violation when the violation.type is yet unknown", () => {
+    const lResult = render(unknownViolationType);
+    expect(lResult.output).to.contain("warn unknown-type: a.js → b.js\n");
   });
   it("emits a warning when there's > 1 ignored violation and no other violations", () => {
     const lResult = render(ignoredviolations);

--- a/test/report/error/mocks/circular-deps.mjs
+++ b/test/report/error/mocks/circular-deps.mjs
@@ -88,6 +88,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "cycle",
         from: "src/some/folder/nested/center.js",
         to: "src/some/folder/loop-a.js",
         rule: {
@@ -101,6 +102,7 @@ export default {
         ],
       },
       {
+        type: "cycle",
         from: "src/some/folder/loop-a.js",
         to: "src/some/folder/loop-b.js",
         rule: {
@@ -114,6 +116,7 @@ export default {
         ],
       },
       {
+        type: "cycle",
         from: "src/some/folder/loop-b.js",
         to: "src/some/folder/nested/center.js",
         rule: {

--- a/test/report/error/mocks/cjs-no-dependency-valid.mjs
+++ b/test/report/error/mocks/cjs-no-dependency-valid.mjs
@@ -349,6 +349,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "aap",
         to: "noot",
         rule: {
@@ -357,6 +358,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "aap",
         to: "noot",
         rule: {

--- a/test/report/error/mocks/err-only-warnings.mjs
+++ b/test/report/error/mocks/err-only-warnings.mjs
@@ -3,6 +3,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "aap",
         to: "noot",
         rule: {

--- a/test/report/error/mocks/err-with-additional-information.mjs
+++ b/test/report/error/mocks/err-with-additional-information.mjs
@@ -3,6 +3,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "aap",
         to: "noot",
         rule: {

--- a/test/report/error/mocks/ignored-and-real-violations.mjs
+++ b/test/report/error/mocks/ignored-and-real-violations.mjs
@@ -3,6 +3,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "module",
         from: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
         to: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
         rule: {
@@ -11,6 +12,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/baseline/baseline-result.json",
         to: "test/report/baseline/baseline-result.json",
         rule: {
@@ -19,6 +21,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/baseline/dc-result-no-violations.json",
         to: "test/report/baseline/dc-result-no-violations.json",
         rule: {
@@ -27,6 +30,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/baseline/dc-result-with-violations.json",
         to: "test/report/baseline/dc-result-with-violations.json",
         rule: {
@@ -35,6 +39,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/dot/module-level/bare-theme.json",
         to: "test/report/dot/module-level/bare-theme.json",
         rule: {
@@ -43,6 +48,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/cli/format.js",
         to: "src/cli/format.js",
         rule: {
@@ -51,6 +57,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/cli/tools/wrap-stream-in-html.js",
         to: "src/cli/tools/wrap-stream-in-html.js",
         rule: {
@@ -59,6 +66,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/cli/validate-node-environment.js",
         to: "src/cli/validate-node-environment.js",
         rule: {
@@ -67,6 +75,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/schema/baseline-violations.schema.js",
         to: "src/schema/baseline-violations.schema.js",
         rule: {
@@ -75,6 +84,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/utl/array-util.js",
         to: "src/utl/array-util.js",
         rule: {
@@ -83,6 +93,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/utl/wrap-and-indent.js",
         to: "src/utl/wrap-and-indent.js",
         rule: {

--- a/test/report/error/mocks/ignored-violations.mjs
+++ b/test/report/error/mocks/ignored-violations.mjs
@@ -3,6 +3,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "module",
         from: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
         to: "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
         rule: {
@@ -11,6 +12,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/baseline/baseline-result.json",
         to: "test/report/baseline/baseline-result.json",
         rule: {
@@ -19,6 +21,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/baseline/dc-result-no-violations.json",
         to: "test/report/baseline/dc-result-no-violations.json",
         rule: {
@@ -27,6 +30,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/baseline/dc-result-with-violations.json",
         to: "test/report/baseline/dc-result-with-violations.json",
         rule: {
@@ -35,6 +39,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "test/report/dot/module-level/bare-theme.json",
         to: "test/report/dot/module-level/bare-theme.json",
         rule: {
@@ -43,6 +48,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/cli/format.js",
         to: "src/cli/format.js",
         rule: {
@@ -51,6 +57,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/cli/tools/wrap-stream-in-html.js",
         to: "src/cli/tools/wrap-stream-in-html.js",
         rule: {
@@ -59,6 +66,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/cli/validate-node-environment.js",
         to: "src/cli/validate-node-environment.js",
         rule: {
@@ -67,6 +75,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/schema/baseline-violations.schema.js",
         to: "src/schema/baseline-violations.schema.js",
         rule: {
@@ -75,6 +84,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/utl/array-util.js",
         to: "src/utl/array-util.js",
         rule: {
@@ -83,6 +93,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/utl/wrap-and-indent.js",
         to: "src/utl/wrap-and-indent.js",
         rule: {

--- a/test/report/error/mocks/missing-violation-type.mjs
+++ b/test/report/error/mocks/missing-violation-type.mjs
@@ -1,0 +1,81 @@
+export default {
+  modules: [
+    {
+      source: "a.js",
+      instability: 0.42,
+      dependencies: [
+        {
+          resolved: "b.js",
+          instability: 1,
+          coreModule: false,
+          followable: false,
+          couldNotResolve: false,
+          dependencyTypes: [],
+          dynamic: false,
+          module: "./less-stable.js",
+          moduleSystem: "es6",
+          valid: false,
+          rules: [
+            {
+              severity: "warn",
+              name: "sdp",
+            },
+          ],
+        },
+      ],
+      valid: true,
+    },
+    {
+      source: "b.js",
+      instability: 1,
+      dependencies: [],
+      dependents: ["a.js"],
+      valid: true,
+    },
+  ],
+  summary: {
+    violations: [
+      {
+        // type: "instability",
+        from: "a.js",
+        to: "b.js",
+        rule: {
+          severity: "warn",
+          name: "missing-type",
+        },
+        metrics: {
+          from: {
+            instability: 0.42,
+          },
+          to: {
+            instability: 1,
+          },
+        },
+      },
+    ],
+    error: 0,
+    warn: 1,
+    info: 0,
+    totalCruised: 3,
+    totalDependenciesCruised: 3,
+    optionsUsed: {
+      rulesFile: ".dependency-cruiser-custom.json",
+      moduleSystems: ["amd", "cjs", "es6"],
+      outputType: "json",
+      tsPreCompilationDeps: false,
+      preserveSymlinks: false,
+    },
+    ruleSetUsed: {
+      forbidden: [
+        {
+          name: "sdp",
+          severity: "warn",
+          from: {},
+          to: {
+            moreUnstable: true,
+          },
+        },
+      ],
+    },
+  },
+};

--- a/test/report/error/mocks/orphan-deps.mjs
+++ b/test/report/error/mocks/orphan-deps.mjs
@@ -16,6 +16,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "module",
         from: "remi.js",
         to: "remi.js",
         rule: {

--- a/test/report/error/mocks/sdp-errors.mjs
+++ b/test/report/error/mocks/sdp-errors.mjs
@@ -1,0 +1,81 @@
+export default {
+  modules: [
+    {
+      source: "src/more-stable.js",
+      instability: 0.42,
+      dependencies: [
+        {
+          resolved: "src/less-stable.js",
+          instability: 1,
+          coreModule: false,
+          followable: false,
+          couldNotResolve: false,
+          dependencyTypes: [],
+          dynamic: false,
+          module: "./less-stable.js",
+          moduleSystem: "es6",
+          valid: false,
+          rules: [
+            {
+              severity: "warn",
+              name: "sdp",
+            },
+          ],
+        },
+      ],
+      valid: true,
+    },
+    {
+      source: "src/less-stable.js",
+      instability: 1,
+      dependencies: [],
+      dependents: ["src/more-stable.js"],
+      valid: true,
+    },
+  ],
+  summary: {
+    violations: [
+      {
+        type: "instability",
+        from: "src/more-stable.js",
+        to: "src/less-stable.js",
+        rule: {
+          severity: "warn",
+          name: "sdp",
+        },
+        metrics: {
+          from: {
+            instability: 0.42,
+          },
+          to: {
+            instability: 1,
+          },
+        },
+      },
+    ],
+    error: 0,
+    warn: 1,
+    info: 0,
+    totalCruised: 3,
+    totalDependenciesCruised: 3,
+    optionsUsed: {
+      rulesFile: ".dependency-cruiser-custom.json",
+      moduleSystems: ["amd", "cjs", "es6"],
+      outputType: "json",
+      tsPreCompilationDeps: false,
+      preserveSymlinks: false,
+    },
+    ruleSetUsed: {
+      forbidden: [
+        {
+          name: "sdp",
+          severity: "warn",
+          from: {},
+          to: {
+            moreUnstable: true,
+          },
+        },
+      ],
+    },
+  },
+};

--- a/test/report/error/mocks/unknown-violation-type.mjs
+++ b/test/report/error/mocks/unknown-violation-type.mjs
@@ -1,0 +1,81 @@
+export default {
+  modules: [
+    {
+      source: "a.js",
+      instability: 0.42,
+      dependencies: [
+        {
+          resolved: "b.js",
+          instability: 1,
+          coreModule: false,
+          followable: false,
+          couldNotResolve: false,
+          dependencyTypes: [],
+          dynamic: false,
+          module: "./less-stable.js",
+          moduleSystem: "es6",
+          valid: false,
+          rules: [
+            {
+              severity: "warn",
+              name: "sdp",
+            },
+          ],
+        },
+      ],
+      valid: true,
+    },
+    {
+      source: "b.js",
+      instability: 1,
+      dependencies: [],
+      dependents: ["a.js"],
+      valid: true,
+    },
+  ],
+  summary: {
+    violations: [
+      {
+        type: "unknown violation type",
+        from: "a.js",
+        to: "b.js",
+        rule: {
+          severity: "warn",
+          name: "unknown-type",
+        },
+        metrics: {
+          from: {
+            instability: 0.42,
+          },
+          to: {
+            instability: 1,
+          },
+        },
+      },
+    ],
+    error: 0,
+    warn: 1,
+    info: 0,
+    totalCruised: 3,
+    totalDependenciesCruised: 3,
+    optionsUsed: {
+      rulesFile: ".dependency-cruiser-custom.json",
+      moduleSystems: ["amd", "cjs", "es6"],
+      outputType: "json",
+      tsPreCompilationDeps: false,
+      preserveSymlinks: false,
+    },
+    ruleSetUsed: {
+      forbidden: [
+        {
+          name: "sdp",
+          severity: "warn",
+          from: {},
+          to: {
+            moreUnstable: true,
+          },
+        },
+      ],
+    },
+  },
+};

--- a/test/report/error/mocks/via-deps.mjs
+++ b/test/report/error/mocks/via-deps.mjs
@@ -196,6 +196,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "reachability",
         from: "src/extract/index.js",
         to: "src/utl/array-util.js",
         rule: {
@@ -205,6 +206,7 @@ export default {
         via: ["(via via)"],
       },
       {
+        type: "reachability",
         from: "src/extract/index.js",
         to: "src/utl/find-rule-by-name.js",
         rule: {
@@ -214,6 +216,7 @@ export default {
         via: ["(via via)"],
       },
       {
+        type: "module",
         from: "src/utl/array-util.js",
         to: "src/utl/array-util.js",
         rule: {
@@ -222,6 +225,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/utl/find-rule-by-name.js",
         to: "src/utl/find-rule-by-name.js",
         rule: {

--- a/test/report/error/mocks/violation-more-than-once.mjs
+++ b/test/report/error/mocks/violation-more-than-once.mjs
@@ -5064,6 +5064,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "src/cli/compileConfig/index.js",
         to: "src/extract/resolve/resolve.js",
         rule: {
@@ -5072,6 +5073,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/extract/extract.js",
         to: "node_modules/lodash/lodash.js",
         rule: {
@@ -5080,6 +5082,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/extract/index.js",
         to: "node_modules/lodash/lodash.js",
         rule: {

--- a/tools/schema/violations.mjs
+++ b/tools/schema/violations.mjs
@@ -20,6 +20,16 @@ export default {
         to: {
           type: "string",
         },
+        type: {
+          type: "string",
+          enum: [
+            "dependency",
+            "module",
+            "reachability",
+            "cycle",
+            "instability",
+          ],
+        },
         rule: { $ref: "#/definitions/RuleSummaryType" },
         cycle: {
           type: "array",
@@ -32,6 +42,29 @@ export default {
           items: { type: "string" },
           description:
             "The path from the from to the to if the violation is transitive",
+        },
+        metrics: {
+          type: "object",
+          required: ["from", "to"],
+          additionalProperties: false,
+          properties: {
+            from: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: {
+                instability: { type: "number" },
+              },
+            },
+            to: {
+              type: "object",
+              required: ["instability"],
+              additionalProperties: false,
+              properties: {
+                instability: { type: "number" },
+              },
+            },
+          },
         },
       },
     },

--- a/types/shared-types.d.ts
+++ b/types/shared-types.d.ts
@@ -42,3 +42,10 @@ export type DependencyType =
   | "type-only";
 
 export type ProtocolType = "data:" | "file:" | "node:";
+
+export type ViolationType =
+  | "dependency"
+  | "module"
+  | "cycle"
+  | "reachability"
+  | "instability";

--- a/types/violations.d.ts
+++ b/types/violations.d.ts
@@ -1,6 +1,20 @@
 import { IRuleSummary } from "./rule-summary";
+import { ViolationType } from "./shared-types";
+
+export interface IMetricsSummary {
+  from: {
+    instability: number;
+  };
+  to: {
+    instability: number;
+  };
+}
 
 export interface IViolation {
+  /**
+   * Type of violation. When left out assumed to be of type 'dependency'
+   */
+  type?: ViolationType;
   /**
    * The violated rule
    */
@@ -21,4 +35,9 @@ export interface IViolation {
    * The path from the from to the to if the violation is transitive
    */
   via?: string[];
+  /**
+   * metrics - when the violation pertains to a violation of a metrics
+   * principle
+   */
+  metrics?: IMetricsSummary;
 }


### PR DESCRIPTION
## Description

- adds a 'metrics' object to any violation of a rule with a `moreUnstable` attribute
- in the error (`err`, `err-long`) reporters show the instability scores next to the _from_ and _to_ of any violation having a metrics property
- refactors the error reporter to ease extensibility & reduce changes to existing code when doing so

## Motivation and Context

A rule violation of the stable dependency principle is more easy to understand when the instability scores are mentioned in the violation. Addition to make the fix for #523 easier to use. The err-html and teamcity reporters will use the same _metrics_ property - but these additions will follow in separate PR's.

## How Has This Been Tested?

- [x] automated non-regression tests 
- [x] green ci
- [x] additional automated unit/ integration tests
- [x] manual check

## Screenshots

<img width="637" alt="image" src="https://user-images.githubusercontent.com/4822597/146762862-d57ee103-e9fd-4b9d-bcab-8e98843e4264.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
