### PR TITLE
feature(validate): relaxes safe-regex check on on repeats within rule sets

### DIFF
--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -81,10 +81,10 @@ function validateCruiseOptions(pOptions) {
   let lReturnValue = {};
 
   if (Boolean(pOptions)) {
-    // neccessary because can slip through the cracks when passed as a cli parameter
+    // necessary because can slip through the cracks when passed as a cli parameter
     validateSystems(pOptions.moduleSystems);
 
-    // neccessary because this safety check can't be done in json schema (a.f.a.i.k.)
+    // necessary because this safety check can't be done in json schema (a.f.a.i.k.)
     validatePathsSafety(pOptions.doNotFollow);
     validatePathsSafety(pOptions.exclude);
     validateRegExpSafety(pOptions.includeOnly);
@@ -95,7 +95,7 @@ function validateCruiseOptions(pOptions) {
     // necessary because not in the config schema
     validateOutputType(pOptions.outputType);
 
-    // neccessary because not found a way to do this properly in JSON schema
+    // necessary because not found a way to do this properly in JSON schema
     validateMaxDepth(pOptions.maxDepth);
 
     validateFocusDepth(pOptions.focusDepth);


### PR DESCRIPTION
## Description

- relaxes the safe-regex check on repeats within regular expressions that are used within rule sets

See the comment added to src/main/rule-set/validate.js for details on the implementation.

Published on npm as `dependency-cruiser-11.16.0-beta-1`, shasum: `ff83cf05411f7d11d465de7143c82d02ef149b17`

## Motivation and Context

fixes #651

## How Has This Been Tested?

- [x] green ci
- [x] automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
