### PR TITLE
chore: upgrades lint staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npx lint-staged --config=package.json

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "eslint-plugin-unicorn": "^45.0.0",
     "husky": "8.0.2",
     "intercept-stdout": "0.1.2",
-    "lint-staged": "12.3.4",
+    "lint-staged": "13.1.0",
     "mocha": "10.2.0",
     "normalize-newline": "^3.0.0",
     "npm-run-all": "4.1.5",
@@ -235,11 +235,6 @@
         "package": "interpret",
         "policy": "wanted",
         "because": "we want to keep interpret ~similar to what webpack-cli uses (which is ^2.2.0)"
-      },
-      {
-        "package": "lint-staged",
-        "policy": "pin",
-        "because": "12.3.5 fails with SyntaxError: Unexpected token o in JSON at position 1"
       },
       {
         "package": "normalize-newline",


### PR DESCRIPTION
## Description

- upgrades lint-staged to latest
This was an issue because later versions than the one we were using borked with 'invalid json' errors. Turns out newer versions of lint-staged autodiscovered their way to all possible configuration files that can be in a repository. This included package.json's in our test tree that are deliberately invalid. The way to stop this autodiscovery to make the one configuration file explicit (add a --config parameter in the lint-staged call in .husky/pre-commit).

## Motivation and Context

Chore/ LCM

## How Has This Been Tested?

- [x] green ci
- [x] local commit

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
