### PR TITLE
bugfix(mermaid): small fixes to types, tests

### DIFF
--- a/src/report/mermaid.js
+++ b/src/report/mermaid.js
@@ -75,19 +75,19 @@ const mermaidSubgraphs = (pSource, pOptions, pDepth = 0) => {
 
 /**
  * @param {import('../../types/dependency-cruiser').ICruiseResult} pCruiseResult
- * @param {Map<string, string>} pMinifiedNames
+ * @param {Map<string, string>} pNamesHashMap
  */
-const convertedSubgraphSources = (pCruiseResult, pMinifiedNames) => {
+const convertedSubgraphSources = (pCruiseResult, pNamesHashMap) => {
   let lTree = {};
 
   pCruiseResult.modules.forEach((pModule) => {
-    const paths = pModule.source.split("/");
+    const lPaths = pModule.source.split("/");
 
-    paths.reduce((pChildren, pCurrentPath, pIndex) => {
+    lPaths.reduce((pChildren, pCurrentPath, pIndex) => {
       if (!pChildren[pCurrentPath]) {
-        const node = paths.slice(0, pIndex + 1).join("/");
+        const node = lPaths.slice(0, pIndex + 1).join("/");
         pChildren[pCurrentPath] = {
-          node: pMinifiedNames.get(node),
+          node: pNamesHashMap.get(node),
           text: pCurrentPath,
           children: {},
         };
@@ -129,7 +129,7 @@ const hashModuleNames = (pModules, pMinify) => {
 
     for (let lIndex = 0; lIndex < lPaths.length; lIndex += 1) {
       const lName = lPaths.slice(0, lIndex + 1).join("/");
-      if (!lNamesHashMap.get(lName)) {
+      if (!lNamesHashMap.has(lName)) {
         if (pMinify) {
           lNamesHashMap.set(lName, lCount.toString(lBase));
           lCount += 1;

--- a/src/report/mermaid.js
+++ b/src/report/mermaid.js
@@ -1,34 +1,21 @@
 /* eslint-disable security/detect-object-injection */
 const ACORN_DUMMY_VALUE = "✖";
-
 const REPORT_DEFAULTS = {
   minify: true,
 };
 
-const hashNodeName = (pNode) =>
-  pNode
-    .replace(ACORN_DUMMY_VALUE, "__unknown__")
-    .replace(/^\.$|^\.\//g, "__currentPath__")
-    .replace(/^\.{2}$|^\.{2}\//g, "__prevPath__")
-    .replace(/[[\]/.@~-]/g, "_");
+const renderNode = (pNode, pText) => `${pNode}["${pText}"]`;
 
-const mermaidNode = (pNode, pText) => `${pNode}["${pText}"]`;
+const renderEdge = (pFrom, pTo) => `${pFrom.node}-->${pTo.node}`;
 
-const mermaidEdge = (pFrom, pTo) => {
-  const lFromNode = pFrom.node;
-  const lToNode = pTo.node;
-  return `${lFromNode}-->${lToNode}`;
-};
-
-const mermaidEdges = (pEdges) => {
-  return pEdges.map((pEdge) => mermaidEdge(pEdge.from, pEdge.to)).join("\n");
-};
+const renderEdges = (pEdges) =>
+  pEdges.map((pEdge) => renderEdge(pEdge.from, pEdge.to)).join("\n");
 
 /**
  * @param {import('../../types/dependency-cruiser').ICruiseResult} pCruiseResult
  * @param {Map<string, string>} pNamesHashMap
  */
-const convertedEdgeSources = (pCruiseResult, pNamesHashMap) => {
+function convertEdgeSources(pCruiseResult, pNamesHashMap) {
   return pCruiseResult.modules.flatMap((pModule) => {
     const lFromNode = pNamesHashMap.get(pModule.source);
     const lFrom = {
@@ -36,48 +23,45 @@ const convertedEdgeSources = (pCruiseResult, pNamesHashMap) => {
       text: pModule.source.split("/").slice(-1)[0],
     };
 
-    return pModule.dependencies.map((pDep) => {
-      const lToNode = pNamesHashMap.get(pDep.resolved);
+    return pModule.dependencies.map((pDependency) => {
+      const lToNode = pNamesHashMap.get(pDependency.resolved);
       return {
         from: lFrom,
         to: {
           node: lToNode,
-          text: pDep.resolved.split("/").slice(-1)[0],
+          text: pDependency.resolved.split("/").slice(-1)[0],
         },
       };
     });
   });
-};
+}
 
-const indent = (pDepth = 0, pMinify) => {
-  return pMinify ? "" : "  ".repeat(pDepth);
-};
+const indent = (pDepth = 0, pMinify) => (pMinify ? "" : "  ".repeat(pDepth));
 
-const mermaidSubgraph = (pNode, pText, pChildren, pIndent) => {
-  return `${pIndent}subgraph ${mermaidNode(pNode, pText)}
+const renderSubgraph = (pNode, pText, pChildren, pIndent) =>
+  `${pIndent}subgraph ${renderNode(pNode, pText)}
 ${pChildren}
 ${pIndent}end`;
-};
 
-const mermaidSubgraphs = (pSource, pOptions, pDepth = 0) => {
+function renderSubgraphs(pSource, pOptions, pDepth = 0) {
   return Object.keys(pSource)
     .map((pName) => {
       const lIndent = indent(pDepth, pOptions.minify);
       const source = pSource[pName];
-      const children = mermaidSubgraphs(source.children, pOptions, pDepth + 1);
+      const children = renderSubgraphs(source.children, pOptions, pDepth + 1);
       if (children === "")
-        return `${lIndent}${mermaidNode(source.node, source.text)}`;
+        return `${lIndent}${renderNode(source.node, source.text)}`;
 
-      return mermaidSubgraph(source.node, source.text, children, lIndent);
+      return renderSubgraph(source.node, source.text, children, lIndent);
     })
     .join("\n");
-};
+}
 
 /**
  * @param {import('../../types/dependency-cruiser').ICruiseResult} pCruiseResult
  * @param {Map<string, string>} pNamesHashMap
  */
-const convertedSubgraphSources = (pCruiseResult, pNamesHashMap) => {
+function convertSubgraphSources(pCruiseResult, pNamesHashMap) {
   let lTree = {};
 
   pCruiseResult.modules.forEach((pModule) => {
@@ -97,13 +81,13 @@ const convertedSubgraphSources = (pCruiseResult, pNamesHashMap) => {
   });
 
   return lTree;
-};
+}
 
 /**
  * @param {import("../../types/cruise-result").IModule[]} pModules
  * @param {Map<string, string>} pNamesHashMap
  */
-const focusHighlights = (pModules, pNamesHashMap) => {
+function focusHighlights(pModules, pNamesHashMap) {
   const lHighLightStyle = "fill:lime,color:black";
 
   return pModules
@@ -112,14 +96,21 @@ const focusHighlights = (pModules, pNamesHashMap) => {
       const lSource = pNamesHashMap.get(pModule.source);
       return (pAll += `\nstyle ${lSource} ${lHighLightStyle}`);
     }, "");
-};
+}
+
+const hashToReadableNodeName = (pNode) =>
+  pNode
+    .replace(ACORN_DUMMY_VALUE, "__unknown__")
+    .replace(/^\.$|^\.\//g, "__currentPath__")
+    .replace(/^\.{2}$|^\.{2}\//g, "__prevPath__")
+    .replace(/[[\]/.@~-]/g, "_");
 
 /**
  * @param {import("../../types/cruise-result").IModule[]} pModules
  * @param {Boolean} pMinify
  * @return {Map<string, string>}
  */
-const hashModuleNames = (pModules, pMinify) => {
+function hashModuleNames(pModules, pMinify) {
   const lBase = 36;
   const lNamesHashMap = new Map();
   let lCount = 0;
@@ -134,31 +125,31 @@ const hashModuleNames = (pModules, pMinify) => {
           lNamesHashMap.set(lName, lCount.toString(lBase));
           lCount += 1;
         } else {
-          lNamesHashMap.set(lName, hashNodeName(lName));
+          lNamesHashMap.set(lName, hashToReadableNodeName(lName));
         }
       }
     }
   });
 
   return lNamesHashMap;
-};
+}
 
 /**
  * @param {import('../../types/dependency-cruiser').ICruiseResult} pCruiseResult
  * @param {import("../../types/reporter-options").IMermaidReporterOptions} pOptions
  */
-const renderMermaidThing = (pCruiseResult, pOptions) => {
+function renderMermaidSource(pCruiseResult, pOptions) {
   const lOptions = { ...REPORT_DEFAULTS, ...(pOptions || {}) };
   const lNamesHashMap = hashModuleNames(pCruiseResult.modules, lOptions.minify);
-  const lSubgraphs = convertedSubgraphSources(pCruiseResult, lNamesHashMap);
-  const lEdges = convertedEdgeSources(pCruiseResult, lNamesHashMap);
+  const lSubgraphs = convertSubgraphSources(pCruiseResult, lNamesHashMap);
+  const lEdges = convertEdgeSources(pCruiseResult, lNamesHashMap);
 
   return `flowchart LR
 
-${mermaidSubgraphs(lSubgraphs, lOptions)}
-${mermaidEdges(lEdges)}
+${renderSubgraphs(lSubgraphs, lOptions)}
+${renderEdges(lEdges)}
 ${focusHighlights(pCruiseResult.modules, lNamesHashMap)}`;
-};
+}
 
 /**
  * mermaid reporter
@@ -168,6 +159,6 @@ ${focusHighlights(pCruiseResult.modules, lNamesHashMap)}`;
  * @return {import('../../types/dependency-cruiser').IReporterOutput}
  */
 module.exports = (pCruiseResult, pOptions) => ({
-  output: renderMermaidThing(pCruiseResult, pOptions),
+  output: renderMermaidSource(pCruiseResult, pOptions),
   exitCode: 0,
 });

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { dir } from "node:console";
 import { expect } from "chai";
 import mermaid from "../../../src/report/mermaid.js";
 import mermaidReporterPlugin from "../../../configs/plugins/mermaid-reporter-plugin.js";
@@ -12,7 +11,6 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const mockPath = join(__dirname, "__mocks__");
 
 const same = (pName, pOptions, pMermaidModule = mermaid) => {
-  dir(pOptions);
   const definition = requireJSON(`./__mocks__/${pName}.json`);
   const expected = readFileSync(
     join(

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { dir } from "node:console";
 import { expect } from "chai";
 import mermaid from "../../../src/report/mermaid.js";
 import mermaidReporterPlugin from "../../../configs/plugins/mermaid-reporter-plugin.js";
@@ -10,45 +11,60 @@ const requireJSON = createRequireJSON(import.meta.url);
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const mockPath = join(__dirname, "__mocks__");
 
-const same = (pName, pMermaidModule = mermaid) => {
+const same = (pName, pOptions, pMermaidModule = mermaid) => {
+  dir(pOptions);
   const definition = requireJSON(`./__mocks__/${pName}.json`);
-  const expected = readFileSync(join(mockPath, `${pName}.mmd`), "utf8");
-  const output = pMermaidModule(definition, { minify: false }).output;
-  expect(output).to.deep.equal(expected);
-};
-
-const sameWithMinified = (pName, pMermaidModule = mermaid) => {
-  const definition = requireJSON(`./__mocks__/${pName}.json`);
-  const expected = readFileSync(join(mockPath, `${pName}.min.mmd`), "utf8");
-  const output = pMermaidModule(definition, { minify: true }).output;
+  const expected = readFileSync(
+    join(
+      mockPath,
+      `${pName}${(pOptions || {}).minify === false ? ".mmd" : ".min.mmd"}`
+    ),
+    "utf8"
+  );
+  const output = pMermaidModule(definition, pOptions).output;
   expect(output).to.deep.equal(expected);
 };
 
 describe("[I] report/mermaid", () => {
   it("renders a mermaid - render directories", () => {
-    same("dependency-cruiser-2019-01-14");
-    sameWithMinified("dependency-cruiser-2019-01-14");
+    same("dependency-cruiser-2019-01-14", { minify: false });
+    same("dependency-cruiser-2019-01-14", { minify: true });
   });
   it("renders a mermaid - modules in the root don't come in a cluster", () =>
-    same("clusterless"));
+    same("clusterless", { minify: false }));
   it("renders a mermaid - unresolvable in a sub folder (either existing or not) get labeled as unresolvable", () =>
-    same("es6-unresolvable-deps"));
+    same("es6-unresolvable-deps", { minify: false }));
   it("renders a mermaid - matchesDoNotFollow NOT rendered as folders", () =>
-    same("do-not-follow-deps"));
-  it("renders a mermaid - renders orphan module", () => same("orphan-deps"));
+    same("do-not-follow-deps", { minify: false }));
+  it("renders a mermaid - renders orphan module", () =>
+    same("orphan-deps", { minify: false }));
   it("renders a mermaid - rendered strings that mermaid cannot parse are escaped.", () =>
-    same("contains-strings-to-be-escaped"));
+    same("contains-strings-to-be-escaped", { minify: false }));
   it("renders a mermaid - rendered strings that replaced from unknown figures.", () =>
-    same("unknown-deps"));
-  it("renders a mermaid - renders focussed elements with highlights", () => {
-    same("with-focus");
-    sameWithMinified("with-focus");
+    same("unknown-deps", { minify: false }));
+  it("renders a mermaid - renders focused elements with highlights - unminified", () => {
+    same("with-focus", { minify: false });
+  });
+  it("renders a mermaid - renders focused elements with highlights - no options passed", () => {
+    // eslint-disable-next-line no-undefined
+    same("with-focus", undefined);
+  });
+  it("renders a mermaid - renders focused elements with highlights - minified", () => {
+    same("with-focus", { minify: true });
   });
 });
 
 describe("[I] configs/plugins/mermaid-reporter-plugin", () => {
   it("still renders mermaid with the mermaid reporter as a 'plugin'", () => {
-    same("dependency-cruiser-2019-01-14", mermaidReporterPlugin);
-    sameWithMinified("dependency-cruiser-2019-01-14", mermaidReporterPlugin);
+    same(
+      "dependency-cruiser-2019-01-14",
+      { minify: false },
+      mermaidReporterPlugin
+    );
+    same(
+      "dependency-cruiser-2019-01-14",
+      { minify: true },
+      mermaidReporterPlugin
+    );
   });
 });

--- a/types/reporter-options.d.ts
+++ b/types/reporter-options.d.ts
@@ -33,7 +33,7 @@ export interface IReporterOptions {
   /**
    * Options that influence rendition in the mermad reporter
    */
-  mermaid: IMermaidReporterOptions;
+  mermaid?: IMermaidReporterOptions;
 }
 
 export interface IReporterFiltersType {


### PR DESCRIPTION
## Description

Some things I forget to add (/ didn't notice in the PR review):

* bugfix(types): make mermaid optional in options type
* bugfix(test|mermaid): adds scenario where no options are passed to the reporter
* refactor(test|mermaid): dedupe comparison function
* refactor(mermaid): use .has instead of .get to test whether a key is in the hash map
* style(mermaid): apply some code style rules that don't have an automated check on them yet
  * these are things that don't matter for the functioning of the code, but do
    make it look a bit more familiar to the code style of the rest of the code base.
    As long as there's no automated check (or even better: automatic fix) on them
    I'm not comfortable to put these as review comments.
  * Replaces arrow function expressions with a regular named `function` where the function
    expression is a bit longer
  * Replaces shorter, single line function expressions with only `=> { return <somestatement>` } in theme with `=> <somestatement>`
  * Puts verbs in function names where this wasn't already done
  * Prefixes local variables/ constants with an `l` (eslint plugin budapestian missed these,
    which is an improvement that should go into that plugin).
  * Moves the hashNodeName closer to the function it's called from.


## How Has This Been Tested?

- [x] green ci


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
