### PR TITLE
feature(metrics): calculate metrics when the current reporter's option specifies to show them

### DIFF
--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -986,13 +986,12 @@ depcruise-fmt -e -T err results.json
 ### showMetrics - (`dot` and `flat` reporters)
 
 With the showMetrics switch you can influence whether you want to show metrics
-in in the graph or not (_not_ is also the default).
-This only works when you instructed dependency-cruiser to actually calculate metrics
-(e.g. by passing the `--metrics` option on the command line or by [having a rule that validates modules against metrics](./rules-reference.md#moreunstable)).
+in the graph or not (_not_ is also the default).
 
 > Dependency-cruiser doesn't calculate these metrics by default - as likely not
 > a lot of folks need them, and it _does_ involve serious numbers of CPU-cycles
-> to calculate them.
+> to calculate them - switching the showMetrics option for these reporters to
+> true will ensure metrics _are_ calculated.
 
 ```javascript
 module.exports = {

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -95,6 +95,21 @@ function ruleSetHasMetricsRule(pRuleSet) {
 }
 
 /**
+ *
+ * @param {import('../../../types/dependency-cruiser').ICruiseOptions} pOptions
+ * @returns Boolean
+ */
+function reporterShowsMetrics(pOptions) {
+  return (
+    get(
+      pOptions,
+      `reporterOptions.${pOptions.outputType}.showMetrics`,
+      false
+    ) === true
+  );
+}
+
+/**
  * Determines whether (instability) metrics should be calculated
  *
  * @param {import('../../../types/dependency-cruiser').ICruiseOptions} pOptions
@@ -104,6 +119,7 @@ function shouldCalculateMetrics(pOptions) {
   return (
     pOptions.metrics ||
     pOptions.outputType === "metrics" ||
+    reporterShowsMetrics(pOptions) ||
     ruleSetHasMetricsRule(pOptions.ruleSet)
   );
 }

--- a/test/main/options/normalize.cruise-options.spec.mjs
+++ b/test/main/options/normalize.cruise-options.spec.mjs
@@ -126,6 +126,38 @@ describe("[U] main/options/normalize - cruise options", () => {
       collapse: "^packages/[^/]+",
     });
   });
+
+  it("calculates metrics when the selected reporter specifies to show metrics", () => {
+    expect(
+      normalize.normalizeCruiseOptions({
+        outputType: "dot",
+        reporterOptions: { dot: { showMetrics: true } },
+      })
+    ).to.contain({
+      metrics: true,
+    });
+  });
+
+  it("calculates metrics when the selected reporter specifies to not show metrics", () => {
+    expect(
+      normalize.normalizeCruiseOptions({
+        outputType: "dot",
+        reporterOptions: { dot: { showMetrics: false } },
+      })
+    ).to.contain({
+      metrics: false,
+    });
+  });
+
+  it("calculates metrics when the selected reporter doesn't specify to show metrics", () => {
+    expect(
+      normalize.normalizeCruiseOptions({
+        outputType: "dot",
+      })
+    ).to.contain({
+      metrics: false,
+    });
+  });
 });
 
 /* eslint no-magic-numbers: 0*/


### PR DESCRIPTION
## Description

- calculate metrics when the current reporter's option specifies to show them

## Motivation and Context

It's non-obvious when `showMetrics === true` for a reporter but they don't show up. The original reason for this behaviour was to prevent unexpected performance hits. However, when you set showMetrics to true in a reporter you either take that for granted or don't care either way.

Fixes #610 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
