### PR TITLE
feature(cli): adds --no-cache option

### DIFF
--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -111,6 +111,11 @@ try {
       "(experimental) strategy to use for detecting changed files in the cache. " +
         "Possible values: metadata (= use git, the default), content"
     )
+    .option(
+      "--no-cache",
+      "switch off caching. Overrides the 'cache' key in .dependency-cruiser.js " +
+        "and --cache options set earlier on the command line"
+    )
     .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
     .option("-v, --validate [file]", `alias for --config`)
     .option(

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -44,6 +44,7 @@ available in dependency-cruiser configurations.
 1. [`--preserve-symlinks`](#--preserve-symlinks)
 1. [`--cache`: use a cache to speed up cruising (experimental)](#--cache-use-a-cache-to-speed-up-cruising-experimental)
 1. [`--cache-strategy`: influence how the cache functionality detects changes (experimental)]
+1. [`--no-cache`: switch off caching](#--no-cache-switch-off-caching)
 
 ### Standalone formatting of dependency graphs: [depcruise-fmt](#depcruise-fmt)
 
@@ -1224,6 +1225,12 @@ don't have git available or are working on a shallow clone of your repository
 
 When you don't pass --cache-strategy (and don't specify a `strategy` in the
 `cache` option in you .dependency-cruiser.js) the strategy defaults to `metadata`.
+
+### `--no-cache`: switch off caching
+
+This overrides any `--cache`, `--cache-strategy` options set earlier on the
+command line as well as the [`cache`](./options-reference.md#cache)
+configuration option.
 
 ## depcruise-fmt
 


### PR DESCRIPTION
## Description

- adds `--no-cache` command line option

## Motivation and Context

If you want or need to override an earlier set --cache, --cache-strategy cli option or a `cache` option. The functionality is already built into dependency-cruiser, we only didn't include it in the commander definition yet. This PR does just that.

## How Has This Been Tested?

- [x] green ci
- [x] manual double check whether it works as intended

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
