### PR TITLE
bugfix(report): shows the instability metric as percentage in the metrics reporter as well

### DIFF
--- a/src/report/metrics.js
+++ b/src/report/metrics.js
@@ -1,10 +1,9 @@
 const { EOL } = require("os");
 const chalk = require("chalk");
+const utl = require("./utl");
 
 const DECIMAL_BASE = 10;
 const METRIC_WIDTH = 4;
-const INSTABILITY_DECIMALS = 2;
-const YADDUM = DECIMAL_BASE ** INSTABILITY_DECIMALS;
 const COMPONENT_HEADER = "name";
 
 function getHeader(pMaxNameWidth) {
@@ -12,7 +11,7 @@ function getHeader(pMaxNameWidth) {
     METRIC_WIDTH + 1
   )} ${"Ca".padStart(METRIC_WIDTH + 1)} ${"Ce".padStart(
     METRIC_WIDTH + 1
-  )}  ${"I".padEnd(METRIC_WIDTH + 1)}`;
+  )}  ${"I (%)".padEnd(METRIC_WIDTH + 1)}`;
 }
 
 function getDemarcationLine(pMaxNameWidth) {
@@ -38,9 +37,10 @@ function getMetricsTable(pMetrics, pMaxNameWidth) {
         .toString(DECIMAL_BASE)
         .padStart(METRIC_WIDTH)}  ${efferentCouplings
         .toString(DECIMAL_BASE)
-        .padStart(METRIC_WIDTH)}  ${(Math.round(YADDUM * instability) / YADDUM)
+        .padStart(METRIC_WIDTH)}  ${utl
+        .formatInstability(instability)
         .toString(DECIMAL_BASE)
-        .padEnd(METRIC_WIDTH)}`
+        .padStart(METRIC_WIDTH)}`
   );
 }
 

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -26,7 +26,7 @@ describe("[I] report/metrics", () => {
     });
 
     expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain("src      1     1     1  0.5");
+    expect(lResult.output).to.contain("src      1     1     1    50");
   });
 
   it("does not emit folder metrics when asked to hide them", () => {
@@ -47,7 +47,7 @@ describe("[I] report/metrics", () => {
     );
 
     expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.not.contain("src      1     1     1  0.5");
+    expect(lResult.output).to.not.contain("src      1     1     1    50");
   });
 
   it("emits module metrics (sorted by instability by default)", () => {
@@ -77,7 +77,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.contain(
-      `src/mies.js     1     1     1  0.5 ${EOL}src/aap.js      1     1     3  0.25${EOL}src/noot`
+      `src/mies.js     1     1     1    50${EOL}src/aap.js      1     1     3    25${EOL}src/noot.js`
     );
   });
 
@@ -111,7 +111,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.contain(
-      `src/aap.js      1     1     3  0.25${EOL}src/mies.js     1     1     1  0.5 ${EOL}src/noot.js`
+      `src/aap.js      1     1     3    25${EOL}src/mies.js     1     1     1    50${EOL}src/noot.js`
     );
   });
 
@@ -145,7 +145,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.not.contain(
-      `src/mies.js     1     1     1  0.5 ${EOL}src/aap.js      1     1     3  0.25${EOL}src/noot`
+      `src/mies.js     1     1     1    50${EOL}src/aap.js      1     1     3    25${EOL}src/noot.js`
     );
   });
 


### PR DESCRIPTION
## Description

- makes the `metrics` reporter emit the Instability metric as a percentage
- adapts the unit test's expectation to account for this change

## Motivation and Context

... so it's (1) more readable (2) consistent with all other reporters that show the instability metric


## How Has This Been Tested?

- [x] green ci
- [x] adapted unit tests


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
