### PR TITLE
bugfix(main): in report-wrap retain any options already in the summary

### DIFF
--- a/src/enrich/summarize/summarize-options.js
+++ b/src/enrich/summarize/summarize-options.js
@@ -29,23 +29,27 @@ const SHAREABLE_OPTIONS = [
 
 function makeOptionsPresentable(pOptions) {
   return SHAREABLE_OPTIONS.filter(
-    (pOption) => _has(pOptions, pOption) && pOptions[pOption] !== 0
+    (pShareableOptionKey) =>
+      _has(pOptions, pShareableOptionKey) && pOptions[pShareableOptionKey] !== 0
   )
     .filter(
-      (pOption) =>
-        pOption !== "doNotFollow" ||
+      (pShareableOptionKey) =>
+        pShareableOptionKey !== "doNotFollow" ||
         Object.keys(pOptions.doNotFollow).length > 0
     )
     .filter(
-      (pOption) =>
-        pOption !== "exclude" || Object.keys(pOptions.exclude).length > 0
+      (pShareableOptionKey) =>
+        pShareableOptionKey !== "exclude" ||
+        Object.keys(pOptions.exclude).length > 0
     )
     .filter(
-      (pOption) =>
-        pOption !== "knownViolations" || pOptions.knownViolations.length > 0
+      (pShareableOptionKey) =>
+        pShareableOptionKey !== "knownViolations" ||
+        pOptions.knownViolations.length > 0
     )
-    .reduce((pAll, pOption) => {
-      pAll[pOption] = pOptions[pOption];
+    .reduce((pAll, pShareableOptionKey) => {
+      // console.error(pOption);
+      pAll[pShareableOptionKey] = pOptions[pShareableOptionKey];
       return pAll;
     }, {});
 }

--- a/src/main/report-wrap.js
+++ b/src/main/report-wrap.js
@@ -27,7 +27,10 @@ function reSummarizeResults(pResult, pFormatOptions) {
       ...pResult.summary,
       ...summarize(
         lModules,
-        pFormatOptions,
+        {
+          ...pResult.summary.optionsUsed,
+          ...pFormatOptions,
+        },
         (pResult.summary.optionsUsed.args || "").split(" "),
         // TODO: apply filters to the folders too
         pResult.folders

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -89,6 +89,7 @@ describe("[E] main.format - format", () => {
       "This cli module depends on something not in the public interface"
     );
   });
+
   it("returns string without error explanations when asked for the err report", () => {
     const lErrorResult = main.format(cruiseResult, {
       outputType: "err",
@@ -97,5 +98,19 @@ describe("[E] main.format - format", () => {
     expect(lErrorResult).to.not.contain(
       "This cli module depends on something not in the public interface"
     );
+  });
+
+  it("retains options that are in .summary.optionsUsed unless overriden", () => {
+    const lJSONResult = JSON.parse(
+      main.format(cruiseResult, {
+        outputType: "anon",
+        includeOnly: "^src/",
+      }).output
+    );
+    expect(Object.keys(lJSONResult.summary.optionsUsed).length).to.equal(16);
+    expect(lJSONResult.summary.optionsUsed.outputType).to.equal("anon");
+    expect(lJSONResult.summary.optionsUsed.includeOnly).to.equal("^src/");
+    // without includeOnly it'd be 53
+    expect(lJSONResult.modules.length).to.equal(33);
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

ℹ️  this is a fix for a bug introduced in code that wasn't released yet. 

After the merge of PR #554 (90c140a9),  depcruise-fmt ignored any filters, collapse patterns, reporter options etc that were part of that cruise result. This PR ...
- ... adds an e2e test that checks for this regression
- ... fixes the bug

## How Has This Been Tested?

- [x] automated non-regression test & green ci
- [x] additional e2e test to assure non-regression
- [x] manual test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
