### PR TITLE
fix: right-click is the correct for pin in UI

### DIFF
--- a/doc/assets/theming/base.svg
+++ b/doc/assets/theming/base.svg
@@ -19,11 +19,6 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M28,-16C28,-16 425.5,-16 425.5,-16 431.5,-16 437.5,-22 437.5,-28 437.5,-28 437.5,-294 437.5,-294 437.5,-300 431.5,-306 425.5,-306 425.5,-306 28,-306 28,-306 22,-306 16,-300 16,-294 16,-294 16,-28 16,-28 16,-22 22,-16 28,-16"/>
 <text text-anchor="middle" x="226.75" y="-294.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">main</text>
 </g>
-<g id="clust3" class="cluster">
-<title>cluster_src/main/files&#45;and&#45;dirs</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M114.5,-24C114.5,-24 172.5,-24 172.5,-24 178.5,-24 184.5,-30 184.5,-36 184.5,-36 184.5,-64 184.5,-64 184.5,-70 178.5,-76 172.5,-76 172.5,-76 114.5,-76 114.5,-76 108.5,-76 102.5,-70 102.5,-64 102.5,-64 102.5,-36 102.5,-36 102.5,-30 108.5,-24 114.5,-24"/>
-<text text-anchor="middle" x="143.5" y="-64.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">files&#45;and&#45;dirs</text>
-</g>
 <g id="clust4" class="cluster">
 <title>cluster_src/main/options</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M221.5,-103C221.5,-103 385.5,-103 385.5,-103 391.5,-103 397.5,-109 397.5,-115 397.5,-115 397.5,-173 397.5,-173 397.5,-179 391.5,-185 385.5,-185 385.5,-185 221.5,-185 221.5,-185 215.5,-185 209.5,-179 209.5,-173 209.5,-173 209.5,-115 209.5,-115 209.5,-109 215.5,-103 221.5,-103"/>
@@ -43,6 +38,11 @@
 <title>cluster_src/main/utl</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M303.5,-198C303.5,-198 417.5,-198 417.5,-198 423.5,-198 429.5,-204 429.5,-210 429.5,-210 429.5,-238 429.5,-238 429.5,-244 423.5,-250 417.5,-250 417.5,-250 303.5,-250 303.5,-250 297.5,-250 291.5,-244 291.5,-238 291.5,-238 291.5,-210 291.5,-210 291.5,-204 297.5,-198 303.5,-198"/>
 <text text-anchor="middle" x="360.5" y="-238.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust3" class="cluster">
+<title>cluster_src/main/files&#45;and&#45;dirs</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M114.5,-24C114.5,-24 172.5,-24 172.5,-24 178.5,-24 184.5,-30 184.5,-36 184.5,-36 184.5,-64 184.5,-64 184.5,-70 178.5,-76 172.5,-76 172.5,-76 114.5,-76 114.5,-76 108.5,-76 102.5,-70 102.5,-64 102.5,-64 102.5,-36 102.5,-36 102.5,-30 108.5,-24 114.5,-24"/>
+<text text-anchor="middle" x="143.5" y="-64.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">files&#45;and&#45;dirs</text>
 </g>
 <!-- src/main/files&#45;and&#45;dirs/normalize.js -->
 <g id="node1" class="node">

--- a/doc/real-world-samples/dependency-cruiser-dir-graph.svg
+++ b/doc/real-world-samples/dependency-cruiser-dir-graph.svg
@@ -14,15 +14,10 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M20,-8C20,-8 1767,-8 1767,-8 1773,-8 1779,-14 1779,-20 1779,-20 1779,-364.6 1779,-364.6 1779,-370.6 1773,-376.6 1767,-376.6 1767,-376.6 20,-376.6 20,-376.6 14,-376.6 8,-370.6 8,-364.6 8,-364.6 8,-20 8,-20 8,-14 14,-8 20,-8"/>
 <text text-anchor="middle" x="893.5" y="-365.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">src</text>
 </g>
-<g id="clust7" class="cluster">
-<title>cluster_src/extract</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1354,-81C1354,-81 1604,-81 1604,-81 1610,-81 1616,-87 1616,-93 1616,-93 1616,-218.6 1616,-218.6 1616,-224.6 1610,-230.6 1604,-230.6 1604,-230.6 1354,-230.6 1354,-230.6 1348,-230.6 1342,-224.6 1342,-218.6 1342,-218.6 1342,-93 1342,-93 1342,-87 1348,-81 1354,-81"/>
-<text text-anchor="start" x="1463.5" y="-219.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
-</g>
-<g id="clust8" class="cluster">
-<title>cluster_src/extract/resolve</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1536,-89C1536,-89 1596,-89 1596,-89 1602,-89 1608,-95 1608,-101 1608,-101 1608,-166.6 1608,-166.6 1608,-172.6 1602,-178.6 1596,-178.6 1596,-178.6 1536,-178.6 1536,-178.6 1530,-178.6 1524,-172.6 1524,-166.6 1524,-166.6 1524,-101 1524,-101 1524,-95 1530,-89 1536,-89"/>
-<text text-anchor="start" x="1549.5" y="-167.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
+<g id="clust10" class="cluster">
+<title>cluster_src/report</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M28,-16C28,-16 354,-16 354,-16 360,-16 366,-22 366,-28 366,-28 366,-121.8 366,-121.8 366,-127.8 360,-133.8 354,-133.8 354,-133.8 28,-133.8 28,-133.8 22,-133.8 16,-127.8 16,-121.8 16,-121.8 16,-28 16,-28 16,-22 22,-16 28,-16"/>
+<text text-anchor="start" x="177.5" y="-122.6" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">report</text>
 </g>
 <g id="clust2" class="cluster">
 <title>cluster_src/cli</title>
@@ -49,15 +44,20 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M504,-89C504,-89 830,-89 830,-89 836,-89 842,-95 842,-101 842,-101 842,-173.8 842,-173.8 842,-179.8 836,-185.8 830,-185.8 830,-185.8 504,-185.8 504,-185.8 498,-185.8 492,-179.8 492,-173.8 492,-173.8 492,-101 492,-101 492,-95 498,-89 504,-89"/>
 <text text-anchor="start" x="653" y="-174.6" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">derive</text>
 </g>
+<g id="clust7" class="cluster">
+<title>cluster_src/extract</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1354,-81C1354,-81 1604,-81 1604,-81 1610,-81 1616,-87 1616,-93 1616,-93 1616,-218.6 1616,-218.6 1616,-224.6 1610,-230.6 1604,-230.6 1604,-230.6 1354,-230.6 1354,-230.6 1348,-230.6 1342,-224.6 1342,-218.6 1342,-218.6 1342,-93 1342,-93 1342,-87 1348,-81 1354,-81"/>
+<text text-anchor="start" x="1463.5" y="-219.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
+</g>
+<g id="clust8" class="cluster">
+<title>cluster_src/extract/resolve</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1536,-89C1536,-89 1596,-89 1596,-89 1602,-89 1608,-95 1608,-101 1608,-101 1608,-166.6 1608,-166.6 1608,-172.6 1602,-178.6 1596,-178.6 1596,-178.6 1536,-178.6 1536,-178.6 1530,-178.6 1524,-172.6 1524,-166.6 1524,-166.6 1524,-101 1524,-101 1524,-95 1530,-89 1536,-89"/>
+<text text-anchor="start" x="1549.5" y="-167.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
+</g>
 <g id="clust9" class="cluster">
 <title>cluster_src/main</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1026,-89C1026,-89 1260,-89 1260,-89 1266,-89 1272,-95 1272,-101 1272,-101 1272,-279.4 1272,-279.4 1272,-285.4 1266,-291.4 1260,-291.4 1260,-291.4 1026,-291.4 1026,-291.4 1020,-291.4 1014,-285.4 1014,-279.4 1014,-279.4 1014,-101 1014,-101 1014,-95 1020,-89 1026,-89"/>
 <text text-anchor="start" x="1132" y="-280.2" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">main</text>
-</g>
-<g id="clust10" class="cluster">
-<title>cluster_src/report</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M28,-16C28,-16 354,-16 354,-16 360,-16 366,-22 366,-28 366,-28 366,-121.8 366,-121.8 366,-127.8 360,-133.8 354,-133.8 354,-133.8 28,-133.8 28,-133.8 22,-133.8 16,-127.8 16,-121.8 16,-121.8 16,-28 16,-28 16,-22 22,-16 28,-16"/>
-<text text-anchor="start" x="177.5" y="-122.6" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">report</text>
 </g>
 <!-- bin -->
 <g id="node1" class="node">

--- a/doc/real-world-samples/dependency-cruiser-without-node_modules.svg
+++ b/doc/real-world-samples/dependency-cruiser-without-node_modules.svg
@@ -59,6 +59,21 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M794.5,-568C794.5,-568 1306.5,-568 1306.5,-568 1312.5,-568 1318.5,-574 1318.5,-580 1318.5,-580 1318.5,-946 1318.5,-946 1318.5,-952 1312.5,-958 1306.5,-958 1306.5,-958 794.5,-958 794.5,-958 788.5,-958 782.5,-952 782.5,-946 782.5,-946 782.5,-580 782.5,-580 782.5,-574 788.5,-568 794.5,-568"/>
 <text text-anchor="middle" x="1050.5" y="-946.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">report</text>
 </g>
+<g id="clust31" class="cluster">
+<title>cluster_src/schema</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M747.5,-1798C747.5,-1798 887.5,-1798 887.5,-1798 893.5,-1798 899.5,-1804 899.5,-1810 899.5,-1810 899.5,-2008 899.5,-2008 899.5,-2014 893.5,-2020 887.5,-2020 887.5,-2020 747.5,-2020 747.5,-2020 741.5,-2020 735.5,-2014 735.5,-2008 735.5,-2008 735.5,-1810 735.5,-1810 735.5,-1804 741.5,-1798 747.5,-1798"/>
+<text text-anchor="middle" x="817.5" y="-2008.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">schema</text>
+</g>
+<g id="clust32" class="cluster">
+<title>cluster_src/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1703.5,-972C1703.5,-972 1788.5,-972 1788.5,-972 1794.5,-972 1800.5,-978 1800.5,-984 1800.5,-984 1800.5,-1072 1800.5,-1072 1800.5,-1078 1794.5,-1084 1788.5,-1084 1788.5,-1084 1703.5,-1084 1703.5,-1084 1697.5,-1084 1691.5,-1078 1691.5,-1072 1691.5,-1072 1691.5,-984 1691.5,-984 1691.5,-978 1697.5,-972 1703.5,-972"/>
+<text text-anchor="middle" x="1746" y="-1072.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust33" class="cluster">
+<title>cluster_src/validate</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1259.5,-976C1259.5,-976 1652,-976 1652,-976 1658,-976 1664,-982 1664,-988 1664,-988 1664,-1106 1664,-1106 1664,-1112 1658,-1118 1652,-1118 1652,-1118 1259.5,-1118 1259.5,-1118 1253.5,-1118 1247.5,-1112 1247.5,-1106 1247.5,-1106 1247.5,-988 1247.5,-988 1247.5,-982 1253.5,-976 1259.5,-976"/>
+<text text-anchor="middle" x="1455.75" y="-1106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">validate</text>
+</g>
 <g id="clust3" class="cluster">
 <title>cluster_src/cache</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M646,-2038C646,-2038 999.5,-2038 999.5,-2038 1005.5,-2038 1011.5,-2044 1011.5,-2050 1011.5,-2050 1011.5,-2108 1011.5,-2108 1011.5,-2114 1005.5,-2120 999.5,-2120 999.5,-2120 646,-2120 646,-2120 640,-2120 634,-2114 634,-2108 634,-2108 634,-2050 634,-2050 634,-2044 640,-2038 646,-2038"/>
@@ -129,6 +144,21 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M646,-2128C646,-2128 1799,-2128 1799,-2128 1805,-2128 1811,-2134 1811,-2140 1811,-2140 1811,-2816 1811,-2816 1811,-2822 1805,-2828 1799,-2828 1799,-2828 646,-2828 646,-2828 640,-2828 634,-2822 634,-2816 634,-2816 634,-2140 634,-2140 634,-2134 640,-2128 646,-2128"/>
 <text text-anchor="middle" x="1222.5" y="-2816.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
 </g>
+<g id="clust21" class="cluster">
+<title>cluster_src/extract/transpile</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1260.5,-2436C1260.5,-2436 1791,-2436 1791,-2436 1797,-2436 1803,-2442 1803,-2448 1803,-2448 1803,-2656 1803,-2656 1803,-2662 1797,-2668 1791,-2668 1791,-2668 1260.5,-2668 1260.5,-2668 1254.5,-2668 1248.5,-2662 1248.5,-2656 1248.5,-2656 1248.5,-2448 1248.5,-2448 1248.5,-2442 1254.5,-2436 1260.5,-2436"/>
+<text text-anchor="middle" x="1525.75" y="-2656.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
+</g>
+<g id="clust22" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1547.5,-2209C1547.5,-2209 1773,-2209 1773,-2209 1779,-2209 1785,-2215 1785,-2221 1785,-2221 1785,-2369 1785,-2369 1785,-2375 1779,-2381 1773,-2381 1773,-2381 1547.5,-2381 1547.5,-2381 1541.5,-2381 1535.5,-2375 1535.5,-2369 1535.5,-2369 1535.5,-2221 1535.5,-2221 1535.5,-2215 1541.5,-2209 1547.5,-2209"/>
+<text text-anchor="middle" x="1660.25" y="-2369.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust17" class="cluster">
+<title>cluster_src/extract/ast&#45;extractors</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M921.5,-2676C921.5,-2676 1322,-2676 1322,-2676 1328,-2676 1334,-2682 1334,-2688 1334,-2688 1334,-2790 1334,-2790 1334,-2796 1328,-2802 1322,-2802 1322,-2802 921.5,-2802 921.5,-2802 915.5,-2802 909.5,-2796 909.5,-2790 909.5,-2790 909.5,-2688 909.5,-2688 909.5,-2682 915.5,-2676 921.5,-2676"/>
+<text text-anchor="middle" x="1121.75" y="-2790.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
+</g>
 <g id="clust18" class="cluster">
 <title>cluster_src/extract/parse</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1093.5,-2422C1093.5,-2422 1175.5,-2422 1175.5,-2422 1181.5,-2422 1187.5,-2428 1187.5,-2434 1187.5,-2434 1187.5,-2522 1187.5,-2522 1187.5,-2528 1181.5,-2534 1175.5,-2534 1175.5,-2534 1093.5,-2534 1093.5,-2534 1087.5,-2534 1081.5,-2528 1081.5,-2522 1081.5,-2522 1081.5,-2434 1081.5,-2434 1081.5,-2428 1087.5,-2422 1093.5,-2422"/>
@@ -143,36 +173,6 @@
 <title>cluster_src/extract/resolve/get&#45;manifest</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1111.5,-2296C1111.5,-2296 1326.5,-2296 1326.5,-2296 1332.5,-2296 1338.5,-2302 1338.5,-2308 1338.5,-2308 1338.5,-2336 1338.5,-2336 1338.5,-2342 1332.5,-2348 1326.5,-2348 1326.5,-2348 1111.5,-2348 1111.5,-2348 1105.5,-2348 1099.5,-2342 1099.5,-2336 1099.5,-2336 1099.5,-2308 1099.5,-2308 1099.5,-2302 1105.5,-2296 1111.5,-2296"/>
 <text text-anchor="middle" x="1219" y="-2336.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">get&#45;manifest</text>
