### PR TITLE
fix(report): adds a percentage sign to reporters that emit stability metrics

### DIFF
--- a/src/report/dot/module-utl.js
+++ b/src/report/dot/module-utl.js
@@ -69,7 +69,7 @@ function makeInstabilityString(pModule, pShowMetrics = false) {
   if (pShowMetrics && has(pModule, "instability") && !pModule.consolidated) {
     lInstabilityString = ` <FONT color="#808080" point-size="8">${utl.formatInstability(
       pModule.instability
-    )}</FONT>`;
+    )}%</FONT>`;
   }
   return lInstabilityString;
 }

--- a/src/report/error-html/utl.js
+++ b/src/report/error-html/utl.js
@@ -48,7 +48,7 @@ function formatModuleTo() {
 function formatInstabilityTo(pViolation) {
   return `${pViolation.to}&nbsp;<span class="extra">(I: ${formatInstability(
     pViolation.metrics.to.instability
-  )})</span>`;
+  )}%)</span>`;
 }
 
 function determineTo(pViolation) {
@@ -69,7 +69,7 @@ function determineTo(pViolation) {
 function formatInstabilityFromExtras(pViolation) {
   return `&nbsp;<span class="extra">(I: ${formatInstability(
     pViolation.metrics.from.instability
-  )})</span>`;
+  )}%)</span>`;
 }
 
 function determineFromExtras(pViolation) {

--- a/src/report/error.js
+++ b/src/report/error.js
@@ -49,9 +49,9 @@ function formatInstabilityViolation(pViolation) {
     chalk.dim(
       `instability: ${utl.formatInstability(
         pViolation.metrics.from.instability
-      )} ${figures.arrowRight} ${utl.formatInstability(
+      )}% ${figures.arrowRight} ${utl.formatInstability(
         pViolation.metrics.to.instability
-      )}`
+      )}%`
     ),
     EXTRA_PATH_INFORMATION_INDENT
   )}`;

--- a/src/report/teamcity.js
+++ b/src/report/teamcity.js
@@ -91,7 +91,7 @@ function formatInstabilityViolation(pViolation) {
     pViolation
   )} (instability: ${utl.formatInstability(
     pViolation.metrics.from.instability
-  )} -> ${utl.formatInstability(pViolation.metrics.to.instability)})`;
+  )}% -> ${utl.formatInstability(pViolation.metrics.to.instability)}%)`;
 }
 
 function bakeViolationMessage(pViolation) {

--- a/test/report/dot/module-utl.spec.mjs
+++ b/test/report/dot/module-utl.spec.mjs
@@ -72,7 +72,7 @@ describe("[U] report/dot/module-utl", () => {
       })
     ).to.deep.equal({
       source: "aap/noot/mies/wim/zus.jet",
-      label: `<aap/noot/mies/wim/<BR/><B>zus.jet</B> <FONT color="#808080" point-size="8">48</FONT>>`,
+      label: `<aap/noot/mies/wim/<BR/><B>zus.jet</B> <FONT color="#808080" point-size="8">48%</FONT>>`,
       tooltip: "zus.jet",
       instability: "0.481",
     });

--- a/test/report/error-html/utl.spec.mjs
+++ b/test/report/error-html/utl.spec.mjs
@@ -214,7 +214,7 @@ describe("[U] report/error-html/utl", () => {
       metrics: { from: { instability: 0.1 }, to: { instability: 1 } },
     };
 
-    const lExpectation = 'b&nbsp;<span class="extra">(I: 100)</span>';
+    const lExpectation = 'b&nbsp;<span class="extra">(I: 100%)</span>';
 
     expect(utl.determineTo(lInputViolation)).to.deep.equal(lExpectation);
   });
@@ -227,7 +227,7 @@ describe("[U] report/error-html/utl", () => {
       metrics: { from: { instability: 0.1 }, to: { instability: 1 } },
     };
 
-    const lExpectation = '&nbsp;<span class="extra">(I: 10)</span>';
+    const lExpectation = '&nbsp;<span class="extra">(I: 10%)</span>';
 
     expect(utl.determineFromExtras(lInputViolation)).to.deep.equal(
       lExpectation

--- a/test/report/error/error.spec.mjs
+++ b/test/report/error/error.spec.mjs
@@ -83,7 +83,7 @@ describe("[I] report/error", () => {
     const lResult = render(sdperrors);
 
     expect(lResult.output).to.contain(
-      "warn sdp: src/more-stable.js → src/less-stable.js\n      instability: 42 → 100\n"
+      "warn sdp: src/more-stable.js → src/less-stable.js\n      instability: 42% → 100%\n"
     );
   });
   it("renders a violation as a dependency-violation when the violation.type ain't there", () => {

--- a/test/report/markdown/markdown.spec.mjs
+++ b/test/report/markdown/markdown.spec.mjs
@@ -137,7 +137,7 @@ describe("[I] report/markdown", () => {
     );
     // metrics violations with the 'instability' for the involved modules in:
     expect(lResult.output).to.contain(
-      '|:grey_exclamation:&nbsp;_SDP_|src/extract/gather-initial-sources.js&nbsp;<span class="extra">(I: 75)</span>|src/extract/transpile/meta.js&nbsp;<span class="extra">(I: 80)</span>|'
+      '|:grey_exclamation:&nbsp;_SDP_|src/extract/gather-initial-sources.js&nbsp;<span class="extra">(I: 75%)</span>|src/extract/transpile/meta.js&nbsp;<span class="extra">(I: 80%)</span>|'
     );
   });
 });

--- a/test/report/teamcity/__mocks__/instabilities-teamcity-format.txt
+++ b/test/report/teamcity/__mocks__/instabilities-teamcity-format.txt
@@ -1,2 +1,2 @@
 ##teamcity[inspectionType id='sdp' name='sdp' description='sdp' category='dependency-cruiser']
-##teamcity[inspection typeId='sdp' message='src/more-stable.js -> src/less-stable.js (instability: 42 -> 100)' file='src/more-stable.js' SEVERITY='WARNING']
+##teamcity[inspection typeId='sdp' message='src/more-stable.js -> src/less-stable.js (instability: 42% -> 100%)' file='src/more-stable.js' SEVERITY='WARNING']


### PR DESCRIPTION
## Description

- Adds a `%` sign to metrics in those reporters that emit them as a value from 0-100 instead of from 0.0 - 1.0:
  - `dot` (and with that all dot-derived ones)
  - `error-html`
  - `err`, `err-long`
  - `markdown`
  - `teamcity`
- Updates the unit test expectations for these reporters to match that.

## Motivation and Context

We use values between 0 and 100 for readability reasons, whereas the original stability metrics were defined as values between 0 and 1. Adding a % sign next to these numbers will clarify that difference.

Addresses #683

## How Has This Been Tested?

- [x] green ci
- [x] updated automated non-regression tests

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
