### PR TITLE
feature(mermaid-plugin): adds focus highlighting

### DIFF
--- a/configs/plugins/mermaid-reporter-plugin.js
+++ b/configs/plugins/mermaid-reporter-plugin.js
@@ -1,19 +1,18 @@
+/* eslint-disable security/detect-object-injection */
 const ACORN_DUMMY_VALUE = "✖";
 
-/* eslint-disable security/detect-object-injection */
-const mermaidNode = (pNode, pText) => {
-  const lNode = pNode
+const hashNodeName = (pNode) =>
+  pNode
     .replace(ACORN_DUMMY_VALUE, "__unknown__")
     .replace(/^\.$|^\.\//g, "__currentPath__")
     .replace(/^\.{2}$|^\.{2}\//g, "__prevPath__")
     .replace(/[[\]/.@~-]/g, "_");
-  const lText = pText ? `["${pText}"]` : "";
-  return `${lNode}${lText}`;
-};
+
+const mermaidNode = (pNode, pText) => `${hashNodeName(pNode)}["${pText}"]`;
 
 const mermaidEdge = (pFrom, pTo) => {
-  const lFromNode = mermaidNode(pFrom.node);
-  const lToNode = mermaidNode(pTo.node);
+  const lFromNode = hashNodeName(pFrom.node);
+  const lToNode = hashNodeName(pTo.node);
   return `${lFromNode} --> ${lToNode}`;
 };
 
@@ -84,6 +83,18 @@ const convertedSubgraphSources = (pCruiseResult) => {
   return lTree;
 };
 
+const focusHighlights = (pModules) => {
+  const lHighLightStyle = "fill:lime,color:black";
+
+  return pModules
+    .filter((pModule) => pModule.matchesFocus === true)
+    .reduce(
+      (pAll, pModule) =>
+        (pAll += `\nstyle ${hashNodeName(pModule.source)} ${lHighLightStyle}`),
+      ""
+    );
+};
+
 const renderMermaidThing = (pCruiseResult) => {
   const subgraphs = convertedSubgraphSources(pCruiseResult);
   const edges = convertedEdgeSources(pCruiseResult);
@@ -92,7 +103,7 @@ const renderMermaidThing = (pCruiseResult) => {
 
 ${mermaidSubgraphs(subgraphs)}
 ${mermaidEdges(edges)}
-`;
+${focusHighlights(pCruiseResult.modules)}`;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "test:i": "mocha --timeout 4000 \"test/**/*.spec.{js,mjs,cjs}\" -g \"^\\[[I]\\]\"",
     "test:u": "mocha --timeout 4000 \"test/**/*.spec.{js,mjs,cjs}\" --grep \"^\\[[U]\\]\"",
     "test:e": "mocha --timeout 4000 \"test/**/*.spec.{js,mjs,cjs}\" --grep \"^\\[[E]\\]\"",
-    "test:cover": "c8 --check-coverage --statements 99.9 --branches 99.7 --functions 100 --lines 99.9 --exclude \"{bin,configs,doc,docs,coverage,test,tools,webpack.conf.js,tmp*,src/**/*.template.js,src/cli/tools/svg-in-html-snippets/script.snippet.js,src/cli/init-config/get-user-input.js,src/cli/listeners/*/index.js}\" --reporter text-summary --reporter html --reporter json-summary npm test",
+    "test:cover": "c8 --check-coverage --statements 99.9 --branches 99.7 --functions 100 --lines 99.9 --exclude \"{bin,configs/*.js,configs/rules,configs/plugins/3d-*.js,configs/plugins/stats-*.js,doc,docs,coverage,test,tools,webpack.conf.js,tmp*,src/**/*.template.js,src/cli/tools/svg-in-html-snippets/script.snippet.js,src/cli/init-config/get-user-input.js,src/cli/listeners/*/index.js}\" --reporter text-summary --reporter html --reporter json-summary npm test",
     "test:glob": "set -f && test \"`bin/dependency-cruise.js test/extract/__mocks__/gather-globbing/packages/**/src/**/*.js | grep \"no dependency violations found\"`\" = \"✔ no dependency violations found (6 modules, 0 dependencies cruised)\"",
     "test:yarn-pnp": "npm-run-all test:yarn-pnp:cleanup test:yarn-pnp:pack test:yarn-pnp:copy test:yarn-pnp:install test:yarn-pnp:version test:yarn-pnp:run test:yarn-pnp:test test:yarn-pnp:cleanup",
     "test:yarn-pnp:pack": "npm pack",

--- a/test/configs/plugins/mermaid-reporter-plugin/module-level/__mocks__/with-focus.json
+++ b/test/configs/plugins/mermaid-reporter-plugin/module-level/__mocks__/with-focus.json
@@ -1,0 +1,1032 @@
+{
+  "modules": [
+    {
+      "source": "src/main/rule-set/normalize.js",
+      "dependencies": [
+        {
+          "dynamic": false,
+          "module": "../utl/normalize-re-properties",
+          "moduleSystem": "cjs",
+          "exoticallyRequired": false,
+          "resolved": "src/main/utl/normalize-re-properties.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        },
+        {
+          "dynamic": false,
+          "module": "lodash/cloneDeep",
+          "moduleSystem": "cjs",
+          "exoticallyRequired": false,
+          "resolved": "node_modules/lodash/cloneDeep.js",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": false,
+          "license": "MIT",
+          "dependencyTypes": [
+            "npm"
+          ],
+          "matchesDoNotFollow": true,
+          "circular": false,
+          "valid": true
+        },
+        {
+          "dynamic": false,
+          "module": "lodash/has",
+          "moduleSystem": "cjs",
+          "exoticallyRequired": false,
+          "resolved": "node_modules/lodash/has.js",
+          "coreModule": false,
+          "followable": false,
+          "couldNotResolve": false,
+          "license": "MIT",
+          "dependencyTypes": [
+            "npm"
+          ],
+          "matchesDoNotFollow": true,
+          "circular": false,
+          "valid": true
+        }
+      ],
+      "dependents": [
+        "src/main/index.js",
+        "test/enrich/derive/reachable/index.spec.mjs",
+        "test/main/rule-set/normalize.spec.mjs",
+        "test/validate/parse-ruleset.utl.mjs"
+      ],
+      "orphan": false,
+      "reachable": [
+        {
+          "value": true,
+          "asDefinedInRule": "not-unreachable-from-cli",
+          "matchedFrom": "bin/depcruise-baseline.js"
+        },
+        {
+          "value": true,
+          "asDefinedInRule": "not-unreachable-from-test",
+          "matchedFrom": "test/api.spec.mjs"
+        },
+        {
+          "value": true,
+          "asDefinedInRule": "not-reachable-from-folder-index",
+          "matchedFrom": "src/main/index.js"
+        }
+      ],
+      "matchesFocus": true,
+      "valid": true
+    },
+    {
+      "source": "src/main/index.js",
+      "dependencies": [
+        {
+          "dynamic": false,
+          "module": "./rule-set/normalize",
+          "moduleSystem": "cjs",
+          "exoticallyRequired": false,
+          "resolved": "src/main/rule-set/normalize.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        }
+      ],
+      "dependents": [
+        "src/cli/index.js",
+        "src/cli/format-meta-info.js",
+        "src/cli/format.js",
+        "test/api.spec.cjs",
+        "test/api.spec.mjs",
+        "test/main/main.cruise-reporterless.spec.mjs",
+        "test/main/main.cruise.dynamic-imports.spec.mjs",
+        "test/main/main.cruise.reachable-integration.spec.mjs",
+        "test/main/main.cruise.spec.mjs",
+        "test/main/main.cruise.ts-pre-compilation-deps.spec.mjs",
+        "test/main/main.cruise.type-only-imports.spec.mjs",
+        "test/main/main.cruise.type-only-module-references.spec.mjs",
+        "test/main/main.format.spec.mjs"
+      ],
+      "orphan": false,
+      "reachable": [
+        {
+          "value": true,
+          "asDefinedInRule": "not-unreachable-from-cli",
+          "matchedFrom": "bin/depcruise-baseline.js"
+        },
+        {
+          "value": true,
+          "asDefinedInRule": "not-unreachable-from-test",
+          "matchedFrom": "test/api.spec.mjs"
+        }
+      ],
+      "matchesFocus": false,
+      "valid": true
+    },
+    {
+      "source": "test/enrich/derive/reachable/index.spec.mjs",
+      "dependencies": [
+        {
+          "dynamic": false,
+          "module": "../../../../src/main/rule-set/normalize.js",
+          "moduleSystem": "es6",
+          "exoticallyRequired": false,
+          "resolved": "src/main/rule-set/normalize.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        }
+      ],
+      "dependents": [],
+      "orphan": false,
+      "matchesFocus": false,
+      "valid": true
+    },
+    {
+      "source": "test/main/rule-set/normalize.spec.mjs",
+      "dependencies": [
+        {
+          "dynamic": false,
+          "module": "../../../src/main/rule-set/normalize.js",
+          "moduleSystem": "es6",
+          "exoticallyRequired": false,
+          "resolved": "src/main/rule-set/normalize.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        }
+      ],
+      "dependents": [],
+      "orphan": false,
+      "matchesFocus": false,
+      "valid": true
+    },
+    {
+      "source": "test/validate/parse-ruleset.utl.mjs",
+      "dependencies": [
+        {
+          "dynamic": false,
+          "module": "../../src/main/rule-set/normalize.js",
+          "moduleSystem": "es6",
+          "exoticallyRequired": false,
+          "resolved": "src/main/rule-set/normalize.js",
+          "coreModule": false,
+          "followable": true,
+          "couldNotResolve": false,
+          "dependencyTypes": [
+            "local"
+          ],
+          "matchesDoNotFollow": false,
+          "circular": false,
+          "valid": true
+        }
+      ],
+      "dependents": [
+        "test/validate/index.core.spec.mjs",
+        "test/validate/index.could-not-resolve.spec.mjs",
+        "test/validate/index.cycle-via-not.spec.mjs",
+        "test/validate/index.cycle-via-some-not.spec.mjs",
+        "test/validate/index.cycle-via.spec.mjs",
+        "test/validate/index.exotic-require.spec.mjs",
+        "test/validate/index.groupmatching.spec.mjs",
+        "test/validate/index.license.spec.mjs",
+        "test/validate/index.more-than-one-dependency-type.spec.mjs",
+        "test/validate/index.more-unstable.spec.mjs",
+        "test/validate/index.orphans.spec.mjs",
+        "test/validate/index.pre-compilation-only.spec.mjs",
+        "test/validate/index.reachable.spec.mjs",
+        "test/validate/index.required-rules.spec.mjs",
+        "test/validate/index.spec.mjs",
+        "test/validate/index.type-only.spec.mjs"
+      ],
+      "orphan": false,
+      "matchesFocus": false,
+      "valid": true
+    },
+    {
+      "source": "node_modules/lodash/has.js",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": false,
+      "matchesDoNotFollow": true,
+      "dependencyTypes": [
+        "npm"
+      ],
+      "dependencies": [],
+      "dependents": [
+        "src/config-utl/extract-babel-config.js",
+        "src/validate/index.js",
+        "src/validate/matchers.js",
+        "src/validate/rule-classifiers.js",
+        "src/validate/match-module-rule.js",
+        "src/enrich/derive/reachable/index.js",
+        "src/enrich/summarize/summarize-folders.js",
+        "src/graph-utl/rule-set.js",
+        "src/enrich/summarize/summarize-modules.js",
+        "src/enrich/summarize/summarize-options.js",
+        "src/extract/index.js",
+        "src/extract/resolve/external-module-helpers.js",
+        "src/extract/resolve/determine-dependency-types.js",
+        "src/main/options/normalize.js",
+        "src/main/utl/normalize-re-properties.js",
+        "src/main/options/validate.js",
+        "src/report/anon/index.js",
+        "src/report/dot/module-utl.js",
+        "src/report/dot/theming.js",
+        "src/report/error-html/utl.js",
+        "src/report/plugins/index.js",
+        "src/main/report-wrap.js",
+        "src/main/resolve-options/normalize.js",
+        "src/main/rule-set/normalize.js",
+        "src/main/rule-set/validate.js",
+        "src/cli/init-config/environment-helpers.js",
+        "src/cli/init-config/normalize-init-options.js",
+        "src/cli/normalize-cli-options.js",
+        "src/config-utl/extract-depcruise-config/index.js",
+        "test/extract/resolve/external-module-helpers.spec.mjs"
+      ],
+      "orphan": false,
+      "matchesFocus": false,
+      "valid": true
+    },
+    {
+      "source": "src/main/utl/normalize-re-properties.js",
+      "dependencies": [],
+      "dependents": [
+        "src/main/options/normalize.js",
+        "src/main/rule-set/normalize.js",
+        "test/main/utl/normalize-re-properties.spec.mjs"
+      ],
+      "orphan": false,
+      "reachable": [
+        {
+          "value": true,
+          "asDefinedInRule": "not-unreachable-from-cli",
+          "matchedFrom": "bin/depcruise-baseline.js"
+        },
+        {
+          "value": true,
+          "asDefinedInRule": "not-unreachable-from-test",
+          "matchedFrom": "test/api.spec.mjs"
+        },
+        {
+          "value": true,
+          "asDefinedInRule": "not-reachable-from-folder-index",
+          "matchedFrom": "src/main/index.js"
+        }
+      ],
+      "matchesFocus": false,
+      "valid": true
+    },
+    {
+      "source": "node_modules/lodash/cloneDeep.js",
+      "followable": false,
+      "coreModule": false,
+      "couldNotResolve": false,
+      "matchesDoNotFollow": true,
+      "dependencyTypes": [
+        "npm"
+      ],
+      "dependencies": [],
+      "dependents": [
+        "src/main/utl/normalize-re-properties.js",
+        "src/report/dot/theming.js",
+        "src/main/rule-set/normalize.js",
+        "test/report/dot/theming.spec.mjs"
+      ],
+      "orphan": false,
+      "matchesFocus": false,
+      "valid": true
+    }
+  ],
+  "summary": {
+    "violations": [],
+    "error": 0,
+    "warn": 0,
+    "info": 0,
+    "ignore": 0,
+    "totalCruised": 8,
+    "totalDependenciesCruised": 7,
+    "optionsUsed": {
+      "combinedDependencies": false,
+      "doNotFollow": {
+        "path": "node_modules",
+        "dependencyTypes": [
+          "npm",
+          "npm-dev",
+          "npm-optional",
+          "npm-peer",
+          "npm-bundled",
+          "npm-no-pkg"
+        ]
+      },
+      "exclude": {
+        "path": "mocks|fixtures|test/integration|src/cli/tools/svg-in-html-snippets/script.snippet.js"
+      },
+      "externalModuleResolutionStrategy": "node_modules",
+      "focus": {
+        "path": "^src/main/rule-set/normalize.js"
+      },
+      "knownViolations": [
+        {
+          "type": "module",
+          "from": "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
+          "to": "test/extract/ast-extractors/typescript2.8-union-types-ast.json",
+          "rule": {
+            "severity": "error",
+            "name": "no-orphans"
+          }
+        },
+        {
+          "type": "module",
+          "from": "src/schema/baseline-violations.schema.js",
+          "to": "src/schema/baseline-violations.schema.js",
+          "rule": {
+            "severity": "error",
+            "name": "not-unreachable-from-cli"
+          }
+        },
+        {
+          "type": "module",
+          "from": "src/cli/format.js",
+          "to": "src/cli/format.js",
+          "rule": {
+            "severity": "info",
+            "name": "not-reachable-from-folder-index"
+          }
+        },
+        {
+          "type": "module",
+          "from": "src/cli/tools/wrap-stream-in-html.js",
+          "to": "src/cli/tools/wrap-stream-in-html.js",
+          "rule": {
+            "severity": "info",
+            "name": "not-reachable-from-folder-index"
+          }
+        },
+        {
+          "type": "module",
+          "from": "src/cli/validate-node-environment.js",
+          "to": "src/cli/validate-node-environment.js",
+          "rule": {
+            "severity": "info",
+            "name": "not-reachable-from-folder-index"
+          }
+        },
+        {
+          "type": "module",
+          "from": "src/utl/array-util.js",
+          "to": "src/utl/array-util.js",
+          "rule": {
+            "severity": "info",
+            "name": "utl-module-not-shared-enough"
+          }
+        },
+        {
+          "type": "module",
+          "from": "src/utl/wrap-and-indent.js",
+          "to": "src/utl/wrap-and-indent.js",
+          "rule": {
+            "severity": "info",
+            "name": "utl-module-not-shared-enough"
+          }
+        }
+      ],
+      "moduleSystems": [
+        "cjs",
+        "es6"
+      ],
+      "outputTo": "-",
+      "outputType": "json",
+      "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/",
+      "preserveSymlinks": false,
+      "rulesFile": ".dependency-cruiser.json",
+      "tsPreCompilationDeps": true,
+      "exoticRequireStrings": [
+        "tryRequire",
+        "requireJSON"
+      ],
+      "reporterOptions": {
+        "archi": {
+          "collapsePattern": "^(src|test)/[^/]+|^bin/|node_modules/[^/]+"
+        },
+        "dot": {
+          "collapsePattern": "^src/report/[^/]+|^src/enrich/derive/[^/]+",
+          "filters": {
+            "includeOnly": {
+              "path": "^(src|bin)"
+            },
+            "exclude": {
+              "path": "^src/meta\\.js$|^src/utl/bus.+"
+            }
+          },
+          "theme": {
+            "replace": false,
+            "graph": {
+              "splines": "ortho"
+            },
+            "modules": [
+              {
+                "criteria": {
+                  "matchesFocus": true
+                },
+                "attributes": {
+                  "fillcolor": "lime",
+                  "penwidth": 2
+                }
+              },
+              {
+                "criteria": {
+                  "matchesFocus": false
+                },
+                "attributes": {
+                  "fillcolor": "lightgrey"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/cli"
+                },
+                "attributes": {
+                  "fillcolor": "#ccccff"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/config-utl"
+                },
+                "attributes": {
+                  "fillcolor": "#99ffff"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/report"
+                },
+                "attributes": {
+                  "fillcolor": "#ffccff"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/extract"
+                },
+                "attributes": {
+                  "fillcolor": "#ccffcc"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/enrich"
+                },
+                "attributes": {
+                  "fillcolor": "#77eeaa"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/validate"
+                },
+                "attributes": {
+                  "fillcolor": "#ccccff"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/main"
+                },
+                "attributes": {
+                  "fillcolor": "#ffcccc"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/utl"
+                },
+                "attributes": {
+                  "fillcolor": "#cccccc"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/graph-utl"
+                },
+                "attributes": {
+                  "fillcolor": "#ffcccc"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "^src/meta\\.js$|\\.template\\.js$|\\.schema\\.js$"
+                },
+                "attributes": {
+                  "style": "filled"
+                }
+              },
+              {
+                "criteria": {
+                  "source": "\\.json$"
+                },
+                "attributes": {
+                  "shape": "cylinder"
+                }
+              }
+            ],
+            "dependencies": [
+              {
+                "criteria": {
+                  "rules[0].severity": "error"
+                },
+                "attributes": {
+                  "fontcolor": "red",
+                  "color": "red"
+                }
+              },
+              {
+                "criteria": {
+                  "rules[0].severity": "warn"
+                },
+                "attributes": {
+                  "fontcolor": "orange",
+                  "color": "orange"
+                }
+              },
+              {
+                "criteria": {
+                  "rules[0].severity": "info"
+                },
+                "attributes": {
+                  "fontcolor": "blue",
+                  "color": "blue"
+                }
+              },
+              {
+                "criteria": {
+                  "valid": false
+                },
+                "attributes": {
+                  "fontcolor": "red",
+                  "color": "red"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/cli"
+                },
+                "attributes": {
+                  "color": "#0000ff77"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/config-utl"
+                },
+                "attributes": {
+                  "color": "#22999977"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/report"
+                },
+                "attributes": {
+                  "color": "#ff00ff77"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/extract"
+                },
+                "attributes": {
+                  "color": "#00770077"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/enrich"
+                },
+                "attributes": {
+                  "color": "#00776677"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/validate"
+                },
+                "attributes": {
+                  "color": "#0000ff77"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/main"
+                },
+                "attributes": {
+                  "color": "#77000077"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/utl"
+                },
+                "attributes": {
+                  "color": "#aaaaaa77"
+                }
+              },
+              {
+                "criteria": {
+                  "resolved": "^src/graph-utl"
+                },
+                "attributes": {
+                  "color": "#77000077"
+                }
+              }
+            ]
+          }
+        },
+        "metrics": {
+          "orderBy": "name",
+          "hideModules": true,
+          "hideFolders": false
+        },
+        "anon": {
+          "wordlist": [
+            "aap",
+            "noot",
+            "mies",
+            "wim",
+            "zus",
+            "jet",
+            "teun",
+            "vuur",
+            "gijs",
+            "lam",
+            "kees",
+            "bok",
+            "weide",
+            "does",
+            "hok",
+            "duif",
+            "schapen"
+          ]
+        }
+      },
+      "enhancedResolveOptions": {
+        "exportsFields": [
+          "exports"
+        ],
+        "conditionNames": [
+          "require"
+        ],
+        "extensions": [
+          ".js",
+          ".d.ts"
+        ]
+      },
+      "args": "src bin test configs types tools"
+    },
+    "ruleSetUsed": {
+      "forbidden": [
+        {
+          "name": "not-to-unresolvable",
+          "comment": "This module tried to depend on something that can't be resolved to disk. Revise yer code",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "couldNotResolve": true,
+            "exoticallyRequired": false
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-orphans",
+          "comment": "This is an orphan module - it's likely not used (anymore?). Either use it or remove it. If it's logical this module is an orphan (i.e. it's a config file), add an exception for it in your dependency-cruiser configuration. By default this rule does not scrutinize dotfiles (e.g. .eslintrc.js), TypeScript declaration files (.d.ts), tsconfig.json and some of the babel and webpack configs.",
+          "severity": "error",
+          "from": {
+            "orphan": true,
+            "pathNot": "(^|/)\\.[^/]+\\.(js|cjs|mjs|ts|json)$|\\.d\\.ts$|(^|/)tsconfig\\.json$|(^|/)(babel|webpack)\\.config\\.(js|cjs|mjs|ts|json)$|-reporter-plugin\\.js$|\\.schema\\.json$"
+          },
+          "to": {},
+          "scope": "module"
+        },
+        {
+          "name": "cli-to-main-only",
+          "comment": "This cli module depends on something not in the public interface - which means it either doesn't belong in cli, or the main public interface needs to be expanded.",
+          "severity": "error",
+          "from": {
+            "path": "(^src/cli/)"
+          },
+          "to": {
+            "pathNot": "^src/(main|utl|config-utl)/|^node_modules|^\\.yarn/cache|^fs$|^path$|$1|^src/meta.js$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "report-stays-in-report",
+          "comment": "This reporting module depends directly on a non-reporting one that is not a utility. That is odd as reporting modules should only read dependency cruiser output json.",
+          "severity": "error",
+          "from": {
+            "path": "(^src/report/)"
+          },
+          "to": {
+            "pathNot": "$1|^node_modules|^\\.yarn/cache|^os$|^path$|^src/meta\\.js$|^src/graph-utl|^src/utl"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "extract-to-utl-only",
+          "comment": "This extraction module depends on something outside extraction that is not a utility. Which is odd, given the goal of the extraction step.",
+          "severity": "error",
+          "from": {
+            "path": "(^src/extract/)"
+          },
+          "to": {
+            "pathNot": "$1|^node_modules|^\\.yarn/cache|^(path|fs|module|os)$|^src/meta\\.js$|^src/graph-utl|^src/utl",
+            "exoticallyRequired": false
+          },
+          "scope": "module"
+        },
+        {
+          "name": "not-to-json",
+          "comment": "We don't want to depende on .json modules as long as they're still impractical to work with in ecmascript modules",
+          "from": {
+            "path": "^src/"
+          },
+          "to": {
+            "path": "\\.json$"
+          },
+          "severity": "warn",
+          "scope": "module"
+        },
+        {
+          "name": "bin-to-cli-only",
+          "comment": "This module in the bin/ folder depends on something not in the cli interface. This means it either contains code that doesn't belong in bin/, or the thing it depends upon should be put in the cli interface. ",
+          "severity": "error",
+          "from": {
+            "path": "(^bin/)"
+          },
+          "to": {
+            "pathNot": "^src/cli|^node_modules|^\\.yarn/cache|^src/meta\\.js$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "restrict-fs-access",
+          "comment": "This module depends on a the node 'fs' module, and it resides in a spot where that is not allowed.",
+          "severity": "error",
+          "from": {
+            "pathNot": "^src/(main/resolve-options/normalize\\.js|extract/parse|extract/resolve|extract/gather-initial-sources\\.js|config-utl|cli)|^test|^tools"
+          },
+          "to": {
+            "path": "^fs$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-inter-module-test",
+          "comment": "This test depends on something in the test tree that is neither a utility, nor a mock nor a fixture.",
+          "severity": "error",
+          "from": {
+            "path": "(^test/[^\\/]+/)[^\\.]+\\.spec\\.js"
+          },
+          "to": {
+            "path": "^test/[^\\/]+/.+",
+            "pathNot": "utl|$1.+\\.json$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "prefer-lodash-individuals",
+          "comment": "This module directly depends on 'lodash' as a whole. Preferably don't include lodash as a whole, but use individual lodash packages instead e.g. 'lodash/get' - this keeps the download of the package small(er)",
+          "severity": "info",
+          "from": {},
+          "to": {
+            "path": "lodash\\.js$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-dep-on-test",
+          "comment": "This module depends on a spec files. A spec file should have a single responsibility (testing whether a module function correctly). If there's something in a spec that's of use, factor it out into (e.g.) a separate utility/ helper or mock",
+          "severity": "error",
+          "from": {
+            "path": "^(src|bin)"
+          },
+          "to": {
+            "path": "^test|\\.spec\\.js$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-external-to-here",
+          "comment": "Apparently something outside of the src/ test/ and bin/ points to something inside them. That's incredibly odd and might denote a security problem.",
+          "severity": "error",
+          "from": {
+            "pathNot": "^(src|test|bin)"
+          },
+          "to": {
+            "path": "^(src|test)"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "not-to-dev-dep",
+          "severity": "error",
+          "comment": "In production code do not depend on external ('npm') modules not declared in your package.json's dependencies - otherwise a production only install (i.e. 'npm ci') will break. If this rule triggers on something that's only used during development, adapt the 'from' of the rule in the dependency-cruiser configuration.",
+          "from": {
+            "path": "^(bin|src)"
+          },
+          "to": {
+            "dependencyTypes": [
+              "npm-dev"
+            ],
+            "exoticallyRequired": false
+          },
+          "scope": "module"
+        },
+        {
+          "name": "only-known-exotic",
+          "severity": "error",
+          "comment": "The only 'exotic' requires allowed are tryRequire and requireJSON",
+          "from": {},
+          "to": {
+            "exoticRequireNot": "^(tryRequire|requireJSON)$",
+            "exoticallyRequired": true
+          },
+          "scope": "module"
+        },
+        {
+          "name": "optional-deps-used",
+          "severity": "error",
+          "comment": "This module uses an external dependency that in package.json shows up as an optional dependency. In dependency-cruiser optional dependencies donot make sense - and are hence forbidden. Either make it a regular dependency (if it's production code) or a dev one (if it's for development only)",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "npm-optional"
+            ]
+          },
+          "scope": "module"
+        },
+        {
+          "name": "peer-deps-used",
+          "comment": "This module uses an external dependency that in package.json shows up as a peer dependency. In dependency-cruiser peer dependencies donot make sense - and are hence forbidden. Either make it a regular dependency (if it's production code) or a dev one (if it's for development only)",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "npm-peer"
+            ]
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-unvetted-license",
+          "comment": "This module uses an external dependency that has license that's not vetted. The license itself might be OK, but bigcorp legal departments might get jittery over anything other than MIT (or ISC).",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "licenseNot": "MIT|ISC|Apache-2\\.0"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "not-unreachable-from-cli",
+          "severity": "error",
+          "comment": "This module in the src/ tree is not reachable from the cli - and is likely dead wood. Either use it or remove it. If a module is flagged for which it's logical it is not reachable from cli (i.e. a configuration file), add it to the pathNot in the 'to' of this rule.",
+          "from": {
+            "path": "^bin/"
+          },
+          "to": {
+            "path": "^src",
+            "pathNot": "\\.schema\\.json$|\\.d\\.ts$",
+            "reachable": false
+          },
+          "scope": "module"
+        },
+        {
+          "name": "not-unreachable-from-test",
+          "comment": "This module in src is not reachable by any test. Please provide a test that covers this (poor man's test coverage - this task is better suited for a proper test coverage tool :-) )",
+          "severity": "warn",
+          "from": {
+            "path": "\\.spec\\.m?js$"
+          },
+          "to": {
+            "path": "^src",
+            "pathNot": "\\.schema\\.json$|\\.d\\.ts$",
+            "reachable": false
+          },
+          "scope": "module"
+        },
+        {
+          "name": "not-reachable-from-folder-index",
+          "comment": "(sample rule to demo reachable rules with capturing groups)",
+          "severity": "info",
+          "from": {
+            "path": "^src/([^/]+)/index\\.js$"
+          },
+          "to": {
+            "path": "^src/$1/",
+            "pathNot": "\\.d\\.ts$",
+            "reachable": false
+          },
+          "scope": "module"
+        },
+        {
+          "name": "utl-module-not-shared-enough",
+          "comment": "(sample rule to demo demo rules based on dependents)",
+          "severity": "info",
+          "from": {
+            "path": "^src"
+          },
+          "module": {
+            "path": "^src/utl",
+            "numberOfDependentsLessThan": 3
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-circular",
+          "comment": "This dependency is part of a circular relationship. You might want to revise your solution (i.e. use dependency inversion, make sure the modules have a single responsibility) ",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "circular": true
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-deprecated-core",
+          "comment": "This module depends on a node core module that has been deprecated. Find an alternative - these are bound to exist - node doesn't deprecate lightly.",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "core"
+            ],
+            "path": "^(punycode|domain|constants|sys|_linklist|_stream_wrap)$"
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-duplicate-dep-types",
+          "comment": "Likley this module depends on an external ('npm') package that occurs more than once in your package.json i.e. bot as a devDependencies and in dependencies. This will cause maintenance problems later on. If it's intentional, you can disable this rule by adding this override as a rule in the 'forbidden' section of your dependency-cruiser configuration: {\"name\": \"no-duplicate-dep-types\", \"severity\": \"ignore\"}",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "moreThanOneDependencyType": true,
+            "dependencyTypesNot": [
+              "type-only"
+            ]
+          },
+          "scope": "module"
+        },
+        {
+          "name": "no-non-package-json",
+          "severity": "error",
+          "comment": "This module depends on an npm package that isn't in the 'dependencies' section of your package.json. That's problematic as the package either (1) won't be available on live (2 - worse) will be available on live with an non-guaranteed version. Fix it by adding the package to the dependencies in your package.json.",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "npm-no-pkg",
+              "npm-unknown"
+            ]
+          },
+          "scope": "module"
+        },
+        {
+          "name": "not-to-deprecated",
+          "comment": "This module uses a (version of an) npm module that has been deprecated. Either upgrade to a later version of that module, or find an alternative. Deprecated modules are a security risk.",
+          "severity": "error",
+          "from": {},
+          "to": {
+            "dependencyTypes": [
+              "deprecated"
+            ]
+          },
+          "scope": "module"
+        }
+      ]
+    }
+  }
+}

--- a/test/configs/plugins/mermaid-reporter-plugin/module-level/__mocks__/with-focus.mmd
+++ b/test/configs/plugins/mermaid-reporter-plugin/module-level/__mocks__/with-focus.mmd
@@ -1,0 +1,45 @@
+flowchart LR
+
+subgraph src["src"]
+  subgraph src_main["main"]
+    subgraph src_main_rule_set["rule-set"]
+      src_main_rule_set_normalize_js["normalize.js"]
+    end
+    src_main_index_js["index.js"]
+    subgraph src_main_utl["utl"]
+      src_main_utl_normalize_re_properties_js["normalize-re-properties.js"]
+    end
+  end
+end
+subgraph test["test"]
+  subgraph test_enrich["enrich"]
+    subgraph test_enrich_derive["derive"]
+      subgraph test_enrich_derive_reachable["reachable"]
+        test_enrich_derive_reachable_index_spec_mjs["index.spec.mjs"]
+      end
+    end
+  end
+  subgraph test_main["main"]
+    subgraph test_main_rule_set["rule-set"]
+      test_main_rule_set_normalize_spec_mjs["normalize.spec.mjs"]
+    end
+  end
+  subgraph test_validate["validate"]
+    test_validate_parse_ruleset_utl_mjs["parse-ruleset.utl.mjs"]
+  end
+end
+subgraph node_modules["node_modules"]
+  subgraph node_modules_lodash["lodash"]
+    node_modules_lodash_has_js["has.js"]
+    node_modules_lodash_cloneDeep_js["cloneDeep.js"]
+  end
+end
+src_main_rule_set_normalize_js --> src_main_utl_normalize_re_properties_js
+src_main_rule_set_normalize_js --> node_modules_lodash_cloneDeep_js
+src_main_rule_set_normalize_js --> node_modules_lodash_has_js
+src_main_index_js --> src_main_rule_set_normalize_js
+test_enrich_derive_reachable_index_spec_mjs --> src_main_rule_set_normalize_js
+test_main_rule_set_normalize_spec_mjs --> src_main_rule_set_normalize_js
+test_validate_parse_ruleset_utl_mjs --> src_main_rule_set_normalize_js
+
+style src_main_rule_set_normalize_js fill:lime,color:black

--- a/test/configs/plugins/mermaid-reporter-plugin/module-level/index.spec.mjs
+++ b/test/configs/plugins/mermaid-reporter-plugin/module-level/index.spec.mjs
@@ -30,4 +30,6 @@ describe("[I] configs/plugins/mermaid-reporter-plugin module-level reporter", ()
     same("contains-strings-to-be-escaped"));
   it("renders a mermaid - rendered strings that replaced from unknown figures.", () =>
     same("unknown-deps"));
+  it("renders a mermaid - renders focussed elements with highlights", () =>
+    same("with-focus"));
 });


### PR DESCRIPTION
## Description

- adds focus highlighting to the mermaid reporter;

Also includes the mermaid reporter plugin along with the regular test coverage (it was already 100% covered to start with - and we don't want that to grow less ;-) )

## Motivation and Context

@MH4GF has been working on a _very nice_ [GitHub action](https://github.com/MH4GF/dependency-cruiser-report-action) that can add a mermaid report to
your pull request that shows the modules the PR is about. It'd be awesome if they could expand a bit to not only show the modules touched by the PR, but _also_ the immediate context. This is what dependency-cruiser's (existing) focus feature is for. 

In the context of a PR it'd however be useful to see which modules are the ones _touched_ by the PR and which are included in the model for _context_ only. This PR adjusts that.

> This feature might profit from an implementation for #564; it might be useful
> to see even _more_ context than the direct dependents and dependencies of the modules
> at hand. 


## How Has This Been Tested?

- [x] green ci
- [x] additional unit test


## Screenshots

Given a dependency-cruiser result which has a `focus` set to one or more modules the output will show these modules highlighted (in green) and the modules in its context in a slightly subdued gray:

### After

Here a reviewer would see _normalize.js_ has been updated - but interestingly enough not any of the test files that directly include it.


```mermaid
flowchart LR

subgraph src["src"]
  subgraph src_main["main"]
    subgraph src_main_rule_set["rule-set"]
      src_main_rule_set_normalize_js["normalize.js"]
    end
    src_main_index_js["index.js"]
    subgraph src_main_utl["utl"]
      src_main_utl_normalize_re_properties_js["normalize-re-properties.js"]
    end
  end
end
subgraph test["test"]
  subgraph test_enrich["enrich"]
    subgraph test_enrich_derive["derive"]
      subgraph test_enrich_derive_reachable["reachable"]
        test_enrich_derive_reachable_index_spec_mjs["index.spec.mjs"]
      end
    end
  end
  subgraph test_main["main"]
    subgraph test_main_rule_set["rule-set"]
      test_main_rule_set_normalize_spec_mjs["normalize.spec.mjs"]
    end
  end
  subgraph test_validate["validate"]
    test_validate_parse_ruleset_utl_mjs["parse-ruleset.utl.mjs"]
  end
end
subgraph node_modules["node_modules"]
  subgraph node_modules_lodash["lodash"]
    node_modules_lodash_has_js["has.js"]
    node_modules_lodash_cloneDeep_js["cloneDeep.js"]
  end
end
src_main_rule_set_normalize_js --> src_main_utl_normalize_re_properties_js
src_main_rule_set_normalize_js --> node_modules_lodash_cloneDeep_js
src_main_rule_set_normalize_js --> node_modules_lodash_has_js
src_main_index_js --> src_main_rule_set_normalize_js
test_enrich_derive_reachable_index_spec_mjs --> src_main_rule_set_normalize_js
test_main_rule_set_normalize_spec_mjs --> src_main_rule_set_normalize_js
test_validate_parse_ruleset_utl_mjs --> src_main_rule_set_normalize_js

style src_main_rule_set_normalize_js fill:lime,color:black
```
> update 2022-06-08: replaced with diagram that _only_ highlights, and doesn't subdue

### Before

```mermaid
flowchart LR

subgraph src["src"]
  subgraph src_main["main"]
    subgraph src_main_rule_set["rule-set"]
      src_main_rule_set_normalize_js["normalize.js"]
    end
    src_main_index_js["index.js"]
    subgraph src_main_utl["utl"]
      src_main_utl_normalize_re_properties_js["normalize-re-properties.js"]
    end
  end
end
subgraph test["test"]
  subgraph test_enrich["enrich"]
    subgraph test_enrich_derive["derive"]
      subgraph test_enrich_derive_reachable["reachable"]
        test_enrich_derive_reachable_index_spec_mjs["index.spec.mjs"]
      end
    end
  end
  subgraph test_main["main"]
    subgraph test_main_rule_set["rule-set"]
      test_main_rule_set_normalize_spec_mjs["normalize.spec.mjs"]
    end
  end
  subgraph test_validate["validate"]
    test_validate_parse_ruleset_utl_mjs["parse-ruleset.utl.mjs"]
  end
end
subgraph node_modules["node_modules"]
  subgraph node_modules_lodash["lodash"]
    node_modules_lodash_has_js["has.js"]
    node_modules_lodash_cloneDeep_js["cloneDeep.js"]
  end
end
src_main_rule_set_normalize_js --> src_main_utl_normalize_re_properties_js
src_main_rule_set_normalize_js --> node_modules_lodash_cloneDeep_js
src_main_rule_set_normalize_js --> node_modules_lodash_has_js
src_main_index_js --> src_main_rule_set_normalize_js
test_enrich_derive_reachable_index_spec_mjs --> src_main_rule_set_normalize_js
test_main_rule_set_normalize_spec_mjs --> src_main_rule_set_normalize_js
test_validate_parse_ruleset_utl_mjs --> src_main_rule_set_normalize_js

```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
