### PR TITLE
chore: drops support for node 12 and 17 (BREAKING CHANGE)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,14 @@
 {
   "root": true,
   "extends": ["moving-meadow"],
+  "parserOptions": {
+    "ecmaVersion": 2021
+  },
   "rules": {
     "security/detect-non-literal-fs-filename": "off",
-    "unicorn/prefer-node-protocol": "off", // doesn't march on node 12, which we still run on
     "unicorn/prefer-top-level-await": "off", // only works as of node 16
-    "unicorn/no-useless-fallback-in-spread": "off" // useful, probably. We'll try it later, though
+    "unicorn/no-useless-fallback-in-spread": "off", // useful, probably. We'll try it later, though
+    "unicorn/prefer-node-protocol": "off" // yarn 1 pnp doesn't understand node: protocol, and as we still support yarn 1 pnp we're not doing this
   },
   "overrides": [
     {
@@ -28,9 +31,6 @@
     },
     {
       "files": ["**/*.mjs"],
-      "parserOptions": {
-        "ecmaVersion": 2021
-      },
       "rules": {
         "node/no-unsupported-features/es-syntax": "off"
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
             .yarnrc.yml
             .pnp.js
             yarn.lock
-          key: ${{env.NODE_VERSION}}@${{env.PLATFORM}}-build-${{hashFiles('package.json')}}
+          key: ${{env.NODE_LATEST}}@${{env.PLATFORM}}-build-${{hashFiles('package.json')}}
           restore-keys: |
-            ${{env.NODE_VERSION}}@${{env.PLATFORM}}-build-
+            ${{env.NODE_LATEST}}@${{env.PLATFORM}}-build-
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{env.NODE_VERSION}}
+          node-version: ${{env.NODE_LATEST}}
       - name: install & build
         run: |
           rm -f .npmrc
@@ -119,6 +119,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{env.NODE_VERSION}}
+          node-version: ${{env.NODE_LATEST}}
       - run: npm install
       - run: npm run test:yarn-pnp

--- a/doc/assets/theming/engineering.config.js
+++ b/doc/assets/theming/engineering.config.js
@@ -10,45 +10,45 @@ module.exports = {
             color: "white",
             fontcolor: "white",
             fillcolor: "transparent",
-            splines: "ortho"
+            splines: "ortho",
           },
           node: {
             color: "white",
             fillcolor: "#ffffff33",
-            fontcolor: "white"
+            fontcolor: "white",
           },
           edge: {
             arrowhead: "vee",
             arrowsize: "0.5",
             penwidth: "1.0",
             color: "white",
-            fontcolor: "white"
+            fontcolor: "white",
           },
           modules: [
             {
               criteria: { source: "\\.json$" },
               attributes: {
                 shape: "cylinder",
-                fillcolor: "#ffffff33:#ffffff88"
-              }
+                fillcolor: "#ffffff33:#ffffff88",
+              },
             },
             {
               criteria: { coreModule: true },
               attributes: {
                 color: "white",
                 fillcolor: "#ffffff33",
-                fontcolor: "white"
-              }
-            }
+                fontcolor: "white",
+              },
+            },
           ],
           dependencies: [
             {
               criteria: { resolved: "\\.json$" },
-              attributes: { arrowhead: "obox" }
-            }
-          ]
-        }
-      }
-    }
-  }
+              attributes: { arrowhead: "obox" },
+            },
+          ],
+        },
+      },
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "types/**"
   ],
   "engines": {
-    "node": "^12.20||^14||>=16"
+    "node": "^14||^16||>=18"
   },
   "supportedTranspilers": {
     "babel": ">=7.0.0 <8.0.0",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,5 +1,4 @@
 const glob = require("glob");
-const get = require("lodash/get");
 const clone = require("lodash/clone");
 const set = require("lodash/set");
 const isInstalledGlobally = require("is-installed-globally");
@@ -21,17 +20,14 @@ const setUpPerformanceLogListener = require("./listeners/performance-log");
 
 function extractResolveOptions(pCruiseOptions) {
   let lResolveOptions = {};
-  const lWebPackConfigFileName = get(
-    pCruiseOptions,
-    "ruleSet.options.webpackConfig.fileName",
-    null
-  );
+  const lWebPackConfigFileName =
+    pCruiseOptions?.ruleSet?.options?.webpackConfig?.fileName ?? null;
 
   if (lWebPackConfigFileName) {
     lResolveOptions = extractWebpackResolveConfig(
       lWebPackConfigFileName,
-      get(pCruiseOptions, "ruleSet.options.webpackConfig.env", null),
-      get(pCruiseOptions, "ruleSet.options.webpackConfig.arguments", null)
+      pCruiseOptions?.ruleSet?.options?.webpackConfig?.env ?? null,
+      pCruiseOptions?.ruleSet?.options?.webpackConfig?.arguments ?? null
     );
   }
   return lResolveOptions;
@@ -54,11 +50,8 @@ function addKnownViolations(pCruiseOptions) {
 
 function extractTSConfigOptions(pCruiseOptions) {
   let lReturnValue = {};
-  const lTSConfigFileName = get(
-    pCruiseOptions,
-    "ruleSet.options.tsConfig.fileName",
-    null
-  );
+  const lTSConfigFileName =
+    pCruiseOptions?.ruleSet?.options?.tsConfig?.fileName ?? null;
 
   if (lTSConfigFileName) {
     lReturnValue = extractTSConfig(lTSConfigFileName);
@@ -69,11 +62,8 @@ function extractTSConfigOptions(pCruiseOptions) {
 
 function extractBabelConfigOptions(pCruiseOptions) {
   let lReturnValue = {};
-  const lBabelConfigFileName = get(
-    pCruiseOptions,
-    "ruleSet.options.babelConfig.fileName",
-    null
-  );
+  const lBabelConfigFileName =
+    pCruiseOptions?.ruleSet?.options?.babelConfig?.fileName ?? null;
 
   if (lBabelConfigFileName) {
     lReturnValue = extractBabelConfig(lBabelConfigFileName);
@@ -87,12 +77,11 @@ function setUpListener(pCruiseOptions) {
     "cli-feedback": setUpCliFeedbackListener,
     "performance-log": setUpPerformanceLogListener,
   };
-  const lListenerID = get(
-    pCruiseOptions,
-    "progress",
-    get(pCruiseOptions, "ruleSet.options.progress.type")
-  );
-  const lListenerFunction = get(lString2Listener, lListenerID);
+  const lListenerID =
+    pCruiseOptions?.progress ??
+    pCruiseOptions?.ruleSet?.options?.progress?.type;
+  // eslint-disable-next-line security/detect-object-injection
+  const lListenerFunction = lString2Listener?.[lListenerID];
   /* c8 ignore next 3 */
   if (Boolean(lListenerFunction)) {
     lListenerFunction(bus);

--- a/src/config-utl/extract-babel-config.js
+++ b/src/config-utl/extract-babel-config.js
@@ -4,7 +4,6 @@
 const fs = require("fs");
 const path = require("path");
 const json5 = require("json5");
-const get = require("lodash/get");
 const has = require("lodash/has");
 const tryRequire = require("semver-try-require");
 const { supportedTranspilers } = require("../../src/meta.js");
@@ -48,7 +47,7 @@ function getJSON5Config(pBabelConfigFileName) {
   }
 
   if (pBabelConfigFileName.endsWith("package.json")) {
-    lReturnValue = get(lReturnValue, "babel", {});
+    lReturnValue = lReturnValue?.babel ?? {};
   }
   return lReturnValue;
 }

--- a/src/config-utl/extract-known-violations.js
+++ b/src/config-utl/extract-known-violations.js
@@ -7,10 +7,6 @@ module.exports = function extractKnownViolations(pKnownViolationsFileName) {
     return json5.parse(
       readFileSync(makeAbsolute(pKnownViolationsFileName), "utf8")
     );
-    // TODO: apparently node12 native coverage doesn't see this is covered with UT
-    //      (node 14 and 16 do), so c8 doesn't either. The ignore can be removed
-    //      once we stop supporting node 12
-    /* c8 ignore start */
   } catch (pError) {
     if (pError instanceof SyntaxError) {
       throw new SyntaxError(
@@ -19,9 +15,8 @@ module.exports = function extractKnownViolations(pKnownViolationsFileName) {
     }
     throw pError;
   }
-  /* c8 ignore stop */
 
-  // TODO: validate the json against the schme? (might be more clear to do it here,
+  // TODO: validate the json against the schema? (might be more clear to do it here,
   // even if (in context of the cli) it's done again when validating the whole
   // config
 };

--- a/src/config-utl/extract-ts-config.js
+++ b/src/config-utl/extract-ts-config.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const tryRequire = require("semver-try-require");
-const get = require("lodash/get");
 const { supportedTranspilers } = require("../../src/meta.js");
 
 const typescript = tryRequire("typescript", supportedTranspilers.typescript);
@@ -11,7 +10,7 @@ const FORMAT_DIAGNOSTICS_HOST = {
 
     // depends on the platform which branch is taken, hence the c8 ignore
     /* c8 ignore start */
-    if (get(typescript, "sys.useCaseSensitiveFileNames", false)) {
+    if (typescript?.sys?.useCaseSensitiveFileNames ?? false) {
       lReturnValue = pFileName;
     }
     /* c8 ignore stop */

--- a/src/enrich/derive/reachable/index.js
+++ b/src/enrich/derive/reachable/index.js
@@ -1,17 +1,16 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
 
 const clone = require("lodash/clone");
-const get = require("lodash/get");
 const has = require("lodash/has");
 const matchers = require("../../../validate/matchers");
 const { extractGroups } = require("../../../utl/regex-util");
 const getPath = require("./get-path");
 
 function getReachableRules(pRuleSet) {
-  return get(pRuleSet, "forbidden", [])
+  return (pRuleSet?.forbidden ?? [])
     .filter((pRule) => has(pRule.to, "reachable"))
     .concat(
-      get(pRuleSet, "allowed", []).filter((pRule) => has(pRule.to, "reachable"))
+      (pRuleSet?.allowed ?? []).filter((pRule) => has(pRule.to, "reachable"))
     );
 }
 
@@ -85,8 +84,8 @@ function hasCapturingGroups(pRule) {
   const lCapturingGroupPlaceholderRe = "\\$[0-9]+";
 
   return Boolean(
-    get(pRule, "to.path", "").match(lCapturingGroupPlaceholderRe) ||
-      get(pRule, "to.pathNot", "").match(lCapturingGroupPlaceholderRe)
+    (pRule?.to?.path ?? "").match(lCapturingGroupPlaceholderRe) ||
+      (pRule?.to?.pathNot ?? "").match(lCapturingGroupPlaceholderRe)
   );
 }
 function shouldAddReachable(pRule, pModuleTo, pGraph) {

--- a/src/enrich/enrich-modules.js
+++ b/src/enrich/enrich-modules.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const bus = require("../utl/bus");
 const busLogLevels = require("../utl/bus-log-levels");
 const addFocus = require("../../src/graph-utl/add-focus");
@@ -31,7 +30,7 @@ module.exports = function enrichModules(pModules, pOptions) {
   bus.emit("progress", "analyzing: add focus (if any)", {
     level: busLogLevels.INFO,
   });
-  lModules = addFocus(lModules, get(pOptions, "focus"));
+  lModules = addFocus(lModules, pOptions.focus);
 
   // when validate === false we might want to skip the addValidations.
   // We don't at this time, however, as "valid" is a mandatory

--- a/src/enrich/summarize/add-rule-set-used.js
+++ b/src/enrich/summarize/add-rule-set-used.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const clone = require("lodash/clone");
 
 // the fixed name for allowed rules served a purpose during the extraction
@@ -11,10 +10,10 @@ function removeNames(pRule) {
 }
 
 module.exports = function addRuleSetUsed(pOptions) {
-  const lForbidden = get(pOptions, "ruleSet.forbidden");
-  const lAllowed = get(pOptions, "ruleSet.allowed");
-  const lAllowedSeverity = get(pOptions, "ruleSet.allowedSeverity");
-  const lRequired = get(pOptions, "ruleSet.required");
+  const lForbidden = pOptions?.ruleSet?.forbidden;
+  const lAllowed = pOptions?.ruleSet?.allowed;
+  const lAllowedSeverity = pOptions?.ruleSet?.allowedSeverity;
+  const lRequired = pOptions?.ruleSet?.required;
 
   return Object.assign(
     lForbidden ? { forbidden: lForbidden } : {},

--- a/src/enrich/summarize/summarize-modules.js
+++ b/src/enrich/summarize/summarize-modules.js
@@ -1,5 +1,4 @@
 const _flattenDeep = require("lodash/flattenDeep");
-const get = require("lodash/get");
 const has = require("lodash/has");
 const uniqWith = require("lodash/uniqWith");
 const { findRuleByName } = require("../../graph-utl/rule-set");
@@ -25,7 +24,7 @@ function toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet) {
 
   if (
     has(pDependency, "cycle") &&
-    get(findRuleByName(pRuleSet, pRule.name), "to.circular")
+    findRuleByName(pRuleSet, pRule.name)?.to?.circular
   ) {
     lReturnValue = {
       ...lReturnValue,
@@ -88,10 +87,7 @@ function toModuleViolationSummary(pRule, pModule, pRuleSet) {
   let lReturnValue = [
     { type: "module", from: pModule.source, to: pModule.source, rule: pRule },
   ];
-  if (
-    pModule.reaches &&
-    get(findRuleByName(pRuleSet, pRule.name), "to.reachable")
-  ) {
+  if (pModule.reaches && findRuleByName(pRuleSet, pRule.name)?.to?.reachable) {
     lReturnValue = pModule.reaches
       .filter((pReachable) => pReachable.asDefinedInRule === pRule.name)
       .reduce(

--- a/src/enrich/summarize/summarize-options.js
+++ b/src/enrich/summarize/summarize-options.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const has = require("lodash/has");
 
 const SHAREABLE_OPTIONS = [
@@ -62,7 +61,7 @@ function makeIncludeOnlyBackwardsCompatible(pOptions) {
   return pOptions.includeOnly
     ? {
         ...pOptions,
-        includeOnly: get(pOptions, "includeOnly.path"),
+        includeOnly: pOptions?.includeOnly?.path,
       }
     : pOptions;
 }

--- a/src/extract/ast-extractors/estree-helpers.js
+++ b/src/extract/ast-extractors/estree-helpers.js
@@ -1,5 +1,3 @@
-const get = require("lodash/get");
-
 function isStringLiteral(pArgument) {
   return pArgument.type === "Literal" && typeof pArgument.value === "string";
 }
@@ -40,10 +38,7 @@ function isMemberCallExpression(pNode, pObjectName, pPropertyName) {
 }
 
 function isCalleeIdentifier(pNode, pName) {
-  return (
-    "Identifier" === get(pNode, "callee.type") &&
-    pName === get(pNode, "callee.name")
-  );
+  return "Identifier" === pNode?.callee?.type && pName === pNode?.callee?.name;
 }
 
 function isRequireOfSomeSort(pNode, pName) {

--- a/src/extract/parse/to-javascript-ast.js
+++ b/src/extract/parse/to-javascript-ast.js
@@ -2,7 +2,6 @@ const fs = require("fs");
 const acorn = require("acorn");
 const acornLoose = require("acorn-loose");
 const acornJsx = require("acorn-jsx");
-const get = require("lodash/get");
 const memoize = require("lodash/memoize");
 const transpile = require("../transpile");
 const getExtension = require("../utl/get-extension");
@@ -22,7 +21,7 @@ function needsJSXTreatment(pFileRecord, pTranspileOptions) {
   return (
     pFileRecord.extension === ".jsx" ||
     (pFileRecord.extension === ".tsx" &&
-      get(pTranspileOptions, "tsConfig.options.jsx") ===
+      pTranspileOptions?.tsConfig?.options?.jsx ===
         TSCONFIG_CONSTANTS.PRESERVE_JSX)
   );
 }

--- a/src/extract/resolve/get-manifest/merge-manifests.js
+++ b/src/extract/resolve/get-manifest/merge-manifests.js
@@ -1,5 +1,5 @@
+/* eslint-disable security/detect-object-injection */
 const uniq = require("lodash/uniq");
-const get = require("lodash/get");
 const clone = require("lodash/clone");
 
 function normalizeManifestKeys(pManifest) {
@@ -64,12 +64,12 @@ module.exports = function mergeManifests(pClosestManifest, pFurtherManifest) {
       key: pKey,
       value: pKey.startsWith("bundle")
         ? mergeDependencyArray(
-            get(pClosestManifest, pKey, []),
-            get(pFurtherManifest, pKey, [])
+            pClosestManifest?.[pKey] ?? [],
+            pFurtherManifest?.[pKey] ?? []
           )
         : mergeDependencyKey(
-            get(pClosestManifest, pKey, {}),
-            get(pFurtherManifest, pKey, {})
+            pClosestManifest?.[pKey] ?? {},
+            pFurtherManifest?.[pKey] ?? {}
           ),
     }))
     .reduce((pJoinedObject, pJoinedKey) => {

--- a/src/extract/resolve/index.js
+++ b/src/extract/resolve/index.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const path = require("path");
 const monkeyPatchedModule = require("module");
-const get = require("lodash/get");
 const pathToPosix = require("../utl/path-to-posix");
 const { isRelativeModuleName } = require("./module-classifiers");
 const resolveAMD = require("./resolve-amd");
@@ -55,14 +54,14 @@ function isTypeScriptIshExtension(pModuleName) {
   return [".ts", ".tsx", ".cts", ".mts"].includes(path.extname(pModuleName));
 }
 function resolveYarnVirtual(pPath) {
-  const pnpAPI = get(monkeyPatchedModule, "findPnpApi", () => false)(pPath);
+  const pnpAPI = (monkeyPatchedModule?.findPnpApi ?? (() => false))(pPath);
 
   // the pnp api only works in plug'n play environments, and resolveVirtual
   // only under yarn(berry). As we can't run a 'regular' nodejs environment
   // and a yarn(berry) one at the same time, ignore in the test coverage and
   // cover it in a separate integration test.
   /* c8 ignore start */
-  if (pnpAPI && get(pnpAPI, "VERSIONS.resolveVirtual", 0) === 1) {
+  if (pnpAPI && (pnpAPI?.VERSIONS?.resolveVirtual ?? 0) === 1) {
     return pnpAPI.resolveVirtual(path.resolve(pPath)) || pPath;
   }
   /* c8 ignore stop */

--- a/src/extract/transpile/meta.js
+++ b/src/extract/transpile/meta.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const { supportedTranspilers } = require("../../../src/meta.js");
 const swc = require("../parse/to-swc-ast");
 const javaScriptWrap = require("./javascript-wrap");
@@ -88,7 +87,7 @@ function extensionIsAvailable(pExtension) {
  */
 module.exports.getWrapper = (pExtension, pTranspilerOptions) => {
   if (
-    Object.keys(get(pTranspilerOptions, "babelConfig", {})).length > 0 &&
+    Object.keys(pTranspilerOptions?.babelConfig ?? {}).length > 0 &&
     BABELEABLE_EXTENSIONS.includes(pExtension)
   ) {
     return babelWrap;

--- a/src/extract/transpile/svelte-preprocess.js
+++ b/src/extract/transpile/svelte-preprocess.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-magic-numbers */
-/* eslint-disable security/detect-object-injection */
-const get = require("lodash/get");
+/* eslint-disable no-magic-numbers, security/detect-object-injection */
 
 /*
  parseAttributes copied verbatim from
@@ -35,9 +33,9 @@ function composeTranspilerOptions(pTranspilerOptions) {
   return {
     ...pTranspilerOptions,
     tsConfig: {
-      ...get(pTranspilerOptions, "tsConfig", {}),
+      ...(pTranspilerOptions?.tsConfig ?? {}),
       options: {
-        ...get(pTranspilerOptions, "tsConfig.options", {}),
+        ...(pTranspilerOptions?.tsConfig?.options ?? {}),
         importsNotUsedAsValues: "preserve",
         jsx: "preserve",
       },

--- a/src/extract/transpile/typescript-wrap.js
+++ b/src/extract/transpile/typescript-wrap.js
@@ -1,5 +1,4 @@
 const tryRequire = require("semver-try-require");
-const get = require("lodash/get");
 const { supportedTranspilers } = require("../../../src/meta.js");
 
 const typescript = tryRequire("typescript", supportedTranspilers.typescript);
@@ -26,7 +25,7 @@ function getCompilerOptions(pFlavor, pTSConfig) {
     // compatibility.
     target: "es2015",
     ...lCompilerOptions,
-    ...get(pTSConfig, "options", {}),
+    ...(pTSConfig?.options ?? {}),
   };
 }
 

--- a/src/extract/utl/get-extension.js
+++ b/src/extract/utl/get-extension.js
@@ -18,18 +18,5 @@ const EXTENSION_RE = /(?<extension>((\.d\.(c|m)?ts)|\.coffee\.md)$)/;
 module.exports = function getExtensions(pFileName) {
   const lMatchResult = pFileName.match(EXTENSION_RE);
 
-  if (lMatchResult) {
-    // @ts-expect-error if there _is_ a non-falsy result in
-    // lMatchResult we're sure there is a groups object in there
-    // with an extension attribute. TS doesn't detect that, however.
-    // we could also, more elegantly
-    //
-    //   return lMatchResult?.groups?.extension ?? path.extname(pFileName);
-    //
-    // which TS _does_ understand, but we still support node 12
-    // where this is invalid syntax
-    return lMatchResult.groups.extension;
-  }
-
-  return path.extname(pFileName);
+  return lMatchResult?.groups?.extension ?? path.extname(pFileName);
 };

--- a/src/graph-utl/consolidate-module-dependencies.js
+++ b/src/graph-utl/consolidate-module-dependencies.js
@@ -1,5 +1,4 @@
 const clone = require("lodash/clone");
-const get = require("lodash/get");
 const _reject = require("lodash/reject");
 const uniq = require("lodash/uniq");
 const compare = require("./compare");
@@ -12,7 +11,7 @@ function mergeDependency(pLeftDependency, pRightDependency) {
       pLeftDependency.dependencyTypes.concat(pRightDependency.dependencyTypes)
     ),
     rules: pLeftDependency.rules
-      .concat(get(pRightDependency, "rules", []))
+      .concat(pRightDependency?.rules ?? [])
       .sort(compare.rules),
     valid: pLeftDependency.valid && pRightDependency.valid,
   };

--- a/src/graph-utl/consolidate-modules.js
+++ b/src/graph-utl/consolidate-modules.js
@@ -1,5 +1,4 @@
 const clone = require("lodash/clone");
-const get = require("lodash/get");
 const _reject = require("lodash/reject");
 const uniqBy = require("lodash/uniqBy");
 const compare = require("./compare");
@@ -13,7 +12,7 @@ function mergeModule(pLeftModule, pRightModule) {
       (pDependency) => pDependency.resolved
     ),
     rules: pLeftModule.rules
-      .concat(get(pRightModule, "rules", []))
+      .concat(pRightModule?.rules ?? [])
       .sort(compare.rules),
     valid: pLeftModule.valid && pRightModule.valid,
     consolidated:

--- a/src/graph-utl/rule-set.js
+++ b/src/graph-utl/rule-set.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const has = require("lodash/has");
 
 /**
@@ -13,7 +12,7 @@ const has = require("lodash/has");
  * @return {import("../../types/rule-set").IForbiddenRuleType|undefined} - a rule (or 'undefined' if nothing found)
  */
 function findRuleByName(pRuleSet, pName) {
-  return get(pRuleSet, "forbidden", []).find(
+  return (pRuleSet?.forbidden ?? []).find(
     (pForbiddenRule) => pForbiddenRule.name === pName
   );
 }
@@ -29,10 +28,10 @@ function findRuleByName(pRuleSet, pName) {
  */
 function ruleSetHasLicenseRule(pRuleSet) {
   return (
-    get(pRuleSet, "forbidden", []).some(
+    (pRuleSet?.forbidden ?? []).some(
       (pRule) => has(pRule, "to.license") || has(pRule, "to.licenseNot")
     ) ||
-    get(pRuleSet, "allowed", []).some(
+    (pRuleSet?.allowed ?? []).some(
       (pRule) => has(pRule, "to.license") || has(pRule, "to.licenseNot")
     )
   );
@@ -44,11 +43,11 @@ function ruleSetHasLicenseRule(pRuleSet) {
  */
 function ruleSetHasDeprecationRule(pRuleSet) {
   return (
-    get(pRuleSet, "forbidden", []).some((pRule) =>
-      get(pRule, "to.dependencyTypes", []).includes("deprecated")
+    (pRuleSet?.forbidden ?? []).some((pRule) =>
+      (pRule?.to?.dependencyTypes ?? []).includes("deprecated")
     ) ||
-    get(pRuleSet, "allowed", []).some((pRule) =>
-      get(pRule, "to.dependencyTypes", []).includes("deprecated")
+    (pRuleSet?.allowed ?? []).some((pRule) =>
+      (pRule?.to?.dependencyTypes ?? []).includes("deprecated")
     )
   );
 }

--- a/src/main/options/validate.js
+++ b/src/main/options/validate.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const has = require("lodash/has");
 const safeRegex = require("safe-regex");
 const report = require("../../report");
@@ -67,8 +66,8 @@ function validatePathsSafety(pFilterOption) {
     validateRegExpSafety(pFilterOption);
   }
 
-  validateRegExpSafety(get(pFilterOption, "path", ""));
-  validateRegExpSafety(get(pFilterOption, "pathNot", ""));
+  validateRegExpSafety(pFilterOption?.path ?? "");
+  validateRegExpSafety(pFilterOption?.pathNot ?? "");
 }
 
 /**

--- a/src/meta.js
+++ b/src/meta.js
@@ -3,7 +3,7 @@
 module.exports = {
   version: "11.18.0",
   engines: {
-    node: "^12.20||^14||>=16",
+    node: "^14||^16||>=18",
   },
   supportedTranspilers: {
     babel: ">=7.0.0 <8.0.0",

--- a/src/report/dot/prepare-folder-level.js
+++ b/src/report/dot/prepare-folder-level.js
@@ -1,4 +1,3 @@
-const get = require("lodash/get");
 const consolidateToFolder = require("../../graph-utl/consolidate-to-folder");
 const compare = require("../../graph-utl/compare");
 const stripSelfTransitions = require("../../graph-utl/strip-self-transitions");
@@ -11,5 +10,5 @@ module.exports = (pResults, pTheme, _, pShowMetrics) => {
     .map(moduleUtl.folderify(pShowMetrics))
     .map(stripSelfTransitions)
     .map(moduleUtl.applyTheme(pTheme))
-    .map(moduleUtl.addURL(get(pResults, "summary.optionsUsed.prefix", "")));
+    .map(moduleUtl.addURL(pResults?.summary?.optionsUsed?.prefix ?? ""));
 };

--- a/src/report/error-html/utl.js
+++ b/src/report/error-html/utl.js
@@ -1,10 +1,9 @@
-const get = require("lodash/get");
 const has = require("lodash/has");
 const { version } = require("../../../src/meta.js");
 const { formatViolation, formatInstability } = require("../utl/index.js");
 
 function getFormattedAllowedRule(pRuleSetUsed) {
-  const lAllowed = get(pRuleSetUsed, "allowed", []);
+  const lAllowed = pRuleSetUsed?.allowed ?? [];
   const lCommentedRule = lAllowed.find((pRule) => has(pRule, "comment"));
   const lComment = lCommentedRule ? lCommentedRule.comment : "-";
 
@@ -12,7 +11,7 @@ function getFormattedAllowedRule(pRuleSetUsed) {
     ? {
         name: "not-in-allowed",
         comment: lComment,
-        severity: get(pRuleSetUsed, "allowedSeverity", "warn"),
+        severity: pRuleSetUsed?.allowedSeverity ?? "warn",
       }
     : [];
 }
@@ -125,8 +124,8 @@ function aggregateCountsPerRule(pViolations) {
 function aggregateViolations(pViolations, pRuleSetUsed) {
   const lViolationCounts = aggregateCountsPerRule(pViolations);
 
-  return get(pRuleSetUsed, "forbidden", [])
-    .concat(get(pRuleSetUsed, "required", []))
+  return (pRuleSetUsed?.forbidden ?? [])
+    .concat(pRuleSetUsed?.required ?? [])
     .concat(getFormattedAllowedRule(pRuleSetUsed))
     .map((pRule) => mergeCountsIntoRule(pRule, lViolationCounts))
     .sort(

--- a/src/report/error.js
+++ b/src/report/error.js
@@ -1,6 +1,5 @@
 const chalk = require("chalk");
 const figures = require("figures");
-const get = require("lodash/get");
 const { findRuleByName } = require("../graph-utl/rule-set");
 const wrapAndIndent = require("../utl/wrap-and-indent");
 const utl = require("./utl/index.js");
@@ -106,11 +105,7 @@ function addExplanation(pRuleSet, pLong) {
   return pLong
     ? (pViolation) => ({
         ...pViolation,
-        comment: get(
-          findRuleByName(pRuleSet, pViolation.rule.name),
-          "comment",
-          "-"
-        ),
+        comment: findRuleByName(pRuleSet, pViolation.rule.name)?.comment ?? "-",
       })
     : (pViolation) => pViolation;
 }

--- a/src/validate/rule-classifiers.js
+++ b/src/validate/rule-classifiers.js
@@ -1,5 +1,4 @@
 const has = require("lodash/has");
-const get = require("lodash/get");
 
 /**
  * @param {import("../../types/strict-rule-set").IStrictAnyRuleType} pRule a dependency-cruiser rule
@@ -21,7 +20,7 @@ function isModuleOnlyRule(pRule) {
 function isFolderScope(pRule) {
   // TODO might be possible to just rule pRule.scope as it's now
   // normalized away before getting here.
-  return get(pRule, "scope", "module") === "folder";
+  return (pRule?.scope ?? module) === "folder";
 }
 
 module.exports = { isModuleOnlyRule, isFolderScope };

--- a/test/backwards.utl.mjs
+++ b/test/backwards.utl.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync } from "fs";
 import JSON5 from "json5";
 
 export function createRequireJSON(pBaseURL) {

--- a/test/cli/asserthelpers.utl.mjs
+++ b/test/cli/asserthelpers.utl.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync } from "fs";
 import { expect } from "chai";
 
 export function assertFileEqual(pActualFileName, pExpectedFileName) {

--- a/test/cli/format.spec.mjs
+++ b/test/cli/format.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import format from "../../src/cli/format.js";
 import deleteDammit from "./delete-dammit.utl.cjs";

--- a/test/cli/index.spec.mjs
+++ b/test/cli/index.spec.mjs
@@ -1,7 +1,7 @@
-import { unlinkSync, readFileSync } from "node:fs";
+import { unlinkSync, readFileSync } from "fs";
 // path.posix instead of path because otherwise on win32 the resulting
 // outputTo would contain \\ instead of / which for this unit test doesn't matter
-import { posix as path } from "node:path";
+import { posix as path } from "path";
 import { expect } from "chai";
 import intercept from "intercept-stdout";
 import chalk from "chalk";

--- a/test/cli/tools/wrap-stream-in-html.spec.mjs
+++ b/test/cli/tools/wrap-stream-in-html.spec.mjs
@@ -1,5 +1,5 @@
-import { createReadStream } from "node:fs";
-import { Writable } from "node:stream";
+import { createReadStream } from "fs";
+import { Writable } from "stream";
 import { expect } from "chai";
 import wrapStreamInHTML from "../../../src/cli/tools/wrap-stream-in-html.js";
 

--- a/test/cli/utl/io.spec.mjs
+++ b/test/cli/utl/io.spec.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
-import { ReadStream } from "node:fs";
-import { Readable } from "node:stream";
-import { fileURLToPath } from "node:url";
+import { ReadStream } from "fs";
+import { Readable } from "stream";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import io from "../../../src/cli/utl/io.js";
 

--- a/test/config-utl/extract-depcruise-config/read-config.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/read-config.spec.mjs
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import readConfig from "../../../src/config-utl/extract-depcruise-config/read-config.js";
 

--- a/test/extract/ast-extractors/extract-typescript-others.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-others.spec.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import extractTypescriptFromAST from "../../../src/extract/ast-extractors/extract-typescript-deps.js";
 

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -1,4 +1,4 @@
-import { lstatSync } from "node:fs";
+import { lstatSync } from "fs";
 import { expect } from "chai";
 import gatherInitialSources from "../../src/extract/gather-initial-sources.js";
 import p2p from "../../src/extract/utl/path-to-posix.js";

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -1,6 +1,6 @@
-import { join } from "node:path";
-import { unlinkSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { join } from "path";
+import { unlinkSync } from "fs";
+import { fileURLToPath } from "url";
 import symlinkDir from "symlink-dir";
 import { expect } from "chai";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.js";

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -1,6 +1,6 @@
-import { join } from "node:path";
-import { unlinkSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { join } from "path";
+import { unlinkSync } from "fs";
+import { fileURLToPath } from "url";
 import symlinkDir from "symlink-dir";
 import { expect } from "chai";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.js";

--- a/test/extract/resolve/determine-dependency-types.spec.mjs
+++ b/test/extract/resolve/determine-dependency-types.spec.mjs
@@ -1,5 +1,5 @@
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import determineDependencyTypes from "../../../src/extract/resolve/determine-dependency-types.js";
 

--- a/test/extract/resolve/get-manifest/index.spec.mjs
+++ b/test/extract/resolve/get-manifest/index.spec.mjs
@@ -1,6 +1,6 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import getManifest from "../../../../src/extract/resolve/get-manifest/index.js";
 

--- a/test/extract/transpile/babel-wrap.spec.mjs
+++ b/test/extract/transpile/babel-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync } from "fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
 import wrap from "../../../src/extract/transpile/babel-wrap.js";

--- a/test/extract/transpile/index.spec.mjs
+++ b/test/extract/transpile/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import transpile from "../../../src/extract/transpile/index.js";
 import normalizeSource from "../normalize-source.utl.mjs";

--- a/test/extract/transpile/javascript-wrap.spec.mjs
+++ b/test/extract/transpile/javascript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync } from "fs";
 import { expect } from "chai";
 import wrap from "../../../src/extract/transpile/javascript-wrap.js";
 

--- a/test/extract/transpile/svelte-wrap.spec.mjs
+++ b/test/extract/transpile/svelte-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { promises as fsPromise } from "node:fs";
+import { promises as fsPromise } from "fs";
 import { expect } from "chai";
 import svelteWrap from "../../../src/extract/transpile/svelte-wrap.js";
 import normalizeSource from "../normalize-source.utl.mjs";

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import fs from "fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
 import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.js";

--- a/test/extract/transpile/vue-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue-template-wrap.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import normalizeNewline from "normalize-newline";
 import wrap from "../../../src/extract/transpile/vue-template-wrap.js";

--- a/test/main/files-and-dirs/normalize.spec.mjs
+++ b/test/main/files-and-dirs/normalize.spec.mjs
@@ -1,5 +1,5 @@
-import { win32, posix } from "node:path";
-import { fileURLToPath } from "node:url";
+import { win32, posix } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import normalizeFilesAndDirectories from "../../../src/main/files-and-dirs/normalize.js";
 

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -1,6 +1,6 @@
-import { posix as path } from "node:path";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { posix as path } from "path";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import pathToPosix from "../../src/extract/utl/path-to-posix.js";

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -1,5 +1,5 @@
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import normalize from "../../../src/main/options/normalize.js";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.js";

--- a/test/main/rule-set/validate.spec.mjs
+++ b/test/main/rule-set/validate.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync } from "fs";
 import { expect } from "chai";
 import validate from "../../../src/main/rule-set/validate.js";
 

--- a/test/report/dot/custom-level/index.spec.mjs
+++ b/test/report/dot/custom-level/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/dot/flat-level/index.spec.mjs
+++ b/test/report/dot/flat-level/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/dot/folder-level/folder-level.spec.mjs
+++ b/test/report/dot/folder-level/folder-level.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/dot/module-level/index.spec.mjs
+++ b/test/report/dot/module-level/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 import defaultTheme from "../../../../src/report/dot/default-theme.js";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 import { expect } from "chai";
 // eslint-plugins import and node don't yet understand these 'self references'
 // eslint-disable-next-line import/no-unresolved, node/no-missing-import

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -1,4 +1,4 @@
-import { EOL } from "node:os";
+import { EOL } from "os";
 import { expect } from "chai";
 import metrics from "../../../src/report/metrics.js";
 import cruiseResultWithMetricsForModulesAndFolders from "./__mocks/cruise-result-with-metrics-for-modules-and-folders.mjs";

--- a/tools/generate-schemas.utl.mjs
+++ b/tools/generate-schemas.utl.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
-import fs from "node:fs";
-import path from "node:path";
+import fs from "fs";
+import path from "path";
 import prettier from "prettier";
 import clone from "lodash/clone.js";
 

--- a/tools/regenerate-main-fixtures.utl.mjs
+++ b/tools/regenerate-main-fixtures.utl.mjs
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "url";
-import fs from "node:fs";
-import path from "node:path";
+import fs from "fs";
+import path from "path";
 import prettier from "prettier";
 import main from "../src/main/index.js";
 


### PR DESCRIPTION
## Description

- sets the `engines` field in the package manifest to support node 14, 16, 18 and up.
- updates the linter config to reflect new features
- in choice spots replaces lodash' `get` with optional chaining and nullish coalescing.

## Motivation and Context

node 12 has been end of life since April 2022 - about half a year ago now. It was not possible to keep testing against node 12 on the ci for some time (3rd party dependencies not supporting it anymore, dependency-cruiser's tests using newer features) - so it'll be harder to keep any level of certainty on whether dependency-cruiser will keep working well.

Besides the node platform and subsequent versions of JavaScript have grown useful features that we'd like to exploit going forward.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
