### PR TITLE
refactor(cache): uses util/isDeepStictEqual instead of its assert variant

### DIFF
--- a/src/cache/cache.js
+++ b/src/cache/cache.js
@@ -28,7 +28,6 @@ function writeCache(pCacheFolder, pCruiseResult, pRevisionData) {
     ),
     "utf8"
   );
-  gRevisionData = null;
 }
 
 /**

--- a/src/cache/git-revision-data.js
+++ b/src/cache/git-revision-data.js
@@ -1,6 +1,7 @@
 const { extname } = require("path");
+const { isDeepStrictEqual } = require("util");
 const { getSHASync, listSync } = require("watskeburt");
-const { objectsAreEqual, getFileHash } = require("./utl");
+const { getFileHash } = require("./utl");
 
 // skipping: "pairing broken", "unmodified", "unmerged", "type changed"
 const DEFAULT_INTERESTING_CHANGE_TYPES = new Set([
@@ -95,7 +96,7 @@ function revisionDataEqual(pExistingRevisionData, pNewRevisionData) {
     Boolean(pExistingRevisionData) &&
     Boolean(pNewRevisionData) &&
     pExistingRevisionData.SHA1 === pNewRevisionData.SHA1 &&
-    objectsAreEqual(pExistingRevisionData.changes, pNewRevisionData.changes)
+    isDeepStrictEqual(pExistingRevisionData.changes, pNewRevisionData.changes)
   );
 }
 

--- a/src/cache/options-compatible.js
+++ b/src/cache/options-compatible.js
@@ -1,4 +1,4 @@
-const { objectsAreEqual } = require("./utl");
+const { isDeepStrictEqual } = require("util");
 
 /*
 # command line options
@@ -55,11 +55,11 @@ const { objectsAreEqual } = require("./utl");
 
 function includeOnlyIsCompatible(pExistingFilter, pNewFilter) {
   return (
-    !pExistingFilter || objectsAreEqual({ path: pExistingFilter }, pNewFilter)
+    !pExistingFilter || isDeepStrictEqual({ path: pExistingFilter }, pNewFilter)
   );
 }
 function optionIsCompatible(pExistingOption, pNewOption) {
-  return !pExistingOption || objectsAreEqual(pExistingOption, pNewOption);
+  return !pExistingOption || isDeepStrictEqual(pExistingOption, pNewOption);
 }
 
 function limitIsCompatible(pExistingLimit, pNewLimit) {
@@ -76,7 +76,7 @@ function cacheOptionIsCompatible(pExistingCacheOption, pNewCacheOption) {
   }
   return (
     pExistingCacheOption === pNewCacheOption ||
-    objectsAreEqual(pExistingCacheOption, pNewCacheOption)
+    isDeepStrictEqual(pExistingCacheOption, pNewCacheOption)
   );
 }
 

--- a/src/cache/utl.js
+++ b/src/cache/utl.js
@@ -1,20 +1,5 @@
-const { deepStrictEqual } = require("assert");
 const { createHash } = require("crypto");
 const { readFileSync } = require("fs");
-/**
- *
- * @param {any} pLeftObject
- * @param {any} pRightObject
- * @returns {boolean}
- */
-function objectsAreEqual(pLeftObject, pRightObject) {
-  try {
-    deepStrictEqual(pLeftObject, pRightObject);
-    return true;
-  } catch (pError) {
-    return false;
-  }
-}
 
 /**
  * @param {string} pString
@@ -36,4 +21,4 @@ function getFileHash(pFileName) {
   }
 }
 
-module.exports = { objectsAreEqual, getFileHash };
+module.exports = { getFileHash };


### PR DESCRIPTION
## Description, Motivation and Context

- uses util.isDeepStrictEqual for checking deep equality. Should've used that in the first place (it's used elsewhere in the code base as well ...).
- camping site rule: removes cache reset from cache.writeCache (not its responsibility + it's happening in the right spot already anyway)

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
