### PR TITLE
doc: clarify when the showMetrics dot reporter attribute works and when it doesn't

### DIFF
--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -984,9 +984,14 @@ depcruise-fmt -e -T err results.json
 
 ### showMetrics - (`dot` and `flat` reporters)
 
-When you instructed dependency-cruiser to calculate metrics, with the showMetrics
-switch you can influence whether you want to show them in the graph or not (which
-is also the default).
+With the showMetrics switch you can influence whether you want to show metrics
+in in the graph or not (_not_ is also the default).
+This only works when you instructed dependency-cruiser to actually calculate metrics
+(e.g. by passing the `--metrics` option on the command line or by [having a rule that validates modules against metrics](./rules-reference.md#moreunstable)).
+
+> Dependency-cruiser doesn't calculate these metrics by default - as likely not
+> a lot of folks need them, and it _does_ involve serious numbers of CPU-cycles
+> to calculate them.
 
 ```javascript
 module.exports = {

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -1090,12 +1090,14 @@ when the opposite is true; the dependency has an equal or lower Instability.
 
 This attribute is useful when you want to check against Robert C. Martin's
 stable dependencies principle: "depend in the direction of stability". Martin
-defines Instability as a function of the number of dependents and dependencies
-a component has: Instability = #dependencies/ (#dependents + #dependencies).
+defines $Instability$ as a function of the number of dependents and dependencies
+a component has:
+
+$$Instability = {\#dependencies \over \#dependents + \#dependencies}$$
 
 E.g. a module with no dependencies and one or more dependents has a Instability
 of 0%; as stable as it can get. Conversely a module with no dependents, but
-a one or more dependencies is 100% Instable.
+with one or more dependencies is 100% Instable.
 
 Instability has a bit of an unusual connotation here - it's not 'bad' to be
 an 100% Instable module - it's just the nature of the module. A CLI or GUI


### PR DESCRIPTION
## Description

See title

## Motivation and Context

Addresses #610 

## How Has This Been Tested?

- [x] green CI
- [x] strenuous re-reading

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
