### PR TITLE
feature(report): show folder cycles in textual reporters

### DIFF
--- a/src/enrich/summarize/index.js
+++ b/src/enrich/summarize/index.js
@@ -1,3 +1,4 @@
+const compare = require("../../graph-utl/compare");
 const addRuleSetUsed = require("./add-rule-set-used");
 const summarizeModules = require("./summarize-modules");
 const summarizeFolders = require("./summarize-folders");
@@ -28,9 +29,9 @@ module.exports = function summarize(
   pFileDirectoryArray,
   pFolders
 ) {
-  const lViolations = summarizeModules(pModules, pOptions.ruleSet).concat(
-    summarizeFolders(pFolders || [], pOptions.ruleSet)
-  );
+  const lViolations = summarizeModules(pModules, pOptions.ruleSet)
+    .concat(summarizeFolders(pFolders || [], pOptions.ruleSet))
+    .sort(compare.violations);
 
   return {
     violations: lViolations,

--- a/src/enrich/summarize/summarize-folders.js
+++ b/src/enrich/summarize/summarize-folders.js
@@ -1,9 +1,13 @@
-const _has = require("lodash/has");
+const has = require("lodash/has");
 const { findRuleByName } = require("../../graph-utl/rule-set");
 
 function classifyViolation(pRule, pRuleSet) {
-  if (_has(findRuleByName(pRuleSet, pRule.name), "to.moreUnstable")) {
+  const lRule = findRuleByName(pRuleSet, pRule.name);
+  if (has(lRule, "to.moreUnstable")) {
     return "instability";
+  }
+  if (has(lRule, "to.circular")) {
+    return "cycle";
   }
   return "folder";
 }
@@ -26,6 +30,11 @@ function getViolations(pFolder, pRuleSet) {
                   from: { instability: pFolder.instability },
                   to: { instability: pDependency.instability },
                 },
+              }
+            : {}),
+          ...(lViolationType === "cycle"
+            ? {
+                cycle: pDependency.cycle,
               }
             : {}),
         };


### PR DESCRIPTION
## Description

- ensures that in text reporters (err, err-long, err-html, teamcity) next to the cycle violation the cycle itself appears.
- also incorporate folder level violations into the violation sorting

## Motivation and Context

- makes it easier to see what the offending cycles are
- the ordering helps prioritise easier

## How Has This Been Tested?

- [x] green ci
- [x] additional automated integration tests
- [x] manual tests


## Screenshots
### err
<img width="654" alt="image" src="https://user-images.githubusercontent.com/4822597/162615908-4847ea0c-4ff6-428c-a36b-9d76ab6d73d3.png">

### err-long

<img width="654" alt="image" src="https://user-images.githubusercontent.com/4822597/162615933-cb901ff9-1259-4cdd-8d13-fe7b2c37c3a0.png">


### err-html
![image](https://user-images.githubusercontent.com/4822597/162615874-052450a2-befa-4257-9d4a-d8581863d1be.png)

### teamcity
```
##teamcity[inspectionType id='no-folder-cycles' name='no-folder-cycles' description='This folder is part of a circular relationship. You might want to refactor that a bit.' category='dependency-cruiser' flowId='6411767984' timestamp='2022-04-10T11:32:16.622']
##teamcity[inspectionType id='ignored-known-violations' name='ignored-known-violations' description='some dependency violations were ignored; run without --ignore-known to see them' category='dependency-cruiser' flowId='6411767984' timestamp='2022-04-10T11:32:16.623']
##teamcity[inspection typeId='no-folder-cycles' message='src/extract/parse -> src/extract/transpile -> src/extract/parse' file='src/extract/parse' SEVERITY='WARNING' flowId='6411767984' timestamp='2022-04-10T11:32:16.623']
##teamcity[inspection typeId='no-folder-cycles' message='src/extract/transpile -> src/extract/parse -> src/extract/transpile' file='src/extract/transpile' SEVERITY='WARNING' flowId='6411767984' timestamp='2022-04-10T11:32:16.623']
##teamcity[inspection typeId='ignored-known-violations' message='6 known violations ignored. Run without --ignore-known to see them.' SEVERITY='WARNING' flowId='6411767984' timestamp='2022-04-10T11:32:16.623']
```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
