### PR TITLE
feature(cli): adds --no-config option

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-without-config.md
+++ b/.github/ISSUE_TEMPLATE/use-without-config.md
@@ -1,0 +1,11 @@
+---
+name: No configuration file use case
+about: Use this to tell about your use case for running dependency-cruiser without a configuration ile
+title: "I use dependency-cruiser without a configuration file. This is why."
+---
+
+### Summary
+
+Hi! I do use the dependency-cruiser cli without a configuration file. This is why:
+
+<!-- a short description on how you use it -->

--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -25,6 +25,11 @@ try {
       "read rules and options from [file] (e.g. .dependency-cruiser.js)"
     )
     .option(
+      "--no-config",
+      "do not use a configuration file. " +
+        "Overrides any --config option set earlier"
+    )
+    .option(
       "-T, --output-type <type>",
       "output type; e.g. err, err-html, dot, ddot, archi, flat, baseline or json\n(default: err)"
     )

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -18,6 +18,7 @@ available in dependency-cruiser configurations.
 1. [arguments - files and/ or directories](#arguments---files-and-or-directories)
 1. [`--output-type`: specify the output format](#--output-type-specify-the-output-format)
 1. [`--config`/ `--validate`: use a configuration with rules and/or options](#--config---validate)
+1. [`--no-config`: do not use a configuration file](#--no-config)
 1. [`--init`](#--init)
 1. [`--metrics`: calculate stability metrics](#--metrics)
 1. [`--info`: show what alt-js are supported](#--info-showing-what-alt-js-are-supported)
@@ -677,6 +678,16 @@ For more information about writing rules see the [tutorial](rules-tutorial.md) a
 [options reference](options-reference.md).
 
 For an easy set up of both use [--init](#--init)
+
+### `--no-config`
+
+Use this if you don't want to use a configuration file. Overrides any earlier
+specified --config (or --validate) option.
+
+> If you actually use this, I'm interested in your use case. Please drop an
+> [issue on GitHub](https://github.com/sverweij/dependency-cruiser/issues/new?assignees=&labels=&template=use-without-config.md&title=I+use+dependency-cruiser+without+a+configuration+file.+This+is+why:) or contact me on mastodon
+> ([@mcmeadow@mstdn.social](https://mstdn.social/@mcmeadow)) or twitter
+> ([@mcmeadow](https://twitter.com/mcmeadow)).
 
 ### `--init`
 

--- a/src/cli/normalize-cli-options.js
+++ b/src/cli/normalize-cli-options.js
@@ -108,7 +108,7 @@ function normalizeKnownViolationsOption(pCliOptions) {
 }
 
 function normalizeValidationOption(pCliOptions) {
-  if (!has(pCliOptions, "validate")) {
+  if (!pCliOptions.validate) {
     return {
       validate: false,
     };


### PR DESCRIPTION
## Description

- Adds a `--no-config` option

## Motivation and Context

In the future we want dependency-cruiser to pick up configuration files without having to specify one.  That future feature will be a breaking change a.o. because it would be harder to run without a configuration file if there's one available. This option ensures  that that behavior remains available, because, altough dependency-cruiser is most useful when used _with_ a configuration file, it _can_ be used without one and we can't be certain that it isn't used  without one.


## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
