### PR TITLE
refactor(init): replaces 'inquirer' with 'prompts'

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,9 +152,9 @@
     "glob": "7.2.0",
     "handlebars": "4.7.7",
     "indent-string": "^4.0.0",
-    "inquirer": "^8.2.4",
     "json5": "2.2.1",
     "lodash": "4.17.21",
+    "prompts": "2.4.2",
     "safe-regex": "2.1.1",
     "semver": "^7.3.7",
     "semver-try-require": "^5.0.2",
@@ -170,6 +170,7 @@
     "@swc/core": "1.2.220",
     "@types/lodash": "4.14.182",
     "@types/node": "18.6.2",
+    "@types/prompts": "2.0.14",
     "@typescript-eslint/eslint-plugin": "5.31.0",
     "@typescript-eslint/parser": "5.31.0",
     "@vue/compiler-sfc": "3.2.37",
@@ -223,11 +224,6 @@
         "package": "husky",
         "policy": "wanted",
         "because": "https://github.com/typicode/husky/issues/822"
-      },
-      {
-        "package": "inquirer",
-        "policy": "wanted",
-        "because": "version 9 only exports ejs - and we use cjs and don't transpile"
       },
       {
         "package": "indent-string",


### PR DESCRIPTION
## Description

- replaces the interactive prompt dependency 'inquirer' with 'prompts'


## Motivation and Context

- the newer version of inquirer is ESM only, which means we can't use it until the moment we are as well (this might happen in the future, but 
- I've selected 'prompts' because:
  - prompts is used about as much as inquirer (which is _a lot_ - 17M per week vs 23M)
  - prompts has a relatively small footprint (inquirer a.o. drags in rxjs which is a 10Mb+ node module, prompts has two very small dependencies)
  - has all features we need (inquirer likely has more features, but those we don't use)
  - its usage in the code is testable whereas last time I checked inquirer this wasn't possible with inquirer
  - migration from inquirer to prompts is trivial
- I've selected 'prompts' in spite of:
  - sparse updates (last update was 9 months ago)
  - slightly less popularity a.c.t. inquirer
  - slightly less elegant interface (inquirer functionally separates the _when_ and _type_ fields - prompts puts them both in the. _type_ field)

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
