### PR TITLE
refactor(performance-log): improves readability of code

### DIFF
--- a/src/cli/listeners/performance-log/format-helpers.js
+++ b/src/cli/listeners/performance-log/format-helpers.js
@@ -7,10 +7,9 @@ const NUMBER_OF_COLUMNS = 8;
 const K = 1024;
 /*
  * using `undefined` as the first parameter to Intl.NumberFormat so
- * it will fall back to the 'current' locale. Another way to
- * accomplish this is to use a non-existent language (e.g. `zz`) also works,
- * but this seems to be the lesser of the two evil as `undefined` is closer
- * to the intent of just skipping the optional parameter.
+ * it will fall back to the 'current' locale. Using a non-existent language
+ * (e.g. `zz`) also works, but `undefined`  seems to be the lesser of the two
+ * evil as it is closer to the intent (skip the optional parameter).
  */
 // eslint-disable-next-line no-undefined
 const LOCALE = undefined;
@@ -29,16 +28,20 @@ const gSizeFormat = new Intl.NumberFormat(LOCALE, {
   maximumFractionDigits: 0,
 }).format;
 
-const pad = (pString) => pString.padStart(MAX_LENGTH_EXPECTED);
+const pad = (pString) => pString.padStart(MAX_LENGTH_EXPECTED).concat(" ");
 
 function formatHeader() {
   return chalk
     .bold(
-      `${pad("elapsed real")} ${pad("user")} ${pad("system")} ${pad(
-        "∆ rss"
-      )} ${pad("∆ heapTotal")} ${pad("∆ heapUsed")} ${pad(
-        "∆ external"
-      )} after step...\n`
+      `${
+        pad("elapsed real") +
+        pad("user") +
+        pad("system") +
+        pad("∆ rss") +
+        pad("∆ heapTotal") +
+        pad("∆ heapUsed") +
+        pad("∆ external")
+      }after step...\n`
     )
     .concat(
       `${`${"-".repeat(MAX_LENGTH_EXPECTED)} `.repeat(NUMBER_OF_COLUMNS)}\n`
@@ -46,15 +49,15 @@ function formatHeader() {
 }
 
 function formatTime(pNumber, pConversionMultiplier = MS_PER_SECOND) {
-  return gTimeFormat(pConversionMultiplier * pNumber).padStart(
-    MAX_LENGTH_EXPECTED
-  );
+  return gTimeFormat(pConversionMultiplier * pNumber)
+    .padStart(MAX_LENGTH_EXPECTED)
+    .concat(" ");
 }
 
 function formatMemory(pBytes) {
   const lReturnValue = gSizeFormat(pBytes / K).padStart(MAX_LENGTH_EXPECTED);
 
-  return pBytes < 0 ? chalk.blue(lReturnValue) : lReturnValue;
+  return (pBytes < 0 ? chalk.blue(lReturnValue) : lReturnValue).concat(" ");
 }
 
 function formatPerfLine({
@@ -67,14 +70,16 @@ function formatPerfLine({
   deltaExternal,
   message,
 }) {
-  return `${formatTime(elapsedTime)} ${formatTime(
-    elapsedUser,
-    MS_PER_MICRO_SECOND
-  )} ${formatTime(elapsedSystem, MS_PER_MICRO_SECOND)} ${formatMemory(
-    deltaRss
-  )} ${formatMemory(deltaHeapTotal)} ${formatMemory(
-    deltaHeapUsed
-  )} ${formatMemory(deltaExternal)} ${message}\n`;
+  return `${
+    formatTime(elapsedTime) +
+    formatTime(elapsedUser, MS_PER_MICRO_SECOND) +
+    formatTime(elapsedSystem, MS_PER_MICRO_SECOND) +
+    formatMemory(deltaRss) +
+    formatMemory(deltaHeapTotal) +
+    formatMemory(deltaHeapUsed) +
+    formatMemory(deltaExternal) +
+    message
+  }\n`;
 }
 
 module.exports = {

--- a/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
@@ -20,27 +20,27 @@ import formatHelpers from "../../../../src/cli/listeners/performance-log/format-
 
 describe("[U] cli/listeners/performance-log/format-helpers - formatTime", () => {
   it("converts to ms, left pads & adds the unit at the end", () => {
-    expect(formatHelpers.formatTime(14.88041018)).to.equal("    14,880ms");
+    expect(formatHelpers.formatTime(14.88041018)).to.equal("    14,880ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (0)", () => {
-    expect(formatHelpers.formatTime(0)).to.equal("         0ms");
+    expect(formatHelpers.formatTime(0)).to.equal("         0ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (negative numbers)", () => {
-    expect(formatHelpers.formatTime(-3.1415926535)).to.equal("    -3,142ms");
+    expect(formatHelpers.formatTime(-3.1415926535)).to.equal("    -3,142ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (null treatment => 0)", () => {
-    expect(formatHelpers.formatTime(null)).to.equal("         0ms");
+    expect(formatHelpers.formatTime(null)).to.equal("         0ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (undefined treatment => NaN)", () => {
-    expect(formatHelpers.formatTime()).to.equal("       NaNms");
+    expect(formatHelpers.formatTime()).to.equal("       NaNms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (non-number treatment => NaN)", () => {
-    expect(formatHelpers.formatTime("not a number")).to.equal("       NaNms");
+    expect(formatHelpers.formatTime("not a number")).to.equal("       NaNms ");
   });
 });
 
@@ -56,27 +56,29 @@ describe("[U] cli/listeners/performance-log/format-helpers - formatMemory", () =
   });
 
   it("converts to kB, left pads & adds the unit at the end", () => {
-    expect(formatHelpers.formatMemory(4033856)).to.equal("    +3,939kB");
+    expect(formatHelpers.formatMemory(4033856)).to.equal("    +3,939kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (0)", () => {
-    expect(formatHelpers.formatMemory(0)).to.equal("         0kB");
+    expect(formatHelpers.formatMemory(0)).to.equal("         0kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (negative numbers)", () => {
-    expect(formatHelpers.formatMemory(-403385623)).to.equal("  -393,931kB");
+    expect(formatHelpers.formatMemory(-403385623)).to.equal("  -393,931kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (null)", () => {
-    expect(formatHelpers.formatMemory(0)).to.equal("         0kB");
+    expect(formatHelpers.formatMemory(0)).to.equal("         0kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (undefined)", () => {
-    expect(formatHelpers.formatMemory()).to.equal("       NaNkB");
+    expect(formatHelpers.formatMemory()).to.equal("       NaNkB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (not a number)", () => {
-    expect(formatHelpers.formatMemory("not a number")).to.equal("       NaNkB");
+    expect(formatHelpers.formatMemory("not a number")).to.equal(
+      "       NaNkB "
+    );
   });
 });
 


### PR DESCRIPTION
## Description

- uses `+` & `concats` in stead of template strings to improve readability of the code that produces the performance logs

## Motivation and Context

Improves readability & maintainability of the code.

## How Has This Been Tested?

- [x] green ci
- [x] adapted unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
