### PR TITLE
feature(cli): adds --no-progress option

### DIFF
--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -88,6 +88,7 @@ try {
       "-p, --progress [type]",
       "show progress while dependency-cruiser is busy. Possible values: cli-feedback, performance-log, none"
     )
+    .option("--no-progress", "Alias of --progress none")
     .option(
       "-d, --max-depth <n>",
       "You probably want to use --collapse instead of --max-depth. " +

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -35,7 +35,8 @@ available in dependency-cruiser configurations.
 1. [`--collapse`: summarize to folder depth or pattern](#--collapse-summarize-to-folder-depth-or-pattern)
 1. [`--exclude`: exclude dependencies from being cruised](#--exclude-exclude-dependencies-from-being-cruised)
 1. [`--max-depth`](#--max-depth)
-1. [`--progress`: get feedback on what dependency-cruiser is doing while it's running](#--progress-get-feedbakc-on-what-dependency-cruiser-is-doing-while-its-running)
+1. [`--progress`: get feedback on what dependency-cruiser is doing while it's running](#--progress-get-feedback-on-what-dependency-cruiser-is-doing-while-its-running)
+1. [`--no-progress`: don't show feedback on what dependency-cruiser is doing](#--no-progress-dont-show-feedback-on-what-dependency-cruiser-is-doing)
 1. [`--prefix` prefixing links](#--prefix-prefixing-links)
 1. [`--module-systems`](#--module-systems)
 1. [`--ts-pre-compilation-deps` (typescript only)](#--ts-pre-compilation-deps-typescript-only)
@@ -1116,6 +1117,14 @@ and units might look slightly different.
 Make sure dependency-cruiser doesn't print any feedback. Useful if you want to
 override the progress option configured in a configuration file (currently
 an undocumented feature that is subject to change).
+
+### `--no-progress`: don't show feedback on what dependency-cruiser is doing
+
+The equivalent of `--progress none`.
+
+As showing no progress is dependency-cruiser's default the only use for this
+option is to override a `progress` setting from a configuration file or a
+`--progress` command line option set earlier on the command line.
 
 ### `--prefix` prefixing links
 


### PR DESCRIPTION
## Description

- adds a `--no-progress` option to the command line interface
- corrects a typo in a link in the cli doc

## Motivation and Context

symmetry is a beautifull thing

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests: nope; the option was already available in the API (commander translates --no-progress to `progress: false`), so no additional unit tests added, as we're not going to test whether commander works
- [x] manual tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
