### PR TITLE
feature(summarize): adds the 'baseDir' option to the optionsUsed object in the summary

### DIFF
--- a/src/enrich/summarize/summarize-options.js
+++ b/src/enrich/summarize/summarize-options.js
@@ -2,6 +2,7 @@ const has = require("lodash/has");
 
 const SHAREABLE_OPTIONS = [
   "babelConfig",
+  "baseDir",
   "cache",
   "collapse",
   "combinedDependencies",

--- a/test/cli/__fixtures__/alternate-basedir/expected.json
+++ b/test/cli/__fixtures__/alternate-basedir/expected.json
@@ -24,17 +24,13 @@
       "exoticRequireStrings": [],
       "externalModuleResolutionStrategy": "node_modules",
       "metrics": false,
-      "moduleSystems": [
-        "es6",
-        "cjs",
-        "tsd",
-        "amd"
-      ],
+      "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "outputTo": "test/cli/__output__/alternate-basedir.json",
       "outputType": "json",
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/cli/__fixtures__/alternate-basedir"
     },
     "ruleSetUsed": {}
   }

--- a/test/cli/asserthelpers.utl.mjs
+++ b/test/cli/asserthelpers.utl.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { expect } from "chai";
+import normBaseDirectory from "../main/norm-base-directory.utl.mjs";
 
 export function assertFileEqual(pActualFileName, pExpectedFileName) {
   expect(readFileSync(pActualFileName, { encoding: "utf8" })).to.equal(
@@ -10,6 +11,8 @@ export function assertJSONFileEqual(pActualFileName, pExpectedFileName) {
   expect(
     JSON.parse(readFileSync(pActualFileName, { encoding: "utf8" }))
   ).to.deep.equal(
-    JSON.parse(readFileSync(pExpectedFileName, { encoding: "utf8" }))
+    normBaseDirectory(
+      JSON.parse(readFileSync(pExpectedFileName, { encoding: "utf8" }))
+    )
   );
 }

--- a/test/cli/index.spec.mjs
+++ b/test/cli/index.spec.mjs
@@ -1,7 +1,7 @@
 import { unlinkSync, readFileSync } from "fs";
 // path.posix instead of path because otherwise on win32 the resulting
 // outputTo would contain \\ instead of / which for this unit test doesn't matter
-import { posix as path } from "path";
+import { join, posix as path } from "path";
 import { expect } from "chai";
 import intercept from "intercept-stdout";
 import chalk from "chalk";
@@ -115,7 +115,10 @@ const TEST_PAIRS = [
       doNotFollow: "node_modules",
       ruleSet: {
         options: {
-          baseDir: "test/cli/__fixtures__/alternate-basedir",
+          baseDir: join(
+            process.cwd(),
+            "test/cli/__fixtures__/alternate-basedir"
+          ),
         },
       },
     },

--- a/test/main/__fixtures__/ts-no-precomp-cjs.json
+++ b/test/main/__fixtures__/ts-no-precomp-cjs.json
@@ -78,7 +78,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
-      "args": "test/main/__mocks__/ts-precompilation-deps-off-cjs"
+      "args": "test/main/__mocks__/ts-precompilation-deps-off-cjs",
+      "baseDir": ""
     }
   }
 }

--- a/test/main/__fixtures__/ts-no-precomp-es.json
+++ b/test/main/__fixtures__/ts-no-precomp-es.json
@@ -78,7 +78,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
-      "args": "test/main/__mocks__/ts-precompilation-deps-off-es"
+      "args": "test/main/__mocks__/ts-precompilation-deps-off-es",
+      "baseDir": ""
     }
   }
 }

--- a/test/main/__mocks__/dynamic-imports/es/output.json
+++ b/test/main/__mocks__/dynamic-imports/es/output.json
@@ -119,7 +119,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/dynamic-imports/es"
     },
     "ruleSetUsed": {
       "forbidden": [

--- a/test/main/__mocks__/dynamic-imports/typescript/output-pre-compilation-deps.json
+++ b/test/main/__mocks__/dynamic-imports/typescript/output-pre-compilation-deps.json
@@ -119,7 +119,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/dynamic-imports/typescript"
     },
     "ruleSetUsed": {
       "forbidden": [

--- a/test/main/__mocks__/dynamic-imports/typescript/output.json
+++ b/test/main/__mocks__/dynamic-imports/typescript/output.json
@@ -119,7 +119,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/dynamic-imports/typescript"
     },
     "ruleSetUsed": {
       "forbidden": [

--- a/test/main/__mocks__/type-only-imports/output-with-rules.json
+++ b/test/main/__mocks__/type-only-imports/output-with-rules.json
@@ -54,7 +54,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/type-only-imports"
     },
     "ruleSetUsed": {
       "forbidden": [

--- a/test/main/__mocks__/type-only-imports/output.json
+++ b/test/main/__mocks__/type-only-imports/output.json
@@ -46,7 +46,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/type-only-imports"
     }
   }
 }

--- a/test/main/__mocks__/type-only-module-references/output-no-ts.json
+++ b/test/main/__mocks__/type-only-module-references/output-no-ts.json
@@ -24,7 +24,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/type-only-module-references"
     }
   }
 }

--- a/test/main/__mocks__/type-only-module-references/output.json
+++ b/test/main/__mocks__/type-only-module-references/output.json
@@ -47,7 +47,8 @@
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
       "tsPreCompilationDeps": true,
-      "args": "src"
+      "args": "src",
+      "baseDir": "test/main/__mocks__/type-only-module-references"
     }
   }
 }

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -3,13 +3,20 @@ import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
 import main from "../../src/main/index.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 
