### PR TITLE
feature(depcruise-fmt): adds a --prefix command line option

### DIFF
--- a/bin/depcruise-fmt.js
+++ b/bin/depcruise-fmt.js
@@ -47,6 +47,10 @@ try {
         "modules/ folders directly under your packages folder. "
     )
     .option(
+      "-P, --prefix <prefix>",
+      "prefix to use for links in the dot and err-html reporters"
+    )
+    .option(
       "-e, --exit-code",
       "exit with a non-zero exit code when the input json contains error level " +
         "dependency violations. Works for err, err-long and teamcity output types"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1038,6 +1038,16 @@ depcruise-fmt -T text --focus "^src/main/spelunkme\\.ts$" cruise_result.json
 Summarize or collapse to either a folder depth or (if you're feeling fancy) a regular
 expression. It works the same as the regular depcruise command's [`--collapse`](#--collapse-summarize-to-folder-depth-or-pattern) option.
 
+### prefix
+
+To enable different prefixes on the same depcruise run, you can uses the `--prefix`
+option to set (or override) the prefix used in e.g. the `err-html` and the
+`dot`-like reporters. It works the same as depcruise's
+[option of the same name](https://github.com/sverweij/dependency-cruiser/blob/develop/doc/cli.md#--prefix-prefixing-links)
+
+See [prefix](./options-reference.md#prefix-prefix-links-in-reports) in the options
+reference for details.
+
 ### getting non-zero exit codes
 
 If you want to see non-zero exit codes when there's error level dependency

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -12,6 +12,7 @@ const KNOWN_FMT_OPTIONS = [
   "includeOnly",
   "outputTo",
   "outputType",
+  "prefix",
   "version",
 ];
 

--- a/test/cli/format.spec.mjs
+++ b/test/cli/format.spec.mjs
@@ -57,6 +57,27 @@ describe("[E] cli/format", () => {
     deleteDammit(lOutFile);
   });
 
+  it("formats a cruise result --prefix is reflected into the summary", async () => {
+    const lOutFile = "thing.json";
+    const lAlternatePrefix = "http://localhost:2022/";
+
+    deleteDammit(lOutFile);
+
+    await format(
+      relative("__fixtures__/result-has-a-dependency-violation.json"),
+      {
+        outputTo: lOutFile,
+        outputType: "json",
+        prefix: lAlternatePrefix,
+      }
+    );
+    const lResult = JSON.parse(readFileSync(lOutFile, "utf8"));
+
+    expect(lResult.summary.optionsUsed.prefix).to.equal(lAlternatePrefix);
+
+    deleteDammit(lOutFile);
+  });
+
   it("returns a non-zero exit code when there's error level dependency violations in the output (regardless the value of exitCode)", async () => {
     const lOutFile = "otherthing";
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -276,4 +276,10 @@ export interface IFormatOptions {
    * out the function will return a javascript object as dependencies
    */
   outputType?: OutputType;
+  /**
+   * a string to insert before links (in dot/ svg output) so with
+   * cruising local dependencies it is possible to point to sources
+   * elsewhere (e.g. in an online repository)
+   */
+  prefix?: string;
 }


### PR DESCRIPTION
## Description

- adds a `--prefix` option to the depcruise-fmt command that works the same as the one in the depcruise command

## Motivation and Context

So there's no need to recalculate all dependencies just to add a different prefix to a report

## How Has This Been Tested?

- [x] green ci
- [x] additional e2e test
- [x] manual tests (before automating them in the thing above)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
