### PR TITLE
chore(test): moves c8 cli parameters to .c8rc.json

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,23 @@
+{
+  "statements": 99.9,
+  "branches": 99.7,
+  "functions": 100,
+  "lines": 99.9,
+  "exclude": [
+    "bin",
+    "configs",
+    "doc",
+    "docs",
+    "coverage",
+    "test",
+    "tools",
+    "webpack.conf.js",
+    "tmp*",
+    "src/**/*.template.js",
+    "src/cli/tools/svg-in-html-snippets/script.snippet.js",
+    "src/cli/init-config/get-user-input.js",
+    "src/cli/listeners/*/index.js",
+    "src/cli/listeners/{cli-feedback,ndjson}.js"
+  ],
+  "reporter": ["text-summary", "html", "json-summary"]
+}

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "test:i": "LANG=en_US.UTF-8 mocha --grep \"^\\[[I]\\]\"",
     "test:u": "LANG=en_US.UTF-8 mocha --grep \"^\\[[U]\\]\"",
     "test:e": "LANG=en_US.UTF-8 mocha --grep \"^\\[[E]\\]\"",
-    "test:cover": "LANG=en_US.UTF-8 c8 --check-coverage --statements 99.9 --branches 99.7 --functions 100 --lines 99.9 --exclude \"{bin,configs/*.js,configs/rules,configs/plugins/3d-*.js,configs/plugins/stats-*.js,doc,docs,coverage,test,tools,webpack.conf.js,tmp*,src/**/*.template.js,src/cli/tools/svg-in-html-snippets/script.snippet.js,src/cli/init-config/get-user-input.js,src/cli/listeners/*/index.js,src/cli/listeners/{cli-feedback,ndjson}.js}\" --reporter text-summary --reporter html --reporter json-summary mocha",
+    "test:cover": "LANG=en_US.UTF-8 c8 mocha",
     "test:glob": "set -f && test \"`bin/dependency-cruise.js test/extract/__mocks__/gather-globbing/packages/**/src/**/*.js | grep \"no dependency violations found\"`\" = \"✔ no dependency violations found (6 modules, 0 dependencies cruised)\"",
     "test:yarn-pnp": "npm-run-all test:yarn-pnp:cleanup test:yarn-pnp:pack test:yarn-pnp:copy test:yarn-pnp:install test:yarn-pnp:version test:yarn-pnp:run test:yarn-pnp:test test:yarn-pnp:cleanup",
     "test:yarn-pnp:pack": "npm pack",


### PR DESCRIPTION
## Description

- moves c8 cli parameters to a separate configuration file

## Motivation and Context

- more readable & easier to maintain
- smaller package.json

When we first started using c8 there wasn't (or didn't seem to be?) an option to put things in a configuration file, so we used the command line parameters.

## How Has This Been Tested?

- [ ] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
