### PR TITLE
fix broken links in .md: default-theme.js

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -354,7 +354,7 @@ src/report/dot/index.js → src/report/dot/prepare-custom-level.js
 src/report/dot/index.js → src/report/dot/prepare-folder-level.js
 src/report/dot/index.js → src/report/dot/theming.js
 src/report/dot/module-utl.js → src/report/dot/theming.js
-src/report/dot/theming.js → src/report/dot/default-theme.json
+src/report/dot/theming.js → src/report/dot/default-theme.js
 src/report/dot/prepare-custom-level.js → src/report/utl/consolidate-to-pattern.js
 src/report/dot/prepare-custom-level.js → src/report/dot/module-utl.js
 src/report/utl/consolidate-to-pattern.js → src/report/utl/consolidate-module-dependencies.js

--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -812,7 +812,7 @@ The criteria are evaluated top to bottom:
 - Criteria in the configuration file take precedence over the default ones.
 
 For an extensive example you can have a look at the default theme dependency-cruiser
-ships with - [default-theme.json](../src/report/dot/default-theme.json).
+ships with - [default-theme.js](../src/report/dot/default-theme.js).
 
 #### theming examples
 


### PR DESCRIPTION
## Description

Fixed a couple broken links in the markdown docs: `default-theme.json -> default-theme.js`

I didn't make this fix elsewhere, you may want to to a search to fix in non-markdown locations.

## Motivation and Context

I clicked a link and found it was broken.

## How Has This Been Tested?

Not tested, simple change in markdown.

- [ ] green ci

## Screenshots

NA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
