### PR TITLE
feature(cache): adds a cache option compatibility check

### DIFF
--- a/src/cache/options-compatible.js
+++ b/src/cache/options-compatible.js
@@ -58,8 +58,8 @@ function includeOnlyIsCompatible(pExistingFilter, pNewFilter) {
     !pExistingFilter || objectsAreEqual({ path: pExistingFilter }, pNewFilter)
   );
 }
-function optionIsCompatible(pExistingFilter, pNewFilter) {
-  return !pExistingFilter || objectsAreEqual(pExistingFilter, pNewFilter);
+function optionIsCompatible(pExistingOption, pNewOption) {
+  return !pExistingOption || objectsAreEqual(pExistingOption, pNewOption);
 }
 
 function limitIsCompatible(pExistingLimit, pNewLimit) {
@@ -68,6 +68,16 @@ function limitIsCompatible(pExistingLimit, pNewLimit) {
 
 function metricsIsCompatible(pExistingMetrics, pNewMetrics) {
   return pExistingMetrics || pExistingMetrics === pNewMetrics;
+}
+
+function cacheOptionIsCompatible(pExistingCacheOption, pNewCacheOption) {
+  if (!pExistingCacheOption || !pNewCacheOption) {
+    return false;
+  }
+  return (
+    pExistingCacheOption === pNewCacheOption ||
+    objectsAreEqual(pExistingCacheOption, pNewCacheOption)
+  );
 }
 
 /**
@@ -106,7 +116,8 @@ function optionsAreCompatible(pOldOptions, pNewOptions) {
     optionIsCompatible(
       pOldOptions.exoticRequireStrings,
       pNewOptions.exoticRequireStrings
-    )
+    ) &&
+    cacheOptionIsCompatible(pOldOptions.cache, pNewOptions.cache)
   );
 }
 
@@ -116,4 +127,5 @@ module.exports = {
   limitsAreCompatible: limitIsCompatible,
   metricsAreCompatible: metricsIsCompatible,
   includeOnlyFiltersAreCompatible: includeOnlyIsCompatible,
+  cacheOptionIsCompatible,
 };

--- a/src/cache/utl.js
+++ b/src/cache/utl.js
@@ -1,4 +1,4 @@
-const { deepEqual } = require("assert");
+const { deepStrictEqual } = require("assert");
 const { createHash } = require("crypto");
 const { readFileSync } = require("fs");
 /**
@@ -9,7 +9,7 @@ const { readFileSync } = require("fs");
  */
 function objectsAreEqual(pLeftObject, pRightObject) {
   try {
-    deepEqual(pLeftObject, pRightObject);
+    deepStrictEqual(pLeftObject, pRightObject);
     return true;
   } catch (pError) {
     return false;

--- a/test/cache/cache.spec.mjs
+++ b/test/cache/cache.spec.mjs
@@ -69,10 +69,19 @@ describe("[I] cache/cache - writeCache", () => {
 });
 
 describe("[I] cache/cache - canServeFromCache", () => {
+  const lOriginalCacheFolder = join(
+    OUTPUTS_FOLDER,
+    "serve-from-cache-compatible"
+  );
+  /** @type import("../..").ICruiseResult */
   const lMinimalCruiseResult = {
     modules: [],
     summary: {
       optionsUsed: {
+        cache: {
+          folder: lOriginalCacheFolder,
+          strategy: "metadata",
+        },
         args: "src test tools",
       },
     },
@@ -84,10 +93,14 @@ describe("[I] cache/cache - canServeFromCache", () => {
     const lEmptyCruiseResult = { modules: [], summary: [] };
 
     expect(
-      canServeFromCache({ cache: lCacheFolder }, lEmptyCruiseResult, {
-        SHA1: "dummy-sha",
-        changes: [],
-      })
+      canServeFromCache(
+        { cache: { folder: lCacheFolder, strategy: "metadata" } },
+        lEmptyCruiseResult,
+        {
+          SHA1: "dummy-sha",
+          changes: [],
+        }
+      )
     ).to.equal(false);
   });
 
@@ -96,7 +109,10 @@ describe("[I] cache/cache - canServeFromCache", () => {
 
     expect(
       canServeFromCache(
-        { args: "src test tools", cache: lCacheFolder },
+        {
+          args: "src test tools",
+          cache: { folder: lCacheFolder, strategy: "metadata" },
+        },
         lMinimalCruiseResult,
         {
           SHA1: "another-sha",
@@ -111,7 +127,10 @@ describe("[I] cache/cache - canServeFromCache", () => {
 
     expect(
       canServeFromCache(
-        { args: "src test tools", cache: lCacheFolder },
+        {
+          args: "src test tools",
+          cache: { folder: lCacheFolder, strategy: "metadata" },
+        },
         lMinimalCruiseResult,
         {
           SHA1: "dummy-sha",
@@ -135,7 +154,10 @@ describe("[I] cache/cache - canServeFromCache", () => {
 
     expect(
       canServeFromCache(
-        { args: "src test tools configs", cache: lCacheFolder },
+        {
+          args: "src test tools configs",
+          cache: { folder: lCacheFolder, strategy: "metadata" },
+        },
         lMinimalCruiseResult,
         { SHA1: "dummy-sha", changes: [] }
       )
@@ -143,11 +165,12 @@ describe("[I] cache/cache - canServeFromCache", () => {
   });
 
   it("returns true when cache written & revision data equal & options compatible", () => {
-    const lCacheFolder = join(OUTPUTS_FOLDER, "serve-from-cache-compatible");
-
     expect(
       canServeFromCache(
-        { args: "src test tools", cache: lCacheFolder },
+        {
+          args: "src test tools",
+          cache: { folder: lOriginalCacheFolder, strategy: "metadata" },
+        },
         lMinimalCruiseResult,
         { SHA1: "dummy-sha", changes: [] }
       )

--- a/test/cache/options-compatible.spec.mjs
+++ b/test/cache/options-compatible.spec.mjs
@@ -6,6 +6,7 @@ import {
   limitsAreCompatible,
   metricsAreCompatible,
   optionsAreCompatible,
+  cacheOptionIsCompatible,
 } from "../../src/cache/options-compatible.js";
 
 describe("[U] cache/options-compatible - filtersAreCompatible", () => {
@@ -125,33 +126,102 @@ describe("[U] cache/options-compatible - metricsAreCompatible", () => {
   });
 });
 
+describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
+  it("returns true when both equal 'true'", () => {
+    expect(cacheOptionIsCompatible(true, true)).to.equal(true);
+  });
+  it("returns true when are objects & they're 100% equal", () => {
+    expect(
+      cacheOptionIsCompatible(
+        { folder: "x", strategy: "metadata" },
+        { folder: "x", strategy: "metadata" }
+      )
+    ).to.equal(true);
+  });
+  it("returns false when are objects & the folders differ", () => {
+    expect(
+      cacheOptionIsCompatible(
+        { folder: "x", strategy: "metadata" },
+        { folder: "not-x", strategy: "metadata" }
+      )
+    ).to.equal(false);
+  });
+  it("returns false when both cache options are objects & the strategies differ", () => {
+    expect(
+      cacheOptionIsCompatible(
+        { folder: "x", strategy: "metadata" },
+        { folder: "x", strategy: "content" }
+      )
+    ).to.equal(false);
+  });
+  it("returns false when one cache option is an object and the other one isn't", () => {
+    expect(
+      cacheOptionIsCompatible(true, { folder: "x", strategy: "metadata" })
+    ).to.equal(false);
+    expect(
+      cacheOptionIsCompatible("x", { folder: "x", strategy: "metadata" })
+    ).to.equal(false);
+  });
+});
+
 describe("[U] cache/options-compatible - optionsAreCompatible", () => {
-  it("options are compatible when there's none in either", () => {
-    expect(optionsAreCompatible({}, {})).to.equal(true);
+  it("options are not compatible when there's none in either", () => {
+    expect(optionsAreCompatible({}, {})).to.equal(false);
+  });
+  it("options are compatible when there's none in either (except a cache option)", () => {
+    expect(optionsAreCompatible({ cache: true }, { cache: true })).to.equal(
+      true
+    );
   });
   it("options are compatible when args are exactly equal", () => {
     expect(
-      optionsAreCompatible({ args: "aap noot mies" }, { args: "aap noot mies" })
+      optionsAreCompatible(
+        { args: "aap noot mies", cache: true },
+        { args: "aap noot mies", cache: true }
+      )
     ).to.equal(true);
   });
   it("options are not compatible when args are not exactly equal", () => {
     expect(
-      optionsAreCompatible({ args: "aap noot mies" }, { args: "aap noot" })
+      optionsAreCompatible(
+        { args: "aap noot mies", cache: true },
+        { args: "aap noot", cache: true }
+      )
     ).to.equal(false);
   });
   it("options are compatible when also rulesFiles are exactly equal", () => {
     expect(
       optionsAreCompatible(
-        { args: "aap", rulesFile: "thing.js", tsPreCompilationDeps: false },
-        { args: "aap", rulesFile: "thing.js", tsPreCompilationDeps: false }
+        {
+          args: "aap",
+          rulesFile: "thing.js",
+          tsPreCompilationDeps: false,
+          cache: true,
+        },
+        {
+          args: "aap",
+          rulesFile: "thing.js",
+          tsPreCompilationDeps: false,
+          cache: true,
+        }
       )
     ).to.equal(true);
   });
   it("options are not compatible when also tsPreCompilationDeps are not exactly equal", () => {
     expect(
       optionsAreCompatible(
-        { args: "aap", rulesFile: "thing.js", tsPreCompilationDeps: false },
-        { args: "aap", rulesFile: "thing.js", tsPreCompilationDeps: true }
+        {
+          args: "aap",
+          rulesFile: "thing.js",
+          tsPreCompilationDeps: false,
+          cache: true,
+        },
+        {
+          args: "aap",
+          rulesFile: "thing.js",
+          tsPreCompilationDeps: true,
+          cache: true,
+        }
       )
     ).to.equal(false);
   });
@@ -164,12 +234,14 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
           rulesFile: "thing.js",
           tsPreCompilationDeps: false,
           includeOnly: "mies",
+          cache: true,
         },
         {
           args: "aap",
           rulesFile: "thing.js",
           tsPreCompilationDeps: false,
           includeOnly: { path: "mies" },
+          cache: true,
         }
       )
     ).to.equal(true);
@@ -178,8 +250,8 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
   it("options are not compatible when also collapse filters are not compatible equal", () => {
     expect(
       optionsAreCompatible(
-        { args: "aap", rulesFile: "thing.js", collapse: "zus" },
-        { args: "aap", rulesFile: "thing.js", collapse: "jet" }
+        { args: "aap", rulesFile: "thing.js", collapse: "zus", cache: true },
+        { args: "aap", rulesFile: "thing.js", collapse: "jet", cache: true }
       )
     ).to.equal(false);
   });
@@ -191,12 +263,14 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
           args: "aap",
           rulesFile: "thing.js",
           tsPreCompilationDeps: false,
+          cache: true,
         },
         {
           args: "aap",
           rulesFile: "thing.js",
           tsPreCompilationDeps: false,
           collapse: "jet",
+          cache: true,
         }
       )
     ).to.equal(true);


### PR DESCRIPTION
## Description, Motivation and Context

- adds a cache option compatibility check to the check whether options are compatible as different cache strategies will yield different outcomes no matter what.
- 🏕️ also swaps out  assert.deepEqual with assert.deepStrictEqual as the former is deprecated in favor of the latter.

## How Has This Been Tested?

- [x] green ci
- [x] additional automated tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
