### PR TITLE
refactor(report): replaces metrics formatting code with Intl API calls

### DIFF
--- a/src/report/dot/module-utl.js
+++ b/src/report/dot/module-utl.js
@@ -67,9 +67,9 @@ function makeInstabilityString(pModule, pShowMetrics = false) {
   let lInstabilityString = "";
 
   if (pShowMetrics && has(pModule, "instability") && !pModule.consolidated) {
-    lInstabilityString = ` <FONT color="#808080" point-size="8">${utl.formatInstability(
+    lInstabilityString = ` <FONT color="#808080" point-size="8">${utl.formatPercentage(
       pModule.instability
-    )}%</FONT>`;
+    )}</FONT>`;
   }
   return lInstabilityString;
 }

--- a/src/report/error-html/utl.js
+++ b/src/report/error-html/utl.js
@@ -1,6 +1,6 @@
 const has = require("lodash/has");
 const { version } = require("../../../src/meta.js");
-const { formatViolation, formatInstability } = require("../utl/index.js");
+const { formatViolation, formatPercentage } = require("../utl/index.js");
 
 function getFormattedAllowedRule(pRuleSetUsed) {
   const lAllowed = pRuleSetUsed?.allowed ?? [];
@@ -46,9 +46,9 @@ function formatModuleTo() {
 }
 
 function formatInstabilityTo(pViolation) {
-  return `${pViolation.to}&nbsp;<span class="extra">(I: ${formatInstability(
+  return `${pViolation.to}&nbsp;<span class="extra">(I: ${formatPercentage(
     pViolation.metrics.to.instability
-  )}%)</span>`;
+  )})</span>`;
 }
 
 function determineTo(pViolation) {
@@ -67,9 +67,9 @@ function determineTo(pViolation) {
 }
 
 function formatInstabilityFromExtras(pViolation) {
-  return `&nbsp;<span class="extra">(I: ${formatInstability(
+  return `&nbsp;<span class="extra">(I: ${formatPercentage(
     pViolation.metrics.from.instability
-  )}%)</span>`;
+  )})</span>`;
 }
 
 function determineFromExtras(pViolation) {

--- a/src/report/error.js
+++ b/src/report/error.js
@@ -47,11 +47,11 @@ function formatReachabilityViolation(pViolation) {
 function formatInstabilityViolation(pViolation) {
   return `${formatDependencyViolation(pViolation)}\n${wrapAndIndent(
     chalk.dim(
-      `instability: ${utl.formatInstability(
+      `instability: ${utl.formatPercentage(
         pViolation.metrics.from.instability
-      )}% ${figures.arrowRight} ${utl.formatInstability(
+      )} ${figures.arrowRight} ${utl.formatPercentage(
         pViolation.metrics.to.instability
-      )}%`
+      )}`
     ),
     EXTRA_PATH_INFORMATION_INDENT
   )}`;

--- a/src/report/metrics.js
+++ b/src/report/metrics.js
@@ -38,7 +38,7 @@ function getMetricsTable(pMetrics, pMaxNameWidth) {
         .padStart(METRIC_WIDTH)}  ${efferentCouplings
         .toString(DECIMAL_BASE)
         .padStart(METRIC_WIDTH)}  ${utl
-        .formatInstability(instability)
+        .formatPercentage(instability)
         .toString(DECIMAL_BASE)
         .padStart(METRIC_WIDTH)}`
   );

--- a/src/report/teamcity.js
+++ b/src/report/teamcity.js
@@ -89,9 +89,9 @@ function formatReachabilityViolation(pViolation) {
 function formatInstabilityViolation(pViolation) {
   return `${formatDependencyViolation(
     pViolation
-  )} (instability: ${utl.formatInstability(
+  )} (instability: ${utl.formatPercentage(
     pViolation.metrics.from.instability
-  )}% -> ${utl.formatInstability(pViolation.metrics.to.instability)}%)`;
+  )} -> ${utl.formatPercentage(pViolation.metrics.to.instability)})`;
 }
 
 function bakeViolationMessage(pViolation) {

--- a/src/report/utl/index.js
+++ b/src/report/utl/index.js
@@ -1,7 +1,6 @@
-function formatInstability(pNumber) {
-  // eslint-disable-next-line no-magic-numbers
-  return Math.round(100 * pNumber);
-}
+// eslint-disable-next-line no-undefined
+const formatPercentage = new Intl.NumberFormat(undefined, { style: "percent" })
+  .format;
 
 function formatViolation(
   pViolation,
@@ -13,4 +12,4 @@ function formatViolation(
   );
 }
 
-module.exports = { formatViolation, formatInstability };
+module.exports = { formatViolation, formatPercentage };

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -26,7 +26,7 @@ describe("[I] report/metrics", () => {
     });
 
     expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain("src      1     1     1    50");
+    expect(lResult.output).to.contain("src      1     1     1   50%");
   });
 
   it("does not emit folder metrics when asked to hide them", () => {
@@ -47,7 +47,7 @@ describe("[I] report/metrics", () => {
     );
 
     expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.not.contain("src      1     1     1    50");
+    expect(lResult.output).to.not.contain("src      1     1     1   50%");
   });
 
   it("emits module metrics (sorted by instability by default)", () => {
@@ -77,7 +77,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.contain(
-      `src/mies.js     1     1     1    50${EOL}src/aap.js      1     1     3    25${EOL}src/noot.js`
+      `src/mies.js     1     1     1   50%${EOL}src/aap.js      1     1     3   25%${EOL}src/noot.js`
     );
   });
 
@@ -111,7 +111,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.contain(
-      `src/aap.js      1     1     3    25${EOL}src/mies.js     1     1     1    50${EOL}src/noot.js`
+      `src/aap.js      1     1     3   25%${EOL}src/mies.js     1     1     1   50%${EOL}src/noot.js`
     );
   });
 
@@ -145,7 +145,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.not.contain(
-      `src/mies.js     1     1     1    50${EOL}src/aap.js      1     1     3    25${EOL}src/noot.js`
+      `src/mies.js     1     1     1    50${EOL}src/aap.js      1     1     3    25%${EOL}src/noot.js`
     );
   });
 


### PR DESCRIPTION
## Description

- replaces the instability metrics formatting code with an Intl function call

## Motivation and Context

- reduces maintenance
- output is localized, so at least in theory easier to grasp for the reader

## How Has This Been Tested?

- [x] green ci
- [x] adapted unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