-</g>
-<g id="clust21" class="cluster">
-<title>cluster_src/extract/transpile</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1260.5,-2436C1260.5,-2436 1791,-2436 1791,-2436 1797,-2436 1803,-2442 1803,-2448 1803,-2448 1803,-2656 1803,-2656 1803,-2662 1797,-2668 1791,-2668 1791,-2668 1260.5,-2668 1260.5,-2668 1254.5,-2668 1248.5,-2662 1248.5,-2656 1248.5,-2656 1248.5,-2448 1248.5,-2448 1248.5,-2442 1254.5,-2436 1260.5,-2436"/>
-<text text-anchor="middle" x="1525.75" y="-2656.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
-</g>
-<g id="clust22" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1547.5,-2196C1547.5,-2196 1773,-2196 1773,-2196 1779,-2196 1785,-2202 1785,-2208 1785,-2208 1785,-2356 1785,-2356 1785,-2362 1779,-2368 1773,-2368 1773,-2368 1547.5,-2368 1547.5,-2368 1541.5,-2368 1535.5,-2362 1535.5,-2356 1535.5,-2356 1535.5,-2208 1535.5,-2208 1535.5,-2202 1541.5,-2196 1547.5,-2196"/>
-<text text-anchor="middle" x="1660.25" y="-2356.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust17" class="cluster">
-<title>cluster_src/extract/ast&#45;extractors</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M921.5,-2676C921.5,-2676 1322,-2676 1322,-2676 1328,-2676 1334,-2682 1334,-2688 1334,-2688 1334,-2790 1334,-2790 1334,-2796 1328,-2802 1322,-2802 1322,-2802 921.5,-2802 921.5,-2802 915.5,-2802 909.5,-2796 909.5,-2790 909.5,-2790 909.5,-2688 909.5,-2688 909.5,-2682 915.5,-2676 921.5,-2676"/>
-<text text-anchor="middle" x="1121.75" y="-2790.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
-</g>
-<g id="clust31" class="cluster">
-<title>cluster_src/schema</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M747.5,-1798C747.5,-1798 887.5,-1798 887.5,-1798 893.5,-1798 899.5,-1804 899.5,-1810 899.5,-1810 899.5,-2008 899.5,-2008 899.5,-2014 893.5,-2020 887.5,-2020 887.5,-2020 747.5,-2020 747.5,-2020 741.5,-2020 735.5,-2014 735.5,-2008 735.5,-2008 735.5,-1810 735.5,-1810 735.5,-1804 741.5,-1798 747.5,-1798"/>
-<text text-anchor="middle" x="817.5" y="-2008.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">schema</text>
-</g>
-<g id="clust32" class="cluster">
-<title>cluster_src/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1703.5,-972C1703.5,-972 1788.5,-972 1788.5,-972 1794.5,-972 1800.5,-978 1800.5,-984 1800.5,-984 1800.5,-1072 1800.5,-1072 1800.5,-1078 1794.5,-1084 1788.5,-1084 1788.5,-1084 1703.5,-1084 1703.5,-1084 1697.5,-1084 1691.5,-1078 1691.5,-1072 1691.5,-1072 1691.5,-984 1691.5,-984 1691.5,-978 1697.5,-972 1703.5,-972"/>
-<text text-anchor="middle" x="1746" y="-1072.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust33" class="cluster">
-<title>cluster_src/validate</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1259.5,-976C1259.5,-976 1652,-976 1652,-976 1658,-976 1664,-982 1664,-988 1664,-988 1664,-1106 1664,-1106 1664,-1112 1658,-1118 1652,-1118 1652,-1118 1259.5,-1118 1259.5,-1118 1253.5,-1118 1247.5,-1112 1247.5,-1106 1247.5,-1106 1247.5,-988 1247.5,-988 1247.5,-982 1253.5,-976 1259.5,-976"/>
-<text text-anchor="middle" x="1455.75" y="-1106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">validate</text>
 </g>
 <!-- bin/depcruise&#45;baseline.js -->
 <g id="node1" class="node">
@@ -621,23 +621,23 @@
 <!-- src/main/index.js&#45;&gt;src/extract/transpile/meta.js -->
 <g id="edge176" class="edge">
 <title>src/main/index.js&#45;&gt;src/extract/transpile/meta.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M502,-1191.24C502,-1299.89 502,-2330 502,-2330 502,-2330 1439,-2330 1439,-2330 1439,-2330 1439,-2494.65 1439,-2494.65"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1436.9,-2494.65 1439,-2500.65 1441.1,-2494.65 1436.9,-2494.65"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M502,-1191.21C502,-1301.64 502,-2368.5 502,-2368.5 502,-2368.5 1439,-2368.5 1439,-2368.5 1439,-2368.5 1439,-2494.49 1439,-2494.49"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1436.9,-2494.49 1439,-2500.49 1441.1,-2494.49 1436.9,-2494.49"/>
 </g>
 <!-- src/extract/index.js -->
 <g id="node93" class="node">
 <title>src/extract/index.js</title>
 <g id="a_node93"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/index.js" xlink:title="index.js">
-<path fill="#ccffcc" stroke="black" d="M690,-2221C690,-2221 648,-2221 648,-2221 645,-2221 642,-2218 642,-2215 642,-2215 642,-2209 642,-2209 642,-2206 645,-2203 648,-2203 648,-2203 690,-2203 690,-2203 693,-2203 696,-2206 696,-2209 696,-2209 696,-2215 696,-2215 696,-2218 693,-2221 690,-2221"/>
-<text text-anchor="start" x="653" y="-2209.8" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
+<path fill="#ccffcc" stroke="black" d="M690,-2287C690,-2287 648,-2287 648,-2287 645,-2287 642,-2284 642,-2281 642,-2281 642,-2275 642,-2275 642,-2272 645,-2269 648,-2269 648,-2269 690,-2269 690,-2269 693,-2269 696,-2272 696,-2275 696,-2275 696,-2281 696,-2281 696,-2284 693,-2287 690,-2287"/>
+<text text-anchor="start" x="653" y="-2275.8" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
 </a>
 </g>
 </g>
 <!-- src/main/index.js&#45;&gt;src/extract/index.js -->
 <g id="edge175" class="edge">
 <title>src/main/index.js&#45;&gt;src/extract/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M508,-1191.22C508,-1293.48 508,-2212 508,-2212 508,-2212 632.66,-2212 632.66,-2212"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="632.66,-2214.1 638.66,-2212 632.66,-2209.9 632.66,-2214.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M508,-1191.47C508,-1298.6 508,-2278 508,-2278 508,-2278 632.66,-2278 632.66,-2278"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="632.66,-2280.1 638.66,-2278 632.66,-2275.9 632.66,-2280.1"/>
 </g>
 <!-- src/main/files&#45;and&#45;dirs/normalize.js -->
 <g id="node118" class="node">
@@ -1030,16 +1030,16 @@
 <g id="node40" class="node">
 <title>src/extract/resolve/resolve.js</title>
 <g id="a_node40"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve.js" xlink:title="resolve.js">
-<path fill="#ccffcc" stroke="black" d="M1465.5,-2246C1465.5,-2246 1421.5,-2246 1421.5,-2246 1418.5,-2246 1415.5,-2243 1415.5,-2240 1415.5,-2240 1415.5,-2234 1415.5,-2234 1415.5,-2231 1418.5,-2228 1421.5,-2228 1421.5,-2228 1465.5,-2228 1465.5,-2228 1468.5,-2228 1471.5,-2231 1471.5,-2234 1471.5,-2234 1471.5,-2240 1471.5,-2240 1471.5,-2243 1468.5,-2246 1465.5,-2246"/>
-<text text-anchor="start" x="1423.5" y="-2234.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve.js</text>
+<path fill="#ccffcc" stroke="black" d="M1465.5,-2248C1465.5,-2248 1421.5,-2248 1421.5,-2248 1418.5,-2248 1415.5,-2245 1415.5,-2242 1415.5,-2242 1415.5,-2236 1415.5,-2236 1415.5,-2233 1418.5,-2230 1421.5,-2230 1421.5,-2230 1465.5,-2230 1465.5,-2230 1468.5,-2230 1471.5,-2233 1471.5,-2236 1471.5,-2236 1471.5,-2242 1471.5,-2242 1471.5,-2245 1468.5,-2248 1465.5,-2248"/>
+<text text-anchor="start" x="1423.5" y="-2236.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve.js</text>
 </a>
 </g>
 </g>
 <!-- src/config&#45;utl/extract&#45;depcruise&#45;config/index.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge53" class="edge">
 <title>src/config&#45;utl/extract&#45;depcruise&#45;config/index.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M549.76,-713.5C562.11,-713.5 574,-713.5 574,-713.5 574,-713.5 574,-1420 574,-1420 574,-1420 1450,-1420 1450,-1420 1450,-1420 1450,-2218.52 1450,-2218.52"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1447.9,-2218.52 1450,-2224.52 1452.1,-2218.52 1447.9,-2218.52"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M549.76,-713.5C562.11,-713.5 574,-713.5 574,-713.5 574,-713.5 574,-1420 574,-1420 574,-1420 1450,-1420 1450,-1420 1450,-1420 1450,-2220.49 1450,-2220.49"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1447.9,-2220.49 1450,-2226.49 1452.1,-2220.49 1447.9,-2220.49"/>
 </g>
 <!-- src/config&#45;utl/extract&#45;depcruise&#45;config/index.js&#45;&gt;src/main/resolve&#45;options/normalize.js -->
 <g id="edge54" class="edge">
@@ -1081,31 +1081,31 @@
 <g id="node87" class="node">
 <title>src/extract/utl/path&#45;to&#45;posix.js</title>
 <g id="a_node87"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/path-to-posix.js" xlink:title="path&#45;to&#45;posix.js">
-<path fill="#ccffcc" stroke="black" d="M1647,-2222C1647,-2222 1580,-2222 1580,-2222 1577,-2222 1574,-2219 1574,-2216 1574,-2216 1574,-2210 1574,-2210 1574,-2207 1577,-2204 1580,-2204 1580,-2204 1647,-2204 1647,-2204 1650,-2204 1653,-2207 1653,-2210 1653,-2210 1653,-2216 1653,-2216 1653,-2219 1650,-2222 1647,-2222"/>
-<text text-anchor="start" x="1582" y="-2210.8" font-family="Helvetica,sans-Serif" font-size="9.00">path&#45;to&#45;posix.js</text>
+<path fill="#ccffcc" stroke="black" d="M1647,-2235C1647,-2235 1580,-2235 1580,-2235 1577,-2235 1574,-2232 1574,-2229 1574,-2229 1574,-2223 1574,-2223 1574,-2220 1577,-2217 1580,-2217 1580,-2217 1647,-2217 1647,-2217 1650,-2217 1653,-2220 1653,-2223 1653,-2223 1653,-2229 1653,-2229 1653,-2232 1650,-2235 1647,-2235"/>
+<text text-anchor="start" x="1582" y="-2223.8" font-family="Helvetica,sans-Serif" font-size="9.00">path&#45;to&#45;posix.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge148" class="edge">
 <title>src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1461,-2227.56C1461,-2219.77 1461,-2210 1461,-2210 1461,-2210 1564.8,-2210 1564.8,-2210"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.8,-2212.1 1570.8,-2210 1564.8,-2207.9 1564.8,-2212.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1461,-2229.55C1461,-2226.89 1461,-2224.71 1461,-2224.71 1461,-2224.71 1564.8,-2224.71 1564.8,-2224.71"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.8,-2226.81 1570.8,-2224.71 1564.8,-2222.61 1564.8,-2226.81"/>
 </g>
 <!-- src/extract/utl/strip&#45;query&#45;parameters.js -->
 <g id="node100" class="node">
 <title>src/extract/utl/strip&#45;query&#45;parameters.js</title>
 <g id="a_node100"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/strip-query-parameters.js" xlink:title="strip&#45;query&#45;parameters.js">
-<path fill="#ccffcc" stroke="black" d="M1667,-2252C1667,-2252 1560,-2252 1560,-2252 1557,-2252 1554,-2249 1554,-2246 1554,-2246 1554,-2240 1554,-2240 1554,-2237 1557,-2234 1560,-2234 1560,-2234 1667,-2234 1667,-2234 1670,-2234 1673,-2237 1673,-2240 1673,-2240 1673,-2246 1673,-2246 1673,-2249 1670,-2252 1667,-2252"/>
-<text text-anchor="start" x="1562" y="-2240.8" font-family="Helvetica,sans-Serif" font-size="9.00">strip&#45;query&#45;parameters.js</text>
+<path fill="#ccffcc" stroke="black" d="M1667,-2265C1667,-2265 1560,-2265 1560,-2265 1557,-2265 1554,-2262 1554,-2259 1554,-2259 1554,-2253 1554,-2253 1554,-2250 1557,-2247 1560,-2247 1560,-2247 1667,-2247 1667,-2247 1670,-2247 1673,-2250 1673,-2253 1673,-2253 1673,-2259 1673,-2259 1673,-2262 1670,-2265 1667,-2265"/>
+<text text-anchor="start" x="1562" y="-2253.8" font-family="Helvetica,sans-Serif" font-size="9.00">strip&#45;query&#45;parameters.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/strip&#45;query&#45;parameters.js -->
 <g id="edge149" class="edge">
 <title>src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/strip&#45;query&#45;parameters.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1471.95,-2240C1471.95,-2240 1544.52,-2240 1544.52,-2240"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1544.52,-2242.1 1550.52,-2240 1544.52,-2237.9 1544.52,-2242.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1471.83,-2241C1508.29,-2241 1567,-2241 1567,-2241 1567,-2241 1567,-2241.58 1567,-2241.58"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.9,-2237.73 1567,-2243.73 1569.1,-2237.73 1564.9,-2237.73"/>
 </g>
 <!-- src/graph&#45;utl/rule&#45;set.js -->
 <g id="node68" class="node">
@@ -1125,8 +1125,8 @@
 <!-- src/main/resolve&#45;options/normalize.js&#45;&gt;src/extract/transpile/meta.js -->
 <g id="edge194" class="edge">
 <title>src/main/resolve&#45;options/normalize.js&#45;&gt;src/extract/transpile/meta.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M702.45,-1084.5C839.78,-1084.5 1353,-1084.5 1353,-1084.5 1353,-1084.5 1353,-2508.5 1353,-2508.5 1353,-2508.5 1407.32,-2508.5 1407.32,-2508.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.32,-2510.6 1413.32,-2508.5 1407.32,-2506.4 1407.32,-2510.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M702.4,-1084.5C839.53,-1084.5 1352,-1084.5 1352,-1084.5 1352,-1084.5 1352,-2508.5 1352,-2508.5 1352,-2508.5 1407.02,-2508.5 1407.02,-2508.5"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.02,-2510.6 1413.02,-2508.5 1407.02,-2506.4 1407.02,-2510.6"/>
 </g>
 <!-- src/enrich/add&#45;validations.js -->
 <g id="node44" class="node">
@@ -1281,8 +1281,8 @@
 <!-- src/enrich/derive/folders&#45;&gt;src/validate/index.js -->
 <g id="edge62" class="edge">
 <title>src/enrich/derive/folders&#45;&gt;src/validate/index.js</title>
-<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1161.9,-1698.5C1179.85,-1698.5 1200,-1698.5 1200,-1698.5 1200,-1698.5 1200,-1069 1200,-1069 1200,-1069 1247.13,-1069 1247.13,-1069"/>
-<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1247.13,-1071.1 1253.13,-1069 1247.13,-1066.9 1247.13,-1071.1"/>
+<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1161.95,-1698.5C1180.64,-1698.5 1202,-1698.5 1202,-1698.5 1202,-1698.5 1202,-1069 1202,-1069 1202,-1069 1247.33,-1069 1247.33,-1069"/>
+<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1247.33,-1071.1 1253.33,-1069 1247.33,-1066.9 1247.33,-1071.1"/>
 </g>
 <!-- src/enrich/derive/folders&#45;&gt;src/enrich/derive/module&#45;utl.js -->
 <g id="edge64" class="edge">
@@ -1509,8 +1509,8 @@
 <!-- src/graph&#45;utl/add&#45;focus.js&#45;&gt;src/graph&#45;utl/indexed&#45;module&#45;graph.js -->
 <g id="edge161" class="edge">
 <title>src/graph&#45;utl/add&#45;focus.js&#45;&gt;src/graph&#45;utl/indexed&#45;module&#45;graph.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1476.75,-1283C1512.41,-1283 1564,-1283 1564,-1283 1564,-1283 1564,-1268.4 1564,-1268.4"/>
-<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1566.1,-1268.4 1564,-1262.4 1561.9,-1268.4 1566.1,-1268.4"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1476.86,-1283C1511.59,-1283 1561,-1283 1561,-1283 1561,-1283 1561,-1268.4 1561,-1268.4"/>
+<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1563.1,-1268.4 1561,-1262.4 1558.9,-1268.4 1563.1,-1268.4"/>
 </g>
 <!-- src/enrich/summarize/is&#45;same&#45;violation.js -->
 <g id="node61" class="node">
@@ -1779,8 +1779,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge104" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.82,-2388C1083.07,-2388 1213,-2388 1213,-2388 1213,-2388 1213,-2230.8 1213,-2230.8 1213,-2230.8 1406.21,-2230.8 1406.21,-2230.8"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.21,-2232.9 1412.21,-2230.8 1406.21,-2228.7 1406.21,-2232.9"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.82,-2386.5C1083.07,-2386.5 1213,-2386.5 1213,-2386.5 1213,-2386.5 1213,-2234 1213,-2234 1213,-2234 1406.21,-2234 1406.21,-2234"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.21,-2236.1 1412.21,-2234 1406.21,-2231.9 1406.21,-2236.1"/>
 </g>
 <!-- src/extract/parse/to&#45;javascript&#45;ast.js -->
 <g id="node77" class="node">
