### PR TITLE
feature(extract): makes an type import and an import of the same module in the same file two separate dependencies

### DIFF
--- a/src/extract/get-dependencies.js
+++ b/src/extract/get-dependencies.js
@@ -179,8 +179,15 @@ function matchesPattern(pFullPathToFile, pPattern) {
   return RegExp(pPattern, "g").test(pFullPathToFile);
 }
 
+/**
+ *
+ * @param {import("../../types/dependency-cruiser").IDependency} pDependency
+ * @returns {string}
+ */
 function getDependencyUniqueKey(pDependency) {
-  return `${pDependency.module} ${pDependency.moduleSystem}`;
+  return `${pDependency.module} ${pDependency.moduleSystem} ${(
+    pDependency.dependencyTypes || []
+  ).includes("type-only")}`;
 }
 
 function compareDeps(pLeft, pRight) {

--- a/test/backwards.utl.mjs
+++ b/test/backwards.utl.mjs
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
+import JSON5 from "json5";
 
 export function createRequireJSON(pBaseURL) {
   return function requireJSON(pString) {
-    return JSON.parse(readFileSync(new URL(pString, pBaseURL), "utf8"));
+    return JSON5.parse(readFileSync(new URL(pString, pBaseURL), "utf8"));
   };
 }

--- a/test/extract/__fixtures__/ts-types.json
+++ b/test/extract/__fixtures__/ts-types.json
@@ -1,0 +1,67 @@
+[
+  {
+    "title": "type only + regular import from the same module yields 2 dependencies",
+    "input": {
+      "fileName": "test/extract/__mocks__/ts-types/two-import-types-one-dependency.ts"
+    },
+    "expected": [
+      {
+        "module": "./things",
+        "resolved": "test/extract/__mocks__/ts-types/things.ts",
+        "moduleSystem": "es6",
+        "coreModule": false,
+        "dependencyTypes": ["local"],
+        "dynamic": false,
+        "followable": true,
+        "exoticallyRequired": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false
+      },
+      {
+        "module": "./things",
+        "resolved": "test/extract/__mocks__/ts-types/things.ts",
+        "moduleSystem": "es6",
+        "coreModule": false,
+        "dependencyTypes": ["local", "type-only"],
+        "dynamic": false,
+        "followable": true,
+        "exoticallyRequired": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false
+      }
+    ]
+  }
+  // TODO: nope - that doesn't work yet; fix in a separate PR
+  // {
+  //   "title": "type only + regular import in one import statementfrom the same module yields 2 dependencies",
+  //   "input": {
+  //     "fileName": "test/extract/__mocks__/ts-types/two-import-types-one-dependency-one-import-statement.ts"
+  //   },
+  //   "expected": [
+  //     {
+  //       "module": "./things",
+  //       "resolved": "test/extract/__mocks__/ts-types/things.ts",
+  //       "moduleSystem": "es6",
+  //       "coreModule": false,
+  //       "dependencyTypes": ["local"],
+  //       "dynamic": false,
+  //       "followable": true,
+  //       "exoticallyRequired": false,
+  //       "matchesDoNotFollow": false,
+  //       "couldNotResolve": false
+  //     },
+  //     {
+  //       "module": "./things",
+  //       "resolved": "test/extract/__mocks__/ts-types/things.ts",
+  //       "moduleSystem": "es6",
+  //       "coreModule": false,
+  //       "dependencyTypes": ["local", "type-only"],
+  //       "dynamic": false,
+  //       "followable": true,
+  //       "exoticallyRequired": false,
+  //       "matchesDoNotFollow": false,
+  //       "couldNotResolve": false
+  //     }
+  //   ]
+  // }
+]

--- a/test/extract/__mocks__/ts-types/things.ts
+++ b/test/extract/__mocks__/ts-types/things.ts
@@ -1,0 +1,5 @@
+export interface IThing {
+ id: number;
+ thing: string;
+}
+export const otherThing = 481;

--- a/test/extract/__mocks__/ts-types/two-import-types-one-dependency-one-import-statement.ts
+++ b/test/extract/__mocks__/ts-types/two-import-types-one-dependency-one-import-statement.ts
@@ -1,0 +1,1 @@
+import { otherThing, type IThing } from "./things";

--- a/test/extract/__mocks__/ts-types/two-import-types-one-dependency.ts
+++ b/test/extract/__mocks__/ts-types/two-import-types-one-dependency.ts
@@ -1,0 +1,2 @@
+import { otherThing } from "./things";
+import type { IThing } from "./things";

--- a/test/extract/get-dependencies.ts-types.spec.mjs
+++ b/test/extract/get-dependencies.ts-types.spec.mjs
@@ -1,0 +1,13 @@
+import { createRequireJSON } from "../backwards.utl.mjs";
+import { runFixture } from "./run-get-dependencies-fixture.utl.mjs";
+
+const requireJSON = createRequireJSON(import.meta.url);
+
+const tsTypesFixtures = requireJSON("./__fixtures__/ts-types.json");
+
+describe("[I] extract/getDependencies - TypeScript - ", () => {
+  // swc doesn't seem to recognize type only imports yet (or we don't
+  // pick it from the AST yet - TODO: investigate that)
+  // tsTypesFixtures.forEach((pFixture) => runFixture(pFixture, "swc"));
+  tsTypesFixtures.forEach((pFixture) => runFixture(pFixture, "tsc"));
+});


### PR DESCRIPTION
## Description

- if there's a type import _and_ a regular import of the same module in the same file dependency-cruiser now treats these as two separate dependencies

```typescript
// two-import-types-one-dependency.ts
import { otherThing } from "./things";
import type { IThing } from "./things";
```

```typescript
// things.ts
export interface IThing {
 id: number;
 thing: string;
}
export const otherThing = 481;

```

run something like this:
```
npx dependency-cruise --ts-pre-compilation-deps two-import-types-one-dependency.ts -T json 
```

result:
<details>

```javascript
//..
  {
    "source": "two-import-types-one-dependency.ts",
    "dependencies": [
      {
        "dynamic": false,
        "module": "./things",
        "moduleSystem": "es6",
        "exoticallyRequired": false,
        "resolved": "things.ts",
        "coreModule": false,
        "followable": true,
        "couldNotResolve": false,
        "dependencyTypes": [
          "local"
        ],
        "matchesDoNotFollow": false,
        "circular": false,
        "valid": true
      },
      {
        "dynamic": false,
        "module": "./things",
        "moduleSystem": "es6",
        "exoticallyRequired": false,
        "dependencyTypes": [
          "local",
          "type-only"
        ],
        "resolved": "things.ts",
        "coreModule": false,
        "followable": true,
        "couldNotResolve": false,
        "matchesDoNotFollow": false,
        "circular": false,
        "valid": true
      }
    ],
    "orphan": false,
    "valid": true
  },
// ...
```

</details>



## Motivation and Context

adresses the original scenario raised in issue #588 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated integration test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
