### PR TITLE
chore(lint): moves eslintignore from package.json into the .eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,5 +36,22 @@
         "node/no-unsupported-features/es-syntax": "off"
       }
     }
+  ],
+  "ignorePatterns": [
+    ".pnp.cjs",
+    ".yarn",
+    "node_modules",
+    "coverage",
+    "tmp",
+    "src/**/*.schema.js",
+    "src/**/*.template.js",
+    "src/cli/tools/svg-in-html-snippets/script.snippet.js",
+    "test/integration/**",
+    "test/*/__fixtures__/**",
+    "test/*/*/__fixtures__/**",
+    "test/*/*/*/__fixtures__/**",
+    "test/*/__mocks__/**",
+    "test/*/*/__mocks__/**",
+    "types/**"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "format:check": "prettier --loglevel warn --check \"src/**/*.js\" \"configs/**/*.js\" \"tools/**/*.mjs\" \"bin/*\" \"types/*.d.ts\" \"test/**/*.spec.{cjs,js}\" \"test/**/*.{spec,utl}.mjs\"",
     "lint": "npm-run-all --parallel --aggregate-output lint:eslint format:check lint:types",
     "lint:eslint": "eslint bin/dependency-cruise.js bin src test configs tools/**/*.mjs --cache --cache-location node_modules/.cache/eslint/",
-    "lint:eslint:fix": "eslint --fix bin src test configs  tools/**/*.mjs --cache --cache-location node_modules/.cache/eslint/",
+    "lint:eslint:fix": "eslint --fix bin src test configs tools/**/*.mjs --cache --cache-location node_modules/.cache/eslint/",
     "lint:fix": "npm-run-all lint:eslint:fix format lint:types:fix",
     "lint:types": "npm-run-all lint:types:tsc lint:types:lint",
     "lint:types:tsc": "tsc --project types/tsconfig.json",
@@ -256,23 +256,6 @@
       }
     ]
   },
-  "eslintIgnore": [
-    ".pnp.cjs",
-    ".yarn",
-    "node_modules",
-    "coverage",
-    "tmp",
-    "src/**/*.schema.js",
-    "src/**/*.template.js",
-    "src/cli/tools/svg-in-html-snippets/script.snippet.js",
-    "test/integration/**",
-    "test/*/__fixtures__/**",
-    "test/*/*/__fixtures__/**",
-    "test/*/*/*/__fixtures__/**",
-    "test/*/__mocks__/**",
-    "test/*/*/__mocks__/**",
-    "types/**"
-  ],
   "engines": {
     "node": "^14||^16||>=18"
   },


### PR DESCRIPTION
## Description

- moves eslintignore from package.json into the .eslintrc

## Motivation and Context

- it keeps eslint things in one place, which is easier to maintain
- it reduces the size of the package.json and hence the package we ship

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