@@ -1824,8 +1824,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/parse/to&#45;typescript&#45;ast.js -->
 <g id="edge101" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/parse/to&#45;typescript&#45;ast.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.93,-2394C1051.74,-2394 1099,-2394 1099,-2394 1099,-2394 1099,-2420.87 1099,-2420.87"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1096.9,-2420.87 1099,-2426.87 1101.1,-2420.87 1096.9,-2420.87"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.93,-2395.5C1051.74,-2395.5 1099,-2395.5 1099,-2395.5 1099,-2395.5 1099,-2420.75 1099,-2420.75"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1096.9,-2420.75 1099,-2426.75 1101.1,-2420.75 1096.9,-2420.75"/>
 </g>
 <!-- src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="node80" class="node">
@@ -1839,8 +1839,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="edge102" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1010,-2381.62C1010,-2349.8 1010,-2248 1010,-2248 1010,-2248 1211.04,-2248 1211.04,-2248"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.04,-2250.1 1217.04,-2248 1211.04,-2245.9 1211.04,-2250.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.86,-2391C1087.53,-2391 1232,-2391 1232,-2391 1232,-2391 1232,-2269.21 1232,-2269.21"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1234.1,-2269.21 1232,-2263.21 1229.9,-2269.21 1234.1,-2269.21"/>
 </g>
 <!-- src/extract/resolve/get&#45;manifest/index.js -->
 <g id="node81" class="node">
@@ -1854,8 +1854,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js -->
 <g id="edge103" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1013,-2381.5C1013,-2361.32 1013,-2316 1013,-2316 1013,-2316 1098.21,-2316 1098.21,-2316"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1098.21,-2318.1 1104.21,-2316 1098.21,-2313.9 1098.21,-2318.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1012,-2381.5C1012,-2361.32 1012,-2316 1012,-2316 1012,-2316 1097.98,-2316 1097.98,-2316"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1097.98,-2318.1 1103.98,-2316 1097.98,-2313.9 1097.98,-2318.1"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;amd.js -->
 <g id="node82" class="node">
@@ -1869,23 +1869,23 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js -->
 <g id="edge105" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1007,-2381.84C1007,-2345.21 1007,-2211.25 1007,-2211.25 1007,-2211.25 1086.53,-2211.25 1086.53,-2211.25"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.53,-2213.35 1092.53,-2211.25 1086.53,-2209.15 1086.53,-2213.35"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1008,-2381.67C1008,-2344.38 1008,-2208 1008,-2208 1008,-2208 1086.49,-2208 1086.49,-2208"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.49,-2210.1 1092.49,-2208 1086.49,-2205.9 1086.49,-2210.1"/>
 </g>
 <!-- src/extract/utl/get&#45;extension.js -->
 <g id="node86" class="node">
 <title>src/extract/utl/get&#45;extension.js</title>
 <g id="a_node86"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/get-extension.js" xlink:title="get&#45;extension.js">
-<path fill="#ccffcc" stroke="black" d="M1648,-2282C1648,-2282 1579,-2282 1579,-2282 1576,-2282 1573,-2279 1573,-2276 1573,-2276 1573,-2270 1573,-2270 1573,-2267 1576,-2264 1579,-2264 1579,-2264 1648,-2264 1648,-2264 1651,-2264 1654,-2267 1654,-2270 1654,-2270 1654,-2276 1654,-2276 1654,-2279 1651,-2282 1648,-2282"/>
-<text text-anchor="start" x="1581" y="-2270.8" font-family="Helvetica,sans-Serif" font-size="9.00">get&#45;extension.js</text>
+<path fill="#ccffcc" stroke="black" d="M1648,-2295C1648,-2295 1579,-2295 1579,-2295 1576,-2295 1573,-2292 1573,-2289 1573,-2289 1573,-2283 1573,-2283 1573,-2280 1576,-2277 1579,-2277 1579,-2277 1648,-2277 1648,-2277 1651,-2277 1654,-2280 1654,-2283 1654,-2283 1654,-2289 1654,-2289 1654,-2292 1651,-2295 1648,-2295"/>
+<text text-anchor="start" x="1581" y="-2283.8" font-family="Helvetica,sans-Serif" font-size="9.00">get&#45;extension.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/parse/to&#45;javascript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge126" class="edge">
 <title>src/extract/parse/to&#45;javascript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.91,-2468C1280.05,-2468 1511,-2468 1511,-2468 1511,-2468 1511,-2276.8 1511,-2276.8 1511,-2276.8 1563.67,-2276.8 1563.67,-2276.8"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.67,-2278.9 1569.67,-2276.8 1563.67,-2274.7 1563.67,-2278.9"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.89,-2468C1240.13,-2468 1339,-2468 1339,-2468 1339,-2468 1339,-2293.67 1339,-2293.67 1339,-2293.67 1563.67,-2293.67 1563.67,-2293.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.67,-2295.77 1569.67,-2293.67 1563.67,-2291.57 1563.67,-2295.77"/>
 </g>
 <!-- src/extract/transpile/index.js -->
 <g id="node94" class="node">
@@ -1905,20 +1905,20 @@
 <!-- src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge128" class="edge">
 <title>src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.93,-2434.67C1278.26,-2434.67 1502,-2434.67 1502,-2434.67 1502,-2434.67 1502,-2273.6 1502,-2273.6 1502,-2273.6 1563.59,-2273.6 1563.59,-2273.6"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.59,-2275.7 1569.59,-2273.6 1563.59,-2271.5 1563.59,-2275.7"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1171,-2429.83C1171,-2397.72 1171,-2292.33 1171,-2292.33 1171,-2292.33 1563.64,-2292.33 1563.64,-2292.33"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.64,-2294.43 1569.64,-2292.33 1563.64,-2290.23 1563.64,-2294.43"/>
 </g>
 <!-- src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/transpile/index.js -->
 <g id="edge127" class="edge">
 <title>src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/transpile/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.67,-2439.33C1199.35,-2439.33 1218,-2439.33 1218,-2439.33 1218,-2439.33 1218,-2512.67 1218,-2512.67 1218,-2512.67 1247.07,-2512.67 1247.07,-2512.67"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.67,-2437C1199.35,-2437 1218,-2437 1218,-2437 1218,-2437 1218,-2512.67 1218,-2512.67 1218,-2512.67 1247.07,-2512.67 1247.07,-2512.67"/>
 <polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1247.07,-2514.77 1253.07,-2512.67 1247.07,-2510.57 1247.07,-2514.77"/>
 </g>
 <!-- src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge132" class="edge">
 <title>src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1333,-2241.67C1333,-2238.81 1333,-2236.4 1333,-2236.4 1333,-2236.4 1406.02,-2236.4 1406.02,-2236.4"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.02,-2238.5 1412.02,-2236.4 1406.02,-2234.3 1406.02,-2238.5"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1333,-2241.55C1333,-2239.54 1333,-2238 1333,-2238 1333,-2238 1406.02,-2238 1406.02,-2238"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.02,-2240.1 1412.02,-2238 1406.02,-2235.9 1406.02,-2240.1"/>
 </g>
 <!-- src/extract/resolve/module&#45;classifiers.js -->
 <g id="node96" class="node">
@@ -1932,8 +1932,8 @@
 <!-- src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge131" class="edge">
 <title>src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1346.78,-2256C1373.26,-2256 1398,-2256 1398,-2256 1398,-2256 1398,-2256.58 1398,-2256.58"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1395.9,-2252.73 1398,-2258.73 1400.1,-2252.73 1395.9,-2252.73"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1346.86,-2254C1374.19,-2254 1400,-2254 1400,-2254 1400,-2254 1400,-2254.77 1400,-2254.77"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1397.9,-2252.68 1400,-2258.68 1402.1,-2252.68 1397.9,-2252.68"/>
 </g>
 <!-- src/extract/resolve/get&#45;manifest/merge&#45;manifests.js -->
 <g id="node97" class="node">
@@ -1953,8 +1953,8 @@
 <!-- src/extract/resolve/resolve&#45;amd.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge142" class="edge">
 <title>src/extract/resolve/resolve&#45;amd.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1135,-2195.51C1135,-2186.72 1135,-2175 1135,-2175 1135,-2175 1614,-2175 1614,-2175 1614,-2175 1614,-2194.77 1614,-2194.77"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1611.9,-2194.77 1614,-2200.77 1616.1,-2194.77 1611.9,-2194.77"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1135,-2214.41C1135,-2217.82 1135,-2220.86 1135,-2220.86 1135,-2220.86 1564.5,-2220.86 1564.5,-2220.86"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.5,-2222.96 1570.5,-2220.86 1564.5,-2218.76 1564.5,-2222.96"/>
 </g>
 <!-- src/extract/gather&#45;initial&#45;sources.js -->
 <g id="node83" class="node">
@@ -1968,8 +1968,8 @@
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/graph&#45;utl/match&#45;facade.js -->
 <g id="edge106" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/graph&#45;utl/match&#45;facade.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1339.73,-2140.5C1429.21,-2140.5 1594,-2140.5 1594,-2140.5 1594,-2140.5 1594,-1301.36 1594,-1301.36"/>
-<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1596.1,-1301.36 1594,-1295.36 1591.9,-1301.36 1596.1,-1301.36"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1339.94,-2140.5C1434.33,-2140.5 1614,-2140.5 1614,-2140.5 1614,-2140.5 1614,-1301.36 1614,-1301.36"/>
+<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1616.1,-1301.36 1614,-1295.36 1611.9,-1301.36 1616.1,-1301.36"/>
 </g>
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/transpile/meta.js -->
 <g id="edge107" class="edge">
@@ -1980,14 +1980,14 @@
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge108" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1339.91,-2145C1409.58,-2145 1519,-2145 1519,-2145 1519,-2145 1519,-2267.2 1519,-2267.2 1519,-2267.2 1563.57,-2267.2 1563.57,-2267.2"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.57,-2269.3 1569.57,-2267.2 1563.57,-2265.1 1563.57,-2269.3"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1339.84,-2145C1348.7,-2145 1355,-2145 1355,-2145 1355,-2145 1355,-2291 1355,-2291 1355,-2291 1563.51,-2291 1563.51,-2291"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.51,-2293.1 1569.51,-2291 1563.51,-2288.9 1563.51,-2293.1"/>
 </g>
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge109" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1326,-2154.26C1326,-2171.33 1326,-2206 1326,-2206 1326,-2206 1564.5,-2206 1564.5,-2206"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.5,-2208.1 1570.5,-2206 1564.5,-2203.9 1564.5,-2208.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1326,-2154.28C1326,-2174 1326,-2218.29 1326,-2218.29 1326,-2218.29 1564.5,-2218.29 1564.5,-2218.29"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.5,-2220.39 1570.5,-2218.29 1564.5,-2216.19 1564.5,-2220.39"/>
 </g>
 <!-- src/extract/transpile/meta.js&#45;&gt;src/extract/parse/to&#45;swc&#45;ast.js -->
 <g id="edge151" class="edge">
@@ -2175,77 +2175,77 @@
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/resolve/index.js -->
 <g id="edge119" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/resolve/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M801,-2489.7C801,-2447.5 801,-2276 801,-2276 801,-2276 940.05,-2276 940.05,-2276"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="940.05,-2278.1 946.05,-2276 940.05,-2273.9 940.05,-2278.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M801,-2489.58C801,-2447.59 801,-2279.67 801,-2279.67 801,-2279.67 940.05,-2279.67 940.05,-2279.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="940.05,-2281.77 946.05,-2279.67 940.05,-2277.57 940.05,-2281.77"/>
 </g>
 <!-- src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js -->
 <g id="node91" class="node">
 <title>src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js</title>
 <g id="a_node91"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/detect-pre-compilation-ness.js" xlink:title="detect&#45;pre&#45;compilation&#45;ness.js">
-<path fill="#ccffcc" stroke="black" d="M1677.5,-2312C1677.5,-2312 1549.5,-2312 1549.5,-2312 1546.5,-2312 1543.5,-2309 1543.5,-2306 1543.5,-2306 1543.5,-2300 1543.5,-2300 1543.5,-2297 1546.5,-2294 1549.5,-2294 1549.5,-2294 1677.5,-2294 1677.5,-2294 1680.5,-2294 1683.5,-2297 1683.5,-2300 1683.5,-2300 1683.5,-2306 1683.5,-2306 1683.5,-2309 1680.5,-2312 1677.5,-2312"/>
-<text text-anchor="start" x="1551.5" y="-2300.8" font-family="Helvetica,sans-Serif" font-size="9.00">detect&#45;pre&#45;compilation&#45;ness.js</text>
+<path fill="#ccffcc" stroke="black" d="M1677.5,-2325C1677.5,-2325 1549.5,-2325 1549.5,-2325 1546.5,-2325 1543.5,-2322 1543.5,-2319 1543.5,-2319 1543.5,-2313 1543.5,-2313 1543.5,-2310 1546.5,-2307 1549.5,-2307 1549.5,-2307 1677.5,-2307 1677.5,-2307 1680.5,-2307 1683.5,-2310 1683.5,-2313 1683.5,-2313 1683.5,-2319 1683.5,-2319 1683.5,-2322 1680.5,-2325 1677.5,-2325"/>
+<text text-anchor="start" x="1551.5" y="-2313.8" font-family="Helvetica,sans-Serif" font-size="9.00">detect&#45;pre&#45;compilation&#45;ness.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js -->
 <g id="edge120" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818,-2489.62C818,-2450.08 818,-2299 818,-2299 818,-2299 1534.23,-2299 1534.23,-2299"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1534.23,-2301.1 1540.23,-2299 1534.23,-2296.9 1534.23,-2301.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818,-2489.65C818,-2450.2 818,-2299.5 818,-2299.5 818,-2299.5 1549,-2299.5 1549,-2299.5 1549,-2299.5 1549,-2300.21 1549,-2300.21"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1546.9,-2297.57 1549,-2303.57 1551.1,-2297.57 1546.9,-2297.57"/>
 </g>
 <!-- src/extract/utl/extract&#45;module&#45;attributes.js -->
 <g id="node92" class="node">
 <title>src/extract/utl/extract&#45;module&#45;attributes.js</title>
 <g id="a_node92"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/extract-module-attributes.js" xlink:title="extract&#45;module&#45;attributes.js">
-<path fill="#ccffcc" stroke="black" d="M1671,-2342C1671,-2342 1556,-2342 1556,-2342 1553,-2342 1550,-2339 1550,-2336 1550,-2336 1550,-2330 1550,-2330 1550,-2327 1553,-2324 1556,-2324 1556,-2324 1671,-2324 1671,-2324 1674,-2324 1677,-2327 1677,-2330 1677,-2330 1677,-2336 1677,-2336 1677,-2339 1674,-2342 1671,-2342"/>
-<text text-anchor="start" x="1558" y="-2330.8" font-family="Helvetica,sans-Serif" font-size="9.00">extract&#45;module&#45;attributes.js</text>
+<path fill="#ccffcc" stroke="black" d="M1671,-2355C1671,-2355 1556,-2355 1556,-2355 1553,-2355 1550,-2352 1550,-2349 1550,-2349 1550,-2343 1550,-2343 1550,-2340 1553,-2337 1556,-2337 1556,-2337 1671,-2337 1671,-2337 1674,-2337 1677,-2340 1677,-2343 1677,-2343 1677,-2349 1677,-2349 1677,-2352 1674,-2355 1671,-2355"/>
+<text text-anchor="start" x="1558" y="-2343.8" font-family="Helvetica,sans-Serif" font-size="9.00">extract&#45;module&#45;attributes.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/extract&#45;module&#45;attributes.js -->
 <g id="edge121" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/extract&#45;module&#45;attributes.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M835,-2489.77C835,-2455.29 835,-2336 835,-2336 835,-2336 1540.76,-2336 1540.76,-2336"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1540.77,-2338.1 1546.76,-2336 1540.76,-2333.9 1540.77,-2338.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M835,-2489.89C835,-2456.95 835,-2346 835,-2346 835,-2346 1540.76,-2346 1540.76,-2346"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1540.77,-2348.1 1546.76,-2346 1540.76,-2343.9 1540.77,-2348.1"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js -->
 <g id="edge136" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M986,-2285.29C986,-2295.36 986,-2310 986,-2310 986,-2310 1098.24,-2310 1098.24,-2310"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1098.24,-2312.1 1104.24,-2310 1098.24,-2307.9 1098.24,-2312.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M968,-2285.29C968,-2295.36 968,-2310 968,-2310 968,-2310 1097.98,-2310 1097.98,-2310"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1097.98,-2312.1 1103.98,-2310 1097.98,-2307.9 1097.98,-2312.1"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js -->
 <g id="edge138" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M982,-2266.61C982,-2248.07 982,-2208.5 982,-2208.5 982,-2208.5 1086.6,-2208.5 1086.6,-2208.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.6,-2210.6 1092.6,-2208.5 1086.6,-2206.4 1086.6,-2210.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M963,-2266.63C963,-2246.72 963,-2202 963,-2202 963,-2202 1086.56,-2202 1086.56,-2202"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.56,-2204.1 1092.56,-2202 1086.56,-2199.9 1086.56,-2204.1"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge134" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M961,-2266.88C961,-2240.25 961,-2164.5 961,-2164.5 961,-2164.5 1634,-2164.5 1634,-2164.5 1634,-2164.5 1634,-2194.62 1634,-2194.62"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1631.9,-2194.62 1634,-2200.62 1636.1,-2194.62 1631.9,-2194.62"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M990,-2266.84C990,-2251.78 990,-2223.43 990,-2223.43 990,-2223.43 1564.52,-2223.43 1564.52,-2223.43"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.52,-2225.53 1570.52,-2223.43 1564.52,-2221.33 1564.52,-2225.53"/>
 </g>
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js -->
 <g id="node95" class="node">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js</title>
 <g id="a_node95"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/determine-dependency-types.js" xlink:title="determine&#45;dependency&#45;types.js">
