### PR TITLE
bugfix(mermaid): circumvents mermaid edge naming ambiguities

### DIFF
--- a/src/report/mermaid.js
+++ b/src/report/mermaid.js
@@ -128,7 +128,17 @@ function hashModuleNames(pModules, pMinify) {
       const lName = lPaths.slice(0, lIndex + 1).join("/");
       if (!lNamesHashMap.has(lName)) {
         if (pMinify) {
-          lNamesHashMap.set(lName, lCount.toString(lBase));
+          // toUpperCase because otherwise we generate e.g. o-->a and x-->a
+          // which are ambiguous in mermaid (o--> and x--> are edge shapes
+          // whereas e.g. a--> is node 'a' + the arrow shape -->). The only
+          // collision within alphanums are 'o' and 'x', so upper casing
+          // saves us...
+          // ref: https://mermaid.js.org/syntax/flowchart.html#new-arrow-types
+          // another way to solve this would be to place a space between the
+          // node name and the edge shape (x --> a) - however, this would make
+          // for a larger output, running into the mermaid max source size
+          // earlier
+          lNamesHashMap.set(lName, lCount.toString(lBase).toUpperCase());
           lCount += 1;
         } else {
           lNamesHashMap.set(lName, hashToReadableNodeName(lName));

--- a/test/report/mermaid/__mocks__/dependency-cruiser-2019-01-14.min.mmd
+++ b/test/report/mermaid/__mocks__/dependency-cruiser-2019-01-14.min.mmd
@@ -11,17 +11,17 @@ end
 subgraph 6["semver"]
 7["semver.js"]
 end
-subgraph b["glob"]
-c["glob.js"]
+subgraph B["glob"]
+C["glob.js"]
 end
-subgraph d["lodash"]
-e["get.js"]
-m["lodash.js"]
-1n["memoize.js"]
-2h["clone.js"]
-2i["uniq.js"]
-2o["flattenDeep.js"]
-2x["uniqBy.js"]
+subgraph D["lodash"]
+E["get.js"]
+M["lodash.js"]
+1N["memoize.js"]
+2H["clone.js"]
+2I["uniq.js"]
+2O["flattenDeep.js"]
+2X["uniqBy.js"]
 44["set.js"]
 48["isEqual.js"]
 49["uniqWith.js"]
@@ -31,19 +31,19 @@ subgraph 15["dist"]
 16["walk.js"]
 end
 end
-subgraph 1a["semver-try-require"]
-subgraph 1b["src"]
-1c["index.js"]
+subgraph 1A["semver-try-require"]
+subgraph 1B["src"]
+1C["index.js"]
 end
 end
-subgraph 1g["acorn"]
-subgraph 1h["dist"]
-1i["acorn.js"]
+subgraph 1G["acorn"]
+subgraph 1H["dist"]
+1I["acorn.js"]
 end
 end
-subgraph 1j["acorn-loose"]
-subgraph 1k["dist"]
-1l["acorn-loose.js"]
+subgraph 1J["acorn-loose"]
+subgraph 1K["dist"]
+1L["acorn-loose.js"]
 end
 end
 subgraph 22["resolve"]
@@ -54,13 +54,13 @@ subgraph 28["lib"]
 29["node.js"]
 end
 end
-subgraph 2b["awesome-typescript-loader"]
-subgraph 2c["dist"]
-2d["entry.js"]
+subgraph 2B["awesome-typescript-loader"]
+subgraph 2C["dist"]
+2D["entry.js"]
 end
 end
-subgraph 2r["handlebars"]
-2s["runtime.js"]
+subgraph 2R["handlebars"]
+2S["runtime.js"]
 end
 subgraph 34["chalk"]
 35["index.js"]
@@ -68,97 +68,97 @@ end
 subgraph 36["figures"]
 37["index.js"]
 end
-subgraph 3g["safe-regex"]
-3h["index.js"]
+subgraph 3G["safe-regex"]
+3H["index.js"]
 end
-subgraph 3m["ajv"]
-subgraph 3n["lib"]
-3o["ajv.js"]
+subgraph 3M["ajv"]
+subgraph 3N["lib"]
+3O["ajv.js"]
 end
 end
-subgraph 3z["inquirer"]
+subgraph 3Z["inquirer"]
 subgraph 40["lib"]
 41["inquirer.js"]
 end
 end
-subgraph 4b["strip-json-comments"]
-4c["index.js"]
+subgraph 4B["strip-json-comments"]
+4C["index.js"]
 end
 end
 subgraph 8["src"]
 subgraph 9["cli"]
-a["index.js"]
-3p["formatMetaInfo.js"]
-3q["getResolveConfig.js"]
-subgraph 3r["utl"]
-3s["makeAbsolute.js"]
-4e["io.js"]
-4f["validateFileExistence.js"]
+A["index.js"]
+3P["formatMetaInfo.js"]
+3Q["getResolveConfig.js"]
+subgraph 3R["utl"]
+3S["makeAbsolute.js"]
+4E["io.js"]
+4F["validateFileExistence.js"]
 end
-subgraph 3t["initConfig"]
-3u["index.js"]
-3v["createConfigFile.js"]
-3w["config.js.template.js"]
-3x["config.json.template.js"]
-3y["getUserInput.js"]
+subgraph 3T["initConfig"]
+3U["index.js"]
+3V["createConfigFile.js"]
+3W["config.js.template.js"]
+3X["config.json.template.js"]
+3Y["getUserInput.js"]
 end
 42["normalizeOptions.js"]
 43["defaults.json"]
 subgraph 45["compileConfig"]
 46["index.js"]
 47["mergeConfigs.js"]
-4a["readConfig.js"]
+4A["readConfig.js"]
 end
-4d["parseTSConfig.js"]
+4D["parseTSConfig.js"]
 end
-subgraph f["main"]
-g["index.js"]
-subgraph 3c["options"]
-3d["normalize.js"]
-3e["defaults.json"]
-3f["validate.js"]
+subgraph F["main"]
+G["index.js"]
+subgraph 3C["options"]
+3D["normalize.js"]
+3E["defaults.json"]
+3F["validate.js"]
 end
-subgraph 3i["ruleSet"]
-3j["normalize.js"]
-3k["validate.js"]
-3l["jsonschema.json"]
+subgraph 3I["ruleSet"]
+3J["normalize.js"]
+3K["validate.js"]
+3L["jsonschema.json"]
 end
 end
-subgraph h["report"]
-subgraph i["dot"]
-j["richModuleColorScheme.json"]
-2y["coloring.js"]
-2z["defaultModuleColorScheme.json"]
+subgraph H["report"]
+subgraph I["dot"]
+J["richModuleColorScheme.json"]
+2Y["coloring.js"]
+2Z["defaultModuleColorScheme.json"]
 31["index.js"]
 32["dot.template.js"]
 end
-subgraph 2p["csv"]
-2q["index.js"]
-2u["csv.template.js"]
+subgraph 2P["csv"]
+2Q["index.js"]
+2U["csv.template.js"]
 end
-2t["dependencyToIncidenceTransformer.js"]
-subgraph 2v["ddot"]
-2w["index.js"]
+2T["dependencyToIncidenceTransformer.js"]
+subgraph 2V["ddot"]
+2W["index.js"]
 30["ddot.template.js"]
 end
 33["err.js"]
 subgraph 38["html"]
 39["index.js"]
-3a["html.template.js"]
+3A["html.template.js"]
 end
-3b["json.js"]
+3B["json.js"]
 end
-subgraph k["extract"]
-l["index.js"]
-n["addValidations.js"]
-subgraph t["derive"]
-subgraph u["circular"]
-v["index.js"]
-w["dependencyEndsUpAtFrom.js"]
+subgraph K["extract"]
+L["index.js"]
+N["addValidations.js"]
+subgraph T["derive"]
+subgraph U["circular"]
+V["index.js"]
+W["dependencyEndsUpAtFrom.js"]
 end
-subgraph x["orphan"]
-y["index.js"]
-z["isOrphan.js"]
+subgraph X["orphan"]
+Y["index.js"]
+Z["isOrphan.js"]
 end
 end
 10["extract.js"]
@@ -168,252 +168,252 @@ subgraph 12["ast-extractors"]
 18["extract-ES6-deps.js"]
 19["extract-typescript-deps.js"]
 end
-1d["ignore.js"]
-subgraph 1e["parse"]
-1f["toJavascriptAST.js"]
-1x["toTypescriptAST.js"]
+1D["ignore.js"]
+subgraph 1E["parse"]
+1F["toJavascriptAST.js"]
+1X["toTypescriptAST.js"]
 end
-subgraph 1o["transpile"]
-1p["index.js"]
-1q["meta.js"]
-1r["coffeeWrap.js"]
-1s["javaScriptWrap.js"]
-1t["liveScriptWrap.js"]
-1u["typeScriptWrap.js"]
+subgraph 1O["transpile"]
+1P["index.js"]
+1Q["meta.js"]
+1R["coffeeWrap.js"]
+1S["javaScriptWrap.js"]
+1T["liveScriptWrap.js"]
+1U["typeScriptWrap.js"]
 end
-subgraph 1v["utl"]
-1w["getExtension.js"]
+subgraph 1V["utl"]
+1W["getExtension.js"]
 20["pathToPosix.js"]
 end
-subgraph 1y["resolve"]
-1z["index.js"]
+subgraph 1Y["resolve"]
+1Z["index.js"]
 21["resolve-AMD.js"]
 24["determineDependencyTypes.js"]
 25["localNpmHelpers.js"]
 26["resolve.js"]
-2a["compileResolveOptions.js"]
-subgraph 2e["readPackageDeps"]
-2f["index.js"]
-2g["mergePackages.js"]
+2A["compileResolveOptions.js"]
+subgraph 2E["readPackageDeps"]
+2F["index.js"]
+2G["mergePackages.js"]
 end
-2j["resolve-helpers.js"]
-2k["resolve-commonJS.js"]
-2l["isFollowable.js"]
+2J["resolve-helpers.js"]
+2K["resolve-commonJS.js"]
+2L["isFollowable.js"]
 end
-2m["gatherInitialSources.js"]
-2n["summarize.js"]
+2M["gatherInitialSources.js"]
+2N["summarize.js"]
 end
-subgraph o["validate"]
-p["index.js"]
-q["matchDependencyRule.js"]
-r["isModuleOnlyRule.js"]
-s["matchModuleRule.js"]
+subgraph O["validate"]
+P["index.js"]
+Q["matchDependencyRule.js"]
+R["isModuleOnlyRule.js"]
+S["matchModuleRule.js"]
 end
 end
 11["path"]
-1m["fs"]
+1M["fs"]
 1-->2
-1-->a
+1-->A
 1-->5
 1-->7
-a-->g
-a-->3p
-a-->3q
-a-->3u
-a-->42
-a-->4d
-a-->4e
-a-->4f
-a-->c
-a-->e
-g-->l
-g-->1q
-g-->2q
-g-->2w
-g-->31
-g-->j
-g-->33
-g-->39
-g-->3b
-g-->3d
-g-->3f
-g-->3j
-g-->3k
-l-->n
-l-->v
-l-->y
-l-->10
-l-->2m
-l-->2n
-l-->20
-l-->m
-n-->p
-p-->q
-p-->s
-q-->r
-s-->r
-v-->w
-v-->e
-y-->z
-y-->e
+A-->G
+A-->3P
+A-->3Q
+A-->3U
+A-->42
+A-->4D
+A-->4E
+A-->4F
+A-->C
+A-->E
+G-->L
+G-->1Q
+G-->2Q
+G-->2W
+G-->31
+G-->J
+G-->33
+G-->39
+G-->3B
+G-->3D
+G-->3F
+G-->3J
+G-->3K
+L-->N
+L-->V
+L-->Y
+L-->10
+L-->2M
+L-->2N
+L-->20
+L-->M
+N-->P
+P-->Q
+P-->S
+Q-->R
+S-->R
+V-->W
+V-->E
+Y-->Z
+Y-->E
 10-->13
 10-->18
 10-->17
 10-->19
-10-->1d
-10-->1f
-10-->1x
-10-->1z
-10-->m
+10-->1D
+10-->1F
+10-->1X
+10-->1Z
+10-->M
 10-->11
 13-->17
 13-->16
 17-->16
 18-->16
 19-->2
-19-->1c
-1f-->1p
-1f-->1w
-1f-->1i
-1f-->1l
-1f-->1m
-1f-->1n
-1p-->1q
-1q-->2
-1q-->1r
-1q-->1s
-1q-->1t
-1q-->1u
-1r-->2
-1r-->1c
-1t-->2
-1t-->1c
-1u-->2
-1u-->e
-1u-->1c
-1w-->11
-1x-->2
-1x-->1m
-1x-->1n
-1x-->1c
-1z-->20
-1z-->21
-1z-->2k
-1z-->1m
-1z-->11
+19-->1C
+1F-->1P
+1F-->1W
+1F-->1I
+1F-->1L
+1F-->1M
+1F-->1N
+1P-->1Q
+1Q-->2
+1Q-->1R
+1Q-->1S
+1Q-->1T
+1Q-->1U
+1R-->2
+1R-->1C
+1T-->2
+1T-->1C
+1U-->2
+1U-->E
+1U-->1C
+1W-->11
+1X-->2
+1X-->1M
+1X-->1N
+1X-->1C
+1Z-->20
+1Z-->21
+1Z-->2K
+1Z-->1M
+1Z-->11
 20-->11
 21-->20
 21-->24
-21-->2f
-21-->2j
-21-->1m
-21-->1n
+21-->2F
+21-->2J
+21-->1M
+21-->1N
 21-->11
 21-->23
 24-->25
 24-->11
 24-->23
 25-->26
-25-->1m
-25-->1n
+25-->1M
+25-->1N
 25-->11
 26-->20
-26-->2a
+26-->2A
 26-->29
-2a-->1q
-2a-->2d
-2a-->29
-2f-->2g
-2f-->1m
-2f-->1n
-2f-->11
-2g-->2h
-2g-->e
-2g-->2i
-2j-->25
-2k-->20
-2k-->24
-2k-->2l
-2k-->2f
-2k-->26
-2k-->2j
-2k-->11
-2k-->23
-2l-->1w
-2l-->2a
-2m-->1d
-2m-->1q
-2m-->1m
-2m-->c
-2m-->11
-2n-->2o
-2q-->2t
-2q-->2u
-2q-->2s
-2u-->2s
-2w-->2y
-2w-->30
-2w-->2s
-2w-->2h
-2w-->e
-2w-->2x
-2w-->11
-2y-->2z
-2y-->e
-30-->2s
-31-->2y
+2A-->1Q
+2A-->2D
+2A-->29
+2F-->2G
+2F-->1M
+2F-->1N
+2F-->11
+2G-->2H
+2G-->E
+2G-->2I
+2J-->25
+2K-->20
+2K-->24
+2K-->2L
+2K-->2F
+2K-->26
+2K-->2J
+2K-->11
+2K-->23
+2L-->1W
+2L-->2A
+2M-->1D
+2M-->1Q
+2M-->1M
+2M-->C
+2M-->11
+2N-->2O
+2Q-->2T
+2Q-->2U
+2Q-->2S
+2U-->2S
+2W-->2Y
+2W-->30
+2W-->2S
+2W-->2H
+2W-->E
+2W-->2X
+2W-->11
+2Y-->2Z
+2Y-->E
+30-->2S
+31-->2Y
 31-->32
-31-->2s
+31-->2S
 31-->11
-32-->2s
+32-->2S
 33-->35
 33-->37
-39-->2t
-39-->3a
-39-->2s
-3a-->2s
-3d-->3e
-3f-->3h
-3k-->3f
-3k-->3l
-3k-->3o
-3k-->3h
-3p-->g
-3p-->35
-3p-->37
-3q-->3s
-3s-->11
-3u-->3v
-3u-->3y
-3v-->2
-3v-->3w
-3v-->3x
-3v-->1m
-3v-->2s
-3w-->2s
-3x-->2s
-3y-->41
+39-->2T
+39-->3A
+39-->2S
+3A-->2S
+3D-->3E
+3F-->3H
+3K-->3F
+3K-->3L
+3K-->3O
+3K-->3H
+3P-->G
+3P-->35
+3P-->37
+3Q-->3S
+3S-->11
+3U-->3V
+3U-->3Y
+3V-->2
+3V-->3W
+3V-->3X
+3V-->1M
+3V-->2S
+3W-->2S
+3X-->2S
+3Y-->41
 42-->46
 42-->43
-42-->1m
-42-->2h
-42-->e
+42-->1M
+42-->2H
+42-->E
 42-->44
 42-->11
 46-->26
 46-->47
-46-->4a
+46-->4A
 46-->11
-47-->e
+47-->E
 47-->48
-47-->2x
+47-->2X
 47-->49
-4a-->1m
-4a-->11
-4a-->4c
-4d-->2
-4d-->e
-4d-->11
-4d-->1c
-4e-->1m
-4f-->1m
+4A-->1M
+4A-->11
+4A-->4C
+4D-->2
+4D-->E
+4D-->11
+4D-->1C
+4E-->1M
+4F-->1M

--- a/test/report/mermaid/__mocks__/with-focus.min.mmd
+++ b/test/report/mermaid/__mocks__/with-focus.min.mmd
@@ -6,8 +6,8 @@ subgraph 2["rule-set"]
 3["normalize.js"]
 end
 4["index.js"]
-subgraph i["utl"]
-j["normalize-re-properties.js"]
+subgraph I["utl"]
+J["normalize-re-properties.js"]
 end
 end
 end
@@ -19,27 +19,27 @@ subgraph 8["reachable"]
 end
 end
 end
-subgraph a["main"]
-subgraph b["rule-set"]
-c["normalize.spec.mjs"]
+subgraph A["main"]
+subgraph B["rule-set"]
+C["normalize.spec.mjs"]
 end
 end
-subgraph d["validate"]
-e["parse-ruleset.utl.mjs"]
+subgraph D["validate"]
+E["parse-ruleset.utl.mjs"]
 end
 end
-subgraph f["node_modules"]
-subgraph g["lodash"]
-h["has.js"]
-k["cloneDeep.js"]
+subgraph F["node_modules"]
+subgraph G["lodash"]
+H["has.js"]
+K["cloneDeep.js"]
 end
 end
-3-->j
-3-->k
-3-->h
+3-->J
+3-->K
+3-->H
 4-->3
 9-->3
-c-->3
-e-->3
+C-->3
+E-->3
 
 style 3 fill:lime,color:black


### PR DESCRIPTION
## Description

- makes the 'minified' node names in generated mermaid uppercase

## Motivation and Context

There's some interesting edge cases in the mermaid flowchart language. These two seemingly equal flowcharts render differently. Reason is that `o-->` is an arrow shape. Two ways to fix it
- use spaces (`o --> a`) -> this would make the generated .mmd larger, so we'll bump into mermaid's maximum input limit faster
- don't use the characters that manifest the ambiguity (`o` and `x`). Easiest way to accomplish that is to uppercase the 'minified' node names.


```
flowchart LR
o
a
o-->a
```

```mermaid
flowchart LR
o
a
o-->a
```


```
flowchart LR
O
A
O-->A
```

```mermaid
flowchart LR
O
A
O-->A
```



## How Has This Been Tested?

- [x] green ci
- [x] updated automated tests
- [x] some manual testing

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
