### PR TITLE
bugfix(extract): uses tsc or swc for .mts & .cts as well

### DIFF
--- a/src/extract/get-dependencies.js
+++ b/src/extract/get-dependencies.js
@@ -32,9 +32,16 @@ function extractFromTypeScriptAST(pOptions, pFileName, pTranspileOptions) {
 }
 
 function isTypeScriptCompatible(pFileName) {
-  return [".ts", ".tsx", ".js", ".mjs", ".cjs", ".vue"].includes(
-    path.extname(pFileName)
-  );
+  return [
+    ".ts",
+    ".tsx",
+    ".mts",
+    ".cts",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".vue",
+  ].includes(path.extname(pFileName));
 }
 
 function shouldUseTsc(pOptions, pFileName) {

--- a/test/extract/__fixtures__/ts-types.json
+++ b/test/extract/__fixtures__/ts-types.json
@@ -30,6 +30,38 @@
         "couldNotResolve": false
       }
     ]
+  },
+  {
+    "title": "type only from .mts + regular import from the same module yields 2 dependencies",
+    "input": {
+      "fileName": "test/extract/__mocks__/ts-types/two-import-types-one-dependency.mts"
+    },
+    "expected": [
+      {
+        "module": "./things",
+        "resolved": "test/extract/__mocks__/ts-types/things.ts",
+        "moduleSystem": "es6",
+        "coreModule": false,
+        "dependencyTypes": ["local"],
+        "dynamic": false,
+        "followable": true,
+        "exoticallyRequired": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false
+      },
+      {
+        "module": "./things",
+        "resolved": "test/extract/__mocks__/ts-types/things.ts",
+        "moduleSystem": "es6",
+        "coreModule": false,
+        "dependencyTypes": ["local", "type-only"],
+        "dynamic": false,
+        "followable": true,
+        "exoticallyRequired": false,
+        "matchesDoNotFollow": false,
+        "couldNotResolve": false
+      }
+    ]
   }
   // TODO: nope - that doesn't work yet; fix in a separate PR
   // {

--- a/test/extract/__mocks__/ts-types/two-import-types-one-dependency.mts
+++ b/test/extract/__mocks__/ts-types/two-import-types-one-dependency.mts
@@ -1,0 +1,2 @@
+import { otherThing } from "./things";
+import type { IThing } from "./things";


### PR DESCRIPTION
## Description

- expands the extensions for which swc and tsc are used with .mts and .cts

## Motivation and Context

This way pre-compilation dependencies (unused ones, type-only ones) will be detected in .mts and .cts modules as well + it will be a little bit faster because the typescript => javascript step is skipped.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