-<path fill="#ccffcc" stroke="black" d="M1201.5,-2274C1201.5,-2274 1067.5,-2274 1067.5,-2274 1064.5,-2274 1061.5,-2271 1061.5,-2268 1061.5,-2268 1061.5,-2262 1061.5,-2262 1061.5,-2259 1064.5,-2256 1067.5,-2256 1067.5,-2256 1201.5,-2256 1201.5,-2256 1204.5,-2256 1207.5,-2259 1207.5,-2262 1207.5,-2262 1207.5,-2268 1207.5,-2268 1207.5,-2271 1204.5,-2274 1201.5,-2274"/>
-<text text-anchor="start" x="1069.5" y="-2262.8" font-family="Helvetica,sans-Serif" font-size="9.00">determine&#45;dependency&#45;types.js</text>
+<path fill="#ccffcc" stroke="black" d="M1201.5,-2244C1201.5,-2244 1067.5,-2244 1067.5,-2244 1064.5,-2244 1061.5,-2241 1061.5,-2238 1061.5,-2238 1061.5,-2232 1061.5,-2232 1061.5,-2229 1064.5,-2226 1067.5,-2226 1067.5,-2226 1201.5,-2226 1201.5,-2226 1204.5,-2226 1207.5,-2229 1207.5,-2232 1207.5,-2232 1207.5,-2238 1207.5,-2238 1207.5,-2241 1204.5,-2244 1201.5,-2244"/>
+<text text-anchor="start" x="1069.5" y="-2232.8" font-family="Helvetica,sans-Serif" font-size="9.00">determine&#45;dependency&#45;types.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/determine&#45;dependency&#45;types.js -->
 <g id="edge135" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/determine&#45;dependency&#45;types.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1003.66,-2270.5C1003.66,-2270.5 1052.15,-2270.5 1052.15,-2270.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1052.15,-2272.6 1058.15,-2270.5 1052.15,-2268.4 1052.15,-2272.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1003.95,-2269.33C1030.9,-2269.33 1068,-2269.33 1068,-2269.33 1068,-2269.33 1068,-2253.41 1068,-2253.41"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1070.1,-2253.41 1068,-2247.41 1065.9,-2253.41 1070.1,-2253.41"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge137" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M968,-2285.23C968,-2287.6 968,-2289.5 968,-2289.5 968,-2289.5 1405,-2289.5 1405,-2289.5 1405,-2289.5 1405,-2288.57 1405,-2288.57"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.1,-2289.28 1405,-2283.28 1402.9,-2289.28 1407.1,-2289.28"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M986,-2285.47C986,-2287.13 986,-2288.33 986,-2288.33 986,-2288.33 1405,-2288.33 1405,-2288.33 1405,-2288.33 1405,-2287.55 1405,-2287.55"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.1,-2289.51 1405,-2283.51 1402.9,-2289.51 1407.1,-2289.51"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js -->
 <g id="node98" class="node">
@@ -2259,55 +2259,55 @@
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;cjs.js -->
 <g id="edge139" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;cjs.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M972,-2266.66C972,-2243.53 972,-2185.5 972,-2185.5 972,-2185.5 1284,-2185.5 1284,-2185.5 1284,-2185.5 1284,-2188.48 1284,-2188.48"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1281.9,-2188.48 1284,-2194.48 1286.1,-2188.48 1281.9,-2188.48"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M977,-2266.62C977,-2251.19 977,-2222.14 977,-2222.14 977,-2222.14 1272,-2222.14 1272,-2222.14 1272,-2222.14 1272,-2221.56 1272,-2221.56"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1274.1,-2225.36 1272,-2219.36 1269.9,-2225.36 1274.1,-2225.36"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js -->
 <g id="node99" class="node">
 <title>src/extract/resolve/resolve&#45;helpers.js</title>
 <g id="a_node99"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-helpers.js" xlink:title="resolve&#45;helpers.js">
-<path fill="#ccffcc" stroke="black" d="M1173,-2244C1173,-2244 1096,-2244 1096,-2244 1093,-2244 1090,-2241 1090,-2238 1090,-2238 1090,-2232 1090,-2232 1090,-2229 1093,-2226 1096,-2226 1096,-2226 1173,-2226 1173,-2226 1176,-2226 1179,-2229 1179,-2232 1179,-2232 1179,-2238 1179,-2238 1179,-2241 1176,-2244 1173,-2244"/>
-<text text-anchor="start" x="1098" y="-2232.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve&#45;helpers.js</text>
+<path fill="#ccffcc" stroke="black" d="M1173,-2274C1173,-2274 1096,-2274 1096,-2274 1093,-2274 1090,-2271 1090,-2268 1090,-2268 1090,-2262 1090,-2262 1090,-2259 1093,-2256 1096,-2256 1096,-2256 1173,-2256 1173,-2256 1176,-2256 1179,-2259 1179,-2262 1179,-2262 1179,-2268 1179,-2268 1179,-2271 1176,-2274 1173,-2274"/>
+<text text-anchor="start" x="1098" y="-2262.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve&#45;helpers.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;helpers.js -->
 <g id="edge140" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M993,-2266.9C993,-2254.82 993,-2235 993,-2235 993,-2235 1080.7,-2235 1080.7,-2235"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1080.7,-2237.1 1086.7,-2235 1080.7,-2232.9 1080.7,-2237.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1003.66,-2271.67C1003.66,-2271.67 1080.76,-2271.67 1080.76,-2271.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1080.76,-2273.77 1086.76,-2271.67 1080.76,-2269.57 1080.76,-2273.77"/>
 </g>
 <!-- src/extract/utl/compare.js -->
 <g id="node110" class="node">
 <title>src/extract/utl/compare.js</title>
 <g id="a_node110"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/compare.js" xlink:title="compare.js">
-<path fill="#ccffcc" stroke="black" d="M1771,-2312C1771,-2312 1721,-2312 1721,-2312 1718,-2312 1715,-2309 1715,-2306 1715,-2306 1715,-2300 1715,-2300 1715,-2297 1718,-2294 1721,-2294 1721,-2294 1771,-2294 1771,-2294 1774,-2294 1777,-2297 1777,-2300 1777,-2300 1777,-2306 1777,-2306 1777,-2309 1774,-2312 1771,-2312"/>
-<text text-anchor="start" x="1723" y="-2300.8" font-family="Helvetica,sans-Serif" font-size="9.00">compare.js</text>
+<path fill="#ccffcc" stroke="black" d="M1771,-2325C1771,-2325 1721,-2325 1721,-2325 1718,-2325 1715,-2322 1715,-2319 1715,-2319 1715,-2313 1715,-2313 1715,-2310 1718,-2307 1721,-2307 1721,-2307 1771,-2307 1771,-2307 1774,-2307 1777,-2310 1777,-2313 1777,-2313 1777,-2319 1777,-2319 1777,-2322 1774,-2325 1771,-2325"/>
+<text text-anchor="start" x="1723" y="-2313.8" font-family="Helvetica,sans-Serif" font-size="9.00">compare.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js&#45;&gt;src/extract/utl/compare.js -->
 <g id="edge160" class="edge">
 <title>src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js&#45;&gt;src/extract/utl/compare.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1683.63,-2303C1683.63,-2303 1705.76,-2303 1705.76,-2303"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1705.76,-2305.1 1711.76,-2303 1705.76,-2300.9 1705.76,-2305.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1683.63,-2316C1683.63,-2316 1705.76,-2316 1705.76,-2316"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1705.76,-2318.1 1711.76,-2316 1705.76,-2313.9 1705.76,-2318.1"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/clear&#45;caches.js -->
 <g id="edge122" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/clear&#45;caches.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M696.37,-2205.75C765.93,-2205.75 944,-2205.75 944,-2205.75 944,-2205.75 944,-2372.53 944,-2372.53"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="941.9,-2372.53 944,-2378.53 946.1,-2372.53 941.9,-2372.53"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M696.37,-2274.33C765.93,-2274.33 944,-2274.33 944,-2274.33 944,-2274.33 944,-2372.82 944,-2372.82"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="941.9,-2372.82 944,-2378.82 946.1,-2372.82 941.9,-2372.82"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/gather&#45;initial&#45;sources.js -->
 <g id="edge123" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/gather&#45;initial&#45;sources.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2202.68C669,-2184.27 669,-2145 669,-2145 669,-2145 1218.04,-2145 1218.04,-2145"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2268.86C669,-2238.81 669,-2145 669,-2145 669,-2145 1218.04,-2145 1218.04,-2145"/>
 <polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1218.04,-2147.1 1224.04,-2145 1218.04,-2142.9 1218.04,-2147.1"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/get&#45;dependencies.js -->
 <g id="edge124" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/get&#45;dependencies.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2221.22C669,-2270.35 669,-2499 669,-2499 669,-2499 758.2,-2499 758.2,-2499"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2287.5C669,-2329.8 669,-2499 669,-2499 669,-2499 758.2,-2499 758.2,-2499"/>
 <polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="758.2,-2501.1 764.2,-2499 758.2,-2496.9 758.2,-2501.1"/>
 </g>
 <!-- src/extract/transpile/index.js&#45;&gt;src/extract/transpile/meta.js -->
@@ -2319,50 +2319,50 @@
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="edge129" class="edge">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1204,-2255.55C1204,-2253.54 1204,-2252 1204,-2252 1204,-2252 1211.06,-2252 1211.06,-2252"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.06,-2254.1 1217.06,-2252 1211.06,-2249.9 1211.06,-2254.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1204,-2244.24C1204,-2247.33 1204,-2250 1204,-2250 1204,-2250 1211.06,-2250 1211.06,-2250"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.06,-2252.1 1217.06,-2250 1211.06,-2247.9 1211.06,-2252.1"/>
 </g>
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge130" class="edge">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1207.73,-2268C1207.73,-2268 1384.44,-2268 1384.44,-2268"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1384.44,-2270.1 1390.44,-2268 1384.44,-2265.9 1384.44,-2270.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1200,-2244.49C1200,-2253.28 1200,-2265 1200,-2265 1200,-2265 1384.02,-2265 1384.02,-2265"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1384.02,-2267.1 1390.02,-2265 1384.02,-2262.9 1384.02,-2267.1"/>
 </g>
 <!-- src/extract/resolve/module&#45;classifiers.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge141" class="edge">
 <title>src/extract/resolve/module&#45;classifiers.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1493.59,-2270.4C1493.59,-2270.4 1563.6,-2270.4 1563.6,-2270.4"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.6,-2272.5 1569.6,-2270.4 1563.6,-2268.3 1563.6,-2272.5"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1482,-2280.33C1482,-2285 1482,-2289.67 1482,-2289.67 1482,-2289.67 1563.59,-2289.67 1563.59,-2289.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.59,-2291.77 1569.59,-2289.67 1563.59,-2287.57 1563.59,-2291.77"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge145" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.95,-2212C1364.56,-2212 1438,-2212 1438,-2212 1438,-2212 1438,-2218.66 1438,-2218.66"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1435.9,-2218.66 1438,-2224.66 1440.1,-2218.66 1435.9,-2218.66"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.95,-2204C1364.56,-2204 1438,-2204 1438,-2204 1438,-2204 1438,-2220.78 1438,-2220.78"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1435.9,-2220.78 1438,-2226.78 1440.1,-2220.78 1435.9,-2220.78"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge143" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.82,-2208C1318.82,-2208 1564.56,-2208 1564.56,-2208"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.56,-2210.1 1570.56,-2208 1564.56,-2205.9 1564.56,-2210.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1296,-2216.4C1296,-2218.22 1296,-2219.57 1296,-2219.57 1296,-2219.57 1564.58,-2219.57 1564.58,-2219.57"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.58,-2221.67 1570.58,-2219.57 1564.58,-2217.47 1564.58,-2221.67"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge144" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.89,-2214C1355.38,-2214 1407,-2214 1407,-2214 1407,-2214 1407,-2252.56 1407,-2252.56"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1404.9,-2252.56 1407,-2258.56 1409.1,-2252.56 1404.9,-2252.56"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.97,-2210C1354.83,-2210 1405,-2210 1405,-2210 1405,-2210 1405,-2252.71 1405,-2252.71"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1402.9,-2252.71 1405,-2258.71 1407.1,-2252.71 1402.9,-2252.71"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="edge146" class="edge">
 <title>src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.29,-2239.2C1207.27,-2239.2 1238,-2239.2 1238,-2239.2 1238,-2239.2 1238,-2239.47 1238,-2239.47"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1235.9,-2232.91 1238,-2238.91 1240.1,-2232.91 1235.9,-2232.91"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.45,-2268C1202.59,-2268 1226,-2268 1226,-2268 1226,-2268 1226,-2267.23 1226,-2267.23"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1228.1,-2269.32 1226,-2263.32 1223.9,-2269.32 1228.1,-2269.32"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge147" class="edge">
 <title>src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.27,-2233.6C1255.42,-2233.6 1402,-2233.6 1402,-2233.6 1402,-2233.6 1402,-2252.54 1402,-2252.54"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1399.9,-2252.54 1402,-2258.54 1404.1,-2252.54 1399.9,-2252.54"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.43,-2271C1179.43,-2271 1384.1,-2271 1384.1,-2271"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1384.1,-2273.1 1390.1,-2271 1384.1,-2268.9 1384.1,-2273.1"/>
 </g>
 <!-- src/extract/transpile/meta.d.ts -->
 <g id="node105" class="node">
@@ -2430,7 +2430,7 @@
 <!-- src/graph&#45;utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/graph&#45;utl/consolidate&#45;module&#45;dependencies.js -->
 <g id="edge165" class="edge">
 <title>src/graph&#45;utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/graph&#45;utl/consolidate&#45;module&#45;dependencies.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1338.76,-1167.5C1353.3,-1167.5 1365,-1167.5 1365,-1167.5 1365,-1167.5 1365,-1174.48 1365,-1174.48"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1338.76,-1163C1353.3,-1163 1365,-1163 1365,-1163 1365,-1163 1365,-1174.48 1365,-1174.48"/>
 <polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1362.9,-1174.48 1365,-1180.48 1367.1,-1174.48 1362.9,-1174.48"/>
 </g>
 <!-- src/graph&#45;utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/graph&#45;utl/consolidate&#45;modules.js -->
@@ -2457,8 +2457,8 @@
 <!-- src/graph&#45;utl/consolidate&#45;to&#45;pattern.js&#45;&gt;src/graph&#45;utl/consolidate&#45;modules.js -->
 <g id="edge168" class="edge">
 <title>src/graph&#45;utl/consolidate&#45;to&#45;pattern.js&#45;&gt;src/graph&#45;utl/consolidate&#45;modules.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1341.41,-1190C1350.52,-1190 1357,-1190 1357,-1190 1357,-1190 1357,-1163 1357,-1163 1357,-1163 1378.71,-1163 1378.71,-1163"/>
-<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1378.71,-1165.1 1384.71,-1163 1378.71,-1160.9 1378.71,-1165.1"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1341.41,-1190C1350.52,-1190 1357,-1190 1357,-1190 1357,-1190 1357,-1167.5 1357,-1167.5 1357,-1167.5 1378.71,-1167.5 1378.71,-1167.5"/>
+<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1378.71,-1169.6 1384.71,-1167.5 1378.71,-1165.4 1378.71,-1169.6"/>
 </g>
 <!-- src/graph&#45;utl/filter&#45;bank.js -->
 <g id="node116" class="node">

