### PR TITLE
bugfix(mermaid): makes nodes without a name render as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "depcruise:graph:doc:samples": "sh tools/generate-samples.sh",
     "depcruise:graph:dot": "node ./bin/dependency-cruise.js bin src --config --output-type dot | dot -T svg > tmp_deps.svg",
     "depcruise:graph:fdp": "node ./bin/dependency-cruise.js bin src --config --output-type dot | fdp -GK=0.1 -Gsplines=true -T svg > tmp_deps.svg",
-    "depcruise:graph:mermaid": "node ./bin/dependency-cruise.js bin src --include-only ^src/ --config --output-type mermaid",
+    "depcruise:graph:mermaid": "node ./bin/dependency-cruise.js bin src --include-only ^src/ --config --collapse 2 --output-type mermaid",
     "depcruise:graph:mermaid:diff": "node ./bin/dependency-cruise.js bin src test --config configs/.dependency-cruiser-unlimited.json --output-type mermaid --reaches \"$(watskeburt $SHA)\"",
     "depcruise:graph:osage": "node ./bin/dependency-cruise.js bin src --config --output-type dot | osage -Gpack=32 -GpackMode=array2 -T svg > tmp_deps.svg",
     "depcruise:graph:view": "node ./bin/dependency-cruise.js bin src --prefix vscode://file/$(pwd)/ --config configs/.dependency-cruiser-show-metrics-config.json --output-type dot --progress cli-feedback --highlight \"$(watskeburt develop)\" | dot -T svg | node ./bin/wrap-stream-in-html.js | browser",

--- a/src/report/mermaid.js
+++ b/src/report/mermaid.js
@@ -4,7 +4,8 @@ const REPORT_DEFAULTS = {
   minify: true,
 };
 
-const renderNode = (pNode, pText) => `${pNode}["${pText}"]`;
+const renderNode = (pNode, pText) =>
+  `${pNode}["${pText.length > 0 ? pText : " "}"]`;
 
 const renderEdge = (pFrom, pTo) => `${pFrom.node}-->${pTo.node}`;
 

--- a/test/report/mermaid/__mocks__/collapsed.json
+++ b/test/report/mermaid/__mocks__/collapsed.json
@@ -1,0 +1,65 @@
+{
+  "modules": [
+    {
+      "dependencies": [],
+      "rules": [],
+      "valid": false,
+      "source": "src/",
+      "dependents": [],
+      "orphan": true,
+      "consolidated": true
+    }
+  ],
+  "summary": {
+    "violations": [],
+    "error": 0,
+    "warn": 0,
+    "info": 0,
+    "ignore": 0,
+    "totalCruised": 1,
+    "totalDependenciesCruised": 0,
+    "optionsUsed": {
+      "baseDir": "/Users/jdoe/dependency-cruiser",
+      "cache": "node_modules/.cache/dependency-cruiser",
+      "collapse": "node_modules/[^/]+|^[^/]+/",
+      "combinedDependencies": false,
+      "doNotFollow": {
+        "path": "node_modules",
+        "dependencyTypes": [
+          "npm",
+          "npm-dev",
+          "npm-optional",
+          "npm-peer",
+          "npm-bundled",
+          "npm-no-pkg"
+        ]
+      },
+      "enhancedResolveOptions": {
+        "exportsFields": ["exports"],
+        "conditionNames": ["require"],
+        "extensions": [".js", ".d.ts"]
+      },
+      "exclude": {
+        "path": "mocks|fixtures|test/integration|src/cli/tools/svg-in-html-snippets/script.snippet.js"
+      },
+      "exoticRequireStrings": ["tryRequire", "requireJSON"],
+      "externalModuleResolutionStrategy": "node_modules",
+      "includeOnly": "^src/",
+      "metrics": false,
+      "moduleSystems": ["cjs", "es6"],
+      "outputTo": "-",
+      "outputType": "json",
+      "prefix": "https://github.com/sverweij/dependency-cruiser/blob/develop/",
+      "preserveSymlinks": false,
+      "reporterOptions": {},
+      "rulesFile": ".dependency-cruiser.json",
+      "tsPreCompilationDeps": true,
+      "args": "bin src"
+    },
+    "ruleSetUsed": {}
+  },
+  "revisionData": {
+    "SHA1": "3fc6295ac0edfdb8f23957720298be9b8d6d395f",
+    "changes": []
+  }
+}

--- a/test/report/mermaid/__mocks__/collapsed.min.mmd
+++ b/test/report/mermaid/__mocks__/collapsed.min.mmd
@@ -1,0 +1,6 @@
+flowchart LR
+
+subgraph 0["src"]
+1[" "]
+end
+

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -52,6 +52,9 @@ describe("[I] report/mermaid", () => {
   it("renders a mermaid - renders focused elements with highlights - minified", () => {
     same("with-focus", { minify: true });
   });
+  it("renders collapsed nodes correctly", () => {
+    same("collapsed", { minify: true });
+  });
 });
 
 describe("[I] configs/plugins/mermaid-reporter-plugin", () => {


### PR DESCRIPTION
## Description

- if a node has no name, label it `" "` in stead of `""` the latter of which mermaid refuses to render

## Motivation and Context

These nodes occur when running dependency-cruiser with a `--collapse` pattern. This is a temporary band-aid until we've found a way to have the mermaid reporter output these more elegantly.

## How Has This Been Tested?

- [ ] green ci

## Screenshots

coming up

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [ ] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
