### PR TITLE
feature(wrap-stream-in-html): adds simple help system

### DIFF
--- a/src/cli/tools/svg-in-html-snippets/header.snippet.html
+++ b/src/cli/tools/svg-in-html-snippets/header.snippet.html
@@ -9,8 +9,7 @@
       .node.current path,
       .node:active polygon,
       .node:hover polygon,
-      .node.current polygon
-       {
+      .node.current polygon {
         stroke: fuchsia;
         stroke-width: 2;
       }
@@ -44,6 +43,66 @@
       .cluster:hover path {
         fill: #ffff0011;
       }
+      div.hint {
+        background-color: #000000aa;
+        color: white;
+        font-family: Arial, Helvetica, sans-serif;
+        border-radius: 1rem;
+        position: fixed;
+        top: calc(50% - 4em);
+        right: calc(50% - 10em);
+        border: none;
+        padding: 1em 3em 1em 1em;
+      }
+      .hint button {
+        position: absolute;
+        font-weight: bolder;
+        right: 0.6em;
+        top: 0.6em;
+        color: inherit;
+        background-color: inherit;
+        border: 1px solid currentColor;
+        border-radius: 1em;
+        margin-left: 0.6em;
+      }
+      .hint a {
+        color: inherit;
+      }
+      #button_help {
+        color: white;
+        background-color: #00000011;
+        border-radius: 1em;
+        position: fixed;
+        top: 1em;
+        right: 1em;
+        font-size: 24pt;
+        font-weight: bolder;
+        width: 2em;
+        height: 2em;
+        border: none;
+      }
+      #button_help:hover {
+        cursor: pointer;
+        background-color: #00000077;
+      }
+      @media print {
+        #button_help {
+          display: none;
+        }
+        div.hint {
+          display: none;
+        }
+      }
     </style>
   </head>
   <body>
+    <button id="button_help">?</button>
+    <div id="hints" class="hint" style="display: none">
+      <button id="close-hints">x</button>
+      <span id="hint-text"></span>
+      <ul>
+        <li><b>Hover</b> - highlight</li>
+        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>ESC</b> - clear</li>
+      </ul>
+    </div>

--- a/src/cli/tools/svg-in-html-snippets/script.snippet.js
+++ b/src/cli/tools/svg-in-html-snippets/script.snippet.js
@@ -1,6 +1,6 @@
 document.addEventListener("contextmenu", getSelectHandler(title2ElementMap));
 document.addEventListener("mouseover", getHoverHandler(title2ElementMap));
-document.addEventListener("keydown", resetHandler);
+document.addEventListener("keydown", keyboardEventHandler);
 
 var gMode = new Mode();
 
@@ -12,13 +12,6 @@ var title2ElementMap = (function makeElementMap() {
   return new Title2ElementMap(edges, nodes);
 })();
 
-/** @param {KeyboardEvent} pKeyboardEvent */
-function resetHandler(pKeyboardEvent) {
-  if (pKeyboardEvent.key === "Escape") {
-    resetNodesAndEdges();
-    gMode.setToHover();
-  }
-}
 function getHoverHandler() {
   /** @type {string} */
   var currentHighlightedTitle;
@@ -220,3 +213,39 @@ function addHighlight(pGroup) {
     pGroup.classList.add("current");
   }
 }
+
+var hints = {
+  HIDDEN: 1,
+  SHOWN: 2,
+  state: this.HIDDEN,
+  show: function () {
+    document.getElementById("hints").removeAttribute("style");
+    hints.state = hints.SHOWN;
+  },
+  hide: function () {
+    document.getElementById("hints").style = "display:none";
+    hints.state = hints.HIDDEN;
+  },
+  toggle: function () {
+    if ((hints.state || hints.HIDDEN) === hints.HIDDEN) {
+      hints.show();
+    } else {
+      hints.hide();
+    }
+  },
+};
+
+/** @param {KeyboardEvent} pKeyboardEvent */
+function keyboardEventHandler(pKeyboardEvent) {
+  if (pKeyboardEvent.key === "Escape") {
+    resetNodesAndEdges();
+    gMode.setToHover();
+    hints.hide();
+  }
+  if (pKeyboardEvent.key === "F1") {
+    pKeyboardEvent.preventDefault();
+    hints.toggle();
+  }
+}
+document.getElementById("close-hints").addEventListener("click", hints.hide);
+document.getElementById("button_help").addEventListener("click", hints.toggle);

--- a/src/cli/tools/wrap-stream-in-html.js
+++ b/src/cli/tools/wrap-stream-in-html.js
@@ -31,7 +31,7 @@ const FOOTER_FILE = path.join(
  * @param {readStream} pStream stream whose characters are to be slapped between header and footer
  * @param {writeStream} pOutStream stream to write to
  */
-function wrap(pInStream, pOutStream) {
+module.exports = function wrap(pInStream, pOutStream) {
   const lHeader = fs.readFileSync(HEADER_FILE, "utf8");
   const lScript = fs.readFileSync(SCRIPT_FILE, "utf8");
   const lEnd = fs.readFileSync(FOOTER_FILE, "utf8");
@@ -54,6 +54,4 @@ function wrap(pInStream, pOutStream) {
     .on("data", (pChunk) => {
       pOutStream.write(pChunk);
     });
-}
-
-module.exports = (pInStream, pOutStream) => wrap(pInStream, pOutStream);
+};


### PR DESCRIPTION
## Description

- adds a small screen with some hints on how to use the graph
- adds a button on the top right that toggles the visibility of that screen
- binds F1 to toggle that screen as well
- binds ESC to also close that screen

## Motivation and Context

The new 'left click to pin' feature isn't as discoverable as 'highlight-on-hover'. Goal of this PR is to improve its discoverability (hopefully as unobtrusively as possible).

## How Has This Been Tested?

- [x] green ci
- [x] manual tests

## Screenshots

![help](https://user-images.githubusercontent.com/4822597/163721629-3236c700-f7c8-4e56-9785-2934c2b8dccc.gif)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
