### PR TITLE
bugfix(main): also check via's for regex safety

### DIFF
--- a/src/main/rule-set/validate.js
+++ b/src/main/rule-set/validate.js
@@ -33,6 +33,10 @@ function checkRuleSafety(pRule) {
     { section: "to", condition: "pathNot" },
     { section: "to", condition: "license" },
     { section: "to", condition: "licenseNot" },
+    { section: "to", condition: "via" },
+    { section: "to", condition: "viaNot" },
+    { section: "to", condition: "viaOnly" },
+    { section: "to", condition: "viaSomeNot" },
   ];
 
   if (
@@ -58,7 +62,7 @@ function checkRuleSafety(pRule) {
  * - the ruleset adheres to the [config json schema](../../schema/configuration.schema.json)
  * - any regular expression in the rule set is 'safe' (~= won't be too slow)
  *
- * @param  {any} pConfiguration The configuration to validate
+ * @param  {import("../../../types/configuration").IConfiguration} pConfiguration The configuration to validate
  * @return {import("../../../types/configuration").IConfiguration}  The configuration as passed
  * @throws {Error}                 An error with the reason for the error as
  *                                 a message


### PR DESCRIPTION
## Description, Motivation & Context

`via`, `viaNot`, `viaOnly` and `viaSomeNot` hitherto were not checked for regular expression safety like e.g. the `path` and `license` fields do. This will prevent abnormally long running rules on your local machine and your CI's.

## How Has This Been Tested?

- [x] automated non-regression tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
