### PR TITLE
bugfix(extract): makes esm url matching more specific

### DIFF
--- a/src/extract/utl/extract-module-attributes.js
+++ b/src/extract/utl/extract-module-attributes.js
@@ -18,11 +18,11 @@ module.exports = function extractModuleAttributes(pString) {
   let lReturnValue = { module: pString };
   const lModuleAttributes = pString.match(
     // eslint-disable-next-line security/detect-unsafe-regex, unicorn/no-unsafe-regex
-    /^(node:|file:|data:)?(([^,]+),)?(.+)$/
+    /^((node:|file:|data:)(([^,]+),)?)(.+)$/
   );
-  const lProtocolPosition = 1;
-  const lMimeTypePosition = 3;
-  const lModulePosition = 4;
+  const lProtocolPosition = 2;
+  const lMimeTypePosition = 4;
+  const lModulePosition = 5;
 
   if (lModuleAttributes) {
     lReturnValue.module = lModuleAttributes[lModulePosition];
@@ -33,5 +33,6 @@ module.exports = function extractModuleAttributes(pString) {
       lReturnValue.mimeType = lModuleAttributes[lMimeTypePosition];
     }
   }
+
   return lReturnValue;
 };

--- a/test/extract/utl/extract-module-attributes.spec.mjs
+++ b/test/extract/utl/extract-module-attributes.spec.mjs
@@ -44,6 +44,12 @@ describe("[U] extract/utl/extract-module-attributes", () => {
     });
   });
 
+  it("treats comma's without a (known) protocol as part of the filename", () => {
+    expect(extractModuleAttributes("a com, ma.json")).to.deep.equal({
+      module: "a com, ma.json",
+    });
+  });
+
   it("when protocol separator is mistyped, returns it as part of the module name", () => {
     expect(
       extractModuleAttributes("data:application/json;gegevens.json")


### PR DESCRIPTION
## Description

makes esm url matching more specific so non-protocol prefixed strings get returned _as is_. 

See the included UT for specifics.

## Motivation and Context

fixes #567 

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test
- [x] manual test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