--- a/docs/assets/berry-high-level-dependencies.html
+++ b/docs/assets/berry-high-level-dependencies.html
@@ -106,8 +106,6 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/assets/berry-high-level-dependencies.html
+++ b/docs/assets/berry-high-level-dependencies.html
@@ -102,10 +102,12 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/assets/react-high-level-dependencies.html
+++ b/docs/assets/react-high-level-dependencies.html
@@ -106,8 +106,6 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/assets/react-high-level-dependencies.html
+++ b/docs/assets/react-high-level-dependencies.html
@@ -102,10 +102,12 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/dependency-cruiser-archi-graph.html
+++ b/docs/dependency-cruiser-archi-graph.html
@@ -106,8 +106,6 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/dependency-cruiser-archi-graph.html
+++ b/docs/dependency-cruiser-archi-graph.html
@@ -102,10 +102,12 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -106,8 +106,6 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/dependency-cruiser-dependency-graph.html
+++ b/docs/dependency-cruiser-dependency-graph.html
@@ -102,10 +102,12 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
@@ -166,6 +168,21 @@
 <title>cluster_src/report</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M794.5,-568C794.5,-568 1306.5,-568 1306.5,-568 1312.5,-568 1318.5,-574 1318.5,-580 1318.5,-580 1318.5,-946 1318.5,-946 1318.5,-952 1312.5,-958 1306.5,-958 1306.5,-958 794.5,-958 794.5,-958 788.5,-958 782.5,-952 782.5,-946 782.5,-946 782.5,-580 782.5,-580 782.5,-574 788.5,-568 794.5,-568"/>
 <text text-anchor="middle" x="1050.5" y="-946.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">report</text>
+</g>
+<g id="clust31" class="cluster">
+<title>cluster_src/schema</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M747.5,-1798C747.5,-1798 887.5,-1798 887.5,-1798 893.5,-1798 899.5,-1804 899.5,-1810 899.5,-1810 899.5,-2008 899.5,-2008 899.5,-2014 893.5,-2020 887.5,-2020 887.5,-2020 747.5,-2020 747.5,-2020 741.5,-2020 735.5,-2014 735.5,-2008 735.5,-2008 735.5,-1810 735.5,-1810 735.5,-1804 741.5,-1798 747.5,-1798"/>
+<text text-anchor="middle" x="817.5" y="-2008.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">schema</text>
+</g>
+<g id="clust32" class="cluster">
+<title>cluster_src/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1703.5,-972C1703.5,-972 1788.5,-972 1788.5,-972 1794.5,-972 1800.5,-978 1800.5,-984 1800.5,-984 1800.5,-1072 1800.5,-1072 1800.5,-1078 1794.5,-1084 1788.5,-1084 1788.5,-1084 1703.5,-1084 1703.5,-1084 1697.5,-1084 1691.5,-1078 1691.5,-1072 1691.5,-1072 1691.5,-984 1691.5,-984 1691.5,-978 1697.5,-972 1703.5,-972"/>
+<text text-anchor="middle" x="1746" y="-1072.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust33" class="cluster">
+<title>cluster_src/validate</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1259.5,-976C1259.5,-976 1652,-976 1652,-976 1658,-976 1664,-982 1664,-988 1664,-988 1664,-1106 1664,-1106 1664,-1112 1658,-1118 1652,-1118 1652,-1118 1259.5,-1118 1259.5,-1118 1253.5,-1118 1247.5,-1112 1247.5,-1106 1247.5,-1106 1247.5,-988 1247.5,-988 1247.5,-982 1253.5,-976 1259.5,-976"/>
+<text text-anchor="middle" x="1455.75" y="-1106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">validate</text>
 </g>
 <g id="clust3" class="cluster">
 <title>cluster_src/cache</title>
@@ -237,6 +254,21 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M646,-2128C646,-2128 1799,-2128 1799,-2128 1805,-2128 1811,-2134 1811,-2140 1811,-2140 1811,-2816 1811,-2816 1811,-2822 1805,-2828 1799,-2828 1799,-2828 646,-2828 646,-2828 640,-2828 634,-2822 634,-2816 634,-2816 634,-2140 634,-2140 634,-2134 640,-2128 646,-2128"/>
 <text text-anchor="middle" x="1222.5" y="-2816.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
 </g>
+<g id="clust21" class="cluster">
+<title>cluster_src/extract/transpile</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1260.5,-2436C1260.5,-2436 1791,-2436 1791,-2436 1797,-2436 1803,-2442 1803,-2448 1803,-2448 1803,-2656 1803,-2656 1803,-2662 1797,-2668 1791,-2668 1791,-2668 1260.5,-2668 1260.5,-2668 1254.5,-2668 1248.5,-2662 1248.5,-2656 1248.5,-2656 1248.5,-2448 1248.5,-2448 1248.5,-2442 1254.5,-2436 1260.5,-2436"/>
+<text text-anchor="middle" x="1525.75" y="-2656.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
+</g>
+<g id="clust22" class="cluster">
+<title>cluster_src/extract/utl</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1547.5,-2209C1547.5,-2209 1773,-2209 1773,-2209 1779,-2209 1785,-2215 1785,-2221 1785,-2221 1785,-2369 1785,-2369 1785,-2375 1779,-2381 1773,-2381 1773,-2381 1547.5,-2381 1547.5,-2381 1541.5,-2381 1535.5,-2375 1535.5,-2369 1535.5,-2369 1535.5,-2221 1535.5,-2221 1535.5,-2215 1541.5,-2209 1547.5,-2209"/>
+<text text-anchor="middle" x="1660.25" y="-2369.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
+</g>
+<g id="clust17" class="cluster">
+<title>cluster_src/extract/ast&#45;extractors</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M921.5,-2676C921.5,-2676 1322,-2676 1322,-2676 1328,-2676 1334,-2682 1334,-2688 1334,-2688 1334,-2790 1334,-2790 1334,-2796 1328,-2802 1322,-2802 1322,-2802 921.5,-2802 921.5,-2802 915.5,-2802 909.5,-2796 909.5,-2790 909.5,-2790 909.5,-2688 909.5,-2688 909.5,-2682 915.5,-2676 921.5,-2676"/>
+<text text-anchor="middle" x="1121.75" y="-2790.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
+</g>
 <g id="clust18" class="cluster">
 <title>cluster_src/extract/parse</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1093.5,-2422C1093.5,-2422 1175.5,-2422 1175.5,-2422 1181.5,-2422 1187.5,-2428 1187.5,-2434 1187.5,-2434 1187.5,-2522 1187.5,-2522 1187.5,-2528 1181.5,-2534 1175.5,-2534 1175.5,-2534 1093.5,-2534 1093.5,-2534 1087.5,-2534 1081.5,-2528 1081.5,-2522 1081.5,-2522 1081.5,-2434 1081.5,-2434 1081.5,-2428 1087.5,-2422 1093.5,-2422"/>
@@ -251,36 +283,6 @@
 <title>cluster_src/extract/resolve/get&#45;manifest</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1111.5,-2296C1111.5,-2296 1326.5,-2296 1326.5,-2296 1332.5,-2296 1338.5,-2302 1338.5,-2308 1338.5,-2308 1338.5,-2336 1338.5,-2336 1338.5,-2342 1332.5,-2348 1326.5,-2348 1326.5,-2348 1111.5,-2348 1111.5,-2348 1105.5,-2348 1099.5,-2342 1099.5,-2336 1099.5,-2336 1099.5,-2308 1099.5,-2308 1099.5,-2302 1105.5,-2296 1111.5,-2296"/>
 <text text-anchor="middle" x="1219" y="-2336.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">get&#45;manifest</text>
-</g>
-<g id="clust21" class="cluster">
-<title>cluster_src/extract/transpile</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1260.5,-2436C1260.5,-2436 1791,-2436 1791,-2436 1797,-2436 1803,-2442 1803,-2448 1803,-2448 1803,-2656 1803,-2656 1803,-2662 1797,-2668 1791,-2668 1791,-2668 1260.5,-2668 1260.5,-2668 1254.5,-2668 1248.5,-2662 1248.5,-2656 1248.5,-2656 1248.5,-2448 1248.5,-2448 1248.5,-2442 1254.5,-2436 1260.5,-2436"/>
-<text text-anchor="middle" x="1525.75" y="-2656.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">transpile</text>
-</g>
-<g id="clust22" class="cluster">
-<title>cluster_src/extract/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1547.5,-2196C1547.5,-2196 1773,-2196 1773,-2196 1779,-2196 1785,-2202 1785,-2208 1785,-2208 1785,-2356 1785,-2356 1785,-2362 1779,-2368 1773,-2368 1773,-2368 1547.5,-2368 1547.5,-2368 1541.5,-2368 1535.5,-2362 1535.5,-2356 1535.5,-2356 1535.5,-2208 1535.5,-2208 1535.5,-2202 1541.5,-2196 1547.5,-2196"/>
-<text text-anchor="middle" x="1660.25" y="-2356.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust17" class="cluster">
-<title>cluster_src/extract/ast&#45;extractors</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M921.5,-2676C921.5,-2676 1322,-2676 1322,-2676 1328,-2676 1334,-2682 1334,-2688 1334,-2688 1334,-2790 1334,-2790 1334,-2796 1328,-2802 1322,-2802 1322,-2802 921.5,-2802 921.5,-2802 915.5,-2802 909.5,-2796 909.5,-2790 909.5,-2790 909.5,-2688 909.5,-2688 909.5,-2682 915.5,-2676 921.5,-2676"/>
-<text text-anchor="middle" x="1121.75" y="-2790.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">ast&#45;extractors</text>
-</g>
-<g id="clust31" class="cluster">
-<title>cluster_src/schema</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M747.5,-1798C747.5,-1798 887.5,-1798 887.5,-1798 893.5,-1798 899.5,-1804 899.5,-1810 899.5,-1810 899.5,-2008 899.5,-2008 899.5,-2014 893.5,-2020 887.5,-2020 887.5,-2020 747.5,-2020 747.5,-2020 741.5,-2020 735.5,-2014 735.5,-2008 735.5,-2008 735.5,-1810 735.5,-1810 735.5,-1804 741.5,-1798 747.5,-1798"/>
-<text text-anchor="middle" x="817.5" y="-2008.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">schema</text>
-</g>
-<g id="clust32" class="cluster">
-<title>cluster_src/utl</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1703.5,-972C1703.5,-972 1788.5,-972 1788.5,-972 1794.5,-972 1800.5,-978 1800.5,-984 1800.5,-984 1800.5,-1072 1800.5,-1072 1800.5,-1078 1794.5,-1084 1788.5,-1084 1788.5,-1084 1703.5,-1084 1703.5,-1084 1697.5,-1084 1691.5,-1078 1691.5,-1072 1691.5,-1072 1691.5,-984 1691.5,-984 1691.5,-978 1697.5,-972 1703.5,-972"/>
-<text text-anchor="middle" x="1746" y="-1072.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">utl</text>
-</g>
-<g id="clust33" class="cluster">
-<title>cluster_src/validate</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1259.5,-976C1259.5,-976 1652,-976 1652,-976 1658,-976 1664,-982 1664,-988 1664,-988 1664,-1106 1664,-1106 1664,-1112 1658,-1118 1652,-1118 1652,-1118 1259.5,-1118 1259.5,-1118 1253.5,-1118 1247.5,-1112 1247.5,-1106 1247.5,-1106 1247.5,-988 1247.5,-988 1247.5,-982 1253.5,-976 1259.5,-976"/>
-<text text-anchor="middle" x="1455.75" y="-1106.8" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">validate</text>
 </g>
 <!-- bin/depcruise&#45;baseline.js -->
 <g id="node1" class="node">
@@ -729,23 +731,23 @@
 <!-- src/main/index.js&#45;&gt;src/extract/transpile/meta.js -->
 <g id="edge176" class="edge">
 <title>src/main/index.js&#45;&gt;src/extract/transpile/meta.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M502,-1191.24C502,-1299.89 502,-2330 502,-2330 502,-2330 1439,-2330 1439,-2330 1439,-2330 1439,-2494.65 1439,-2494.65"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1436.9,-2494.65 1439,-2500.65 1441.1,-2494.65 1436.9,-2494.65"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M502,-1191.21C502,-1301.64 502,-2368.5 502,-2368.5 502,-2368.5 1439,-2368.5 1439,-2368.5 1439,-2368.5 1439,-2494.49 1439,-2494.49"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1436.9,-2494.49 1439,-2500.49 1441.1,-2494.49 1436.9,-2494.49"/>
 </g>
 <!-- src/extract/index.js -->
 <g id="node93" class="node">
 <title>src/extract/index.js</title>
 <g id="a_node93"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/index.js" xlink:title="index.js">
-<path fill="#ccffcc" stroke="black" d="M690,-2221C690,-2221 648,-2221 648,-2221 645,-2221 642,-2218 642,-2215 642,-2215 642,-2209 642,-2209 642,-2206 645,-2203 648,-2203 648,-2203 690,-2203 690,-2203 693,-2203 696,-2206 696,-2209 696,-2209 696,-2215 696,-2215 696,-2218 693,-2221 690,-2221"/>
-<text text-anchor="start" x="653" y="-2209.8" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
+<path fill="#ccffcc" stroke="black" d="M690,-2287C690,-2287 648,-2287 648,-2287 645,-2287 642,-2284 642,-2281 642,-2281 642,-2275 642,-2275 642,-2272 645,-2269 648,-2269 648,-2269 690,-2269 690,-2269 693,-2269 696,-2272 696,-2275 696,-2275 696,-2281 696,-2281 696,-2284 693,-2287 690,-2287"/>
+<text text-anchor="start" x="653" y="-2275.8" font-family="Helvetica,sans-Serif" font-size="9.00">index.js</text>
 </a>
 </g>
 </g>
 <!-- src/main/index.js&#45;&gt;src/extract/index.js -->
 <g id="edge175" class="edge">
 <title>src/main/index.js&#45;&gt;src/extract/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M508,-1191.22C508,-1293.48 508,-2212 508,-2212 508,-2212 632.66,-2212 632.66,-2212"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="632.66,-2214.1 638.66,-2212 632.66,-2209.9 632.66,-2214.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M508,-1191.47C508,-1298.6 508,-2278 508,-2278 508,-2278 632.66,-2278 632.66,-2278"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="632.66,-2280.1 638.66,-2278 632.66,-2275.9 632.66,-2280.1"/>
 </g>
 <!-- src/main/files&#45;and&#45;dirs/normalize.js -->
 <g id="node118" class="node">
@@ -1138,16 +1140,16 @@
 <g id="node40" class="node">
 <title>src/extract/resolve/resolve.js</title>
 <g id="a_node40"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve.js" xlink:title="resolve.js">
-<path fill="#ccffcc" stroke="black" d="M1465.5,-2246C1465.5,-2246 1421.5,-2246 1421.5,-2246 1418.5,-2246 1415.5,-2243 1415.5,-2240 1415.5,-2240 1415.5,-2234 1415.5,-2234 1415.5,-2231 1418.5,-2228 1421.5,-2228 1421.5,-2228 1465.5,-2228 1465.5,-2228 1468.5,-2228 1471.5,-2231 1471.5,-2234 1471.5,-2234 1471.5,-2240 1471.5,-2240 1471.5,-2243 1468.5,-2246 1465.5,-2246"/>
-<text text-anchor="start" x="1423.5" y="-2234.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve.js</text>
+<path fill="#ccffcc" stroke="black" d="M1465.5,-2248C1465.5,-2248 1421.5,-2248 1421.5,-2248 1418.5,-2248 1415.5,-2245 1415.5,-2242 1415.5,-2242 1415.5,-2236 1415.5,-2236 1415.5,-2233 1418.5,-2230 1421.5,-2230 1421.5,-2230 1465.5,-2230 1465.5,-2230 1468.5,-2230 1471.5,-2233 1471.5,-2236 1471.5,-2236 1471.5,-2242 1471.5,-2242 1471.5,-2245 1468.5,-2248 1465.5,-2248"/>
+<text text-anchor="start" x="1423.5" y="-2236.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve.js</text>
 </a>
 </g>
 </g>
 <!-- src/config&#45;utl/extract&#45;depcruise&#45;config/index.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge53" class="edge">
 <title>src/config&#45;utl/extract&#45;depcruise&#45;config/index.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M549.76,-713.5C562.11,-713.5 574,-713.5 574,-713.5 574,-713.5 574,-1420 574,-1420 574,-1420 1450,-1420 1450,-1420 1450,-1420 1450,-2218.52 1450,-2218.52"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1447.9,-2218.52 1450,-2224.52 1452.1,-2218.52 1447.9,-2218.52"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M549.76,-713.5C562.11,-713.5 574,-713.5 574,-713.5 574,-713.5 574,-1420 574,-1420 574,-1420 1450,-1420 1450,-1420 1450,-1420 1450,-2220.49 1450,-2220.49"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1447.9,-2220.49 1450,-2226.49 1452.1,-2220.49 1447.9,-2220.49"/>
 </g>
 <!-- src/config&#45;utl/extract&#45;depcruise&#45;config/index.js&#45;&gt;src/main/resolve&#45;options/normalize.js -->
 <g id="edge54" class="edge">
@@ -1189,31 +1191,31 @@
 <g id="node87" class="node">
 <title>src/extract/utl/path&#45;to&#45;posix.js</title>
 <g id="a_node87"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/path-to-posix.js" xlink:title="path&#45;to&#45;posix.js">
