### PR TITLE
bugfix(validate): also include the 'from' when validating via's/ & viaNot exceptions to cycle rules

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -727,6 +727,10 @@ to check against multiple paths; all the "via"'s in the cycle. The variants
 exist to enable matching against only _some_ of the modules in the cycle or
 against _all_ of them.
 
+All these restrictions take the whole cycle into account; _including_ the tested
+'from'; if `a/aa.js` has a cycle via `a/ab.js` and `b/bb/js` back to `a/aa.js`
+the via-like restrictions also take `a/aa.js` into account.
+
 The examples below refer to this cycle: `a/aa.js`, `a/ab.js`, `b/bb.js`, `a/aa.js`
 
 | restriction  | what it does                                                        | example input | match?  | because...                    |

--- a/src/validate/matchers.js
+++ b/src/validate/matchers.js
@@ -91,19 +91,13 @@ function toDependencyTypesNot(pRule, pDependency) {
   );
 }
 
-const removeLast = (_via, pIndex, pArray) => pIndex !== pArray.length - 1;
-
 function toVia(pRule, pDependency, pGroups) {
   return Boolean(
     !pRule.to.via ||
       (pDependency.cycle &&
-        pDependency.cycle
-          // the last in the cycle is always the module itself, which, for
-          // via & viaNot checks isn't very useful
-          .filter(removeLast)
-          .some((pVia) =>
-            pVia.match(replaceGroupPlaceholders(pRule.to.via, pGroups))
-          ))
+        pDependency.cycle.some((pVia) =>
+          pVia.match(replaceGroupPlaceholders(pRule.to.via, pGroups))
+        ))
   );
 }
 
@@ -111,13 +105,9 @@ function toViaOnly(pRule, pDependency, pGroups) {
   return Boolean(
     !pRule.to.viaOnly ||
       (pDependency.cycle &&
-        pDependency.cycle
-          // the last in the cycle is always the module itself, which, for
-          // via & viaNot checks isn't very useful
-          .filter(removeLast)
-          .every((pVia) =>
-            pVia.match(replaceGroupPlaceholders(pRule.to.viaOnly, pGroups))
-          ))
+        pDependency.cycle.every((pVia) =>
+          pVia.match(replaceGroupPlaceholders(pRule.to.viaOnly, pGroups))
+        ))
   );
 }
 
@@ -125,13 +115,9 @@ function toViaNot(pRule, pDependency, pGroups) {
   return Boolean(
     !pRule.to.viaNot ||
       (pDependency.cycle &&
-        !pDependency.cycle
-          // the last in the cycle is always the module itself, which, for
-          // via & viaNot checks isn't very useful
-          .filter(removeLast)
-          .some((pVia) =>
-            pVia.match(replaceGroupPlaceholders(pRule.to.viaNot, pGroups))
-          ))
+        !pDependency.cycle.some((pVia) =>
+          pVia.match(replaceGroupPlaceholders(pRule.to.viaNot, pGroups))
+        ))
   );
 }
 
@@ -139,13 +125,9 @@ function toviaSomeNot(pRule, pDependency, pGroups) {
   return Boolean(
     !pRule.to.viaSomeNot ||
       (pDependency.cycle &&
-        !pDependency.cycle
-          // the last in the cycle is always the module itself, which, for
-          // via & viaNot checks isn't very useful
-          .filter(removeLast)
-          .every((pVia) =>
-            pVia.match(replaceGroupPlaceholders(pRule.to.viaSomeNot, pGroups))
-          ))
+        !pDependency.cycle.every((pVia) =>
+          pVia.match(replaceGroupPlaceholders(pRule.to.viaSomeNot, pGroups))
+        ))
   );
 }
 

--- a/test/validate/index.cycle-via-not.spec.mjs
+++ b/test/validate/index.cycle-via-not.spec.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import { expect } from "chai";
 import validate from "../../src/validate/index.js";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
