### PR TITLE
feature(validate): adds possibility to define rules to validate against folder cycles

### DIFF
--- a/configs/.dependency-cruiser-show-metrics-config.json
+++ b/configs/.dependency-cruiser-show-metrics-config.json
@@ -22,6 +22,16 @@
       "to": {
         "moreUnstable": true
       }
+    },
+    {
+      "name": "no-folder-cycles",
+      "scope": "folder",
+      "severity": "warn",
+      "comment": "This folder is part of a circular relationship. You might want to refactor that a bit.",
+      "from": {},
+      "to": {
+        "circular": true
+      }
     }
   ],
   "options": {

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -1,6 +1,7 @@
 /* eslint-disable security/detect-object-injection */
-const _clone = require("lodash/clone");
-const _has = require("lodash/has");
+const get = require("lodash/get");
+const clone = require("lodash/clone");
+const has = require("lodash/has");
 const normalizeREProperties = require("../utl/normalize-re-properties");
 const defaults = require("./defaults.js");
 
@@ -67,7 +68,12 @@ function normalizeCollapse(pCollapse) {
 }
 
 function hasMetricsRule(pRule) {
-  return _has(pRule, "to.moreUnstable");
+  // TODO: philosophy: is a rule with 'folder' in it a metrics rule?
+  //       Or is it a misuse to ensure folder derivations (like cycles) get
+  //       kicked off?
+  return (
+    has(pRule, "to.moreUnstable") || get(pRule, "scope", "module") === "folder"
+  );
 }
 
 function ruleSetHasMetricsRule(pRuleSet) {
@@ -107,7 +113,7 @@ function normalizeCruiseOptions(pOptions) {
 
   lReturnValue.maxDepth = Number.parseInt(lReturnValue.maxDepth, 10);
   lReturnValue.moduleSystems = uniq(lReturnValue.moduleSystems.sort());
-  if (_has(lReturnValue, "collapse")) {
+  if (has(lReturnValue, "collapse")) {
     lReturnValue.collapse = normalizeCollapse(lReturnValue.collapse);
   }
   // TODO: further down the execution path code still relies on .doNotFollow
@@ -133,9 +139,9 @@ function normalizeCruiseOptions(pOptions) {
 }
 
 function normalizeFormatOptions(pFormatOptions) {
-  const lFormatOptions = _clone(pFormatOptions);
+  const lFormatOptions = clone(pFormatOptions);
 
-  if (_has(lFormatOptions, "collapse")) {
+  if (has(lFormatOptions, "collapse")) {
     lFormatOptions.collapse = normalizeCollapse(lFormatOptions.collapse);
   }
   return normalizeFilterOptions(lFormatOptions, [

--- a/src/validate/match-folder-dependency-rule.js
+++ b/src/validate/match-folder-dependency-rule.js
@@ -5,9 +5,8 @@ function match(pFromFolder, pToFolder) {
   return (pRule) =>
     // TODO: add path rules - they need to be frippled from the ones
     // already in place for modules
-    // TODO: same for cycles - but these will additionally have to be
-    // yognated with an adapted cycle detection for folders
-    matchers.toIsMoreUnstable(pRule, pFromFolder, pToFolder);
+    matchers.toIsMoreUnstable(pRule, pFromFolder, pToFolder) &&
+    matchers.propertyEquals(pRule, pToFolder, "circular");
 }
 
 const isInteresting = (pRule) =>

--- a/test/validate/match-folder-rule.spec.mjs
+++ b/test/validate/match-folder-rule.spec.mjs
@@ -3,11 +3,15 @@ import matchFolderRule from "../../src/validate/match-folder-dependency-rule.js"
 
 const EMPTY_RULE = { scope: "folder", from: {}, to: {} };
 const SDP_RULE = { scope: "folder", from: {}, to: { moreUnstable: true } };
+const CYCLE_RULE = { scope: "folder", from: {}, to: { circular: true } };
 
-describe("[I] validate/match-folder-dependency-rule - match", () => {
+describe("[I] validate/match-folder-dependency-rule - match generic", () => {
   it("empty rule => match all the things (empty from & to)", () => {
     expect(matchFolderRule.match({}, {})(EMPTY_RULE)).to.equal(true);
   });
+});
+
+describe("[I] validate/match-folder-dependency-rule - match SDP", () => {
   it("rule with a restriction on the to doesn't match when the criterium is not met (data missing)", () => {
     expect(matchFolderRule.match({}, {})(SDP_RULE)).to.equal(false);
   });
@@ -20,5 +24,21 @@ describe("[I] validate/match-folder-dependency-rule - match", () => {
     expect(
       matchFolderRule.match({ instability: 0 }, { instability: 1 })(SDP_RULE)
     ).to.equal(true);
+  });
+});
+
+describe("[I] validate/match-folder-dependency-rule - match cycle", () => {
+  it("rule with a restriction on the to doesn't match when the criterium is not met (data missing)", () => {
+    expect(matchFolderRule.match({}, {})(CYCLE_RULE)).to.equal(false);
+  });
+  it("rule with a restriction on the to doesn't match when the criterium is not met (data there)", () => {
+    expect(matchFolderRule.match({}, { circular: false })(CYCLE_RULE)).to.equal(
+      false
+    );
+  });
+  it("rule with a restriction on the to doesn't match when the criterium is met (data there)", () => {
+    expect(matchFolderRule.match({}, { circular: true })(CYCLE_RULE)).to.equal(
+      true
+    );
   });
 });


### PR DESCRIPTION
## Description

- adds the possibility to write rules that validate against cycles between folders

Not in scope of this PR: adaptions to reporters to show them, even though the err, err-html and err-long reporters will report them out of the box (just not yet with extended info).

## Motivation and Context

fixes #324 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated integration tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