-<path fill="#ccffcc" stroke="black" d="M1647,-2222C1647,-2222 1580,-2222 1580,-2222 1577,-2222 1574,-2219 1574,-2216 1574,-2216 1574,-2210 1574,-2210 1574,-2207 1577,-2204 1580,-2204 1580,-2204 1647,-2204 1647,-2204 1650,-2204 1653,-2207 1653,-2210 1653,-2210 1653,-2216 1653,-2216 1653,-2219 1650,-2222 1647,-2222"/>
-<text text-anchor="start" x="1582" y="-2210.8" font-family="Helvetica,sans-Serif" font-size="9.00">path&#45;to&#45;posix.js</text>
+<path fill="#ccffcc" stroke="black" d="M1647,-2235C1647,-2235 1580,-2235 1580,-2235 1577,-2235 1574,-2232 1574,-2229 1574,-2229 1574,-2223 1574,-2223 1574,-2220 1577,-2217 1580,-2217 1580,-2217 1647,-2217 1647,-2217 1650,-2217 1653,-2220 1653,-2223 1653,-2223 1653,-2229 1653,-2229 1653,-2232 1650,-2235 1647,-2235"/>
+<text text-anchor="start" x="1582" y="-2223.8" font-family="Helvetica,sans-Serif" font-size="9.00">path&#45;to&#45;posix.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge148" class="edge">
 <title>src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1461,-2227.56C1461,-2219.77 1461,-2210 1461,-2210 1461,-2210 1564.8,-2210 1564.8,-2210"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.8,-2212.1 1570.8,-2210 1564.8,-2207.9 1564.8,-2212.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1461,-2229.55C1461,-2226.89 1461,-2224.71 1461,-2224.71 1461,-2224.71 1564.8,-2224.71 1564.8,-2224.71"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.8,-2226.81 1570.8,-2224.71 1564.8,-2222.61 1564.8,-2226.81"/>
 </g>
 <!-- src/extract/utl/strip&#45;query&#45;parameters.js -->
 <g id="node100" class="node">
 <title>src/extract/utl/strip&#45;query&#45;parameters.js</title>
 <g id="a_node100"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/strip-query-parameters.js" xlink:title="strip&#45;query&#45;parameters.js">
-<path fill="#ccffcc" stroke="black" d="M1667,-2252C1667,-2252 1560,-2252 1560,-2252 1557,-2252 1554,-2249 1554,-2246 1554,-2246 1554,-2240 1554,-2240 1554,-2237 1557,-2234 1560,-2234 1560,-2234 1667,-2234 1667,-2234 1670,-2234 1673,-2237 1673,-2240 1673,-2240 1673,-2246 1673,-2246 1673,-2249 1670,-2252 1667,-2252"/>
-<text text-anchor="start" x="1562" y="-2240.8" font-family="Helvetica,sans-Serif" font-size="9.00">strip&#45;query&#45;parameters.js</text>
+<path fill="#ccffcc" stroke="black" d="M1667,-2265C1667,-2265 1560,-2265 1560,-2265 1557,-2265 1554,-2262 1554,-2259 1554,-2259 1554,-2253 1554,-2253 1554,-2250 1557,-2247 1560,-2247 1560,-2247 1667,-2247 1667,-2247 1670,-2247 1673,-2250 1673,-2253 1673,-2253 1673,-2259 1673,-2259 1673,-2262 1670,-2265 1667,-2265"/>
+<text text-anchor="start" x="1562" y="-2253.8" font-family="Helvetica,sans-Serif" font-size="9.00">strip&#45;query&#45;parameters.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/strip&#45;query&#45;parameters.js -->
 <g id="edge149" class="edge">
 <title>src/extract/resolve/resolve.js&#45;&gt;src/extract/utl/strip&#45;query&#45;parameters.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1471.95,-2240C1471.95,-2240 1544.52,-2240 1544.52,-2240"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1544.52,-2242.1 1550.52,-2240 1544.52,-2237.9 1544.52,-2242.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1471.83,-2241C1508.29,-2241 1567,-2241 1567,-2241 1567,-2241 1567,-2241.58 1567,-2241.58"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.9,-2237.73 1567,-2243.73 1569.1,-2237.73 1564.9,-2237.73"/>
 </g>
 <!-- src/graph&#45;utl/rule&#45;set.js -->
 <g id="node68" class="node">
@@ -1233,8 +1235,8 @@
 <!-- src/main/resolve&#45;options/normalize.js&#45;&gt;src/extract/transpile/meta.js -->
 <g id="edge194" class="edge">
 <title>src/main/resolve&#45;options/normalize.js&#45;&gt;src/extract/transpile/meta.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M702.45,-1084.5C839.78,-1084.5 1353,-1084.5 1353,-1084.5 1353,-1084.5 1353,-2508.5 1353,-2508.5 1353,-2508.5 1407.32,-2508.5 1407.32,-2508.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.32,-2510.6 1413.32,-2508.5 1407.32,-2506.4 1407.32,-2510.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M702.4,-1084.5C839.53,-1084.5 1352,-1084.5 1352,-1084.5 1352,-1084.5 1352,-2508.5 1352,-2508.5 1352,-2508.5 1407.02,-2508.5 1407.02,-2508.5"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.02,-2510.6 1413.02,-2508.5 1407.02,-2506.4 1407.02,-2510.6"/>
 </g>
 <!-- src/enrich/add&#45;validations.js -->
 <g id="node44" class="node">
@@ -1389,8 +1391,8 @@
 <!-- src/enrich/derive/folders&#45;&gt;src/validate/index.js -->
 <g id="edge62" class="edge">
 <title>src/enrich/derive/folders&#45;&gt;src/validate/index.js</title>
-<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1161.9,-1698.5C1179.85,-1698.5 1200,-1698.5 1200,-1698.5 1200,-1698.5 1200,-1069 1200,-1069 1200,-1069 1247.13,-1069 1247.13,-1069"/>
-<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1247.13,-1071.1 1253.13,-1069 1247.13,-1066.9 1247.13,-1071.1"/>
+<path fill="none" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" d="M1161.95,-1698.5C1180.64,-1698.5 1202,-1698.5 1202,-1698.5 1202,-1698.5 1202,-1069 1202,-1069 1202,-1069 1247.33,-1069 1247.33,-1069"/>
+<polygon fill="#0000ff" fill-opacity="0.466667" stroke="#0000ff" stroke-width="2" stroke-opacity="0.466667" points="1247.33,-1071.1 1253.33,-1069 1247.33,-1066.9 1247.33,-1071.1"/>
 </g>
 <!-- src/enrich/derive/folders&#45;&gt;src/enrich/derive/module&#45;utl.js -->
 <g id="edge64" class="edge">
@@ -1617,8 +1619,8 @@
 <!-- src/graph&#45;utl/add&#45;focus.js&#45;&gt;src/graph&#45;utl/indexed&#45;module&#45;graph.js -->
 <g id="edge161" class="edge">
 <title>src/graph&#45;utl/add&#45;focus.js&#45;&gt;src/graph&#45;utl/indexed&#45;module&#45;graph.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1476.75,-1283C1512.41,-1283 1564,-1283 1564,-1283 1564,-1283 1564,-1268.4 1564,-1268.4"/>
-<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1566.1,-1268.4 1564,-1262.4 1561.9,-1268.4 1566.1,-1268.4"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1476.86,-1283C1511.59,-1283 1561,-1283 1561,-1283 1561,-1283 1561,-1268.4 1561,-1268.4"/>
+<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1563.1,-1268.4 1561,-1262.4 1558.9,-1268.4 1563.1,-1268.4"/>
 </g>
 <!-- src/enrich/summarize/is&#45;same&#45;violation.js -->
 <g id="node61" class="node">
@@ -1887,8 +1889,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge104" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.82,-2388C1083.07,-2388 1213,-2388 1213,-2388 1213,-2388 1213,-2230.8 1213,-2230.8 1213,-2230.8 1406.21,-2230.8 1406.21,-2230.8"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.21,-2232.9 1412.21,-2230.8 1406.21,-2228.7 1406.21,-2232.9"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.82,-2386.5C1083.07,-2386.5 1213,-2386.5 1213,-2386.5 1213,-2386.5 1213,-2234 1213,-2234 1213,-2234 1406.21,-2234 1406.21,-2234"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.21,-2236.1 1412.21,-2234 1406.21,-2231.9 1406.21,-2236.1"/>
 </g>
 <!-- src/extract/parse/to&#45;javascript&#45;ast.js -->
 <g id="node77" class="node">
@@ -1932,8 +1934,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/parse/to&#45;typescript&#45;ast.js -->
 <g id="edge101" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/parse/to&#45;typescript&#45;ast.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.93,-2394C1051.74,-2394 1099,-2394 1099,-2394 1099,-2394 1099,-2420.87 1099,-2420.87"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1096.9,-2420.87 1099,-2426.87 1101.1,-2420.87 1096.9,-2420.87"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.93,-2395.5C1051.74,-2395.5 1099,-2395.5 1099,-2395.5 1099,-2395.5 1099,-2420.75 1099,-2420.75"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1096.9,-2420.75 1099,-2426.75 1101.1,-2420.75 1096.9,-2420.75"/>
 </g>
 <!-- src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="node80" class="node">
@@ -1947,8 +1949,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="edge102" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1010,-2381.62C1010,-2349.8 1010,-2248 1010,-2248 1010,-2248 1211.04,-2248 1211.04,-2248"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.04,-2250.1 1217.04,-2248 1211.04,-2245.9 1211.04,-2250.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1015.86,-2391C1087.53,-2391 1232,-2391 1232,-2391 1232,-2391 1232,-2269.21 1232,-2269.21"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1234.1,-2269.21 1232,-2263.21 1229.9,-2269.21 1234.1,-2269.21"/>
 </g>
 <!-- src/extract/resolve/get&#45;manifest/index.js -->
 <g id="node81" class="node">
@@ -1962,8 +1964,8 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js -->
 <g id="edge103" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1013,-2381.5C1013,-2361.32 1013,-2316 1013,-2316 1013,-2316 1098.21,-2316 1098.21,-2316"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1098.21,-2318.1 1104.21,-2316 1098.21,-2313.9 1098.21,-2318.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1012,-2381.5C1012,-2361.32 1012,-2316 1012,-2316 1012,-2316 1097.98,-2316 1097.98,-2316"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1097.98,-2318.1 1103.98,-2316 1097.98,-2313.9 1097.98,-2318.1"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;amd.js -->
 <g id="node82" class="node">
@@ -1977,23 +1979,23 @@
 <!-- src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js -->
 <g id="edge105" class="edge">
 <title>src/extract/clear&#45;caches.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1007,-2381.84C1007,-2345.21 1007,-2211.25 1007,-2211.25 1007,-2211.25 1086.53,-2211.25 1086.53,-2211.25"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.53,-2213.35 1092.53,-2211.25 1086.53,-2209.15 1086.53,-2213.35"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1008,-2381.67C1008,-2344.38 1008,-2208 1008,-2208 1008,-2208 1086.49,-2208 1086.49,-2208"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.49,-2210.1 1092.49,-2208 1086.49,-2205.9 1086.49,-2210.1"/>
 </g>
 <!-- src/extract/utl/get&#45;extension.js -->
 <g id="node86" class="node">
 <title>src/extract/utl/get&#45;extension.js</title>
 <g id="a_node86"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/get-extension.js" xlink:title="get&#45;extension.js">
-<path fill="#ccffcc" stroke="black" d="M1648,-2282C1648,-2282 1579,-2282 1579,-2282 1576,-2282 1573,-2279 1573,-2276 1573,-2276 1573,-2270 1573,-2270 1573,-2267 1576,-2264 1579,-2264 1579,-2264 1648,-2264 1648,-2264 1651,-2264 1654,-2267 1654,-2270 1654,-2270 1654,-2276 1654,-2276 1654,-2279 1651,-2282 1648,-2282"/>
-<text text-anchor="start" x="1581" y="-2270.8" font-family="Helvetica,sans-Serif" font-size="9.00">get&#45;extension.js</text>
+<path fill="#ccffcc" stroke="black" d="M1648,-2295C1648,-2295 1579,-2295 1579,-2295 1576,-2295 1573,-2292 1573,-2289 1573,-2289 1573,-2283 1573,-2283 1573,-2280 1576,-2277 1579,-2277 1579,-2277 1648,-2277 1648,-2277 1651,-2277 1654,-2280 1654,-2283 1654,-2283 1654,-2289 1654,-2289 1654,-2292 1651,-2295 1648,-2295"/>
+<text text-anchor="start" x="1581" y="-2283.8" font-family="Helvetica,sans-Serif" font-size="9.00">get&#45;extension.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/parse/to&#45;javascript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge126" class="edge">
 <title>src/extract/parse/to&#45;javascript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.91,-2468C1280.05,-2468 1511,-2468 1511,-2468 1511,-2468 1511,-2276.8 1511,-2276.8 1511,-2276.8 1563.67,-2276.8 1563.67,-2276.8"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.67,-2278.9 1569.67,-2276.8 1563.67,-2274.7 1563.67,-2278.9"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.89,-2468C1240.13,-2468 1339,-2468 1339,-2468 1339,-2468 1339,-2293.67 1339,-2293.67 1339,-2293.67 1563.67,-2293.67 1563.67,-2293.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.67,-2295.77 1569.67,-2293.67 1563.67,-2291.57 1563.67,-2295.77"/>
 </g>
 <!-- src/extract/transpile/index.js -->
 <g id="node94" class="node">
@@ -2013,20 +2015,20 @@
 <!-- src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge128" class="edge">
 <title>src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.93,-2434.67C1278.26,-2434.67 1502,-2434.67 1502,-2434.67 1502,-2434.67 1502,-2273.6 1502,-2273.6 1502,-2273.6 1563.59,-2273.6 1563.59,-2273.6"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.59,-2275.7 1569.59,-2273.6 1563.59,-2271.5 1563.59,-2275.7"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1171,-2429.83C1171,-2397.72 1171,-2292.33 1171,-2292.33 1171,-2292.33 1563.64,-2292.33 1563.64,-2292.33"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.64,-2294.43 1569.64,-2292.33 1563.64,-2290.23 1563.64,-2294.43"/>
 </g>
 <!-- src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/transpile/index.js -->
 <g id="edge127" class="edge">
 <title>src/extract/parse/to&#45;typescript&#45;ast.js&#45;&gt;src/extract/transpile/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.67,-2439.33C1199.35,-2439.33 1218,-2439.33 1218,-2439.33 1218,-2439.33 1218,-2512.67 1218,-2512.67 1218,-2512.67 1247.07,-2512.67 1247.07,-2512.67"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.67,-2437C1199.35,-2437 1218,-2437 1218,-2437 1218,-2437 1218,-2512.67 1218,-2512.67 1218,-2512.67 1247.07,-2512.67 1247.07,-2512.67"/>
 <polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1247.07,-2514.77 1253.07,-2512.67 1247.07,-2510.57 1247.07,-2514.77"/>
 </g>
 <!-- src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge132" class="edge">
 <title>src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1333,-2241.67C1333,-2238.81 1333,-2236.4 1333,-2236.4 1333,-2236.4 1406.02,-2236.4 1406.02,-2236.4"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.02,-2238.5 1412.02,-2236.4 1406.02,-2234.3 1406.02,-2238.5"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1333,-2241.55C1333,-2239.54 1333,-2238 1333,-2238 1333,-2238 1406.02,-2238 1406.02,-2238"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1406.02,-2240.1 1412.02,-2238 1406.02,-2235.9 1406.02,-2240.1"/>
 </g>
 <!-- src/extract/resolve/module&#45;classifiers.js -->
 <g id="node96" class="node">
@@ -2040,8 +2042,8 @@
 <!-- src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge131" class="edge">
 <title>src/extract/resolve/external&#45;module&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1346.78,-2256C1373.26,-2256 1398,-2256 1398,-2256 1398,-2256 1398,-2256.58 1398,-2256.58"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1395.9,-2252.73 1398,-2258.73 1400.1,-2252.73 1395.9,-2252.73"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1346.86,-2254C1374.19,-2254 1400,-2254 1400,-2254 1400,-2254 1400,-2254.77 1400,-2254.77"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1397.9,-2252.68 1400,-2258.68 1402.1,-2252.68 1397.9,-2252.68"/>
 </g>
 <!-- src/extract/resolve/get&#45;manifest/merge&#45;manifests.js -->
 <g id="node97" class="node">
@@ -2061,8 +2063,8 @@
 <!-- src/extract/resolve/resolve&#45;amd.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge142" class="edge">
 <title>src/extract/resolve/resolve&#45;amd.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1135,-2195.51C1135,-2186.72 1135,-2175 1135,-2175 1135,-2175 1614,-2175 1614,-2175 1614,-2175 1614,-2194.77 1614,-2194.77"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1611.9,-2194.77 1614,-2200.77 1616.1,-2194.77 1611.9,-2194.77"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1135,-2214.41C1135,-2217.82 1135,-2220.86 1135,-2220.86 1135,-2220.86 1564.5,-2220.86 1564.5,-2220.86"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.5,-2222.96 1570.5,-2220.86 1564.5,-2218.76 1564.5,-2222.96"/>
 </g>
 <!-- src/extract/gather&#45;initial&#45;sources.js -->
 <g id="node83" class="node">
