### PR TITLE
feature(progress): adds resident set size & v8 managed memory to the performance-log

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1078,21 +1078,26 @@ stay in view when dependency-cruiser is done.
 <summary>Typical output</summary>
 
 ```
-  elapsed heapTotal  heapUsed after step...
-    712ms      72Mb      46Mb start of node process
-      2ms      72Mb      46Mb parsing options
-    100ms      73Mb      56Mb parsing rule set
-      0ms      73Mb      56Mb making sense of files and directories
-      0ms      73Mb      56Mb determining how to resolve
-   1874ms     158Mb     138Mb reading files
-      0ms     158Mb     138Mb analyzing
-     17ms     161Mb     131Mb analyzing: cycles
-      3ms     161Mb     132Mb analyzing: orphans
-    161ms     163Mb     140Mb analyzing: reachables
-      0ms     163Mb     140Mb analyzing: add focus (if any)
-     51ms     163Mb     135Mb analyzing: validations
-      2ms     163Mb     135Mb reporting
-      0ms     163Mb     135Mb really done (2924ms)
+  elapsed       rss heapTotal  heapUsed  external after step...
+    735ms     125Mb      84Mb      61Mb       2Mb start of node process
+     10ms     125Mb      84Mb      62Mb       2Mb parsing options
+     90ms     128Mb      85Mb      64Mb       2Mb cache: checking freshness
+    202ms     145Mb      91Mb      70Mb       1Mb parsing rule set
+      0ms     145Mb      91Mb      70Mb       1Mb determining how to resolve
+      0ms     145Mb      91Mb      70Mb       1Mb reading files
+     25ms     145Mb      91Mb      73Mb       1Mb reading files: gathering initial sources
+   1190ms     194Mb     137Mb     110Mb       1Mb reading files: visiting dependencies
+      0ms     194Mb     137Mb     110Mb       1Mb analyzing
+     18ms     194Mb     137Mb     116Mb       1Mb analyzing: cycles
+     37ms     197Mb     139Mb     119Mb       1Mb analyzing: dependents
+      1ms     197Mb     139Mb     119Mb       1Mb analyzing: orphans
+    257ms     198Mb     141Mb     122Mb       1Mb analyzing: reachables
+      0ms     198Mb     141Mb     122Mb       1Mb analyzing: module metrics
+      0ms     198Mb     141Mb     122Mb       1Mb analyzing: add focus (if any)
+     87ms     199Mb     141Mb     117Mb       1Mb analyzing: validations
+     10ms     200Mb     142Mb     121Mb       2Mb analyzing: comparing against known errors
+      5ms     200Mb     142Mb     121Mb       2Mb reporting
+      0ms     200Mb     142Mb     121Mb       2Mb really done (2670ms)
 ```
 
 </details>

--- a/src/cli/listeners/performance-log/format-helpers.js
+++ b/src/cli/listeners/performance-log/format-helpers.js
@@ -19,8 +19,10 @@ function formatMemory(pBytes) {
 
 function formatPerfLine(pTime, pPreviousTime, pMessage) {
   return `${formatTime(pTime - pPreviousTime)} ${formatMemory(
-    process.memoryUsage().heapTotal
-  )} ${formatMemory(process.memoryUsage().heapUsed)} ${pMessage}\n`;
+    process.memoryUsage().rss
+  )} ${formatMemory(process.memoryUsage().heapTotal)} ${formatMemory(
+    process.memoryUsage().heapUsed
+  )} ${formatMemory(process.memoryUsage().external)} ${pMessage}\n`;
 }
 
 module.exports = {

--- a/src/cli/listeners/performance-log/handlers.js
+++ b/src/cli/listeners/performance-log/handlers.js
@@ -3,7 +3,9 @@ const { formatTime, formatPerfLine } = require("./format-helpers");
 
 function getHeader(pLevel, pMaxLevel) {
   if (pLevel <= pMaxLevel) {
-    return chalk.bold("  elapsed heapTotal  heapUsed after step...\n");
+    return chalk.bold(
+      "  elapsed       rss heapTotal  heapUsed  external after step...\n"
+    );
   }
   return "";
 }

--- a/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
@@ -58,6 +58,8 @@ describe("[U] cli/ears/performance-log-listener/format-helpers - formatPerfLine"
   it("produces neat columns with time, memmory and a message", () => {
     expect(
       formatHelpers.formatPerfLine(14.88041018, 7.245436738, "sim sala bim")
-    ).to.match(/ {3}7635ms {0,}\d+Mb {0,}\d+Mb sim sala bim\n/);
+    ).to.match(
+      / {3}7635ms {0,}\d+Mb {0,}\d+Mb {0,}\d+Mb {0,}\d+Mb sim sala bim\n/
+    );
   });
 });


### PR DESCRIPTION
## Description

- adds _resident set size_ (rss) and the amount of C++ objects bound to javascript objects managed by v8 ('external') to the `performance-log` output.

## Motivation and Context

- provides more (useful) information to analyze what dependency-cruiser is doing under the hood.

## How Has This Been Tested?

- [x] green ci
- [x] updated unit test

## Screenshots

### after
```
$ node ./bin/dependency-cruise.js src bin test configs types tools --config --ignore-known
  elapsed       rss heapTotal  heapUsed  external after step...
    751ms     127Mb      84Mb      61Mb       2Mb start of node process
     11ms     128Mb      84Mb      62Mb       2Mb parsing options
     93ms     130Mb      85Mb      63Mb       2Mb cache: checking freshness
...
```

### before
```
$ node ./bin/dependency-cruise.js src bin test configs types tools --config --ignore-known
  elapsed heapTotal  heapUsed after step...
    751ms      84Mb      61Mb start of node process
     11ms      84Mb      62Mb parsing options
     93ms      85Mb      64Mb cache: checking freshness
...
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