@@ -77,13 +76,7 @@ describe("[I] validate/index dependency - cycle viaNot - with group matching", (
         }
       )
     ).to.deep.equal({
-      valid: false,
-      rules: [
-        {
-          name: "no-circular-dependency-of-modules",
-          severity: "warn",
-        },
-      ],
+      valid: true,
     });
   });
 
@@ -112,126 +105,6 @@ describe("[I] validate/index dependency - cycle viaNot - with group matching", (
     expect(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
-        { source: "src/module-a/a.js" },
-        {
-          resolved: "src/module-a/aa.js",
-          circular: true,
-          cycle: [
-            "src/module-a/aa.js",
-            "src/module-a/ab.js",
-            "src/module-a/ac.js",
-            "src/module-a/a.js",
-          ],
-        }
-      )
-    ).to.deep.equal({
-      valid: true,
-    });
-  });
-});
-
-describe("[I] validate/index dependency - cycle viaSomeNot - with group matching", () => {
-  const lCycleButNotViaGroupMatchRuleSet = {
-    forbidden: [
-      {
-        name: "no-circular-dependency-of-modules",
-        from: { path: "^src/([^/]+)/.+" },
-        to: { viaSomeNot: "^src/$1/.+", circular: true },
-      },
-    ],
-  };
-
-  it("flags when all of the cycle (except the root) is outside the group-matched viaSomeNot", () => {
-    expect(
-      validate.dependency(
-        parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
-        { source: "src/module-a/a.js" },
-        {
-          resolved: "src/module-b/ba.js",
-          circular: true,
-          cycle: [
-            "src/module-b/ba.js",
-            "src/module-b/bb.js",
-            "src/module-b/bc.js",
-            "src/module-a/a.js",
-          ],
-        }
-      )
-    ).to.deep.equal({
-      valid: false,
-      rules: [
-        {
-          name: "no-circular-dependency-of-modules",
-          severity: "warn",
-        },
-      ],
-    });
-  });
-
-  it("flags when only one of the cycle is outside the group-matched viaNot", () => {
-    expect(
-      validate.dependency(
-        parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
-        { source: "src/module-a/a.js" },
-        {
-          resolved: "src/module-a/aa.js",
-          circular: true,
-          cycle: [
-            "src/module-a/aa.js",
-            "src/module-a/ab.js",
-            "src/module-b/bc.js",
-            "src/module-a/a.js",
-          ],
-        }
-      )
-    ).to.deep.equal({
-      valid: false,
-      rules: [
-        {
-          name: "no-circular-dependency-of-modules",
-          severity: "warn",
-        },
-      ],
-    });
-  });
-
-  it("does not flag when all of the cycle is inside the group-matched viaNot", () => {
-    expect(
-      validate.dependency(
-        parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
-        { source: "src/module-a/a.js" },
-        {
-          resolved: "src/module-a/aa.js",
-          circular: true,
-          cycle: [
-            "src/module-a/aa.js",
-            "src/module-a/ab.js",
-            "src/module-a/ac.js",
-            "src/module-a/a.js",
-          ],
-        }
-      )
-    ).to.deep.equal({
-      valid: true,
-    });
-  });
-
-  it("does not flag when all of the cycle is inside the group-matched viaNot that's represented as an array", () => {
-    const lRuleSet = {
-      forbidden: [
-        {
-          name: "no-circular-dependency-of-modules",
-          from: { path: "^src/([^/]+)/.+" },
-          to: {
-            viaSomeNot: ["something", "^src/$1/.+", "somethingelse"],
-            circular: true,
-          },
-        },
-      ],
-    };
-    expect(
-      validate.dependency(
-        parseRuleSet(lRuleSet),
         { source: "src/module-a/a.js" },
         {
           resolved: "src/module-a/aa.js",

--- a/test/validate/index.cycle-via-some-not.spec.mjs
+++ b/test/validate/index.cycle-via-some-not.spec.mjs
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+import validate from "../../src/validate/index.js";
+import parseRuleSet from "./parse-ruleset.utl.mjs";
+
+describe("[I] validate/index dependency - cycle viaSomeNot - with group matching", () => {
+  const lCycleButNotViaGroupMatchRuleSet = {
+    forbidden: [
+      {
+        name: "no-circular-dependency-of-modules",
+        from: { path: "^src/([^/]+)/.+" },
+        to: { viaSomeNot: "^src/$1/.+", circular: true },
+      },
+    ],
+  };
+
+  it("flags when all of the cycle (except the root) is outside the group-matched viaSomeNot", () => {
+    expect(
+      validate.dependency(
+        parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
+        { source: "src/module-a/a.js" },
+        {
+          resolved: "src/module-b/ba.js",
+          circular: true,
+          cycle: [
+            "src/module-b/ba.js",
+            "src/module-b/bb.js",
+            "src/module-b/bc.js",
+            "src/module-a/a.js",
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [
+        {
+          name: "no-circular-dependency-of-modules",
+          severity: "warn",
+        },
+      ],
+    });
+  });
+
+  it("flags when only one of the cycle is outside the group-matched viaNot", () => {
+    expect(
+      validate.dependency(
+        parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
+        { source: "src/module-a/a.js" },
+        {
+          resolved: "src/module-a/aa.js",
+          circular: true,
+          cycle: [
+            "src/module-a/aa.js",
+            "src/module-a/ab.js",
+            "src/module-b/bc.js",
+            "src/module-a/a.js",
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: false,
+      rules: [
+        {
+          name: "no-circular-dependency-of-modules",
+          severity: "warn",
+        },
+      ],
+    });
+  });
+
+  it("does not flag when all of the cycle is inside the group-matched viaNot", () => {
+    expect(
+      validate.dependency(
+        parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
+        { source: "src/module-a/a.js" },
+        {
+          resolved: "src/module-a/aa.js",
+          circular: true,
+          cycle: [
+            "src/module-a/aa.js",
+            "src/module-a/ab.js",
+            "src/module-a/ac.js",
+            "src/module-a/a.js",
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+
+  it("does not flag when all of the cycle is inside the group-matched viaSomeNot that's represented as an array", () => {
+    const lRuleSet = {
+      forbidden: [
+        {
+          name: "no-circular-dependency-of-modules",
+          from: { path: "^src/([^/]+)/.+" },
+          to: {
+            viaSomeNot: ["something", "^src/$1/.+", "somethingelse"],
+            circular: true,
+          },
+        },
+      ],
+    };
+    expect(
+      validate.dependency(
+        parseRuleSet(lRuleSet),
+        { source: "src/module-a/a.js" },
+        {
+          resolved: "src/module-a/aa.js",
+          circular: true,
+          cycle: [
+            "src/module-a/aa.js",
+            "src/module-a/ab.js",
+            "src/module-a/ac.js",
+            "src/module-a/a.js",
+          ],
+        }
+      )
+    ).to.deep.equal({
+      valid: true,
+    });
+  });
+});

--- a/test/validate/index.cycle-via.spec.mjs
+++ b/test/validate/index.cycle-via.spec.mjs
@@ -228,8 +228,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
         }
       )
     ).to.deep.equal({
-      valid: false,
-      rules: [{ name: "unnamed", severity: "warn" }],
+      valid: true,
     });
   });
 
@@ -320,8 +319,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
         }
       )
     ).to.deep.equal({
-      valid: false,
-      rules: [{ name: "unnamed", severity: "warn" }],
+      valid: true,
     });
   });
 


### PR DESCRIPTION
## Description

Version 11.7.0 started to not consider the 'from' in 'via' like exceptions to cycle rules. This was not only breaking, but also incorrect .

## Motivation and Context

fixes #604

## How Has This Been Tested?

- [x] green ci
- [x] updated automated integration tests
- [x] a manual test to be extra-double-sure

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
