### PR TITLE
feature: adds 'highlight' option to depcruise-fmt as well

### DIFF
--- a/bin/depcruise-fmt.js
+++ b/bin/depcruise-fmt.js
@@ -49,6 +49,10 @@ try {
       "-R, --reaches <regex>",
       "only include modules matching the regex + all modules that can reach it"
     )
+    .option(
+      "-H, --highlight <regex>",
+      "mark modules matching the regex as 'highlighted'"
+    )
     .option("-x, --exclude <regex>", "exclude all modules matching the regex")
     .option(
       "-S, --collapse <regex>",

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1222,10 +1222,16 @@ depcruise-fmt -T dot --focus "^src/main" cruise_result.json | dot -T svg > main.
 depcruise-fmt -T dot --focus "^src/juggle" cruise_result.json | dot -T svg > juggle.svg
 depcruise-fmt -T dot --include-only "^src/the-law" cruise_result.json | dot -T svg > the-law.svg
 
-## or to find dependencies going into or departing from the spelunkme module
+## or to find dependencies going into or departing from the spelunk-me module
 ## and emitting them to stdout:
-depcruise-fmt -T text --focus "^src/main/spelunkme\\.ts$" cruise_result.json
+depcruise-fmt -T text --focus "^src/main/spelunk-me\\.ts$" cruise_result.json
 ```
+
+### highlight
+
+The `--highlight` option is also available in case you want to just highlight
+modules without filtering them. See the [--highlight](#highlight-highlight-modules)
+documentation of the regular depcruise command for more information.
 
 ### collapse/ summarize
 

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -10,6 +10,7 @@ const KNOWN_FMT_OPTIONS = [
   "focus",
   "focusDepth",
   "help",
+  "highlight",
   "includeOnly",
   "outputTo",
   "outputType",

--- a/src/main/options/normalize.js
+++ b/src/main/options/normalize.js
@@ -205,6 +205,7 @@ function normalizeFormatOptions(pFormatOptions) {
   lFormatOptions = normalizeFilterOptions(lFormatOptions, [
     "exclude",
     "focus",
+    "highlight",
     "includeOnly",
     "reaches",
   ]);


### PR DESCRIPTION
## Description

- adds a `--highlight` option to the decpruise-fmt cli interface (see #675)

## Motivation and Context

Consistency.


## How Has This Been Tested?

- [x] green ci

## Screenshots

see #675 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
