### PR TITLE
feature(wrap-stream-in-html): adds ability to 'pin' a highlight with a left mouse click

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1105,8 +1105,12 @@ to write to an alternative output location.
 ## depcruise-wrap-stream-in-html
 
 With `depcruise-wrap-stream-in-html` you can wrap the graphical output of
-GraphViz dot into html that is geared to make the graph easier to use. It a.o.
-adds highlight-on-hover.
+GraphViz dot into html that is geared to make the graph easier to use. It adds a.o.:
+
+- highlighting dependencies on hover
+- the ability to 'pin' that highlight with a left mouse click ("on context menu").
+  Can be cleared with a left mouse click on something not a module or dependency
+  or by pressing the _Escape_ key.
 
 <img width="799" alt="highlight on hover" src="assets/highlight-on-hover.png">
 


### PR DESCRIPTION
## Description

Adds this behaviour to dependency graph visualisations:
- A left mouse click ('on context menu) 'pins' the highlighted modules and dependencies, so when your mouse moves away from them they're still highlighted.
- A left-click on something that isn't a module or dependency clears the highlight again. A press on the  _Escape_ key does the same.

## Motivation and Context

Highlight-on-hover has proven useful, but when you want to trace a dependency in a large graph it's often hard to keep track as you'd need to keep hovering the same dependency. The ability to 'pin' makes it easier to keep track.


## How Has This Been Tested?

- [x] green ci
- [x] manual tests

## Screenshots

![highlight-on-click](https://user-images.githubusercontent.com/4822597/163670936-70f973cf-fad7-4fc9-8db6-448be622e11e.gif)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
