### PR TITLE
bugfix(main): also normalize viaOnly and viaSomeNot

### DIFF
--- a/src/main/utl/normalize-re-properties.js
+++ b/src/main/utl/normalize-re-properties.js
@@ -12,6 +12,8 @@ const RE_PROPERTIES = [
   "exoticRequireNot",
   "via",
   "viaNot",
+  "viaOnly",
+  "viaSomeNot",
 ];
 
 module.exports = function normalizeREProperties(

--- a/test/validate/index.cycle-via-not.spec.mjs
+++ b/test/validate/index.cycle-via-not.spec.mjs
@@ -215,4 +215,37 @@ describe("[I] validate/index dependency - cycle viaSomeNot - with group matching
       valid: true,
     });
   });
+
+  it("does not flag when all of the cycle is inside the group-matched viaNot that's represented as an array", () => {
+    const lRuleSet = {
+      forbidden: [
+        {
+          name: "no-circular-dependency-of-modules",
+          from: { path: "^src/([^/]+)/.+" },
+          to: {
+            viaSomeNot: ["something", "^src/$1/.+", "somethingelse"],
+            circular: true,
+          },
+        },
+      ],
+    };
+    expect(
+      validate.dependency(
+        parseRuleSet(lRuleSet),
+        { source: "src/module-a/a.js" },
+        {
+          resolved: "src/module-a/aa.js",
+          circular: true,
+          cycle: [
+            "src/module-a/aa.js",
+            "src/module-a/ab.js",
+            "src/module-a/ac.js",
+            "src/module-a/a.js",
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
 });

--- a/test/validate/index.cycle-via.spec.mjs
+++ b/test/validate/index.cycle-via.spec.mjs
@@ -332,7 +332,34 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
           from: {},
           to: {
             circular: true,
-            via: "^tmp/[^.]+\\.js$",
+            viaOnly: "^tmp/[^.]+\\.js$",
+          },
+        },
+      ],
+    });
+    expect(
+      validate.dependency(
+        lRuleSet,
+        { source: "tmp/a.js" },
+        {
+          resolved: "tmp/aa.js",
+          circular: true,
+          cycle: ["tmp/aa.js", "tmp/ab.js", "tmp/ac.js", "tmp/a.js"],
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [{ name: "unnamed", severity: "warn" }],
+    });
+  });
+  it("a => aa => ab => ac => a get flagged when all of them are in a viaOnly presented as an array", () => {
+    const lRuleSet = parseRuleSet({
+      forbidden: [
+        {
+          from: {},
+          to: {
+            circular: true,
+            viaOnly: ["somethingelse", "^tmp/[^.]+\\.js$"],
           },
         },
       ],


### PR DESCRIPTION
## Description

An array of strings (string-as-regex'es) passed to `viaOnly` and `viaSomeNot` weren't processed the same as the ones for e.g. `path` were. This PR corrects that, so that feature can also be used for these restrictions

## How Has This Been Tested?

- [x] green ci 
- [x] additional integration tests to prevent this from regressing

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
