### PR TITLE
refactor(init-config): removes superfluous function; touches up the typing a bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "depcruise:graph:dot": "node ./bin/dependency-cruise.js bin src --config --output-type dot | dot -T svg > tmp_deps.svg",
     "depcruise:graph:fdp": "node ./bin/dependency-cruise.js bin src --config --output-type dot | fdp -GK=0.1 -Gsplines=true -T svg > tmp_deps.svg",
     "depcruise:graph:mermaid": "node ./bin/dependency-cruise.js bin src --include-only ^src/ --config --collapse 2 --output-type mermaid",
-    "depcruise:graph:mermaid:diff": "node ./bin/dependency-cruise.js bin src test --config configs/.dependency-cruiser-unlimited.json --output-type mermaid --reaches \"$(watskeburt $SHA)\"",
+    "depcruise:graph:mermaid:diff": "node ./bin/dependency-cruise.js bin src test types tools --config configs/.dependency-cruiser-unlimited.json --output-type mermaid --reaches \"$(watskeburt $SHA)\"",
     "depcruise:graph:osage": "node ./bin/dependency-cruise.js bin src --config --output-type dot | osage -Gpack=32 -GpackMode=array2 -T svg > tmp_deps.svg",
     "depcruise:graph:view": "node ./bin/dependency-cruise.js bin src --prefix vscode://file/$(pwd)/ --config configs/.dependency-cruiser-show-metrics-config.json --output-type dot --progress cli-feedback --highlight \"$(watskeburt develop)\" | dot -T svg | node ./bin/wrap-stream-in-html.js | browser",
     "depcruise:graph:view:diff": "node ./bin/dependency-cruise.js bin src test --prefix vscode://file/$(pwd)/ --config configs/.dependency-cruiser-unlimited.json --output-type dot --progress cli-feedback --reaches \"$(watskeburt develop)\" | dot -T svg | node ./bin/wrap-stream-in-html.js | browser",

--- a/src/cli/init-config/build-config.js
+++ b/src/cli/init-config/build-config.js
@@ -9,9 +9,9 @@ require("./config.js.template");
  * Creates a .dependency-cruiser config with a set of basic validations
  * to the current directory.
  *
- * @returns {void}  Nothing
- * @param  {any}    pNormalizedInitOptions Options that influence the shape of
+ * @param {import("../../../types/init-config").IInitConfig} pNormalizedInitOptions Options that influence the shape of
  *                  the configuration
