### PR TITLE
refactor(plugins): simplify construct to expose mermaid plugin and stay backword compatible

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -1,14 +1,5 @@
 [
   {
-    "type": "dependency",
-    "from": "configs/plugins/mermaid-reporter-plugin.js",
-    "to": "src/report/mermaid.js",
-    "rule": {
-      "severity": "error",
-      "name": "no-external-to-here"
-    }
-  },
-  {
     "type": "module",
     "from": "src/schema/baseline-violations.schema.js",
     "to": "src/schema/baseline-violations.schema.js",

--- a/configs/plugins/mermaid-reporter-plugin.js
+++ b/configs/plugins/mermaid-reporter-plugin.js
@@ -1,1 +1,0 @@
-module.exports = require("../../src/report/mermaid");

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "./config-utl/extract-webpack-resolve-config": "./src/config-utl/extract-webpack-resolve-config.js",
     "./sample-reporter-plugin": "./configs/plugins/stats-reporter-plugin.js",
     "./sample-3d-reporter-plugin": "./configs/plugins/3d-reporter-plugin.js",
-    "./mermaid-reporter-plugin": "./configs/plugins/mermaid-reporter-plugin.js"
+    "./mermaid-reporter-plugin": "./src/report/mermaid.js"
   },
   "types": "types/dependency-cruiser.d.ts",
   "files": [

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -2,8 +2,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "chai";
+// eslint-plugins import and node don't yet understand these 'self references'
+// eslint-disable-next-line import/no-unresolved, node/no-missing-import
+import mermaidReporterPlugin from "dependency-cruiser/mermaid-reporter-plugin";
 import mermaid from "../../../src/report/mermaid.js";
-import mermaidReporterPlugin from "../../../configs/plugins/mermaid-reporter-plugin.js";
 import { createRequireJSON } from "../../backwards.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);


### PR DESCRIPTION
## Description, Motivation and Context

Just a reference to the internal reporter works just as well as the previous construct (that just re-exported the internal reporter) + it's simpler & uses no code.


## How Has This Been Tested?

- [x] green ci
- [x] updated integration test on the plugin

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