-const esOut = requireJSON("./__mocks__/dynamic-imports/es/output.json");
-const tsOut = requireJSON("./__mocks__/dynamic-imports/typescript/output.json");
-const tsOutpre = requireJSON(
-  "./__mocks__/dynamic-imports/typescript/output-pre-compilation-deps.json"
+const esOut = normBaseDirectory(
+  requireJSON("./__mocks__/dynamic-imports/es/output.json")
+);
+const tsOut = normBaseDirectory(
+  requireJSON("./__mocks__/dynamic-imports/typescript/output.json")
+);
+const tsOutpre = normBaseDirectory(
+  requireJSON(
+    "./__mocks__/dynamic-imports/typescript/output-pre-compilation-deps.json"
+  )
 );
 
 use(chaiJSONSchema);

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -7,14 +7,17 @@ import pathToPosix from "../../src/extract/utl/path-to-posix.js";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
 import main from "../../src/main/index.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const requireJSON = createRequireJSON(import.meta.url);
 
-const tsFixture = requireJSON("./__fixtures__/ts.json");
-const tsxFixture = requireJSON("./__fixtures__/tsx.json");
-const jsxFixture = requireJSON("./__fixtures__/jsx.json");
-const jsxAsObjectFixture = requireJSON("./__fixtures__/jsx-as-object.json");
+const tsFixture = normBaseDirectory(requireJSON("./__fixtures__/ts.json"));
+const tsxFixture = normBaseDirectory(requireJSON("./__fixtures__/tsx.json"));
+const jsxFixture = normBaseDirectory(requireJSON("./__fixtures__/jsx.json"));
+const jsxAsObjectFixture = normBaseDirectory(
+  requireJSON("./__fixtures__/jsx-as-object.json")
+);
 
 use(chaiJSONSchema);
 
@@ -89,10 +92,12 @@ describe("[E] main.cruise - main", () => {
     );
 
     expect(pathPosixify(lResult.output)).to.deep.equal(
-      JSON.parse(
-        readFileSync(
-          "test/main/__mocks__/collapse-after-cruise/expected-result.json",
-          "utf8"
+      normBaseDirectory(
+        JSON.parse(
+          readFileSync(
+            "test/main/__mocks__/collapse-after-cruise/expected-result.json",
+            "utf8"
+          )
         )
       )
     );

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -3,16 +3,21 @@ import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
 import { cruise } from "../../src/main/index.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 
-const tsPreCompFixtureCJS = requireJSON("./__fixtures__/ts-precomp-cjs.json");
-const tsPreCompFixtureES = requireJSON("./__fixtures__/ts-precomp-es.json");
-const tsNoPrecompFixtureCJS = requireJSON(
-  "./__fixtures__/ts-no-precomp-cjs.json"
+const tsPreCompFixtureCJS = normBaseDirectory(
+  requireJSON("./__fixtures__/ts-precomp-cjs.json")
 );
-const tsNoPrecompFixtureES = requireJSON(
-  "./__fixtures__/ts-no-precomp-es.json"
+const tsPreCompFixtureES = normBaseDirectory(
+  requireJSON("./__fixtures__/ts-precomp-es.json")
+);
+const tsNoPrecompFixtureCJS = normBaseDirectory(
+  requireJSON("./__fixtures__/ts-no-precomp-cjs.json")
+);
+const tsNoPrecompFixtureES = normBaseDirectory(
+  requireJSON("./__fixtures__/ts-no-precomp-es.json")
 );
 
 use(chaiJSONSchema);

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -3,12 +3,15 @@ import chaiJSONSchema from "chai-json-schema";
 import { cruise } from "../../src/main/index.js";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 
-const output = requireJSON("./__mocks__/type-only-imports/output.json");
-const outputWithRules = requireJSON(
-  "./__mocks__/type-only-imports/output-with-rules.json"
+const output = normBaseDirectory(
+  requireJSON("./__mocks__/type-only-imports/output.json")
+);
+const outputWithRules = normBaseDirectory(
+  requireJSON("./__mocks__/type-only-imports/output-with-rules.json")
 );
 
 use(chaiJSONSchema);

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -3,14 +3,15 @@ import chaiJSONSchema from "chai-json-schema";
 import { cruise } from "../../src/main/index.js";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 
-const output = requireJSON(
-  "./__mocks__/type-only-module-references/output.json"
+const output = normBaseDirectory(
+  requireJSON("./__mocks__/type-only-module-references/output.json")
 );
-const outputNoTS = requireJSON(
-  "./__mocks__/type-only-module-references/output-no-ts.json"
+const outputNoTS = normBaseDirectory(
+  requireJSON("./__mocks__/type-only-module-references/output-no-ts.json")
 );
 
 use(chaiJSONSchema);

--- a/test/main/norm-base-directory.utl.mjs
+++ b/test/main/norm-base-directory.utl.mjs
@@ -1,0 +1,14 @@
+import { join } from "path";
+import cloneDeep from "lodash/cloneDeep.js";
+
+export default function normBaseDirectory(
+  pUnprocessedJSON,
+  pBaseDirectory = process.cwd()
+) {
+  let lReturnValue = cloneDeep(pUnprocessedJSON);
+  lReturnValue.summary.optionsUsed.baseDir = join(
+    pBaseDirectory,
+    lReturnValue.summary.optionsUsed?.baseDir ?? ""
+  );
+  return lReturnValue;
+}


### PR DESCRIPTION
## Description

- adds the used `baseDir` in to the optionsUsed object in the output json
- adapts any automated test that didn't expect it to expect it

## Motivation and Context

- will help with debugging and with creating more rich reporters

## How Has This Been Tested?

- [x] green ci
- [x] new integration test
- [x] adapted automated tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
