### PR TITLE
bugfix(main): don't sort the moduleSystems passed as options; change default order from most used to least used

### DIFF
--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -360,15 +360,15 @@ And with `"maxDepth": 3` like this:
 > :shell: command line option equivalent: `--module-systems`
 
 Here you can pass a list of module systems dependency-cruiser should use
-to detect dependencies. It defaults to `["amd", "cjs", "es6", "tsd]` The
+to detect dependencies. It defaults to `["es6", "cjs", "tsd", "amd"]` The
 'module systems' dependency-cruiser supports:
 
 | System | Meaning                                                                                                                                                                        |
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `amd`  | [Asynchronous Module Definition](https://github.com/amdjs/amdjs-api/wiki/AMD) as used by a.o. [RequireJS](requirejs.org)                                                       |
-| `cjs`  | Common js as popularised by [node.js](https://nodejs.org/dist/latest-v12.x/docs/api/modules.html) which uses the `require` function to include other modules                   |
 | `es6`  | modules as defined for ECMAScript 6 in 2015 in [Emma-262](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-modules), with proper `import` and `export` statements |
+| `cjs`  | Common js as popularised by [node.js](https://nodejs.org/dist/latest-v18.x/docs/api/modules.html) which uses the `require` function to include other modules                   |
 | `tsd`  | [TypeScript 'triple slash directives'](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)                                                              |
+| `amd`  | [Asynchronous Module Definition](https://github.com/amdjs/amdjs-api/wiki/AMD) as used by a.o. [RequireJS](requirejs.org)                                                       |
 
 ## `tsPreCompilationDeps`
 

--- a/src/main/options/defaults.js
+++ b/src/main/options/defaults.js
@@ -1,7 +1,7 @@
 module.exports = {
   validate: false,
   maxDepth: 0,
-  moduleSystems: ["amd", "cjs", "es6", "tsd"],
+  moduleSystems: ["es6", "cjs", "tsd", "amd"],
   tsPreCompilationDeps: false,
   preserveSymlinks: false,
   combinedDependencies: false,

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -112,7 +112,7 @@ function normalizeCruiseOptions(pOptions) {
   };
 
   lReturnValue.maxDepth = Number.parseInt(lReturnValue.maxDepth, 10);
-  lReturnValue.moduleSystems = uniq(lReturnValue.moduleSystems.sort());
+  lReturnValue.moduleSystems = uniq(lReturnValue.moduleSystems);
   if (has(lReturnValue, "collapse")) {
     lReturnValue.collapse = normalizeCollapse(lReturnValue.collapse);
   }
@@ -125,9 +125,7 @@ function normalizeCruiseOptions(pOptions) {
   lReturnValue.extraExtensionsToScan = lReturnValue.extraExtensionsToScan || [];
   lReturnValue = normalizeFilterOptions(lReturnValue, ["focus", "includeOnly"]);
 
-  lReturnValue.exoticRequireStrings = uniq(
-    lReturnValue.exoticRequireStrings.sort()
-  );
+  lReturnValue.exoticRequireStrings = uniq(lReturnValue.exoticRequireStrings);
   if (lReturnValue.reporterOptions) {
     lReturnValue.reporterOptions = normalizeReporterOptions(
       lReturnValue.reporterOptions

--- a/test/cli/__fixtures__/babel/babel-es6-result.json
+++ b/test/cli/__fixtures__/babel/babel-es6-result.json
@@ -12,9 +12,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -41,9 +39,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -64,12 +60,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/babel-es6-result.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/babel/babel-ts-result.json
+++ b/test/cli/__fixtures__/babel/babel-ts-result.json
@@ -12,9 +12,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -41,9 +39,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -64,9 +60,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -81,9 +75,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -106,9 +98,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -122,9 +112,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -138,9 +126,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -154,9 +140,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -171,9 +155,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -190,12 +172,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/babel-ts-result.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/cjs.dir.filtered.json
+++ b/test/cli/__fixtures__/cjs.dir.filtered.json
@@ -12,9 +12,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -29,9 +27,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -48,9 +44,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -71,9 +65,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -87,9 +79,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -103,9 +93,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -119,9 +107,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -135,9 +121,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -152,9 +136,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -171,9 +153,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -194,9 +174,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -210,9 +188,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -233,9 +209,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -256,9 +230,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -272,9 +244,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -288,9 +258,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -304,9 +272,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -321,9 +287,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -334,9 +298,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -353,9 +315,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -379,12 +339,7 @@
         "path": "node_modules"
       },
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/cjs.dir.filtered.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/cjs.dir.json
+++ b/test/cli/__fixtures__/cjs.dir.json
@@ -24,9 +24,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -40,9 +38,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -63,9 +59,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -80,9 +74,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -99,9 +91,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -122,9 +112,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -138,9 +126,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -154,9 +140,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -170,9 +154,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -186,9 +168,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -202,9 +182,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -219,9 +197,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -238,9 +214,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -261,9 +235,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -277,9 +249,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -300,9 +270,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -323,9 +291,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -339,9 +305,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -355,9 +319,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -371,9 +333,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -388,9 +348,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "local"
-      ],
+      "dependencyTypes": ["local"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -401,9 +359,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -420,9 +376,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -443,12 +397,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/cjs.dir.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/cjs.file.json
+++ b/test/cli/__fixtures__/cjs.file.json
@@ -12,9 +12,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -28,9 +26,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -44,9 +40,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -60,9 +54,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -76,9 +68,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -92,9 +82,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -109,9 +97,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -128,9 +114,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -145,9 +129,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -164,9 +146,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -187,9 +167,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -210,9 +188,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -226,9 +202,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -249,9 +223,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -272,9 +244,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -288,9 +258,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "npm-no-pkg"
-          ],
+          "dependencyTypes": ["npm-no-pkg"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -323,12 +291,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/cjs.file.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/dynamic-import-nok.json
+++ b/test/cli/__fixtures__/dynamic-import-nok.json
@@ -12,9 +12,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -41,12 +39,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/dynamic-import-nok.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/dynamic-import-ok.json
+++ b/test/cli/__fixtures__/dynamic-import-ok.json
@@ -12,9 +12,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -41,12 +39,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/dynamic-import-ok.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/multiple-in-one-go.json
+++ b/test/cli/__fixtures__/multiple-in-one-go.json
@@ -12,9 +12,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -29,9 +27,7 @@
       "coreModule": true,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "core"
-      ],
+      "dependencyTypes": ["core"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -48,9 +44,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "local"
-          ],
+          "dependencyTypes": ["local"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -64,9 +58,7 @@
           "coreModule": true,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "core"
-          ],
+          "dependencyTypes": ["core"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -93,9 +85,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -109,9 +99,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": true,
-          "dependencyTypes": [
-            "unknown"
-          ],
+          "dependencyTypes": ["unknown"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -126,9 +114,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -139,9 +125,7 @@
       "coreModule": false,
       "couldNotResolve": true,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "unknown"
-      ],
+      "dependencyTypes": ["unknown"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -158,12 +142,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/multiple-in-one-go.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/typescript-path-resolution.json
+++ b/test/cli/__fixtures__/typescript-path-resolution.json
@@ -12,9 +12,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -41,9 +39,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -64,12 +60,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/typescript-path-resolution.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/webpack-config-alias-cruiser-config.json
+++ b/test/cli/__fixtures__/webpack-config-alias-cruiser-config.json
@@ -18,9 +18,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -34,9 +32,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -51,9 +47,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "aliased"
-      ],
+      "dependencyTypes": ["aliased"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -70,12 +64,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/webpack-config-alias-cruiser-config.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/cli/__fixtures__/webpack-config-alias.json
+++ b/test/cli/__fixtures__/webpack-config-alias.json
@@ -18,9 +18,7 @@
           "coreModule": false,
           "followable": true,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -34,9 +32,7 @@
           "coreModule": false,
           "followable": false,
           "couldNotResolve": false,
-          "dependencyTypes": [
-            "aliased"
-          ],
+          "dependencyTypes": ["aliased"],
           "matchesDoNotFollow": false,
           "circular": false,
           "valid": true
@@ -51,9 +47,7 @@
       "coreModule": false,
       "couldNotResolve": false,
       "matchesDoNotFollow": false,
-      "dependencyTypes": [
-        "aliased"
-      ],
+      "dependencyTypes": ["aliased"],
       "dependencies": [],
       "orphan": false,
       "valid": true
@@ -70,12 +64,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": [
-        "amd",
-        "cjs",
-        "es6",
-        "tsd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/webpack-config-alias.json",
       "outputType": "json",
       "preserveSymlinks": false,

--- a/test/main/__fixtures__/jsx-as-object.json
+++ b/test/main/__fixtures__/jsx-as-object.json
@@ -190,7 +190,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/jsx.json
+++ b/test/main/__fixtures__/jsx.json
@@ -190,7 +190,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/ts-no-precomp-cjs.json
+++ b/test/main/__fixtures__/ts-no-precomp-cjs.json
@@ -65,7 +65,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/ts-no-precomp-es.json
+++ b/test/main/__fixtures__/ts-no-precomp-es.json
@@ -65,7 +65,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/ts-precomp-cjs.json
+++ b/test/main/__fixtures__/ts-precomp-cjs.json
@@ -79,7 +79,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/ts-precomp-es.json
+++ b/test/main/__fixtures__/ts-precomp-es.json
@@ -79,7 +79,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/ts.json
+++ b/test/main/__fixtures__/ts.json
@@ -139,7 +139,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__fixtures__/tsx.json
+++ b/test/main/__fixtures__/tsx.json
@@ -65,7 +65,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/collapse-after-cruise/expected-result.json
+++ b/test/main/__mocks__/collapse-after-cruise/expected-result.json
@@ -165,7 +165,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/dynamic-imports/es/output.json
+++ b/test/main/__mocks__/dynamic-imports/es/output.json
@@ -111,7 +111,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/__mocks__/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -111,7 +111,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/dynamic-imports/typescript/output.json
+++ b/test/main/__mocks__/dynamic-imports/typescript/output.json
@@ -111,7 +111,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/type-only-imports/output-with-rules.json
+++ b/test/main/__mocks__/type-only-imports/output-with-rules.json
@@ -67,7 +67,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/type-only-imports/output.json
+++ b/test/main/__mocks__/type-only-imports/output.json
@@ -39,7 +39,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/type-only-module-references/output-no-ts.json
+++ b/test/main/__mocks__/type-only-module-references/output-no-ts.json
@@ -18,7 +18,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],

--- a/test/main/__mocks__/type-only-module-references/output.json
+++ b/test/main/__mocks__/type-only-module-references/output.json
@@ -40,7 +40,7 @@
     "optionsUsed": {
       "combinedDependencies": false,
       "externalModuleResolutionStrategy": "node_modules",
-      "moduleSystems": ["amd", "cjs", "es6", "tsd"],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
       "exoticRequireStrings": [],


### PR DESCRIPTION
## Description, Motivation and Context

- moduleSystems passed on cli or as options were sorted before they went into any processing. This is slightly unexpected and not necessary.


## How Has This Been Tested?

- [x] green ci
- [x] adapted automated non-regression tests


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
