### PR TITLE
bugfix(cache): ignores unfollowables in content cache strategy

### DIFF
--- a/src/cache/utl.js
+++ b/src/cache/utl.js
@@ -111,7 +111,10 @@ function moduleIsInterestingForDiff(pModule) {
     !pModule.consolidated &&
     !pModule.coreModule &&
     !pModule.couldNotResolve &&
-    !pModule.matchesDoNotFollow
+    !pModule.matchesDoNotFollow &&
+    // as followable is optional, !exists when the module _is_ followable
+    // explicit comparison with false
+    pModule.followable !== false
   );
 }
 

--- a/test/cache/find-content-changes.spec.mjs
+++ b/test/cache/find-content-changes.spec.mjs
@@ -73,6 +73,34 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
     ]);
   });
 
+  it("returns files that have been earmarked as not followable as 'ignored'", () => {
+    expect(
+      findContentChanges(
+        ".",
+        {
+          modules: [
+            {
+              source: "not-in-content-changes-as-extension.weird",
+              followable: false,
+            },
+          ],
+        },
+        {
+          baseDir:
+            "test/cache/__mocks__/find-content-changes/folder-with-unfollowable-extensions",
+          exclude: {},
+          includeOnly: {},
+          extensions: new Set([".js"]),
+        }
+      )
+    ).to.deep.equal([
+      {
+        name: "not-in-content-changes-as-extension.weird",
+        changeType: "ignored",
+      },
+    ]);
+  });
+
   it("returns files both in directory and in cache that are different as 'modified'", () => {
     expect(
       findContentChanges(
@@ -108,6 +136,7 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
       },
     ]);
   });
+
   it("returns files both in directory and in cache that are the same as 'unmodified'", () => {
     expect(
       findContentChanges(
@@ -173,6 +202,7 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
       },
     ]);
   });
+
   it("returns changes when there's file in the directory and modules is empty (missing includeOnly filter)", () => {
     expect(
       findContentChanges(


### PR DESCRIPTION
## Description

The list of 'changes' contains files/  modules dependency-cruiser was not  able to 'follow' (e.g.  because it's an unsupported file type) with changeType _deleted_  - e.g. css or  picture  imports in react projects. Apart from that these entries are  superfluous and make the list larger than necessary, this caused the second run  without any changes to not use the cache.

> A beta  version of dependency-cruiser that includes the fix in this  PR has been published on npmjs:
> - `dependency-cruiser@12.5.1-beta-1`        
> - sha-sum: `c294e758a9dcd5828ebcdd2742c53fd7cd5948f3`


## Motivation and Context

Fixes a bug @7rulnik found  while validating #715 (thanks!)

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test
- [x] run against facebook/react


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
