### PR TITLE
bugfix(validate): don't pass arrays to safe-regex

### DIFF
--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -2,7 +2,7 @@
 const get = require("lodash/get");
 const clone = require("lodash/clone");
 const has = require("lodash/has");
-const normalizeREProperties = require("../utl/normalize-re-properties");
+const { normalizeREProperties } = require("../utl/normalize-re-properties");
 const defaults = require("./defaults.js");
 
 function uniq(pArray) {

--- a/src/main/rule-set/normalize.js
+++ b/src/main/rule-set/normalize.js
@@ -1,6 +1,6 @@
 const cloneDeep = require("lodash/cloneDeep");
 const has = require("lodash/has");
-const normalizeREProperties = require("../utl/normalize-re-properties");
+const { normalizeREProperties } = require("../utl/normalize-re-properties");
 
 const VALID_SEVERITIES = /^(error|warn|info|ignore)$/;
 const DEFAULT_SEVERITY = "warn";

--- a/src/main/rule-set/validate.js
+++ b/src/main/rule-set/validate.js
@@ -3,6 +3,7 @@ const safeRegex = require("safe-regex");
 const has = require("lodash/has");
 const { validateCruiseOptions } = require("../options/validate");
 const configurationSchema = require("../../schema/configuration.schema.js");
+const { normalizeToREAsString } = require("../utl/normalize-re-properties");
 
 const ajv = new Ajv();
 // the default for this is 25 - as noted in the safe-regex source code already,
@@ -33,7 +34,7 @@ function hasPath(pObject, pSection, pCondition) {
 function safeRule(pRule, pSection, pCondition) {
   return (
     !hasPath(pRule, pSection, pCondition) ||
-    safeRegex(pRule[pSection][pCondition], {
+    safeRegex(normalizeToREAsString(pRule[pSection][pCondition]), {
       limit: MAX_SAFE_REGEX_STAR_REPEAT_LIMIT,
     })
   );

--- a/src/main/utl/normalize-re-properties.js
+++ b/src/main/utl/normalize-re-properties.js
@@ -28,7 +28,7 @@ function normalizeToREAsString(pStringish) {
   return pStringish;
 }
 
-module.exports = function normalizeREProperties(
+function normalizeREProperties(
   pPropertyContainer,
   pREProperties = RE_PROPERTIES
 ) {
@@ -44,4 +44,9 @@ module.exports = function normalizeREProperties(
     }
   }
   return lPropertyContainer;
+}
+
+module.exports = {
+  normalizeToREAsString,
+  normalizeREProperties,
 };

--- a/test/main/rule-set/validate.spec.mjs
+++ b/test/main/rule-set/validate.spec.mjs
@@ -67,6 +67,17 @@ describe("[I] main/rule-set/validate - regexp safety checks", () => {
     );
   });
 
+  it("bails out on scary regexps in paths - also when they're arrays", () => {
+    shouldBarfWithMessage(
+      "./test/validate/__mocks__/rules.scary-regex-array.json",
+      'rule {"from":{"path":".+"},"to":{"path":["(.+)*","something else"]}} has an unsafe regular expression. Bailing out.\n'
+    );
+  });
+
+  it("is ok about regexps in paths that just have a bunch of repetition but no scary star-height", () => {
+    shouldBeOK("./test/validate/__mocks__/rules.ok-regex-just-repeating.json");
+  });
+
   it("bails out on scary regexps in pathNots", () => {
     shouldBarfWithMessage(
       "./test/validate/__mocks__/rules.scary-regex-in-pathnot.json",

--- a/test/main/utl/normalize-re-properties.spec.mjs
+++ b/test/main/utl/normalize-re-properties.spec.mjs
@@ -1,6 +1,6 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
-import normalizeREProperties from "../../../src/main/utl/normalize-re-properties.js";
+import { normalizeREProperties } from "../../../src/main/utl/normalize-re-properties.js";
 
 use(chaiJSONSchema);
 

--- a/test/validate/__mocks__/rules.ok-regex-just-repeating.json
+++ b/test/validate/__mocks__/rules.ok-regex-just-repeating.json
@@ -1,0 +1,39 @@
+{
+  "forbidden": [
+    {
+      "from": {
+        "path": ".+"
+      },
+      "to": {
+        "path": [
+          ".+/modules/module-1/",
+          ".+/modules/module-2/",
+          ".+/modules/module-3/",
+          ".+/modules/module-4/",
+          ".+/modules/module-5/",
+          ".+/modules/module-6/",
+          ".+/modules/module-7/",
+          ".+/modules/module-8/",
+          ".+/modules/module-9/",
+          ".+/modules/module-10/",
+          ".+/modules/module-11/",
+          ".+/modules/module-12/",
+          ".+/modules/module-13/",
+          ".+/modules/module-14/",
+          ".+/modules/module-15/",
+          ".+/modules/module-16/",
+          ".+/modules/module-17/",
+          ".+/modules/module-18/",
+          ".+/modules/module-19/",
+          ".+/modules/module-20/",
+          ".+/modules/module-21/",
+          ".+/modules/module-22/",
+          ".+/modules/module-23/",
+          ".+/modules/module-24/",
+          ".+/modules/module-25/",
+          ".+/modules/module-26/"
+        ]
+      }
+    }
+  ]
+}

--- a/test/validate/__mocks__/rules.scary-regex-array.json
+++ b/test/validate/__mocks__/rules.scary-regex-array.json
@@ -1,0 +1,12 @@
+{
+  "forbidden": [
+    {
+      "from": {
+        "path": ".+"
+      },
+      "to": {
+        "path": ["(.+)*", "something else"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

When checking passed paths in rules for regular expression safety, if they were arrays we passed them as such - in stead  of first normalising them to  regular-expression-as-a-string. For safe-regex it didn't seem to matter in its current implementation, but we shouldn't rely on such implementation details.

## Motivation and Context

fixes #651 (second part)

## How Has This Been Tested?

- [x] green ci
- [x] adapted and new automated non-regression tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
