### PR TITLE
bugfix(enrich): removes 'progress' from shareable options in options summary

### DIFF
--- a/src/enrich/summarize/summarize-options.js
+++ b/src/enrich/summarize/summarize-options.js
@@ -21,13 +21,13 @@ const SHAREABLE_OPTIONS = [
   "outputType",
   "prefix",
   "preserveSymlinks",
-  "progress",
   "reaches",
   "reporterOptions",
   "rulesFile",
   "tsPreCompilationDeps",
   "webpackConfig",
   // "metrics", TODO: should be enabled
+  // "progress", TODO: could be enabled
   // "tsConfig", TODO: should be enabled
 ];
 

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,12 +1,17 @@
-import { expect } from "chai";
+import { expect, use } from "chai";
+import chaiJSONSchema from "chai-json-schema";
 import summarize from "../../src/enrich/summarize/index.js";
+import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
 import cycleStartsOnOne from "./__mocks__/cycle-starts-on-one.mjs";
 import cycleStartsOnTwo from "./__mocks__/cycle-starts-on-two.mjs";
 import cycleFest from "./__mocks__/cycle-fest.mjs";
 
+use(chaiJSONSchema);
+
 describe("[I] enrich/summarize", () => {
   it("doesn't add a rule set when there isn't one", () => {
-    expect(summarize([], {}, [])).to.deep.equal({
+    const lSummary = summarize([], {}, []);
+    expect(lSummary).to.deep.equal({
       error: 0,
       info: 0,
       ignore: 0,
@@ -18,9 +23,13 @@ describe("[I] enrich/summarize", () => {
       violations: [],
       warn: 0,
     });
+    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
+      cruiseResultSchema
+    );
   });
   it("adds a rule set when there is one", () => {
-    expect(summarize([], { ruleSet: { required: [] } }, [])).to.deep.equal({
+    const lSummary = summarize([], { ruleSet: { required: [] } }, []);
+    expect(lSummary).to.deep.equal({
       error: 0,
       info: 0,
       ignore: 0,
@@ -35,6 +44,9 @@ describe("[I] enrich/summarize", () => {
       violations: [],
       warn: 0,
     });
+    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
+      cruiseResultSchema
+    );
   });
 
   it("consistently summarizes the same circular dependency, regardless the order", () => {
@@ -56,6 +68,9 @@ describe("[I] enrich/summarize", () => {
     const lResult2 = summarize(cycleStartsOnTwo, lOptions, ["src"]);
 
     expect(lResult1).to.deep.equal(lResult2);
+    expect({ modules: [], summary: lResult1 }).to.be.jsonSchema(
+      cruiseResultSchema
+    );
   });
 
   it("summarizes all circular dependencies, even when there's more per thingus", () => {
@@ -128,8 +143,11 @@ describe("[I] enrich/summarize", () => {
         ],
       },
     };
-    const lResult = summarize(cycleFest, lOptions, ["src"]);
-    expect(lResult).to.deep.equal(lExpected);
+    const lSummary = summarize(cycleFest, lOptions, ["src"]);
+    expect(lSummary).to.deep.equal(lExpected);
+    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
+      cruiseResultSchema
+    );
   });
 
   it("includes known violations in the summary", () => {
@@ -184,7 +202,7 @@ describe("[I] enrich/summarize", () => {
   });
 
   it("violating something with moreUnstable & instabilities", () => {
-    const lResult = summarize(
+    const lSummary = summarize(
       [
         {
           source: "violation.js",
@@ -212,7 +230,7 @@ describe("[I] enrich/summarize", () => {
       []
     );
 
-    expect(lResult).to.deep.equal({
+    expect(lSummary).to.deep.equal({
       violations: [
         {
           type: "instability",
@@ -253,5 +271,8 @@ describe("[I] enrich/summarize", () => {
         ],
       },
     });
+    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
+      cruiseResultSchema
+    );
   });
 });


### PR DESCRIPTION
## Description

- removes 'progress' from shareable options
- adds a schema check to the summarisation unit tests

## Motivation and Context

- it's not properly normalised, as it turns out - so sharing it as is violates the json schema.
- progress isn't super important to reproducing the same results anyway

## How Has This Been Tested?

- [x] green ci
- [x] updated unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
