### PR TITLE
refactor(cli): changes normalize steps to early returns

### DIFF
--- a/src/cli/normalize-cli-options.js
+++ b/src/cli/normalize-cli-options.js
@@ -8,14 +8,7 @@ const loadConfig = require("../config-utl/extract-depcruise-config");
 const defaults = require("./defaults");
 
 function getOptionValue(pDefault) {
-  return (pValue) => {
-    let lReturnValue = pDefault;
-
-    if (typeof pValue === "string") {
-      lReturnValue = pValue;
-    }
-    return lReturnValue;
-  };
+  return (pValue) => (typeof pValue === "string" ? pValue : pDefault);
 }
 
 function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
@@ -104,44 +97,42 @@ function validateAndGetKnownViolationsFileName(pKnownViolations) {
 }
 
 function normalizeKnownViolationsOption(pCliOptions) {
-  if (has(pCliOptions, "ignoreKnown")) {
-    const lReturnValue = {
-      knownViolationsFile: validateAndGetKnownViolationsFileName(
-        pCliOptions.ignoreKnown
-      ),
-    };
-    return lReturnValue;
+  if (!has(pCliOptions, "ignoreKnown")) {
+    return {};
   }
-  return {};
+  return {
+    knownViolationsFile: validateAndGetKnownViolationsFileName(
+      pCliOptions.ignoreKnown
+    ),
+  };
 }
 
 function normalizeValidationOption(pCliOptions) {
-  if (has(pCliOptions, "validate")) {
-    const rulesFile = validateAndNormalizeRulesFileName(pCliOptions.validate);
-    return {
-      rulesFile,
-      ruleSet: loadConfig(
-        path.isAbsolute(rulesFile) ? rulesFile : `./${rulesFile}`
-      ),
-      validate: true,
-    };
-  } else {
+  if (!has(pCliOptions, "validate")) {
     return {
       validate: false,
     };
   }
+  const rulesFile = validateAndNormalizeRulesFileName(pCliOptions.validate);
+  return {
+    rulesFile,
+    ruleSet: loadConfig(
+      path.isAbsolute(rulesFile) ? rulesFile : `./${rulesFile}`
+    ),
+    validate: true,
+  };
 }
 
 function normalizeProgress(pCliOptions) {
-  let lProgress = null;
-
-  if (has(pCliOptions, "progress")) {
-    lProgress = get(pCliOptions, "progress");
-    if (lProgress === true) {
-      lProgress = "cli-feedback";
-    }
+  if (!has(pCliOptions, "progress")) {
+    return {};
   }
-  return lProgress ? { progress: lProgress } : {};
+
+  let lProgress = pCliOptions.progress;
+  if (lProgress === true) {
+    lProgress = "cli-feedback";
+  }
+  return { progress: lProgress };
 }
 
 function normalizeCache(pCliOptions) {


### PR DESCRIPTION
## Description

- changes logic in the cli options normalization step to early returns

## Motivation and Context

I think now that this makes for code that is easier to read

## How Has This Been Tested?

- [x] green ci


## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