+ * @returns {string} the configuration as a string
  */
 
 module.exports = function buildConfig(pNormalizedInitOptions) {

--- a/src/cli/init-config/environment-helpers.js
+++ b/src/cli/init-config/environment-helpers.js
@@ -24,9 +24,12 @@ function readManifest(pManifestFileName = "./package.json") {
   return JSON.parse(readFileSync(pManifestFileName, "utf8"));
 }
 
-/*
-  We could have used utl.fileExists - but that one is cached.
-  Not typically what we want for this util.
+/**
+ * We could have used utl.fileExists - but that one is cached.
+ * Not typically what we want for this util.
+ *
+ * @param {import("fs").PathLike} pFile
+ * @returns {boolean}
  */
 function fileExists(pFile) {
   try {

--- a/src/cli/init-config/get-user-input.js
+++ b/src/cli/init-config/get-user-input.js
@@ -15,7 +15,7 @@ const {
   hasWebpackConfigCandidates,
   getWebpackConfigCandidates,
 } = require("./environment-helpers");
-const { validateLocation } = require("./inquirer-validators");
+const { validateLocation } = require("./validators");
 
 function toPromptChoice(pString) {
   return {
@@ -24,7 +24,7 @@ function toPromptChoice(pString) {
   };
 }
 
-/** @type {import('@types/prompts').PromptObject[]} */
+/** @type {import('prompts').PromptObject[]} */
 const QUESTIONS = [
   {
     name: "isMonoRepo",

--- a/src/cli/init-config/index.js
+++ b/src/cli/init-config/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 const $defaults = require("../defaults");
 const normalizeInitOptions = require("./normalize-init-options");
 const buildConfig = require("./build-config");
@@ -29,8 +30,8 @@ const PACKAGE_MANIFEST = `./${$defaults.PACKAGE_MANIFEST}`;
  * @param {import("../../../types/init-config").OneShotConfigIDType} pOneShotConfigId
  * @return {import("../../../types/init-config").IPartialInitConfig} an initialization configuration
  */
-function getOneshotConfig(pOneShotConfigId) {
-  /** @type {"../../../types/init-config").IPartialInitConfig} */
+function getOneShotConfig(pOneShotConfigId) {
+  /** @type {import("../../../types/init-config").IPartialInitConfig} */
   const lBaseConfig = {
     isMonoRepo: isLikelyMonoRepo(),
     combinedDependencies: false,
@@ -44,7 +45,8 @@ function getOneshotConfig(pOneShotConfigId) {
     useBabelConfig: hasBabelConfigCandidates(),
     babelConfig: getBabelConfigCandidates().shift(),
   };
-  const lOneshotConfigs = {
+  /** @type {Record<import("../../../types/init-config").OneShotConfigIDType, import("../../../types/init-config").IPartialInitConfig>} */
+  const lOneShotConfigs = {
     preset: {
       configType: "preset",
       preset: "dependency-cruiser/configs/recommended-strict",
@@ -58,20 +60,23 @@ function getOneshotConfig(pOneShotConfigId) {
   };
 
   // eslint-disable-next-line security/detect-object-injection
-  return lOneshotConfigs[pOneShotConfigId] || lBaseConfig;
+  return lOneShotConfigs[pOneShotConfigId] || lBaseConfig;
 }
 
 /**
  *
  * @param {import("../../../types/init-config").IInitConfig} pNormalizedInitConfig
  */
-function manifestIsUpdateable(pNormalizedInitConfig) {
+function manifestIsUpdatable(pNormalizedInitConfig) {
   return (
     pNormalizedInitConfig.updateManifest &&
     pNormalizedInitConfig.sourceLocation.length > 0
   );
 }
 
+/**
+ * @param {boolean|import("../../../types/init-config").OneShotConfigIDType} pInit
+ */
 module.exports = function initConfig(pInit) {
   /* c8 ignore start */
   if (pInit === true) {
@@ -83,13 +88,15 @@ module.exports = function initConfig(pInit) {
         process.stderr.write(`\n  ERROR: ${pError.message}\n`);
       });
     /* c8 ignore stop */
+  } else if (pInit === false) {
+    // do nothing; deliberately left empty
   } else {
-    const lNormalizedInitConfig = normalizeInitOptions(getOneshotConfig(pInit));
+    const lNormalizedInitConfig = normalizeInitOptions(getOneShotConfig(pInit));
     if (!fileExists(getDefaultConfigFileName())) {
       writeConfig(buildConfig(lNormalizedInitConfig));
     }
 
-    if (manifestIsUpdateable(lNormalizedInitConfig)) {
+    if (manifestIsUpdatable(lNormalizedInitConfig)) {
       writeRunScriptsToManifest(lNormalizedInitConfig);
     }
   }

--- a/src/cli/init-config/validators.js
+++ b/src/cli/init-config/validators.js
@@ -1,12 +1,5 @@
 const fs = require("fs");
-const { toSourceLocationArray, fileExists } = require("./environment-helpers");
-
-function validateFileExistence(pInput) {
-  return (
-    fileExists(pInput) ||
-    `hmm, '${pInput}' doesn't seem to exist - could you try again?`
-  );
-}
+const { toSourceLocationArray } = require("./environment-helpers");
 
 function validateLocation(pLocations) {
   for (const lLocation of toSourceLocationArray(pLocations)) {
@@ -23,6 +16,5 @@ function validateLocation(pLocations) {
 }
 
 module.exports = {
-  validateFileExistence,
   validateLocation,
 };

--- a/src/cli/init-config/write-config.js
+++ b/src/cli/init-config/write-config.js
@@ -11,7 +11,7 @@ const {
  *
  * @returns {void}  Nothing
  * @param  {string} pConfig - dependency-cruiser configuration
- * @param  {string} pFileName - name of the file to write to
+ * @param  {import("fs").PathOrFileDescriptor} pFileName - name of the file to write to
  * @throws {Error}  An error object with the root cause of the problem
  *                  as a description:
  *                  - file already exists

--- a/test/cli/init-config/validators.spec.mjs
+++ b/test/cli/init-config/validators.spec.mjs
@@ -1,37 +1,5 @@
-/* eslint-disable no-unused-expressions */
 import { expect } from "chai";
-import validators from "../../../src/cli/init-config/inquirer-validators.js";
-
-describe("[U] cli/init-config/inquirer-validators - validateFileExistence", () => {
-  const WORKING_DIR = process.cwd();
-  const lFixturesDirectory =
-    "test/cli/init-config/__fixtures__/validate-file-existence";
-
-  beforeEach("set up", () => {
-    process.chdir(lFixturesDirectory);
-  });
-
-  afterEach("tear down", () => {
-    process.chdir(WORKING_DIR);
-  });
-
-  it("returns an error message when presented with an empty string", () => {
-    expect(validators.validateFileExistence("")).to.equal(
-      `hmm, '' doesn't seem to exist - could you try again?`
-    );
-  });
-
-  it("returns an error message when presented with a name of a non existing file", () => {
-    expect(validators.validateFileExistence("nope-does-not-exist")).to.equal(
-      `hmm, 'nope-does-not-exist' doesn't seem to exist - could you try again?`
-    );
-  });
-
-  it("returns true when presented with the name of a file that does exist", () => {
-    expect(validators.validateFileExistence("i-have-bytes-therefore-i-exist"))
-      .to.be.true;
-  });
-});
+import validators from "../../../src/cli/init-config/validators.js";
 
 describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
   const WORKING_DIR = process.cwd();

--- a/types/init-config.d.ts
+++ b/types/init-config.d.ts
@@ -2,8 +2,6 @@ export type OneShotConfigIDType = "preset" | "yes" | "experimental-scripts";
 
 export type ConfigTypeType = "preset" | "self-contained";
 
-export type ExternalModuleResolutionStrategyType = "yarn-pnp" | "node_modules";
-
 export interface IInitConfig {
   /**
    * Whether or not the current folder houses a mono repo
@@ -17,6 +15,14 @@ export interface IInitConfig {
   /**
    * Whether or not to use a TypeScript config
    */
+  useJsConfig: boolean;
+  /**
+   * The file name of the TypeScript config to use
+   */
+  jsConfig?: string;
+  /**
+   * Whether or not to use a TypeScript config
+   */
   useTsConfig: boolean;
   /**
    * The file name of the TypeScript config to use
@@ -27,15 +33,6 @@ export interface IInitConfig {
    * compilation to javascript
    */
   tsPreCompilationDeps: boolean;
-  /**
-   * Whether or not to use Yarn plug'n play for module resolution (only useful
-   * when the package.json + repo are prepared for this)
-   */
-  useYarnPnP: boolean;
-  /**
-   *
-   */
-  externalModuleResolutionStrategy: ExternalModuleResolutionStrategyType;
   /**
    * Whether or not to use a Webpack config
    */


### PR DESCRIPTION
## Description

- renames the inquirers-validators.js to validators.js (we're not using inquirer anymore and for the validators it's not relevant in any case
- removes a function in that file that wasn't used (other than in a test - which got removed too)
- corrects spelling of some functions & variable names
- corrects/ clarifies some typings in the init-config code (it's not perfect yet, but better than it was)
- removes attributes from IInitOptions interface as they weren't used anymore + added the jsConfig ones 

## Motivation and Context

- should ease maintenance a bit
- dead code will rot ...

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
