### PR TITLE
refactor: bans parameter reassignments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "security/detect-non-literal-fs-filename": "off",
     "unicorn/prefer-top-level-await": "off", // only works as of node 16
     "unicorn/no-useless-fallback-in-spread": "off", // useful, probably. We'll try it later, though
-    "unicorn/prefer-node-protocol": "off" // yarn 1 pnp doesn't understand node: protocol, and as we still support yarn 1 pnp we're not doing this
+    "unicorn/prefer-node-protocol": "off", // yarn 1 pnp doesn't understand node: protocol, and as we still support yarn 1 pnp we're not doing this
+    "no-param-reassign": "error"
   },
   "overrides": [
     {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const glob = require("glob");
-const clone = require("lodash/clone");
+const cloneDeep = require("lodash/cloneDeep");
 const set = require("lodash/set");
 const isInstalledGlobally = require("is-installed-globally");
 const { red, yellow, bold } = require("chalk");
@@ -42,7 +42,7 @@ function addKnownViolations(pCruiseOptions) {
 
     // Check against json schema is already done in src/main/options/validate
     // so here we can just concentrate on the io
-    let lCruiseOptions = clone(pCruiseOptions);
+    let lCruiseOptions = cloneDeep(pCruiseOptions);
     set(lCruiseOptions, "ruleSet.options.knownViolations", lKnownViolations);
     return lCruiseOptions;
   }
@@ -127,11 +127,11 @@ function runCruise(pFileDirectoryArray, pCruiseOptions) {
 /**
  *
  * @param {string[]} pFileDirectoryArray
- * @param {import("../../types/options").ICruiseOptions} pCruiseOptions
+ * @param {import("../../types/options").ICruiseOptions} lCruiseOptions
  * @returns {number}
  */
 module.exports = function executeCli(pFileDirectoryArray, pCruiseOptions) {
-  pCruiseOptions = pCruiseOptions || {};
+  let lCruiseOptions = cloneDeep(pCruiseOptions || {});
   let lExitCode = 0;
 
   try {
@@ -150,9 +150,9 @@ module.exports = function executeCli(pFileDirectoryArray, pCruiseOptions) {
       );
     }
     /* c8 ignore stop */
-    if (pCruiseOptions.info === true) {
+    if (lCruiseOptions.info === true) {
       process.stdout.write(formatMetaInfo());
-    } else if (pCruiseOptions.init) {
+    } else if (lCruiseOptions.init) {
       // requiring init-config took ~100ms (most of it taken up by requiring
       // inquirer, measured on a 2.6GHz quad core i7 with flash storage on
       // macOS 10.15.7). Only requiring it when '--init' is necessary speeds up
@@ -161,9 +161,9 @@ module.exports = function executeCli(pFileDirectoryArray, pCruiseOptions) {
       // holds.
       // eslint-disable-next-line node/global-require
       const initConfig = require("./init-config");
-      initConfig(pCruiseOptions.init);
+      initConfig(lCruiseOptions.init);
     } else {
-      lExitCode = runCruise(pFileDirectoryArray, pCruiseOptions);
+      lExitCode = runCruise(pFileDirectoryArray, lCruiseOptions);
     }
   } catch (pError) {
     process.stderr.write(`\n  ${red("ERROR")}: ${pError.message}\n`);

--- a/src/config-utl/extract-depcruise-config/index.js
+++ b/src/config-utl/extract-depcruise-config/index.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const cloneDeep = require("lodash/cloneDeep");
 const has = require("lodash/has");
 const resolve = require("../../extract/resolve/resolve");
 const normalizeResolveOptions = require("../../main/resolve-options/normalize");
@@ -7,29 +8,31 @@ const mergeConfigs = require("./merge-configs");
 
 /* eslint no-use-before-define: 0 */
 function processExtends(pReturnValue, pAlreadyVisited, pBaseDirectory) {
-  if (typeof pReturnValue.extends === "string") {
-    pReturnValue = mergeConfigs(
-      pReturnValue,
+  let lReturnValue = cloneDeep(pReturnValue);
+
+  if (typeof lReturnValue.extends === "string") {
+    lReturnValue = mergeConfigs(
+      lReturnValue,
       extractDepcruiseConfig(
-        pReturnValue.extends,
+        lReturnValue.extends,
         pAlreadyVisited,
         pBaseDirectory
       )
     );
   }
 
-  if (Array.isArray(pReturnValue.extends)) {
-    pReturnValue = pReturnValue.extends.reduce(
+  if (Array.isArray(lReturnValue.extends)) {
+    lReturnValue = lReturnValue.extends.reduce(
       (pAll, pExtends) =>
         mergeConfigs(
           pAll,
           extractDepcruiseConfig(pExtends, pAlreadyVisited, pBaseDirectory)
         ),
-      pReturnValue
+      lReturnValue
     );
   }
-  Reflect.deleteProperty(pReturnValue, "extends");
-  return pReturnValue;
+  Reflect.deleteProperty(lReturnValue, "extends");
+  return lReturnValue;
 }
 
 /**

--- a/src/config-utl/extract-webpack-resolve-config.js
+++ b/src/config-utl/extract-webpack-resolve-config.js
@@ -33,8 +33,7 @@ function suggestModules(pSuggestionList, pWebpackConfigFilename) {
 
   if (Array.isArray(lSuggestionList) && lSuggestionList.length > 0) {
     lReturnValue = lSuggestionList.reduce(
-      (pAll, pCurrent) =>
-        (pAll += `         - ${pCurrent.module || pCurrent}\n`),
+      (pAll, pCurrent) => `${pAll}         - ${pCurrent.module || pCurrent}\n`,
       `\n         Some npm modules that might fix that problem (one of which you'll` +
         `\n         need so '${pWebpackConfigFilename}' works with webpack anyway):\n`
     );

--- a/src/enrich/derive/circular/get-cycle.js
+++ b/src/enrich/derive/circular/get-cycle.js
@@ -38,11 +38,10 @@ function getCycle(
   { pDependencyName, pFindNodeByName },
   pVisited
 ) {
-  pVisited = pVisited || new Set();
-
+  let lVisited = pVisited || new Set();
   const lCurrentNode = pFindNodeByName(pGraph, pCurrentSource);
   const lDependencies = lCurrentNode.dependencies.filter(
-    (pDependency) => !pVisited.has(pDependency[pDependencyName])
+    (pDependency) => !lVisited.has(pDependency[pDependencyName])
   );
   const lMatch = lDependencies.find(
     (pDependency) => pDependency[pDependencyName] === pInitialSource
@@ -57,7 +56,7 @@ function getCycle(
         pInitialSource,
         pDependency[pDependencyName],
         { pDependencyName, pFindNodeByName },
-        pVisited.add(pDependency[pDependencyName])
+        lVisited.add(pDependency[pDependencyName])
       );
 
       if (lCycle.length > 0 && !lCycle.includes(pCurrentSource)) {

--- a/src/extract/ast-extractors/swc-dependency-visitor.js
+++ b/src/extract/ast-extractors/swc-dependency-visitor.js
@@ -66,7 +66,7 @@ function extractExoticMemberCallExpression(pNode, pExoticRequireStrings) {
           pNode.callee.property.value === pThing.property &&
           argumentsAreUsable(pNode.arguments)
         ) {
-          pAll = pAll.concat({
+          return pAll.concat({
             module: pryStringsFromArguments(pNode.arguments),
             moduleSystem: "cjs",
             exoticallyRequired: true,

--- a/src/extract/get-dependencies.js
+++ b/src/extract/get-dependencies.js
@@ -78,32 +78,26 @@ function extractFromJavaScriptAST(pOptions, pFileName, pTranspileOptions) {
   return lDependencies;
 }
 
-function extractWithSwc(pDependencies, pCruiseOptions, pFileName) {
-  pDependencies = extractFromSwcAST(pCruiseOptions, pFileName).filter((pDep) =>
+function extractWithSwc(pCruiseOptions, pFileName) {
+  return extractFromSwcAST(pCruiseOptions, pFileName).filter((pDep) =>
     pCruiseOptions.moduleSystems.includes(pDep.moduleSystem)
   );
-  return pDependencies;
 }
 
-function extractWithTsc(
-  pDependencies,
-  pCruiseOptions,
-  pFileName,
-  pTranspileOptions
-) {
-  pDependencies = extractFromTypeScriptAST(
+function extractWithTsc(pCruiseOptions, pFileName, pTranspileOptions) {
+  let lDependencies = extractFromTypeScriptAST(
     pCruiseOptions,
     pFileName,
     pTranspileOptions
   ).filter((pDep) => pCruiseOptions.moduleSystems.includes(pDep.moduleSystem));
 
   if (pCruiseOptions.tsPreCompilationDeps === "specify") {
-    pDependencies = detectPreCompilationNess(
-      pDependencies,
+    lDependencies = detectPreCompilationNess(
+      lDependencies,
       extractFromJavaScriptAST(pCruiseOptions, pFileName, pTranspileOptions)
     );
   }
-  return pDependencies;
+  return lDependencies;
 }
 
 /**
@@ -119,10 +113,9 @@ function extractDependencies(pCruiseOptions, pFileName, pTranspileOptions) {
 
   if (!pCruiseOptions.extraExtensionsToScan.includes(path.extname(pFileName))) {
     if (shouldUseSwc(pCruiseOptions, pFileName)) {
-      lDependencies = extractWithSwc(lDependencies, pCruiseOptions, pFileName);
+      lDependencies = extractWithSwc(pCruiseOptions, pFileName);
     } else if (shouldUseTsc(pCruiseOptions, pFileName)) {
       lDependencies = extractWithTsc(
-        lDependencies,
         pCruiseOptions,
         pFileName,
         pTranspileOptions
@@ -208,12 +201,12 @@ function compareDeps(pLeft, pRight) {
  *
  *
  * @param  {string} pFileName path to the file
- * @param  {import("../../types/dependency-cruiser").IStrictCruiseOptions} pCruiseOptions cruise options
- * @param {import("../../types/dependency-cruiser").IResolveOptions} pResolveOptions  webpack 'enhanced-resolve' options
- * @param  {import("../../types/dependency-cruiser").ITranspileOptions} pTranspileOptions       an object with tsconfig ('typescript project') options
+ * @param  {import("../..").IStrictCruiseOptions} pCruiseOptions cruise options
+ * @param {import("../..").IResolveOptions} pResolveOptions  webpack 'enhanced-resolve' options
+ * @param  {import("../..").ITranspileOptions} pTranspileOptions       an object with tsconfig ('typescript project') options
  *                               ('flattened' so there's no need for file access on any
  *                               'extends' option in there)
- * @return {import("../../types/dependency-cruiser").IDependency[]} an array of dependency objects (see above)
+ * @return {import("../..").IDependency[]} an array of dependency objects (see above)
  */
 module.exports = function getDependencies(
   pFileName,

--- a/src/extract/resolve/determine-dependency-types.js
+++ b/src/extract/resolve/determine-dependency-types.js
@@ -185,7 +185,7 @@ module.exports = function determineDependencyTypes(
 ) {
   /** @type {import("../../../types/shared-types").DependencyType[]}*/
   let lReturnValue = ["undetermined"];
-  pResolveOptions = pResolveOptions || {};
+  const lResolveOptions = pResolveOptions || {};
 
   if (pDependency.couldNotResolve) {
     lReturnValue = ["unknown"];
@@ -201,7 +201,7 @@ module.exports = function determineDependencyTypes(
   } else if (
     isExternalModule(
       pDependency.resolved,
-      pResolveOptions.modules,
+      lResolveOptions.modules,
       pBaseDirectory
     )
   ) {
@@ -210,10 +210,10 @@ module.exports = function determineDependencyTypes(
       pModuleName,
       pManifest,
       pFileDirectory,
-      pResolveOptions,
+      lResolveOptions,
       pBaseDirectory
     );
-  } else if (isAliassy(pModuleName, pDependency.resolved, pResolveOptions)) {
+  } else if (isAliassy(pModuleName, pDependency.resolved, lResolveOptions)) {
     lReturnValue = ["aliased"];
   }
 

--- a/src/report/markdown.js
+++ b/src/report/markdown.js
@@ -73,9 +73,9 @@ function formatRulesSummary(pCruiseResult, pIncludeIgnoredInSummary) {
     )
     .reduce(
       (pAll, pRule) =>
-        (pAll += `|${severity2Icon(pRule.severity)}&nbsp;_${pRule.name}_|**${
+        `${pAll}|${severity2Icon(pRule.severity)}&nbsp;_${pRule.name}_|**${
           pRule.count
-        }**|**${pRule.ignoredCount}**|${pRule.comment}|\n`),
+        }**|**${pRule.ignoredCount}**|${pRule.comment}|\n`,
       lTableHead
     );
 }

--- a/src/report/mermaid.js
+++ b/src/report/mermaid.js
@@ -99,7 +99,7 @@ function focusHighlights(pModules, pNamesHashMap) {
     )
     .reduce((pAll, pModule) => {
       const lSource = pNamesHashMap.get(pModule.source);
-      return (pAll += `\nstyle ${lSource} ${lHighLightStyle}`);
+      return `${pAll}\nstyle ${lSource} ${lHighLightStyle}`;
     }, "");
 }
 

--- a/test/extract/transpile/svelte-preprocess.spec.mjs
+++ b/test/extract/transpile/svelte-preprocess.spec.mjs
@@ -18,9 +18,9 @@ const CORPUS = [
 
 describe("[U] sync svelte pre-processor", () => {
   CORPUS.forEach((pInput, pCorpusNumber, pCorpus) => {
-    it(`pre-processes svelte like svelte's preprocessor, but sync (${(pCorpusNumber += 1)}/${
-      pCorpus.length
-    })`, async () => {
+    it(`pre-processes svelte like svelte's preprocessor, but sync (${
+      pCorpusNumber + 1
+    }/${pCorpus.length})`, async () => {
       const lSyncResult = sveltePreProcess(pInput, typeScriptWrap, {});
       const lAsyncResult = await svelteCompiler.preprocess(pInput, {
         script: ({ content, attributes }) => {


### PR DESCRIPTION
## Description

- removes the last parameter reassignments from the code

## Motivation and Context

- makes the concerned code easier to understand + less easy to introduce subtle bugs

## How Has This Been Tested?

- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
