### PR TITLE
chore(ci): moves lintstaged config from package.json to its own file

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged --config=package.json
+npx lint-staged --config=.lintstagedrc.json

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,10 @@
+{
+  "{src,config}/**/*.js": ["eslint --fix"],
+  "{tools,src,config}/**/*.{mjs,js,json}": ["prettier --write"],
+  "bin/*": ["eslint --fix", "prettier --write"],
+  "test/**/*.{utl,spec}.{mjs,cjs}": ["eslint --fix", "prettier --write"],
+  "types/**/*.d.ts": [
+    "eslint --config types/.eslintrc.json --fix",
+    "prettier --write"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -269,25 +269,5 @@
     "typescript": ">=2.0.0 <5.0.0",
     "vue-template-compiler": ">=2.0.0 <3.0.0",
     "@vue/compiler-sfc": ">=3.0.0 <4.0.0"
-  },
-  "lint-staged": {
-    "{src,config}/**/*.js": [
-      "eslint --fix"
-    ],
-    "{tools,src,config}/**/*.{mjs,js,json}": [
-      "prettier --write"
-    ],
-    "bin/*": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "test/**/*.{utl,spec}.{mjs,cjs}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "types/**/*.d.ts": [
-      "eslint --config types/.eslintrc.json --fix",
-      "prettier --write"
-    ]
   }
 }


### PR DESCRIPTION
## Description

- moves lintstaged config from package.json to its own file

## Motivation and Context

- which makes package.json a bit smaller
- is more explicit/ easier to find

## How Has This Been Tested?

- [ ] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
