### PR TITLE
feature(extract): adds support for TypeScript 4.7 .cts and .mts extensions

### DIFF
--- a/configs/.dependency-cruiser-unlimited.json
+++ b/configs/.dependency-cruiser-unlimited.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "../src/schema/configuration.schema.json",
+  "extends": "../.dependency-cruiser.json",
+  "options": {
+    "reporterOptions": {
+      "dot": {
+        "showMetrics": true,
+        "filters": { "includeOnly": { "path": "(bin|src|test|types)" } },
+        "theme": {
+          "replace": false,
+          "graph": {
+            "splines": "ortho"
+          },
+          "modules": [
+            {
+              "criteria": { "matchesFocus": true },
+              "attributes": {
+                "fillcolor": "lime",
+                "penwidth": 2
+              }
+            },
+            {
+              "criteria": { "matchesFocus": false },
+              "attributes": {
+                "color": "grey"
+              }
+            },
+            {
+              "criteria": { "matchesReaches": true },
+              "attributes": {
+                "fillcolor": "lime",
+                "penwidth": 2
+              }
+            },
+            {
+              "criteria": { "matchesReaches": false },
+              "attributes": {
+                "color": "grey"
+              }
+            },
+            {
+              "criteria": { "source": "^src/cli" },
+              "attributes": { "fillcolor": "#ccccff" }
+            },
+            {
+              "criteria": { "source": "^src/config-utl" },
+              "attributes": { "fillcolor": "#99ffff" }
+            },
+            {
+              "criteria": { "source": "^src/report" },
+              "attributes": { "fillcolor": "#ffccff" }
+            },
+            {
+              "criteria": { "source": "^src/extract" },
+              "attributes": { "fillcolor": "#ccffcc" }
+            },
+            {
+              "criteria": { "source": "^src/enrich" },
+              "attributes": { "fillcolor": "#77eeaa" }
+            },
+            {
+              "criteria": { "source": "^src/validate" },
+              "attributes": { "fillcolor": "#ccccff" }
+            },
+            {
+              "criteria": { "source": "^src/main" },
+              "attributes": { "fillcolor": "#ffcccc" }
+            },
+            {
+              "criteria": { "source": "^src/utl" },
+              "attributes": { "fillcolor": "#cccccc" }
+            },
+            {
+              "criteria": { "source": "^src/graph-utl" },
+              "attributes": { "fillcolor": "#ffcccc" }
+            },
+            {
+              "criteria": {
+                "source": "^src/meta\\.js$|\\.template\\.js$|\\.schema\\.js$"
+              },
+              "attributes": { "style": "filled" }
+            },
+            {
+              "criteria": { "source": "\\.json$" },
+              "attributes": { "shape": "cylinder" }
+            }
+          ],
+          "dependencies": [
+            {
+              "criteria": { "rules[0].severity": "error" },
+              "attributes": { "fontcolor": "red", "color": "red" }
+            },
+            {
+              "criteria": { "rules[0].severity": "warn" },
+              "attributes": {
+                "fontcolor": "orange",
+                "color": "orange"
+              }
+            },
+            {
+              "criteria": { "rules[0].severity": "info" },
+              "attributes": { "fontcolor": "blue", "color": "blue" }
+            },
+            {
+              "criteria": { "valid": false },
+              "attributes": { "fontcolor": "red", "color": "red" }
+            },
+            {
+              "criteria": { "resolved": "^src/cli" },
+              "attributes": { "color": "#0000ff77" }
+            },
+            {
+              "criteria": { "resolved": "^src/config-utl" },
+              "attributes": { "color": "#22999977" }
+            },
+            {
+              "criteria": { "resolved": "^src/report" },
+              "attributes": { "color": "#ff00ff77" }
+            },
+            {
+              "criteria": { "resolved": "^src/extract" },
+              "attributes": { "color": "#00770077" }
+            },
+            {
+              "criteria": { "resolved": "^src/enrich" },
+              "attributes": { "color": "#00776677" }
+            },
+            {
+              "criteria": { "resolved": "^src/validate" },
+              "attributes": { "color": "#0000ff77" }
+            },
+            {
+              "criteria": { "resolved": "^src/main" },
+              "attributes": { "color": "#77000077" }
+            },
+            {
+              "criteria": { "resolved": "^src/utl" },
+              "attributes": { "color": "#aaaaaa77" }
+            },
+            {
+              "criteria": { "resolved": "^src/graph-utl" },
+              "attributes": { "color": "#77000077" }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "depcruise:report": "node ./bin/dependency-cruise.js src bin test configs types --output-type err-html --config configs/.dependency-cruiser-show-metrics-config.json --output-to dependency-violations.html",
     "depcruise:report:view": "node ./bin/dependency-cruise.js src bin test configs types --output-type err-html --config configs/.dependency-cruiser-show-metrics-config.json --output-to - | browser",
     "depcruise:focus": "node ./bin/dependency-cruise.js src bin test configs types tools --progress --config configs/.dependency-cruiser-show-metrics-config.json --output-type text --focus",
-    "depcruise:reaches": "node ./bin/dependency-cruise.js src bin test configs types tools --progress --config configs/.dependency-cruiser-show-metrics-config.json --output-type text --reaches",
+    "depcruise:reaches": "node ./bin/dependency-cruise.js src bin test configs types tools --progress --config configs/.dependency-cruiser-unlimited.json --output-type text --reaches",
     "lint": "npm-run-all --parallel --aggregate-output lint:eslint lint:prettier lint:types",
     "lint:eslint": "eslint bin/dependency-cruise.js bin src test configs tools/**/*.mjs --cache --cache-location node_modules/.cache/eslint/",
     "lint:eslint:fix": "eslint --fix bin src test configs  tools/**/*.mjs --cache --cache-location node_modules/.cache/eslint/",

--- a/src/cli/init-config/config.js.template.hbs
+++ b/src/cli/init-config/config.js.template.hbs
@@ -283,7 +283,11 @@ module.exports = {
     // tsPreCompilationDeps: false,
     {{/if}}
     
-    /* list of extensions (typically non-parseable) to scan. Empty by default. */
+    /* 
+       list of extensions to scan that aren't javascript or compile-to-javascript. 
+       Empty by default. Only put extensions in here that you want to take into
+       account that are _not_ parsable. 
+    */
     // extraExtensionsToScan: [".json", ".jpg", ".png", ".svg", ".webp"],
 
     /* if true combines the package.jsons found from the module up to the base
@@ -381,7 +385,7 @@ module.exports = {
          ['exports'] when you use packages that use such a field and your environment
          supports it (e.g. node ^12.19 || >=14.7 or recent versions of webpack).
 
-        If you have an `exportsFields` attribute in your webpack config, that one
+         If you have an `exportsFields` attribute in your webpack config, that one
          will have precedence over the one specified here.
       */ 
       exportsFields: ["exports"],
@@ -395,6 +399,16 @@ module.exports = {
         have precedence over the one specified here.
       */
       conditionNames: ["import", "require", "node", "default"]
+      /*
+         The extensions, by default are the same as the ones dependency-cruiser
+         can access (run `npx depcruise --info` to see which ones that are in
+         _your_ environment. If that list is larger than what you need (e.g. 
+         it contains .js, .jsx, .ts, .tsx, .cts, .mts - but you don't use 
+         TypeScript you can pass just the extensions you actually use (e.g. 
+         [".js", ".jsx"]). This can speed up the most expensive step in 
+         dependency cruising (module resolution) quite a bit.
+       */
+      // extensions: [".js", ".jsx", ".ts", ".tsx", ".d.ts"]
     },
     reporterOptions: {
       dot: {

--- a/src/extract/ast-extractors/swc-dependency-visitor.js
+++ b/src/extract/ast-extractors/swc-dependency-visitor.js
@@ -86,7 +86,7 @@ function isImportCallExpression(pNode) {
     somewhere between swc 1.2.123 and 1.2.133 the swc AST started to
     represent import call expressions with .callee.type === "Import"
     instead of .callee.value === "import". Keeping both detection
-    methods in here for backwards compatiblity
+    methods in here for backwards compatibility
   */
   return pNode.callee.value === "import" || pNode.callee.type === "Import";
 }
@@ -100,7 +100,7 @@ function isInterestingCallExpression(pExoticRequireStrings, pNode) {
     somewhere between swc 1.2.123 and 1.2.133 the swc AST started to
     represent import call expressions with .callee.type === "Import"
     instead of .callee.value === "import". Keeping both detection
-    methods in here for backwards compatiblity
+    methods in here for backwards compatibility
   */
   return (
     pNode.callee.type === "Import" ||

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -90,7 +90,8 @@ function resolveWithRetry(
   //
   // This behavior is very specific:
   // - tsc only (doesn't work in ts-node for instance)
-  // - _only_ for the .js and .jsx extensions
+  // - until TypeScript 4.6 only for the .js and .jsx extensions
+  // - since TypeScript 4.7 also for .cjs and .mjs (=> .cts, .mts) extensions
   //
   // Hence also this oddly specific looking check & retry.
   //
@@ -101,7 +102,7 @@ function resolveWithRetry(
     canBeResolvedToTsVariant(lStrippedModuleName)
   ) {
     const lModuleWithOutExtension = lStrippedModuleName.replace(
-      /\.js(x)?$/g,
+      /\.(js|jsx|mjs|cjs)$/g,
       ""
     );
 

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -3,7 +3,8 @@ const { supportedTranspilers } = require("../../../src/meta.js");
 const swc = require("../parse/to-swc-ast");
 const javaScriptWrap = require("./javascript-wrap");
 const typeScriptWrap = require("./typescript-wrap")();
-const tsxWrap = require("./typescript-wrap")(true);
+const typeScriptESMWrap = require("./typescript-wrap")("esm");
+const typeScriptTsxWrap = require("./typescript-wrap")("tsx");
 const liveScriptWrap = require("./livescript-wrap");
 const coffeeWrap = require("./coffeescript-wrap")();
 const litCoffeeWrap = require("./coffeescript-wrap")(true);
@@ -17,16 +18,18 @@ const EXTENSION2WRAPPER = {
   ".mjs": javaScriptWrap,
   ".jsx": javaScriptWrap,
   ".ts": typeScriptWrap,
-  ".tsx": tsxWrap,
+  ".tsx": typeScriptTsxWrap,
   ".d.ts": typeScriptWrap,
+  ".cts": typeScriptWrap,
+  ".mts": typeScriptESMWrap,
+  ".vue": vueWrap,
+  ".svelte": svelteWrap,
   ".ls": liveScriptWrap,
   ".coffee": coffeeWrap,
   ".litcoffee": litCoffeeWrap,
   ".coffee.md": litCoffeeWrap,
   ".csx": coffeeWrap,
   ".cjsx": coffeeWrap,
-  ".vue": vueWrap,
-  ".svelte": svelteWrap,
 };
 
 const TRANSPILER2WRAPPER = {

--- a/src/extract/transpile/typescript-wrap.js
+++ b/src/extract/transpile/typescript-wrap.js
@@ -4,21 +4,33 @@ const { supportedTranspilers } = require("../../../src/meta.js");
 
 const typescript = tryRequire("typescript", supportedTranspilers.typescript);
 
-function getCompilerOptions(pTsx, pTSConfig) {
+function getCompilerOptions(pFlavor, pTSConfig) {
   let lCompilerOptions = {};
 
-  if (pTsx) {
+  if (pFlavor === "tsx") {
     lCompilerOptions.jsx = "react";
   }
 
+  if (pFlavor === "esm") {
+    // see https://www.typescriptlang.org/docs/handbook/esm-node.html
+    lCompilerOptions.module = "nodenext";
+    // when we're doing something with esm (so cts, mts extensions) we can
+    // assume TypeScript >=4.7 - which supports target es2022 - which should
+    // be easier (and hence we assume faster) to transpile
+    lCompilerOptions.target = "es2022";
+  }
+
   return {
+    // target: "es2022" should also be OK - but we don't know which version of
+    // the TypeScript compiler we're using, so for we keep this for backwards
+    // compatibility.
     target: "es2015",
     ...lCompilerOptions,
     ...get(pTSConfig, "options", {}),
   };
 }
 
-module.exports = function typescriptWrap(pTsx) {
+module.exports = function typescriptWrap(pFlavor) {
   return {
     isAvailable: () => typescript !== false,
 
@@ -26,7 +38,7 @@ module.exports = function typescriptWrap(pTsx) {
       typescript.transpileModule(pSource, {
         ...(pTranspileOptions.tsConfig || {}),
         compilerOptions: getCompilerOptions(
-          pTsx,
+          pFlavor,
           pTranspileOptions.tsConfig || {}
         ),
       }).outputText,

--- a/test/extract/transpile/__fixtures__/mts.mjs
+++ b/test/extract/transpile/__fixtures__/mts.mjs
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.doSomething = exports.version = void 0;
+const version = "1.2.3";
+exports.version = version;
+function doSomething(pString) {
+  console.log(pString);
+}
+exports.doSomething = doSomething;

--- a/test/extract/transpile/__mocks__/mts.mts
+++ b/test/extract/transpile/__mocks__/mts.mts
@@ -1,0 +1,7 @@
+const version = "1.2.3";
+
+function doSomething(pString: string) {
+  console.log(pString);
+}
+
+export { version, doSomething };

--- a/test/extract/transpile/meta.spec.mjs
+++ b/test/extract/transpile/meta.spec.mjs
@@ -15,13 +15,15 @@ describe("[U] extract/transpile/meta", () => {
       ".ts",
       ".tsx",
       ".d.ts",
+      ".cts",
+      ".mts",
+      ".vue",
+      ".svelte",
       ".coffee",
       ".litcoffee",
       ".coffee.md",
       ".csx",
       ".cjsx",
-      ".vue",
-      ".svelte",
     ]);
   });
 

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -3,18 +3,19 @@ import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
 import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.js";
 
-const wrap = typescriptWrap();
-const tsxWrap = typescriptWrap(true);
+const typeScriptRegularWrap = typescriptWrap();
+const typeScriptTsxWrap = typescriptWrap("tsx");
+const typeScriptESMWrap = typescriptWrap("esm");
 
 describe("[I] typescript transpiler", () => {
   it("tells the typescript transpiler is available", () => {
-    expect(wrap.isAvailable()).to.equal(true);
+    expect(typeScriptRegularWrap.isAvailable()).to.equal(true);
   });
 
   it("transpiles typescript", () => {
     expect(
       normalizeSource(
-        wrap.transpile(
+        typeScriptRegularWrap.transpile(
           fs.readFileSync(
             "./test/extract/transpile/__mocks__/typescriptscript.ts",
             "utf8"
@@ -32,21 +33,41 @@ describe("[I] typescript transpiler", () => {
   });
 });
 
-describe("[I] tsx transpiler (plain old typescript)", () => {
+describe("[I] typescript transpiler (tsx)", () => {
   it("tells the tsx transpiler is available", () => {
-    expect(tsxWrap.isAvailable()).to.equal(true);
+    expect(typeScriptTsxWrap.isAvailable()).to.equal(true);
   });
 
   it("transpiles tsx", () => {
     expect(
       normalizeSource(
-        tsxWrap.transpile(
+        typeScriptTsxWrap.transpile(
           fs.readFileSync("./test/extract/transpile/__mocks__/tsx.tsx", "utf8")
         )
       )
     ).to.equal(
       normalizeSource(
         fs.readFileSync("./test/extract/transpile/__fixtures__/tsx.js", "utf8")
+      )
+    );
+  });
+});
+
+describe("[I] typescript transpiler (esm)", () => {
+  it("tells the ts transpiler is available for mts (esm) modules", () => {
+    expect(typeScriptESMWrap.isAvailable()).to.equal(true);
+  });
+
+  it("transpiles mts", () => {
+    expect(
+      normalizeSource(
+        typeScriptESMWrap.transpile(
+          fs.readFileSync("./test/extract/transpile/__mocks__/mts.mts", "utf8")
+        )
+      )
+    ).to.equal(
+      normalizeSource(
+        fs.readFileSync("./test/extract/transpile/__fixtures__/mts.mjs", "utf8")
       )
     );
   });


### PR DESCRIPTION
## Description

- adds .cts and .mts to the supported extensions and instructs the typescript compiler to properly handle .mts (.cts is already handled as it's same as a .ts)
- ensures the weird file resolution (ends in .js? could be the .ts you meant) for typescript also extends to .cts and .mts extensions.
- to ease analysis of files impacted by this PR: adds a config & updates the depcruise:reaches package.json run script to show locally what is impacted on _all_ files, even in test.
- documents the `extensions` option in the template for .dependency-cruiser.js files - the more extensions in there the slower enhanced-resolve will resolve in worst case scenario situations - documenting that will hopefully make it easier to figure out how to tune dependency-cruiser to their environment.
- 🏕️ corrects an unrelated typo in the comments of the swc visitor 

## Motivation and Context

- .cts and .mts extensions got introduced in TypeScript 4.7.x (if I'm not wrong) and will likely find at least some usage in the wild - so better prepare for it.

## How Has This Been Tested?

- [x] green ci
- [x] additional automated integration tests

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