@@ -2076,8 +2078,8 @@
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/graph&#45;utl/match&#45;facade.js -->
 <g id="edge106" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/graph&#45;utl/match&#45;facade.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1339.73,-2140.5C1429.21,-2140.5 1594,-2140.5 1594,-2140.5 1594,-2140.5 1594,-1301.36 1594,-1301.36"/>
-<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1596.1,-1301.36 1594,-1295.36 1591.9,-1301.36 1596.1,-1301.36"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1339.94,-2140.5C1434.33,-2140.5 1614,-2140.5 1614,-2140.5 1614,-2140.5 1614,-1301.36 1614,-1301.36"/>
+<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1616.1,-1301.36 1614,-1295.36 1611.9,-1301.36 1616.1,-1301.36"/>
 </g>
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/transpile/meta.js -->
 <g id="edge107" class="edge">
@@ -2088,14 +2090,14 @@
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge108" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1339.91,-2145C1409.58,-2145 1519,-2145 1519,-2145 1519,-2145 1519,-2267.2 1519,-2267.2 1519,-2267.2 1563.57,-2267.2 1563.57,-2267.2"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.57,-2269.3 1569.57,-2267.2 1563.57,-2265.1 1563.57,-2269.3"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1339.84,-2145C1348.7,-2145 1355,-2145 1355,-2145 1355,-2145 1355,-2291 1355,-2291 1355,-2291 1563.51,-2291 1563.51,-2291"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.51,-2293.1 1569.51,-2291 1563.51,-2288.9 1563.51,-2293.1"/>
 </g>
 <!-- src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge109" class="edge">
 <title>src/extract/gather&#45;initial&#45;sources.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1326,-2154.26C1326,-2171.33 1326,-2206 1326,-2206 1326,-2206 1564.5,-2206 1564.5,-2206"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.5,-2208.1 1570.5,-2206 1564.5,-2203.9 1564.5,-2208.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1326,-2154.28C1326,-2174 1326,-2218.29 1326,-2218.29 1326,-2218.29 1564.5,-2218.29 1564.5,-2218.29"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.5,-2220.39 1570.5,-2218.29 1564.5,-2216.19 1564.5,-2220.39"/>
 </g>
 <!-- src/extract/transpile/meta.js&#45;&gt;src/extract/parse/to&#45;swc&#45;ast.js -->
 <g id="edge151" class="edge">
@@ -2283,77 +2285,77 @@
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/resolve/index.js -->
 <g id="edge119" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/resolve/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M801,-2489.7C801,-2447.5 801,-2276 801,-2276 801,-2276 940.05,-2276 940.05,-2276"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="940.05,-2278.1 946.05,-2276 940.05,-2273.9 940.05,-2278.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M801,-2489.58C801,-2447.59 801,-2279.67 801,-2279.67 801,-2279.67 940.05,-2279.67 940.05,-2279.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="940.05,-2281.77 946.05,-2279.67 940.05,-2277.57 940.05,-2281.77"/>
 </g>
 <!-- src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js -->
 <g id="node91" class="node">
 <title>src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js</title>
 <g id="a_node91"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/detect-pre-compilation-ness.js" xlink:title="detect&#45;pre&#45;compilation&#45;ness.js">
-<path fill="#ccffcc" stroke="black" d="M1677.5,-2312C1677.5,-2312 1549.5,-2312 1549.5,-2312 1546.5,-2312 1543.5,-2309 1543.5,-2306 1543.5,-2306 1543.5,-2300 1543.5,-2300 1543.5,-2297 1546.5,-2294 1549.5,-2294 1549.5,-2294 1677.5,-2294 1677.5,-2294 1680.5,-2294 1683.5,-2297 1683.5,-2300 1683.5,-2300 1683.5,-2306 1683.5,-2306 1683.5,-2309 1680.5,-2312 1677.5,-2312"/>
-<text text-anchor="start" x="1551.5" y="-2300.8" font-family="Helvetica,sans-Serif" font-size="9.00">detect&#45;pre&#45;compilation&#45;ness.js</text>
+<path fill="#ccffcc" stroke="black" d="M1677.5,-2325C1677.5,-2325 1549.5,-2325 1549.5,-2325 1546.5,-2325 1543.5,-2322 1543.5,-2319 1543.5,-2319 1543.5,-2313 1543.5,-2313 1543.5,-2310 1546.5,-2307 1549.5,-2307 1549.5,-2307 1677.5,-2307 1677.5,-2307 1680.5,-2307 1683.5,-2310 1683.5,-2313 1683.5,-2313 1683.5,-2319 1683.5,-2319 1683.5,-2322 1680.5,-2325 1677.5,-2325"/>
+<text text-anchor="start" x="1551.5" y="-2313.8" font-family="Helvetica,sans-Serif" font-size="9.00">detect&#45;pre&#45;compilation&#45;ness.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js -->
 <g id="edge120" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818,-2489.62C818,-2450.08 818,-2299 818,-2299 818,-2299 1534.23,-2299 1534.23,-2299"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1534.23,-2301.1 1540.23,-2299 1534.23,-2296.9 1534.23,-2301.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M818,-2489.65C818,-2450.2 818,-2299.5 818,-2299.5 818,-2299.5 1549,-2299.5 1549,-2299.5 1549,-2299.5 1549,-2300.21 1549,-2300.21"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1546.9,-2297.57 1549,-2303.57 1551.1,-2297.57 1546.9,-2297.57"/>
 </g>
 <!-- src/extract/utl/extract&#45;module&#45;attributes.js -->
 <g id="node92" class="node">
 <title>src/extract/utl/extract&#45;module&#45;attributes.js</title>
 <g id="a_node92"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/extract-module-attributes.js" xlink:title="extract&#45;module&#45;attributes.js">
-<path fill="#ccffcc" stroke="black" d="M1671,-2342C1671,-2342 1556,-2342 1556,-2342 1553,-2342 1550,-2339 1550,-2336 1550,-2336 1550,-2330 1550,-2330 1550,-2327 1553,-2324 1556,-2324 1556,-2324 1671,-2324 1671,-2324 1674,-2324 1677,-2327 1677,-2330 1677,-2330 1677,-2336 1677,-2336 1677,-2339 1674,-2342 1671,-2342"/>
-<text text-anchor="start" x="1558" y="-2330.8" font-family="Helvetica,sans-Serif" font-size="9.00">extract&#45;module&#45;attributes.js</text>
+<path fill="#ccffcc" stroke="black" d="M1671,-2355C1671,-2355 1556,-2355 1556,-2355 1553,-2355 1550,-2352 1550,-2349 1550,-2349 1550,-2343 1550,-2343 1550,-2340 1553,-2337 1556,-2337 1556,-2337 1671,-2337 1671,-2337 1674,-2337 1677,-2340 1677,-2343 1677,-2343 1677,-2349 1677,-2349 1677,-2352 1674,-2355 1671,-2355"/>
+<text text-anchor="start" x="1558" y="-2343.8" font-family="Helvetica,sans-Serif" font-size="9.00">extract&#45;module&#45;attributes.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/extract&#45;module&#45;attributes.js -->
 <g id="edge121" class="edge">
 <title>src/extract/get&#45;dependencies.js&#45;&gt;src/extract/utl/extract&#45;module&#45;attributes.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M835,-2489.77C835,-2455.29 835,-2336 835,-2336 835,-2336 1540.76,-2336 1540.76,-2336"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1540.77,-2338.1 1546.76,-2336 1540.76,-2333.9 1540.77,-2338.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M835,-2489.89C835,-2456.95 835,-2346 835,-2346 835,-2346 1540.76,-2346 1540.76,-2346"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1540.77,-2348.1 1546.76,-2346 1540.76,-2343.9 1540.77,-2348.1"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js -->
 <g id="edge136" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/get&#45;manifest/index.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M986,-2285.29C986,-2295.36 986,-2310 986,-2310 986,-2310 1098.24,-2310 1098.24,-2310"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1098.24,-2312.1 1104.24,-2310 1098.24,-2307.9 1098.24,-2312.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M968,-2285.29C968,-2295.36 968,-2310 968,-2310 968,-2310 1097.98,-2310 1097.98,-2310"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1097.98,-2312.1 1103.98,-2310 1097.98,-2307.9 1097.98,-2312.1"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js -->
 <g id="edge138" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;amd.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M982,-2266.61C982,-2248.07 982,-2208.5 982,-2208.5 982,-2208.5 1086.6,-2208.5 1086.6,-2208.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.6,-2210.6 1092.6,-2208.5 1086.6,-2206.4 1086.6,-2210.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M963,-2266.63C963,-2246.72 963,-2202 963,-2202 963,-2202 1086.56,-2202 1086.56,-2202"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1086.56,-2204.1 1092.56,-2202 1086.56,-2199.9 1086.56,-2204.1"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge134" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M961,-2266.88C961,-2240.25 961,-2164.5 961,-2164.5 961,-2164.5 1634,-2164.5 1634,-2164.5 1634,-2164.5 1634,-2194.62 1634,-2194.62"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1631.9,-2194.62 1634,-2200.62 1636.1,-2194.62 1631.9,-2194.62"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M990,-2266.84C990,-2251.78 990,-2223.43 990,-2223.43 990,-2223.43 1564.52,-2223.43 1564.52,-2223.43"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.52,-2225.53 1570.52,-2223.43 1564.52,-2221.33 1564.52,-2225.53"/>
 </g>
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js -->
 <g id="node95" class="node">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js</title>
 <g id="a_node95"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/determine-dependency-types.js" xlink:title="determine&#45;dependency&#45;types.js">
-<path fill="#ccffcc" stroke="black" d="M1201.5,-2274C1201.5,-2274 1067.5,-2274 1067.5,-2274 1064.5,-2274 1061.5,-2271 1061.5,-2268 1061.5,-2268 1061.5,-2262 1061.5,-2262 1061.5,-2259 1064.5,-2256 1067.5,-2256 1067.5,-2256 1201.5,-2256 1201.5,-2256 1204.5,-2256 1207.5,-2259 1207.5,-2262 1207.5,-2262 1207.5,-2268 1207.5,-2268 1207.5,-2271 1204.5,-2274 1201.5,-2274"/>
-<text text-anchor="start" x="1069.5" y="-2262.8" font-family="Helvetica,sans-Serif" font-size="9.00">determine&#45;dependency&#45;types.js</text>
+<path fill="#ccffcc" stroke="black" d="M1201.5,-2244C1201.5,-2244 1067.5,-2244 1067.5,-2244 1064.5,-2244 1061.5,-2241 1061.5,-2238 1061.5,-2238 1061.5,-2232 1061.5,-2232 1061.5,-2229 1064.5,-2226 1067.5,-2226 1067.5,-2226 1201.5,-2226 1201.5,-2226 1204.5,-2226 1207.5,-2229 1207.5,-2232 1207.5,-2232 1207.5,-2238 1207.5,-2238 1207.5,-2241 1204.5,-2244 1201.5,-2244"/>
+<text text-anchor="start" x="1069.5" y="-2232.8" font-family="Helvetica,sans-Serif" font-size="9.00">determine&#45;dependency&#45;types.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/determine&#45;dependency&#45;types.js -->
 <g id="edge135" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/determine&#45;dependency&#45;types.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1003.66,-2270.5C1003.66,-2270.5 1052.15,-2270.5 1052.15,-2270.5"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1052.15,-2272.6 1058.15,-2270.5 1052.15,-2268.4 1052.15,-2272.6"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1003.95,-2269.33C1030.9,-2269.33 1068,-2269.33 1068,-2269.33 1068,-2269.33 1068,-2253.41 1068,-2253.41"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1070.1,-2253.41 1068,-2247.41 1065.9,-2253.41 1070.1,-2253.41"/>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge137" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M968,-2285.23C968,-2287.6 968,-2289.5 968,-2289.5 968,-2289.5 1405,-2289.5 1405,-2289.5 1405,-2289.5 1405,-2288.57 1405,-2288.57"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.1,-2289.28 1405,-2283.28 1402.9,-2289.28 1407.1,-2289.28"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M986,-2285.47C986,-2287.13 986,-2288.33 986,-2288.33 986,-2288.33 1405,-2288.33 1405,-2288.33 1405,-2288.33 1405,-2287.55 1405,-2287.55"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1407.1,-2289.51 1405,-2283.51 1402.9,-2289.51 1407.1,-2289.51"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js -->
 <g id="node98" class="node">
@@ -2367,55 +2369,55 @@
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;cjs.js -->
 <g id="edge139" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;cjs.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M972,-2266.66C972,-2243.53 972,-2185.5 972,-2185.5 972,-2185.5 1284,-2185.5 1284,-2185.5 1284,-2185.5 1284,-2188.48 1284,-2188.48"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1281.9,-2188.48 1284,-2194.48 1286.1,-2188.48 1281.9,-2188.48"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M977,-2266.62C977,-2251.19 977,-2222.14 977,-2222.14 977,-2222.14 1272,-2222.14 1272,-2222.14 1272,-2222.14 1272,-2221.56 1272,-2221.56"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1274.1,-2225.36 1272,-2219.36 1269.9,-2225.36 1274.1,-2225.36"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js -->
 <g id="node99" class="node">
 <title>src/extract/resolve/resolve&#45;helpers.js</title>
 <g id="a_node99"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/resolve/resolve-helpers.js" xlink:title="resolve&#45;helpers.js">
-<path fill="#ccffcc" stroke="black" d="M1173,-2244C1173,-2244 1096,-2244 1096,-2244 1093,-2244 1090,-2241 1090,-2238 1090,-2238 1090,-2232 1090,-2232 1090,-2229 1093,-2226 1096,-2226 1096,-2226 1173,-2226 1173,-2226 1176,-2226 1179,-2229 1179,-2232 1179,-2232 1179,-2238 1179,-2238 1179,-2241 1176,-2244 1173,-2244"/>
-<text text-anchor="start" x="1098" y="-2232.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve&#45;helpers.js</text>
+<path fill="#ccffcc" stroke="black" d="M1173,-2274C1173,-2274 1096,-2274 1096,-2274 1093,-2274 1090,-2271 1090,-2268 1090,-2268 1090,-2262 1090,-2262 1090,-2259 1093,-2256 1096,-2256 1096,-2256 1173,-2256 1173,-2256 1176,-2256 1179,-2259 1179,-2262 1179,-2262 1179,-2268 1179,-2268 1179,-2271 1176,-2274 1173,-2274"/>
+<text text-anchor="start" x="1098" y="-2262.8" font-family="Helvetica,sans-Serif" font-size="9.00">resolve&#45;helpers.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;helpers.js -->
 <g id="edge140" class="edge">
 <title>src/extract/resolve/index.js&#45;&gt;src/extract/resolve/resolve&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M993,-2266.9C993,-2254.82 993,-2235 993,-2235 993,-2235 1080.7,-2235 1080.7,-2235"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1080.7,-2237.1 1086.7,-2235 1080.7,-2232.9 1080.7,-2237.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1003.66,-2271.67C1003.66,-2271.67 1080.76,-2271.67 1080.76,-2271.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1080.76,-2273.77 1086.76,-2271.67 1080.76,-2269.57 1080.76,-2273.77"/>
 </g>
 <!-- src/extract/utl/compare.js -->
 <g id="node110" class="node">
 <title>src/extract/utl/compare.js</title>
 <g id="a_node110"><a xlink:href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/extract/utl/compare.js" xlink:title="compare.js">
