### PR TITLE
feature(progress): makes performance-log listener show all totals

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1079,27 +1079,30 @@ stay in view when dependency-cruiser is done.
 <summary>Typical output</summary>
 
 ```
-elapsed real         user       system        ∆ rss  ∆ heapTotal   ∆ heapUsed   ∆ external after step...
------------- ------------ ------------ ------------ ------------ ------------ ------------ ------------
-      778 ms       805 ms       104 ms  +130.300 kB   +85.020 kB   +62.024 kB    +2.232 kB start of node process
-       11 ms        11 ms         1 ms      +900 kB         0 kB      +307 kB         0 kB parsing options
-       76 ms        18 ms         4 ms    +2.508 kB      +804 kB    +1.969 kB      +542 kB cache: checking freshness
-      186 ms       339 ms        12 ms   +18.864 kB    +6.512 kB    +7.253 kB    -1.382 kB parsing rule set
-        0 ms         1 ms         0 ms       +24 kB         0 kB       +28 kB         0 kB determining how to resolve
-        0 ms         0 ms         0 ms        +4 kB         0 kB        +8 kB         0 kB reading files
-       21 ms        29 ms         7 ms      +172 kB      +256 kB    +2.420 kB         0 kB reading files: gathering initial sources
-    1.102 ms     1.871 ms       103 ms   +51.520 kB   +46.848 kB   +38.511 kB      +285 kB reading files: visiting dependencies
-        0 ms         0 ms         0 ms       +12 kB         0 kB        +3 kB         0 kB analyzing
-       15 ms        37 ms         0 ms       +28 kB         0 kB    +6.723 kB         0 kB analyzing: cycles
-       26 ms        57 ms         2 ms    +2.852 kB    +2.304 kB    +2.895 kB         0 kB analyzing: dependents
-        1 ms         1 ms         0 ms        +4 kB         0 kB       +48 kB         0 kB analyzing: orphans
-      246 ms       305 ms         4 ms    +1.464 kB    +1.792 kB   -13.542 kB       -29 kB analyzing: reachables
-        0 ms         0 ms         0 ms         0 kB         0 kB        +3 kB         0 kB analyzing: module metrics
-        0 ms         0 ms         0 ms         0 kB         0 kB        +3 kB         0 kB analyzing: add focus (if any)
-       79 ms       148 ms         3 ms      +356 kB         0 kB   +11.700 kB         0 kB analyzing: validations
-       10 ms        16 ms         1 ms    +1.680 kB    +1.088 kB    +2.842 kB      +541 kB analyzing: comparing against known errors
-        4 ms         4 ms         0 ms       +20 kB         0 kB      +723 kB         0 kB reporting
-        0 ms         0 ms         0 ms         0 kB         0 kB        +4 kB         0 kB really done (2.558 ms, +123.921 kB)
+ elapsed real          user        system         ∆ rss   ∆ heapTotal    ∆ heapUsed    ∆ external after step...
+------------- ------------- ------------- ------------- ------------- ------------- ------------- -------------
+        785ms         813ms          98ms    +132,384kB     +85,020kB     +62,483kB      +2,280kB start of node process
+         12ms          11ms           1ms      +1,148kB        +256kB        +785kB           0kB parsing options
+         79ms          18ms           5ms      +2,492kB        +548kB      +1,731kB        +541kB cache: check freshness with metadata
+        187ms         345ms          11ms     +18,620kB      +7,024kB      +9,037kB      -1,430kB parsing rule set
+          0ms           2ms           0ms          +8kB           0kB         +28kB           0kB determining how to resolve
+          0ms           1ms           0ms         +24kB           0kB          +9kB           0kB reading files
+         23ms          32ms           7ms        +724kB      +1,280kB     -12,023kB           0kB reading files: gathering initial sources
+      1,260ms       2,040ms         112ms     +50,152kB     +48,640kB     +51,344kB        +413kB reading files: visiting dependencies
+          0ms           0ms           0ms          +8kB           0kB          +3kB           0kB analyzing
+         13ms          33ms           0ms         +28kB           0kB      +6,083kB           0kB analyzing: cycles
+         27ms          59ms           2ms      +3,012kB      +2,816kB      +1,842kB        -157kB analyzing: dependents
+          1ms           1ms           0ms          +8kB           0kB         +46kB           0kB analyzing: orphans
+        292ms         384ms           8ms      +2,176kB      +2,048kB        +668kB           0kB analyzing: reachables
+          0ms           0ms           0ms         +12kB           0kB          +3kB           0kB analyzing: module metrics
+          0ms           0ms           0ms           0kB           0kB          +3kB           0kB analyzing: add focus (if any)
+         80ms         157ms           3ms        +560kB        +768kB      -3,119kB           0kB analyzing: validations
+          5ms          13ms           0ms         +56kB        +256kB        +960kB           0kB analyzing: comparing against known errors
+          6ms           7ms           1ms      +1,704kB      +1,088kB      +2,314kB        +541kB cache: save
+          5ms           5ms           0ms         +40kB           0kB        +596kB           0kB reporting
+          0ms           0ms           0ms           0kB           0kB          +5kB           0kB really done
+------------- ------------- ------------- ------------- ------------- ------------- ------------- -------------
+      2,775ms       3,920ms         248ms    +213,156kB    +149,744kB    +122,798kB      +2,188kB
 ```
 
 Number formatting takes place with the `Intl` API, so in your locale the numbers

