### PR TITLE
chore: upgrades 'interpret' to stay in line with what webpack-cli uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "glob": "7.2.0",
     "handlebars": "4.7.7",
     "indent-string": "^4.0.0",
-    "interpret": "^2.2.0",
+    "interpret": "^3.1.0",
     "is-installed-globally": "0.4.0",
     "json5": "2.2.2",
     "lodash": "4.17.21",
@@ -234,7 +234,7 @@
       {
         "package": "interpret",
         "policy": "wanted",
-        "because": "we want to keep interpret ~similar to what webpack-cli uses (which is ^2.2.0)"
+        "because": "we want to keep interpret ~similar to what webpack-cli uses (which is ^3.1.0 since 2022-11-15)"
       },
       {
         "package": "normalize-newline",
@@ -244,7 +244,7 @@
       {
         "package": "rechoir",
         "policy": "wanted",
-        "because": "we want to keep rechoir ~similar to what webpack-cli uses (which is ^0.7.0, but ^0.8.0 is similar enough and more recent anyway)"
+        "because": "we want to keep rechoir ~similar to what webpack-cli uses (which is ^0.8.0 since 2022-11-15))"
       },
       {
         "package": "wrap-ansi",

--- a/test/config-utl/extract-webpack-resolve-config.spec.cjs
+++ b/test/config-utl/extract-webpack-resolve-config.spec.cjs
@@ -34,7 +34,7 @@ describe("[I] config-utl/getWebpackResolveConfig - non-native formats", () => {
       loadResolveConfig(
         join(__dirname, "__mocks__", "webpackconfig", "webpack.config.ls")
       )
-    ).to.throw(/- livescript/m);
+    ).to.throw(/No module loader found for ".ls"/m);
   });
 
   it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (yaml)", () => {
@@ -44,7 +44,7 @@ describe("[I] config-utl/getWebpackResolveConfig - non-native formats", () => {
       loadResolveConfig(
         join(__dirname, "__mocks__", "webpackconfig", "webpack.config.yml")
       )
-    ).to.throw(/- require-yaml/m);
+    ).to.throw(/Unable to use specified module loader/m);
   });
 
   it("returns contents of the webpack config when the non-native extension _is_ registered", () => {


### PR DESCRIPTION
## Description

- upgrades `interpret` to ^3.1.0 - so it's the same as webpack-cli's version

## Motivation and Context

- LCM

## How Has This Been Tested?

- [x] green ci
- [x] updated unit test (error messages changed between 2 and 3)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