-<path fill="#ccffcc" stroke="black" d="M1771,-2312C1771,-2312 1721,-2312 1721,-2312 1718,-2312 1715,-2309 1715,-2306 1715,-2306 1715,-2300 1715,-2300 1715,-2297 1718,-2294 1721,-2294 1721,-2294 1771,-2294 1771,-2294 1774,-2294 1777,-2297 1777,-2300 1777,-2300 1777,-2306 1777,-2306 1777,-2309 1774,-2312 1771,-2312"/>
-<text text-anchor="start" x="1723" y="-2300.8" font-family="Helvetica,sans-Serif" font-size="9.00">compare.js</text>
+<path fill="#ccffcc" stroke="black" d="M1771,-2325C1771,-2325 1721,-2325 1721,-2325 1718,-2325 1715,-2322 1715,-2319 1715,-2319 1715,-2313 1715,-2313 1715,-2310 1718,-2307 1721,-2307 1721,-2307 1771,-2307 1771,-2307 1774,-2307 1777,-2310 1777,-2313 1777,-2313 1777,-2319 1777,-2319 1777,-2322 1774,-2325 1771,-2325"/>
+<text text-anchor="start" x="1723" y="-2313.8" font-family="Helvetica,sans-Serif" font-size="9.00">compare.js</text>
 </a>
 </g>
 </g>
 <!-- src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js&#45;&gt;src/extract/utl/compare.js -->
 <g id="edge160" class="edge">
 <title>src/extract/utl/detect&#45;pre&#45;compilation&#45;ness.js&#45;&gt;src/extract/utl/compare.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1683.63,-2303C1683.63,-2303 1705.76,-2303 1705.76,-2303"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1705.76,-2305.1 1711.76,-2303 1705.76,-2300.9 1705.76,-2305.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1683.63,-2316C1683.63,-2316 1705.76,-2316 1705.76,-2316"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1705.76,-2318.1 1711.76,-2316 1705.76,-2313.9 1705.76,-2318.1"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/clear&#45;caches.js -->
 <g id="edge122" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/clear&#45;caches.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M696.37,-2205.75C765.93,-2205.75 944,-2205.75 944,-2205.75 944,-2205.75 944,-2372.53 944,-2372.53"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="941.9,-2372.53 944,-2378.53 946.1,-2372.53 941.9,-2372.53"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M696.37,-2274.33C765.93,-2274.33 944,-2274.33 944,-2274.33 944,-2274.33 944,-2372.82 944,-2372.82"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="941.9,-2372.82 944,-2378.82 946.1,-2372.82 941.9,-2372.82"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/gather&#45;initial&#45;sources.js -->
 <g id="edge123" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/gather&#45;initial&#45;sources.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2202.68C669,-2184.27 669,-2145 669,-2145 669,-2145 1218.04,-2145 1218.04,-2145"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2268.86C669,-2238.81 669,-2145 669,-2145 669,-2145 1218.04,-2145 1218.04,-2145"/>
 <polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1218.04,-2147.1 1224.04,-2145 1218.04,-2142.9 1218.04,-2147.1"/>
 </g>
 <!-- src/extract/index.js&#45;&gt;src/extract/get&#45;dependencies.js -->
 <g id="edge124" class="edge">
 <title>src/extract/index.js&#45;&gt;src/extract/get&#45;dependencies.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2221.22C669,-2270.35 669,-2499 669,-2499 669,-2499 758.2,-2499 758.2,-2499"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M669,-2287.5C669,-2329.8 669,-2499 669,-2499 669,-2499 758.2,-2499 758.2,-2499"/>
 <polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="758.2,-2501.1 764.2,-2499 758.2,-2496.9 758.2,-2501.1"/>
 </g>
 <!-- src/extract/transpile/index.js&#45;&gt;src/extract/transpile/meta.js -->
@@ -2427,50 +2429,50 @@
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="edge129" class="edge">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1204,-2255.55C1204,-2253.54 1204,-2252 1204,-2252 1204,-2252 1211.06,-2252 1211.06,-2252"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.06,-2254.1 1217.06,-2252 1211.06,-2249.9 1211.06,-2254.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1204,-2244.24C1204,-2247.33 1204,-2250 1204,-2250 1204,-2250 1211.06,-2250 1211.06,-2250"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1211.06,-2252.1 1217.06,-2250 1211.06,-2247.9 1211.06,-2252.1"/>
 </g>
 <!-- src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge130" class="edge">
 <title>src/extract/resolve/determine&#45;dependency&#45;types.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1207.73,-2268C1207.73,-2268 1384.44,-2268 1384.44,-2268"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1384.44,-2270.1 1390.44,-2268 1384.44,-2265.9 1384.44,-2270.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1200,-2244.49C1200,-2253.28 1200,-2265 1200,-2265 1200,-2265 1384.02,-2265 1384.02,-2265"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1384.02,-2267.1 1390.02,-2265 1384.02,-2262.9 1384.02,-2267.1"/>
 </g>
 <!-- src/extract/resolve/module&#45;classifiers.js&#45;&gt;src/extract/utl/get&#45;extension.js -->
 <g id="edge141" class="edge">
 <title>src/extract/resolve/module&#45;classifiers.js&#45;&gt;src/extract/utl/get&#45;extension.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1493.59,-2270.4C1493.59,-2270.4 1563.6,-2270.4 1563.6,-2270.4"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.6,-2272.5 1569.6,-2270.4 1563.6,-2268.3 1563.6,-2272.5"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1482,-2280.33C1482,-2285 1482,-2289.67 1482,-2289.67 1482,-2289.67 1563.59,-2289.67 1563.59,-2289.67"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1563.59,-2291.77 1569.59,-2289.67 1563.59,-2287.57 1563.59,-2291.77"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve.js -->
 <g id="edge145" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/resolve.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.95,-2212C1364.56,-2212 1438,-2212 1438,-2212 1438,-2212 1438,-2218.66 1438,-2218.66"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1435.9,-2218.66 1438,-2224.66 1440.1,-2218.66 1435.9,-2218.66"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.95,-2204C1364.56,-2204 1438,-2204 1438,-2204 1438,-2204 1438,-2220.78 1438,-2220.78"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1435.9,-2220.78 1438,-2226.78 1440.1,-2220.78 1435.9,-2220.78"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js -->
 <g id="edge143" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/utl/path&#45;to&#45;posix.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.82,-2208C1318.82,-2208 1564.56,-2208 1564.56,-2208"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.56,-2210.1 1570.56,-2208 1564.56,-2205.9 1564.56,-2210.1"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1296,-2216.4C1296,-2218.22 1296,-2219.57 1296,-2219.57 1296,-2219.57 1564.58,-2219.57 1564.58,-2219.57"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1564.58,-2221.67 1570.58,-2219.57 1564.58,-2217.47 1564.58,-2221.67"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge144" class="edge">
 <title>src/extract/resolve/resolve&#45;cjs.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.89,-2214C1355.38,-2214 1407,-2214 1407,-2214 1407,-2214 1407,-2252.56 1407,-2252.56"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1404.9,-2252.56 1407,-2258.56 1409.1,-2252.56 1404.9,-2252.56"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1318.97,-2210C1354.83,-2210 1405,-2210 1405,-2210 1405,-2210 1405,-2252.71 1405,-2252.71"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1402.9,-2252.71 1405,-2258.71 1407.1,-2252.71 1402.9,-2252.71"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js -->
 <g id="edge146" class="edge">
 <title>src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/external&#45;module&#45;helpers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.29,-2239.2C1207.27,-2239.2 1238,-2239.2 1238,-2239.2 1238,-2239.2 1238,-2239.47 1238,-2239.47"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1235.9,-2232.91 1238,-2238.91 1240.1,-2232.91 1235.9,-2232.91"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.45,-2268C1202.59,-2268 1226,-2268 1226,-2268 1226,-2268 1226,-2267.23 1226,-2267.23"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1228.1,-2269.32 1226,-2263.32 1223.9,-2269.32 1228.1,-2269.32"/>
 </g>
 <!-- src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js -->
 <g id="edge147" class="edge">
 <title>src/extract/resolve/resolve&#45;helpers.js&#45;&gt;src/extract/resolve/module&#45;classifiers.js</title>
-<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.27,-2233.6C1255.42,-2233.6 1402,-2233.6 1402,-2233.6 1402,-2233.6 1402,-2252.54 1402,-2252.54"/>
-<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1399.9,-2252.54 1402,-2258.54 1404.1,-2252.54 1399.9,-2252.54"/>
+<path fill="none" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" d="M1179.43,-2271C1179.43,-2271 1384.1,-2271 1384.1,-2271"/>
+<polygon fill="#007700" fill-opacity="0.466667" stroke="#007700" stroke-width="2" stroke-opacity="0.466667" points="1384.1,-2273.1 1390.1,-2271 1384.1,-2268.9 1384.1,-2273.1"/>
 </g>
 <!-- src/extract/transpile/meta.d.ts -->
 <g id="node105" class="node">
@@ -2538,7 +2540,7 @@
 <!-- src/graph&#45;utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/graph&#45;utl/consolidate&#45;module&#45;dependencies.js -->
 <g id="edge165" class="edge">
 <title>src/graph&#45;utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/graph&#45;utl/consolidate&#45;module&#45;dependencies.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1338.76,-1167.5C1353.3,-1167.5 1365,-1167.5 1365,-1167.5 1365,-1167.5 1365,-1174.48 1365,-1174.48"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1338.76,-1163C1353.3,-1163 1365,-1163 1365,-1163 1365,-1163 1365,-1174.48 1365,-1174.48"/>
 <polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1362.9,-1174.48 1365,-1180.48 1367.1,-1174.48 1362.9,-1174.48"/>
 </g>
 <!-- src/graph&#45;utl/consolidate&#45;to&#45;folder.js&#45;&gt;src/graph&#45;utl/consolidate&#45;modules.js -->
@@ -2565,8 +2567,8 @@
 <!-- src/graph&#45;utl/consolidate&#45;to&#45;pattern.js&#45;&gt;src/graph&#45;utl/consolidate&#45;modules.js -->
 <g id="edge168" class="edge">
 <title>src/graph&#45;utl/consolidate&#45;to&#45;pattern.js&#45;&gt;src/graph&#45;utl/consolidate&#45;modules.js</title>
-<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1341.41,-1190C1350.52,-1190 1357,-1190 1357,-1190 1357,-1190 1357,-1163 1357,-1163 1357,-1163 1378.71,-1163 1378.71,-1163"/>
-<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1378.71,-1165.1 1384.71,-1163 1378.71,-1160.9 1378.71,-1165.1"/>
+<path fill="none" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" d="M1341.41,-1190C1350.52,-1190 1357,-1190 1357,-1190 1357,-1190 1357,-1167.5 1357,-1167.5 1357,-1167.5 1378.71,-1167.5 1378.71,-1167.5"/>
+<polygon fill="#770000" fill-opacity="0.466667" stroke="#770000" stroke-width="2" stroke-opacity="0.466667" points="1378.71,-1169.6 1384.71,-1167.5 1378.71,-1165.4 1378.71,-1169.6"/>
 </g>
 <!-- src/graph&#45;utl/filter&#45;bank.js -->
 <g id="node116" class="node">

--- a/docs/dependency-cruiser-dir-graph.html
+++ b/docs/dependency-cruiser-dir-graph.html
@@ -102,10 +102,12 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
@@ -122,15 +124,10 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M20,-8C20,-8 1767,-8 1767,-8 1773,-8 1779,-14 1779,-20 1779,-20 1779,-364.6 1779,-364.6 1779,-370.6 1773,-376.6 1767,-376.6 1767,-376.6 20,-376.6 20,-376.6 14,-376.6 8,-370.6 8,-364.6 8,-364.6 8,-20 8,-20 8,-14 14,-8 20,-8"/>
 <text text-anchor="middle" x="893.5" y="-365.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">src</text>
 </g>
-<g id="clust7" class="cluster">
-<title>cluster_src/extract</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1354,-81C1354,-81 1604,-81 1604,-81 1610,-81 1616,-87 1616,-93 1616,-93 1616,-218.6 1616,-218.6 1616,-224.6 1610,-230.6 1604,-230.6 1604,-230.6 1354,-230.6 1354,-230.6 1348,-230.6 1342,-224.6 1342,-218.6 1342,-218.6 1342,-93 1342,-93 1342,-87 1348,-81 1354,-81"/>
-<text text-anchor="start" x="1463.5" y="-219.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
-</g>
-<g id="clust8" class="cluster">
-<title>cluster_src/extract/resolve</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M1536,-89C1536,-89 1596,-89 1596,-89 1602,-89 1608,-95 1608,-101 1608,-101 1608,-166.6 1608,-166.6 1608,-172.6 1602,-178.6 1596,-178.6 1596,-178.6 1536,-178.6 1536,-178.6 1530,-178.6 1524,-172.6 1524,-166.6 1524,-166.6 1524,-101 1524,-101 1524,-95 1530,-89 1536,-89"/>
-<text text-anchor="start" x="1549.5" y="-167.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
+<g id="clust10" class="cluster">
+<title>cluster_src/report</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M28,-16C28,-16 354,-16 354,-16 360,-16 366,-22 366,-28 366,-28 366,-121.8 366,-121.8 366,-127.8 360,-133.8 354,-133.8 354,-133.8 28,-133.8 28,-133.8 22,-133.8 16,-127.8 16,-121.8 16,-121.8 16,-28 16,-28 16,-22 22,-16 28,-16"/>
+<text text-anchor="start" x="177.5" y="-122.6" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">report</text>
 </g>
 <g id="clust2" class="cluster">
 <title>cluster_src/cli</title>
@@ -157,15 +154,20 @@
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M504,-89C504,-89 830,-89 830,-89 836,-89 842,-95 842,-101 842,-101 842,-173.8 842,-173.8 842,-179.8 836,-185.8 830,-185.8 830,-185.8 504,-185.8 504,-185.8 498,-185.8 492,-179.8 492,-173.8 492,-173.8 492,-101 492,-101 492,-95 498,-89 504,-89"/>
 <text text-anchor="start" x="653" y="-174.6" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">derive</text>
 </g>
+<g id="clust7" class="cluster">
+<title>cluster_src/extract</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1354,-81C1354,-81 1604,-81 1604,-81 1610,-81 1616,-87 1616,-93 1616,-93 1616,-218.6 1616,-218.6 1616,-224.6 1610,-230.6 1604,-230.6 1604,-230.6 1354,-230.6 1354,-230.6 1348,-230.6 1342,-224.6 1342,-218.6 1342,-218.6 1342,-93 1342,-93 1342,-87 1348,-81 1354,-81"/>
+<text text-anchor="start" x="1463.5" y="-219.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">extract</text>
+</g>
+<g id="clust8" class="cluster">
+<title>cluster_src/extract/resolve</title>
+<path fill="#ffffff" stroke="black" stroke-width="2" d="M1536,-89C1536,-89 1596,-89 1596,-89 1602,-89 1608,-95 1608,-101 1608,-101 1608,-166.6 1608,-166.6 1608,-172.6 1602,-178.6 1596,-178.6 1596,-178.6 1536,-178.6 1536,-178.6 1530,-178.6 1524,-172.6 1524,-166.6 1524,-166.6 1524,-101 1524,-101 1524,-95 1530,-89 1536,-89"/>
+<text text-anchor="start" x="1549.5" y="-167.4" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">resolve</text>
+</g>
 <g id="clust9" class="cluster">
 <title>cluster_src/main</title>
 <path fill="#ffffff" stroke="black" stroke-width="2" d="M1026,-89C1026,-89 1260,-89 1260,-89 1266,-89 1272,-95 1272,-101 1272,-101 1272,-279.4 1272,-279.4 1272,-285.4 1266,-291.4 1260,-291.4 1260,-291.4 1026,-291.4 1026,-291.4 1020,-291.4 1014,-285.4 1014,-279.4 1014,-279.4 1014,-101 1014,-101 1014,-95 1020,-89 1026,-89"/>
 <text text-anchor="start" x="1132" y="-280.2" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">main</text>
-</g>
-<g id="clust10" class="cluster">
-<title>cluster_src/report</title>
-<path fill="#ffffff" stroke="black" stroke-width="2" d="M28,-16C28,-16 354,-16 354,-16 360,-16 366,-22 366,-28 366,-28 366,-121.8 366,-121.8 366,-127.8 360,-133.8 354,-133.8 354,-133.8 28,-133.8 28,-133.8 22,-133.8 16,-127.8 16,-121.8 16,-121.8 16,-28 16,-28 16,-22 22,-16 28,-16"/>
-<text text-anchor="start" x="177.5" y="-122.6" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="9.00">report</text>
 </g>
 <!-- bin -->
 <g id="node1" class="node">

--- a/docs/dependency-cruiser-dir-graph.html
+++ b/docs/dependency-cruiser-dir-graph.html
@@ -106,8 +106,6 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/schema-overview.html
+++ b/docs/schema-overview.html
@@ -106,8 +106,6 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/docs/schema-overview.html
+++ b/docs/schema-overview.html
@@ -102,10 +102,12 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/src/cli/tools/svg-in-html-snippets/header.snippet.html
+++ b/src/cli/tools/svg-in-html-snippets/header.snippet.html
@@ -102,7 +102,9 @@
       <span id="hint-text"></span>
       <ul>
         <li><b>Hover</b> - highlight</li>
-        <li><b>Left-click</b> - pin highlight</li>
+        <li><b>Right-click</b> - pin highlight</li>
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
+  </body>
+</html>

--- a/src/cli/tools/svg-in-html-snippets/header.snippet.html
+++ b/src/cli/tools/svg-in-html-snippets/header.snippet.html
@@ -106,5 +106,3 @@
         <li><b>ESC</b> - clear</li>
       </ul>
     </div>
-  </body>
-</html>


### PR DESCRIPTION
## Description

Just changed the references of Left-Click to right click about pinning dependency graphs

## Motivation and Context

From my experience, Left-Click is to follow the dependency to a remote place (like github or the filesystem)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [ ] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