--- a/src/cli/listeners/performance-log/format-helpers.js
+++ b/src/cli/listeners/performance-log/format-helpers.js
@@ -2,7 +2,7 @@ const chalk = require("chalk");
 
 const MS_PER_SECOND = 1000;
 const MS_PER_MICRO_SECOND = 0.001;
-const MAX_LENGTH_EXPECTED = 12;
+const MAX_EXPECTED_LENGTH = 13;
 const NUMBER_OF_COLUMNS = 8;
 const K = 1024;
 /*
@@ -28,7 +28,11 @@ const gSizeFormat = new Intl.NumberFormat(LOCALE, {
   maximumFractionDigits: 0,
 }).format;
 
-const pad = (pString) => pString.padStart(MAX_LENGTH_EXPECTED).concat(" ");
+const pad = (pString) => pString.padStart(MAX_EXPECTED_LENGTH).concat(" ");
+
+function formatDividerLine() {
+  return `${`${"-".repeat(MAX_EXPECTED_LENGTH)} `.repeat(NUMBER_OF_COLUMNS)}\n`;
+}
 
 function formatHeader() {
   return chalk
@@ -43,19 +47,17 @@ function formatHeader() {
         pad("∆ external")
       }after step...\n`
     )
-    .concat(
-      `${`${"-".repeat(MAX_LENGTH_EXPECTED)} `.repeat(NUMBER_OF_COLUMNS)}\n`
-    );
+    .concat(formatDividerLine());
 }
 
 function formatTime(pNumber, pConversionMultiplier = MS_PER_SECOND) {
   return gTimeFormat(pConversionMultiplier * pNumber)
-    .padStart(MAX_LENGTH_EXPECTED)
+    .padStart(MAX_EXPECTED_LENGTH)
     .concat(" ");
 }
 
 function formatMemory(pBytes) {
-  const lReturnValue = gSizeFormat(pBytes / K).padStart(MAX_LENGTH_EXPECTED);
+  const lReturnValue = gSizeFormat(pBytes / K).padStart(MAX_EXPECTED_LENGTH);
 
   return (pBytes < 0 ? chalk.blue(lReturnValue) : lReturnValue).concat(" ");
 }
@@ -87,4 +89,5 @@ module.exports = {
   formatMemory,
   formatPerfLine,
   formatHeader,
+  formatDividerLine,
 };

--- a/src/cli/listeners/performance-log/handlers.js
+++ b/src/cli/listeners/performance-log/handlers.js
@@ -1,8 +1,7 @@
 const {
-  formatTime,
   formatPerfLine,
   formatHeader,
-  formatMemory,
+  formatDividerLine,
 } = require("./format-helpers");
 
 function getHeader(pLevel, pMaxLevel) {
@@ -47,11 +46,24 @@ function getProgressLine(pMessage, pState, pLevel, pMaxLevel) {
 function getEndText(pState, pLevel, pMaxLevel) {
   if (pLevel <= pMaxLevel) {
     const lTime = process.uptime();
-    const { heapUsed } = process.memoryUsage();
-    pState.previousMessage = `really done (${formatTime(
-      lTime
-    ).trim()}, ${formatMemory(heapUsed).trim()})`;
-    return getProgressLine("", pState, pLevel, pMaxLevel);
+    const { user, system } = process.cpuUsage();
+    const { heapUsed, heapTotal, external, rss } = process.memoryUsage();
+    pState.previousMessage = "really done";
+
+    return (
+      getProgressLine("", pState, pLevel, pMaxLevel) +
+      formatDividerLine() +
+      formatPerfLine({
+        elapsedTime: lTime,
+        elapsedUser: user,
+        elapsedSystem: system,
+        deltaRss: rss,
+        deltaHeapUsed: heapUsed,
+        deltaHeapTotal: heapTotal,
+        deltaExternal: external,
+        message: "",
+      })
+    );
   }
   return "";
 }

--- a/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
@@ -20,27 +20,27 @@ import formatHelpers from "../../../../src/cli/listeners/performance-log/format-
 
 describe("[U] cli/listeners/performance-log/format-helpers - formatTime", () => {
   it("converts to ms, left pads & adds the unit at the end", () => {
-    expect(formatHelpers.formatTime(14.88041018)).to.equal("    14,880ms ");
+    expect(formatHelpers.formatTime(14.88041018)).to.equal("     14,880ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (0)", () => {
-    expect(formatHelpers.formatTime(0)).to.equal("         0ms ");
+    expect(formatHelpers.formatTime(0)).to.equal("          0ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (negative numbers)", () => {
-    expect(formatHelpers.formatTime(-3.1415926535)).to.equal("    -3,142ms ");
+    expect(formatHelpers.formatTime(-3.1415926535)).to.equal("     -3,142ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (null treatment => 0)", () => {
-    expect(formatHelpers.formatTime(null)).to.equal("         0ms ");
+    expect(formatHelpers.formatTime(null)).to.equal("          0ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (undefined treatment => NaN)", () => {
-    expect(formatHelpers.formatTime()).to.equal("       NaNms ");
+    expect(formatHelpers.formatTime()).to.equal("        NaNms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (non-number treatment => NaN)", () => {
-    expect(formatHelpers.formatTime("not a number")).to.equal("       NaNms ");
+    expect(formatHelpers.formatTime("not a number")).to.equal("        NaNms ");
   });
 });
 
@@ -56,28 +56,28 @@ describe("[U] cli/listeners/performance-log/format-helpers - formatMemory", () =
   });
 
   it("converts to kB, left pads & adds the unit at the end", () => {
-    expect(formatHelpers.formatMemory(4033856)).to.equal("    +3,939kB ");
+    expect(formatHelpers.formatMemory(4033856)).to.equal("     +3,939kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (0)", () => {
-    expect(formatHelpers.formatMemory(0)).to.equal("         0kB ");
+    expect(formatHelpers.formatMemory(0)).to.equal("          0kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (negative numbers)", () => {
-    expect(formatHelpers.formatMemory(-403385623)).to.equal("  -393,931kB ");
+    expect(formatHelpers.formatMemory(-403385623)).to.equal("   -393,931kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (null)", () => {
-    expect(formatHelpers.formatMemory(0)).to.equal("         0kB ");
+    expect(formatHelpers.formatMemory(0)).to.equal("          0kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (undefined)", () => {
-    expect(formatHelpers.formatMemory()).to.equal("       NaNkB ");
+    expect(formatHelpers.formatMemory()).to.equal("        NaNkB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (not a number)", () => {
     expect(formatHelpers.formatMemory("not a number")).to.equal(
-      "       NaNkB "
+      "        NaNkB "
     );
   });
 });

--- a/test/cli/listeners/performance-log-listener/handlers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/handlers.spec.mjs
@@ -70,9 +70,9 @@ describe("[U] cli/listeners/performance-log/handlers - getEndText", () => {
     expect(handlers.getEndText(lStateMock, 10, MAX_LEVEL)).to.be.not.empty;
   });
 
-  it("message contains an end time", () => {
+  it("message contains a line with totals", () => {
     expect(handlers.getEndText(lStateMock, 10, MAX_LEVEL)).to.match(
-      /really done \([0-9,]+ms, [+-]?[0-9,]+kB\)\n$/g
+      /really done\n------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------- \n[ ]*[0-9,]+ms[ ]*[0-9,]+ms[ ]*[0-9,]+ms[ ]*[+-]?[0-9,]+kB[ ]*[+-]?[0-9,]+kB[ ]*[+-]?[0-9,]+kB[ ]*[+-]?[0-9,]+kB/g
     );
   });
 });


### PR DESCRIPTION
## Description

- makes the performance-log listener show all totals (instead of only wall-clock time and heap used totals)
- dedicates a separate line to the totals
- widens the width of all columns to accommodate large numbers in locales that use a bit more room.

## Motivation and Context

The listener already showed ∑ wall-clock time and ∑ heap used. This PR adds the ∑ for all other metrics as well (user & system time spent, rss, heap total, external memory). Also instead of putting it in the free format message text it's now in the same column as their per step ∆'s).

The new representation should be easier to read, while at the same time providing more information to analyze performance bottlenecks.


## How Has This Been Tested?

- [x] green ci
- [x] updated automated non-regression test

## Screenshots

A typical output now looks like this (de_DE locale):

```
 elapsed real          user        system         ∆ rss   ∆ heapTotal    ∆ heapUsed    ∆ external after step...
------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------- 
       774 ms        805 ms         97 ms   +132.056 kB    +85.020 kB    +62.670 kB     +2.280 kB start of node process
        12 ms         12 ms          1 ms     +1.144 kB       +256 kB       +785 kB          0 kB parsing options
        80 ms         19 ms          5 ms     +2.536 kB       +548 kB     +1.747 kB       +558 kB cache: check freshness with metadata
         6 ms          6 ms          0 ms     +1.168 kB       +256 kB       +828 kB          0 kB cache: reporting from cache
         1 ms          1 ms          0 ms        +24 kB          0 kB         +5 kB          0 kB really done
------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------- 
       874 ms        842 ms        104 ms   +136.928 kB    +86.080 kB    +66.034 kB     +2.839 kB 
```

Whereas it looked like this before (also de_DE locale):

```
elapsed real         user       system        ∆ rss  ∆ heapTotal   ∆ heapUsed   ∆ external after step...
------------ ------------ ------------ ------------ ------------ ------------ ------------ ------------ 
      770 ms       802 ms        97 ms  +131.624 kB   +85.020 kB   +62.531 kB    +2.280 kB start of node process
       12 ms        11 ms         1 ms    +1.124 kB      +256 kB      +785 kB         0 kB parsing options
       78 ms        18 ms         4 ms    +2.516 kB      +804 kB    +2.010 kB      +558 kB cache: check freshness with metadata
        6 ms         6 ms         0 ms    +1.168 kB         0 kB      +576 kB         0 kB cache: reporting from cache
        1 ms         1 ms         0 ms       +24 kB         0 kB        +5 kB         0 kB really done (867 ms, +65.906 kB)
```

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
