### PR TITLE
bugfix(report): improves instability alignment in metrics reporter

### DIFF
--- a/src/report/metrics.js
+++ b/src/report/metrics.js
@@ -3,7 +3,7 @@ const chalk = require("chalk");
 const utl = require("./utl");
 
 const DECIMAL_BASE = 10;
-const METRIC_WIDTH = 4;
+const METRIC_WIDTH = 5;
 const COMPONENT_HEADER = "name";
 
 function getHeader(pMaxNameWidth) {
@@ -11,7 +11,7 @@ function getHeader(pMaxNameWidth) {
     METRIC_WIDTH + 1
   )} ${"Ca".padStart(METRIC_WIDTH + 1)} ${"Ce".padStart(
     METRIC_WIDTH + 1
-  )}  ${"I (%)".padEnd(METRIC_WIDTH + 1)}`;
+  )} ${"I (%)".padStart(METRIC_WIDTH + 1)}`;
 }
 
 function getDemarcationLine(pMaxNameWidth) {
@@ -19,7 +19,7 @@ function getDemarcationLine(pMaxNameWidth) {
     METRIC_WIDTH + 1
   )} ${"-".repeat(METRIC_WIDTH + 1)} ${"-".repeat(
     METRIC_WIDTH + 1
-  )}  ${"-".repeat(METRIC_WIDTH + 1)}`;
+  )} ${"-".repeat(METRIC_WIDTH + 1)}`;
 }
 
 function getMetricsTable(pMetrics, pMaxNameWidth) {
@@ -39,7 +39,6 @@ function getMetricsTable(pMetrics, pMaxNameWidth) {
         .toString(DECIMAL_BASE)
         .padStart(METRIC_WIDTH)}  ${utl
         .formatPercentage(instability)
-        .toString(DECIMAL_BASE)
         .padStart(METRIC_WIDTH)}`
   );
 }

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -26,7 +26,7 @@ describe("[I] report/metrics", () => {
     });
 
     expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain("src      1     1     1   50%");
+    expect(lResult.output).to.contain("src       1      1      1    50%");
   });
 
   it("does not emit folder metrics when asked to hide them", () => {
@@ -47,7 +47,7 @@ describe("[I] report/metrics", () => {
     );
 
     expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.not.contain("src      1     1     1   50%");
+    expect(lResult.output).to.not.contain("src       1      1      1    50%");
   });
 
   it("emits module metrics (sorted by instability by default)", () => {
@@ -77,7 +77,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.contain(
-      `src/mies.js     1     1     1   50%${EOL}src/aap.js      1     1     3   25%${EOL}src/noot.js`
+      `src/mies.js      1      1      1    50%${EOL}src/aap.js       1      1      3    25%${EOL}src/noot.js`
     );
   });
 
@@ -111,7 +111,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.contain(
-      `src/aap.js      1     1     3   25%${EOL}src/mies.js     1     1     1   50%${EOL}src/noot.js`
+      `src/aap.js       1      1      3    25%${EOL}src/mies.js      1      1      1    50%${EOL}src/noot.js`
     );
   });
 
@@ -145,7 +145,7 @@ describe("[I] report/metrics", () => {
 
     expect(lResult.exitCode).to.equal(0);
     expect(lResult.output).to.not.contain(
-      `src/mies.js     1     1     1    50${EOL}src/aap.js      1     1     3    25%${EOL}src/noot.js`
+      `src/mies.js      1      1      1     50%${EOL}src/aap.js       1      1      3     25%${EOL}src/noot.js`
     );
   });
 


### PR DESCRIPTION
## Description

- reserves an extra character of room for displaying metrics in the metrics reporter
- also removes a superfluous `toString` statement from the same

## Motivation and Context

Some locales put a space between the number and the percentage sign. The max width of the I column didn't account for that - resulting in misalignment between 3 and < 3 number percentages:

```
100 %
90 %
 1 %
100 %
```

After the fix it looks normal in these locales again:

```
100 %
 90 %
  1 %
100 %
```

## How Has This Been Tested?

- [ ] green ci
- [ ] adapted unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
