### PR TITLE
refactor(cli): removes cli option scrubbing

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -4,21 +4,6 @@ const validateFileExistence = require("./utl/validate-file-existence");
 const normalizeOptions = require("./normalize-cli-options");
 const io = require("./utl/io");
 
-const KNOWN_FMT_OPTIONS = [
-  "collapse",
-  "exclude",
-  "focus",
-  "focusDepth",
-  "help",
-  "highlight",
-  "includeOnly",
-  "outputTo",
-  "outputType",
-  "prefix",
-  "reaches",
-  "version",
-];
-
 /**
  *
  * @param {string} pResultFile the name of the file with cruise results
@@ -26,7 +11,7 @@ const KNOWN_FMT_OPTIONS = [
  * @returns {Number} an exitCode
  */
 module.exports = async (pResultFile, pOptions) => {
-  const lOptions = normalizeOptions(pOptions, KNOWN_FMT_OPTIONS);
+  const lOptions = normalizeOptions(pOptions);
 
   if (pResultFile !== "-") {
     validateFileExistence(pResultFile);

--- a/src/cli/normalize-cli-options.js
+++ b/src/cli/normalize-cli-options.js
@@ -7,38 +7,6 @@ const clone = require("lodash/clone");
 const loadConfig = require("../config-utl/extract-depcruise-config");
 const defaults = require("./defaults");
 
-const KNOWN_DEPCRUISE_CLI_OPTIONS = [
-  "babelConfig",
-  "baseDir",
-  "cache",
-  "collapse",
-  "config",
-  "doNotFollow",
-  "exclude",
-  "focus",
-  "focusDepth",
-  "help",
-  "highlight",
-  "ignoreKnown",
-  "includeOnly",
-  "info",
-  "init",
-  "maxDepth",
-  "metrics",
-  "moduleSystems",
-  "outputTo",
-  "outputType",
-  "prefix",
-  "preserveSymlinks",
-  "progress",
-  "reaches",
-  "tsPreCompilationDeps",
-  "tsConfig",
-  "validate",
-  "version",
-  "webpackConfig",
-];
-
 function getOptionValue(pDefault) {
   return (pValue) => {
     let lReturnValue = pDefault;
@@ -48,27 +16,6 @@ function getOptionValue(pDefault) {
     }
     return lReturnValue;
   };
-}
-
-function isKnownCLIOption(pKnownOptions) {
-  return (pCandidateString) => pKnownOptions.includes(pCandidateString);
-}
-
-/**
- * Remove all attributes from the input object (which'd typically be
- * originating from commander) that are not functional dependency-cruiser
- * options so a clean object can be passed through to the main function
- *
- * @param {any} pCliOptions - an options object e.g. as output from commander
- * @returns {ICruiseOptions} - an options object that only contains stuff we care about
- */
-function ejectNonCLIOptions(pCliOptions, pKnownCliOptions) {
-  return Object.keys(pCliOptions)
-    .filter(isKnownCLIOption(pKnownCliOptions))
-    .reduce((pAll, pKey) => {
-      pAll[pKey] = pCliOptions[pKey];
-      return pAll;
-    }, {});
 }
 
 function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
@@ -218,14 +165,12 @@ function normalizeCacheFolderName(pCliOptions) {
  * @param {any} pKnownCliOptions [description]
  * @return {object}          [description]
  */
-module.exports = function normalizeOptions(
-  pOptionsAsPassedFromCommander,
-  pKnownCliOptions = KNOWN_DEPCRUISE_CLI_OPTIONS
-) {
+module.exports = function normalizeOptions(pOptionsAsPassedFromCommander) {
   let lOptions = {
     outputTo: defaults.OUTPUT_TO,
     outputType: defaults.OUTPUT_TYPE,
-    ...ejectNonCLIOptions(pOptionsAsPassedFromCommander, pKnownCliOptions),
+    ...pOptionsAsPassedFromCommander,
+    // ...ejectNonCLIOptions(pOptionsAsPassedFromCommander, pKnownCliOptions),
   };
 
   if (has(lOptions, "moduleSystems")) {


### PR DESCRIPTION
## Description

- removes the scrubbing of unknown options from the cli (both depcruise-fmt.js and dependency-cruise.js)

## Motivation and Context

These days commander already delivers just the passed  options and nothing more, so it's  not necessary anymore to do this. 

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
