### PR TITLE
doc(README): adds a message about the use with pnpx (/ yarn run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,25 @@ npx depcruise --init
 ```
 
 This will look around in your environment a bit, ask you some questions and create
-a `.dependency-cruiser.js` configuration file attuned to your project[^1].
+a `.dependency-cruiser.js` configuration file attuned to your project[^1][^2].
 
 [^1]:
     We're using `npx` in the example scripts for convenience. When you use the
     commands in a script in `package.json` it's not necessary to prefix them with
     `npx`.
 
+[^2]:
+    If you don't don't want to use `npx`, but instead `pnpx` (from the `pnpm`
+    package manager) or `yarn` - please refer to that tool's documentation.
+    Particularly `pnpx` has semantics that differ from `npx` quite significantly
+    and that you want to be aware of before using it. In the mean time: `npx`
+    _should_ work even when you installed the dependency with a package manager
+    different from `npm`.
+
 ### Show stuff to your grandma
 
 To create a graph of the dependencies in your src folder, you'd run dependency
-cruiser with output type `dot` and run _GraphViz dot_[^2] on the result. In
+cruiser with output type `dot` and run _GraphViz dot_[^3] on the result. In
 a one liner:
 
 ```shell
@@ -55,7 +63,7 @@ npx depcruise src --include-only "^src" --config --output-type dot | dot -T svg 
   we've [got her covered](./doc/cli.md#--output-type-specify-the-output-format)
   as well.
 
-[^2]:
+[^3]:
     This assumes the GraphViz `dot` command is available - on most linux and
     comparable systems this will be. In case it's not, see
     [GraphViz' download page](https://www.graphviz.org/download/) for instructions


### PR DESCRIPTION
## Description

- adds a message to the README

## Motivation and Context

Apparently pnpx (from the pnpm package manager) works different from npx - as noted in #725. 

## How Has This Been Tested?

- [x] checking the rendered .md on GH with a pair of eyeballs

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
