### PR TITLE
feature(report): adds instability metrics to the teamcity reporter

### DIFF
--- a/src/report/dot/module-utl.js
+++ b/src/report/dot/module-utl.js
@@ -1,5 +1,6 @@
 const path = require("path").posix;
 const _has = require("lodash/has");
+const utl = require("../utl/index.js");
 const theming = require("./theming");
 
 const PROTOCOL_PREFIX_RE = /^[a-z]+:\/\//;
@@ -66,9 +67,8 @@ function makeInstabilityString(pModule, pShowMetrics = false) {
   let lInstabilityString = "";
 
   if (pShowMetrics && _has(pModule, "instability") && !pModule.consolidated) {
-    lInstabilityString = ` <FONT color="#808080" point-size="8">${Math.round(
-      // eslint-disable-next-line no-magic-numbers
-      100 * pModule.instability
+    lInstabilityString = ` <FONT color="#808080" point-size="8">${utl.formatInstability(
+      pModule.instability
     )}</FONT>`;
   }
   return lInstabilityString;

--- a/src/report/error.js
+++ b/src/report/error.js
@@ -1,10 +1,10 @@
 /* eslint-disable security/detect-object-injection */
 const chalk = require("chalk");
 const figures = require("figures");
-
 const _get = require("lodash/get");
 const { findRuleByName } = require("../graph-utl/rule-set");
 const wrapAndIndent = require("../utl/wrap-and-indent");
+const utl = require("./utl/index.js");
 
 const SEVERITY2CHALK = {
   error: chalk.red,
@@ -46,28 +46,17 @@ function formatReachabilityViolation(pViolation) {
   )}${formatExtraPathInformation(pViolation.via)}`;
 }
 
-function formatInstability(pNumber) {
-  return Math.round(
-    // eslint-disable-next-line no-magic-numbers
-    100 * pNumber
-  );
-}
-
 function formatInstabilityViolation(pViolation) {
   return `${formatDependencyViolation(pViolation)}\n${wrapAndIndent(
     chalk.dim(
-      `instability: ${formatInstability(pViolation.metrics.from.instability)} ${
-        figures.arrowRight
-      } ${formatInstability(pViolation.metrics.to.instability)}`
+      `instability: ${utl.formatInstability(
+        pViolation.metrics.from.instability
+      )} ${figures.arrowRight} ${utl.formatInstability(
+        pViolation.metrics.to.instability
+      )}`
     ),
     EXTRA_PATH_INFORMATION_INDENT
   )}`;
-}
-
-function formatViolators(pViolation, pViolationType2Formatter) {
-  return (
-    pViolationType2Formatter[pViolation.type] || formatDependencyViolation
-  )(pViolation);
 }
 
 function formatViolation(pViolation) {
@@ -78,9 +67,10 @@ function formatViolation(pViolation) {
     reachability: formatReachabilityViolation,
     instability: formatInstabilityViolation,
   };
-  const lFormattedViolators = formatViolators(
+  const lFormattedViolators = utl.formatViolation(
     pViolation,
-    lViolationType2Formatter
+    lViolationType2Formatter,
+    formatDependencyViolation
   );
 
   return (

--- a/src/report/utl/index.js
+++ b/src/report/utl/index.js
@@ -1,0 +1,16 @@
+function formatInstability(pNumber) {
+  // eslint-disable-next-line no-magic-numbers
+  return Math.round(100 * pNumber);
+}
+
+function formatViolation(
+  pViolation,
+  pViolationType2Formatter,
+  pDefaultFormatter
+) {
+  return (pViolationType2Formatter[pViolation.type] || pDefaultFormatter)(
+    pViolation
+  );
+}
+
+module.exports = { formatViolation, formatInstability };

--- a/test/report/teamcity/mocks/circular-deps.mjs
+++ b/test/report/teamcity/mocks/circular-deps.mjs
@@ -88,6 +88,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "cycle",
         from: "src/some/folder/nested/center.js",
         to: "src/some/folder/loop-a.js",
         rule: {
@@ -101,6 +102,7 @@ export default {
         ],
       },
       {
+        type: "cycle",
         from: "src/some/folder/loop-a.js",
         to: "src/some/folder/loop-b.js",
         rule: {
@@ -114,6 +116,7 @@ export default {
         ],
       },
       {
+        type: "cycle",
         from: "src/some/folder/loop-b.js",
         to: "src/some/folder/nested/center.js",
         rule: {

--- a/test/report/teamcity/mocks/instabilities-teamcity-format.txt
+++ b/test/report/teamcity/mocks/instabilities-teamcity-format.txt
@@ -1,0 +1,2 @@
+##teamcity[inspectionType id='sdp' name='sdp' description='sdp' category='dependency-cruiser']
+##teamcity[inspection typeId='sdp' message='src/more-stable.js -> src/less-stable.js (instability: 42 -> 100)' file='src/more-stable.js' SEVERITY='WARNING']

--- a/test/report/teamcity/mocks/instabilities.mjs
+++ b/test/report/teamcity/mocks/instabilities.mjs
@@ -1,0 +1,81 @@
+export default {
+  modules: [
+    {
+      source: "src/more-stable.js",
+      instability: 0.42,
+      dependencies: [
+        {
+          resolved: "src/less-stable.js",
+          instability: 1,
+          coreModule: false,
+          followable: false,
+          couldNotResolve: false,
+          dependencyTypes: [],
+          dynamic: false,
+          module: "./less-stable.js",
+          moduleSystem: "es6",
+          valid: false,
+          rules: [
+            {
+              severity: "warn",
+              name: "sdp",
+            },
+          ],
+        },
+      ],
+      valid: true,
+    },
+    {
+      source: "src/less-stable.js",
+      instability: 1,
+      dependencies: [],
+      dependents: ["src/more-stable.js"],
+      valid: true,
+    },
+  ],
+  summary: {
+    violations: [
+      {
+        type: "instability",
+        from: "src/more-stable.js",
+        to: "src/less-stable.js",
+        rule: {
+          severity: "warn",
+          name: "sdp",
+        },
+        metrics: {
+          from: {
+            instability: 0.42,
+          },
+          to: {
+            instability: 1,
+          },
+        },
+      },
+    ],
+    error: 0,
+    warn: 1,
+    info: 0,
+    totalCruised: 3,
+    totalDependenciesCruised: 3,
+    optionsUsed: {
+      rulesFile: ".dependency-cruiser-custom.json",
+      moduleSystems: ["amd", "cjs", "es6"],
+      outputType: "json",
+      tsPreCompilationDeps: false,
+      preserveSymlinks: false,
+    },
+    ruleSetUsed: {
+      forbidden: [
+        {
+          name: "sdp",
+          severity: "warn",
+          from: {},
+          to: {
+            moreUnstable: true,
+          },
+        },
+      ],
+    },
+  },
+};

--- a/test/report/teamcity/mocks/module-errors.mjs
+++ b/test/report/teamcity/mocks/module-errors.mjs
@@ -162,6 +162,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "src/asneeze.js",
         to: "node_modules/eslint/lib/api.js",
         rule: {
@@ -170,6 +171,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "./medontexist.json",
         rule: {
@@ -178,6 +180,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "node_modules/dependency-cruiser/src/main/index.js",
         rule: {
@@ -186,6 +189,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "node_modules/eslint/lib/api.js",
         rule: {
@@ -194,6 +198,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/orphan.js",
         to: "src/orphan.js",
         rule: {
@@ -202,6 +207,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "./medontexist.json",
         rule: {

--- a/test/report/teamcity/mocks/required-errors.mjs
+++ b/test/report/teamcity/mocks/required-errors.mjs
@@ -162,6 +162,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "src/asneeze.js",
         to: "node_modules/eslint/lib/api.js",
         rule: {
@@ -170,6 +171,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "./medontexist.json",
         rule: {
@@ -178,6 +180,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "node_modules/dependency-cruiser/src/main/index.js",
         rule: {
@@ -186,6 +189,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "node_modules/eslint/lib/api.js",
         rule: {
@@ -194,6 +198,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/orphan.js",
         to: "src/orphan.js",
         rule: {

--- a/test/report/teamcity/mocks/unsupported-severity.mjs
+++ b/test/report/teamcity/mocks/unsupported-severity.mjs
@@ -163,6 +163,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "dependency",
         from: "src/asneeze.js",
         to: "node_modules/eslint/lib/api.js",
         rule: {
@@ -171,6 +172,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "./medontexist.json",
         rule: {
@@ -179,6 +181,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "node_modules/dependency-cruiser/src/main/index.js",
         rule: {
@@ -187,6 +190,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "node_modules/eslint/lib/api.js",
         rule: {
@@ -195,6 +199,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/orphan.js",
         to: "src/orphan.js",
         rule: {
@@ -203,6 +208,7 @@ export default {
         },
       },
       {
+        type: "dependency",
         from: "src/index.js",
         to: "./medontexist.json",
         rule: {

--- a/test/report/teamcity/mocks/via-deps.mjs
+++ b/test/report/teamcity/mocks/via-deps.mjs
@@ -196,6 +196,7 @@ export default {
   summary: {
     violations: [
       {
+        type: "reachability",
         from: "src/extract/index.js",
         to: "src/utl/array-util.js",
         rule: {
@@ -205,6 +206,7 @@ export default {
         via: ["(via via)"],
       },
       {
+        type: "reachability",
         from: "src/extract/index.js",
         to: "src/utl/find-rule-by-name.js",
         rule: {
@@ -214,6 +216,7 @@ export default {
         via: ["(via via)"],
       },
       {
+        type: "module",
         from: "src/utl/array-util.js",
         to: "src/utl/array-util.js",
         rule: {
@@ -222,6 +225,7 @@ export default {
         },
       },
       {
+        type: "module",
         from: "src/utl/find-rule-by-name.js",
         to: "src/utl/find-rule-by-name.js",
         rule: {

--- a/test/report/teamcity/teamcity.spec.mjs
+++ b/test/report/teamcity/teamcity.spec.mjs
@@ -9,6 +9,7 @@ import circulars from "./mocks/circular-deps.mjs";
 import vias from "./mocks/via-deps.mjs";
 import unsupportedErrorLevels from "./mocks/unsupported-severity.mjs";
 import knownViolations from "./mocks/known-violations.mjs";
+import instabilities from "./mocks/instabilities.mjs";
 
 function removePerSessionAttributes(pString) {
   return pString.replace(/ flowId='[^']+' timestamp='[^']+'/g, "");
@@ -71,6 +72,17 @@ describe("report/teamcity", () => {
     );
     // eslint-disable-next-line no-magic-numbers
     expect(lResult.exitCode).to.equal(4);
+  });
+
+  it("renders instability transgressions", () => {
+    const lFixture = readFixture("mocks/instabilities-teamcity-format.txt");
+    const lResult = render(instabilities);
+
+    expect(removePerSessionAttributes(lResult.output)).to.equal(
+      removePerSessionAttributes(lFixture)
+    );
+    // eslint-disable-next-line no-magic-numbers
+    expect(lResult.exitCode).to.equal(0);
   });
 
   it("renders unsupported error levels (like 'ignore') as 'info'", () => {


### PR DESCRIPTION
## Description

- adds instability metrics to the teamcity reporter (in case there was a violation of a rule with moreUnstable in it)
- refactors the teamcity reporter to be more easy to extend

## Motivation and Context

Follow up to adding metrics to dependency-cruiser (issue #523)


## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional automated tests to cover the new functionality
- [x] manual tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
