### PR TITLE
refactor(extract): use getExtension instead of endsWith to determine scannability of extensions

### DIFF
--- a/src/extract/gather-initial-sources.js
+++ b/src/extract/gather-initial-sources.js
@@ -1,11 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 const glob = require("glob");
-const _get = require("lodash/get");
+const get = require("lodash/get");
 const filenameMatchesPattern =
   require("../graph-utl/match-facade").filenameMatchesPattern;
 const pathToPosix = require("./utl/path-to-posix");
 const transpileMeta = require("./transpile/meta");
+const getExtension = require("./utl/get-extension");
 
 /**
  *
@@ -18,18 +19,22 @@ function getScannableExtensions(pOptions) {
   );
 }
 
+function fileIsScannable(pOptions, pPathToFile) {
+  return getScannableExtensions(pOptions).includes(getExtension(pPathToFile));
+}
+
 function shouldBeIncluded(pFullPathToFile, pOptions) {
   return (
-    !_get(pOptions, "includeOnly.path") ||
+    !get(pOptions, "includeOnly.path") ||
     filenameMatchesPattern(pFullPathToFile, pOptions.includeOnly.path)
   );
 }
 
 function shouldNotBeExcluded(pFullPathToFile, pOptions) {
   return (
-    (!_get(pOptions, "exclude.path") ||
+    (!get(pOptions, "exclude.path") ||
       !filenameMatchesPattern(pFullPathToFile, pOptions.exclude.path)) &&
-    (!_get(pOptions, "doNotFollow.path") ||
+    (!get(pOptions, "doNotFollow.path") ||
       !filenameMatchesPattern(pFullPathToFile, pOptions.doNotFollow.path))
   );
 }
@@ -59,11 +64,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
           gatherScannableFilesFromDirectory(pFullPathToFile, pOptions)
         );
       }
-      if (
-        getScannableExtensions(pOptions).some((pExtension) =>
-          pFullPathToFile.endsWith(pExtension)
-        )
-      ) {
+      if (fileIsScannable(pOptions, pFullPathToFile)) {
         return pSum.concat(pFullPathToFile);
       }
       return pSum;


### PR DESCRIPTION
## Description, Motivation and Context

- we still used `.endsWith` to determine scanability of an extension, while we have a specialised central utl for it

## How Has This Been Tested?

- [x] green ci
- [x] automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
