### PR TITLE
feature(validate): adds group matching to folder scoped rules

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -284,10 +284,10 @@ a difference:
 >   If there's a better way dependency-cruiser will switch over to that without
 >   a major version bump.
 > - :warning: at this time only the `moreUnstable`, `circular` and `path`/ `pathNot`
->   attributes works, so it is
+>   attributes (including 'group matching') work, so it is
 >   possible to check the "stable dependencies principle" on folder level. Other
 >   attributes (including, but not limited to _via_)
->   still have to be implemented (after release 11.6.0)
+>   still have to be implemented (after release 11.7.0)
 
 ## Conditions
 

--- a/test/validate/match-folder-dependency-rule.spec.mjs
+++ b/test/validate/match-folder-dependency-rule.spec.mjs
@@ -77,16 +77,47 @@ describe("[I] validate/match-folder-dependency-rule - match from pathNot", () =>
 
 describe("[I] validate/match-folder-dependency-rule - match to path", () => {
   const lPathRule = { scope: "folder", from: {}, to: { path: "src/" } };
+  const lGroupMatchingPathRule = {
+    scope: "folder",
+    from: {
+      path: "src/components/[^/]+",
+    },
+    to: { path: "src/components/", pathNot: "src/components/$1" },
+  };
 
   it("does not match folders not in the from path of the rule", () => {
     expect(
       matchFolderRule.match({}, { name: "test/shouldnotmatch" })(lPathRule)
     ).to.equal(false);
   });
+  it("does not match folders not in the from path of the rule (group matching variant)", () => {
+    expect(
+      matchFolderRule.match(
+        { name: "src/components/thing" },
+        { name: "test/components/other-thing" }
+      )(lGroupMatchingPathRule)
+    ).to.equal(false);
+  });
   it("does match folders in the from path of the rule", () => {
     expect(
       matchFolderRule.match({}, { name: "src/shouldmatch" })(lPathRule)
     ).to.equal(true);
+  });
+  it("does match folders in the from path of the rule (group matching variant - matching one, not the other)", () => {
+    expect(
+      matchFolderRule.match(
+        { name: "src/components/thing" },
+        { name: "src/components/thing/folder-in-thing" }
+      )(lGroupMatchingPathRule)
+    ).to.equal(true);
+  });
+  it("does not match folders in the from path of the rule (group matching  - not matching any)", () => {
+    expect(
+      matchFolderRule.match(
+        { name: "src/components/thing" },
+        { name: "src/not-even-a-component" }
+      )(lGroupMatchingPathRule)
+    ).to.equal(false);
   });
 });
 


### PR DESCRIPTION
## Description

-  adds group matching to folder scoped rules

## Motivation and Context

- provides symmetry with the path & pathNot rules in module scope
- might be helpful with the use case as sketched in #585 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated integration tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
