### PR TITLE
feature(cli): adds --cache-strategy option

### DIFF
--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -106,6 +106,11 @@ try {
       "(experimental) use a cache to speed up execution. " +
         "The directory defaults to node_modules/.cache/dependency-cruiser"
     )
+    .option(
+      "--cache-strategy <strategy>",
+      "(experimental) strategy to use for detecting changed files in the cache. " +
+        "Possible values: metadata (= use git, the default), content"
+    )
     .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
     .option("-v, --validate [file]", `alias for --config`)
     .option(

--- a/src/cli/normalize-cli-options.js
+++ b/src/cli/normalize-cli-options.js
@@ -135,6 +135,28 @@ function normalizeProgress(pCliOptions) {
   return { progress: lProgress };
 }
 
+function normalizeCacheStrategy(pCliOptions) {
+  if (!has(pCliOptions, "cacheStrategy")) {
+    return {};
+  }
+  const lStrategy =
+    pCliOptions.cacheStrategy === "content" ? "content" : "metadata";
+
+  let lReturnValue = {};
+
+  if (pCliOptions.cache && typeof pCliOptions.cache === "object") {
+    lReturnValue.cache = clone(pCliOptions.cache);
+    lReturnValue.cache.strategy = lStrategy;
+  } else {
+    lReturnValue = {
+      cache: {
+        strategy: lStrategy,
+      },
+    };
+  }
+  return lReturnValue;
+}
+
 function normalizeCache(pCliOptions) {
   if (!has(pCliOptions, "cache")) {
     return {};
@@ -183,6 +205,7 @@ module.exports = function normalizeOptions(pOptionsAsPassedFromCommander) {
   lOptions = { ...lOptions, ...normalizeValidationOption(lOptions) };
   lOptions = { ...lOptions, ...normalizeProgress(lOptions) };
   lOptions = { ...lOptions, ...normalizeCache(lOptions) };
+  lOptions = { ...lOptions, ...normalizeCacheStrategy(lOptions) };
   lOptions = { ...lOptions, ...normalizeKnownViolationsOption(lOptions) };
   lOptions = normalizeConfigFileName(
     lOptions,

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -275,10 +275,57 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       cache: false,
     });
   });
+
   it("no cache option translates to still not having a cache option", () => {
     expect(
       normalizeCliOptions({ "not-a-cache-option": true })
     ).to.not.haveOwnProperty("cache");
+  });
+
+  it("cache-strategy with a string value == 'content' translates to the strategy 'content' in the cache option", () => {
+    expect(normalizeCliOptions({ cacheStrategy: "content" })).to.deep.contain({
+      cache: { strategy: "content" },
+    });
+  });
+
+  it("cache-strategy with a string value !== 'content' translates to the strategy 'metadata' in the cache option", () => {
+    expect(
+      normalizeCliOptions({ cacheStrategy: "some-string" })
+    ).to.deep.contain({
+      cache: { strategy: "metadata" },
+    });
+  });
+
+  it("cache with a string value & cache-strategy with a string value translates both present in the cache option", () => {
+    expect(
+      normalizeCliOptions({ cache: "somewhere", cacheStrategy: "some-string" })
+    ).to.deep.contain({
+      cache: { folder: "somewhere", strategy: "metadata" },
+    });
+  });
+
+  it("cache with a value of true & cache-strategy with a string value translates to a cache option with that strategy", () => {
+    expect(
+      normalizeCliOptions({ cache: true, cacheStrategy: "metadata" })
+    ).to.deep.contain({
+      cache: { strategy: "metadata" },
+    });
+  });
+
+  it("cache with a value of false & cache-strategy with a string value translates to a cache option with that strategy", () => {
+    expect(
+      normalizeCliOptions({ cache: false, cacheStrategy: "metadata" })
+    ).to.deep.contain({
+      cache: { strategy: "metadata" },
+    });
+  });
+
+  it("cache with a value of true & cache-strategy with a string value translates to a cache option with that strategy x", () => {
+    expect(
+      normalizeCliOptions({ cache: true, cacheStrategy: "content" })
+    ).to.deep.contain({
+      cache: { strategy: "content" },
+    });
   });
 });
 


### PR DESCRIPTION
## Description

- adds a --cache-strategy option to select the cache strategy from the cli

## Motivation and Context

Likely to be more practical when you want to keep the same configuration, but only need to switch the strategy based on the environment you're on (e.g. on the CI). 


## How Has This Been Tested?

- [x] green ci
- [x] additional automated tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
