### PR TITLE
feature(cli): hides depcrated and implied options from --help output

### DIFF
--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -12,6 +12,7 @@ try {
   const { version } = require("../src/meta.js");
   const cli = require("../src/cli");
 
+  /** @type {import('commander')} */
   program
     .description(
       "Validate and visualize dependencies.\nDetails: https://github.com/sverweij/dependency-cruiser"
@@ -24,14 +25,17 @@ try {
       "-c, --config [file]",
       "read rules and options from [file] (e.g. .dependency-cruiser.js)"
     )
-    .option(
-      "--no-config",
-      "do not use a configuration file. " +
-        "Overrides any --config option set earlier"
+    .addOption(
+      new program.Option(
+        "--no-config",
+        "do not use a configuration file. " +
+          "Overrides any --config option set earlier"
+      ).hideHelp(true)
     )
     .option(
       "-T, --output-type <type>",
-      "output type; e.g. err, err-html, dot, ddot, archi, flat, baseline or json\n(default: err)"
+      "output type; e.g. err, err-html, dot, ddot, archi, flat, baseline or json",
+      "err"
     )
     .option("-m, --metrics", "calculate stability metrics", false)
     .option(
@@ -89,15 +93,23 @@ try {
         "regex collapses to that pattern E.g. ^packages/[^/]+/ would collapse to " +
         "modules/ folders directly under your packages folder. "
     )
-    .option(
-      "-p, --progress [type]",
-      "show progress while dependency-cruiser is busy. Possible values: cli-feedback, performance-log, none"
+    .addOption(
+      new program.Option(
+        "-p, --progress [type]",
+        "show progress while dependency-cruiser is busy"
+      ).choices(["cli-feedback", "performance-log", "none"])
     )
-    .option("--no-progress", "Alias of --progress none")
-    .option(
-      "-d, --max-depth <n>",
-      "You probably want to use --collapse instead of --max-depth. " +
-        "(max-depth would limit the cruise depth; 0 <= n <= 99 (default: 0 - no limit))."
+    .addOption(
+      new program.Option("--no-progress", "Alias of --progress none").hideHelp(
+        true
+      )
+    )
+    .addOption(
+      new program.Option(
+        "-d, --max-depth <n>",
+        "You probably want to use --collapse instead of --max-depth. " +
+          "(max-depth would limit the cruise depth; 0 <= n <= 99 (default: 0 - no limit))."
+      ).hideHelp(true)
     )
     .option(
       "-M, --module-systems <items>",
@@ -112,18 +124,26 @@ try {
       "(experimental) use a cache to speed up execution. " +
         "The directory defaults to node_modules/.cache/dependency-cruiser"
     )
-    .option(
-      "--cache-strategy <strategy>",
-      "(experimental) strategy to use for detecting changed files in the cache. " +
-        "Possible values: metadata (= use git, the default), content"
+    .addOption(
+      new program.Option(
+        "--cache-strategy <strategy>",
+        "(experimental) strategy to use for detecting changed files in the cache. "
+      ).choices(["metadata", "content"])
     )
-    .option(
-      "--no-cache",
-      "switch off caching. Overrides the 'cache' key in .dependency-cruiser.js " +
-        "and --cache options set earlier on the command line"
+    .addOption(
+      new program.Option(
+        "--no-cache",
+        "switch off caching. Overrides the 'cache' key in .dependency-cruiser.js " +
+          "and --cache options set earlier on the command line"
+      ).hideHelp(true)
     )
     .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
-    .option("-v, --validate [file]", `alias for --config`)
+    .addOption(
+      new program.Option(
+        "-v, --validate [file]",
+        `alias for --config`
+      ).hideHelp(true)
+    )
     .option(
       "-i, --info",
       "shows what languages and extensions dependency-cruiser supports"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -829,14 +829,24 @@ When you first deploy dependency-cruiser in a large code base chances are it wil
 detect quite some violations - even when it only uses the default set of rules
 that comes with `--init`. It will not always possible to fix all the violations
 right away. This means that any run of dependency-cruiser will show violations
-you already decided to fix later - possibly burrying any new violations (which
+you already decided to fix later - possibly burying any new violations (which
 you probably want to avoid).
 
 With this option you can avoid that.
 
 ### `--help` / no parameters
 
-Running with no parameters or with `--help` gets you help.
+Running with no parameters or with `--help` gets you help. It doesn't show all
+options documented here in order to keep it inviting to use. The ones left out
+are:
+
+- the _implied_ ones (e.g. `--config` implies the existence of
+  a `--no-config` option)
+- ones that have an _alias_ to prevent a breaking change
+  (`--validate` is an alias for `--config`)
+- ones that have been superseded by better options but were left in to prevent
+  a breaking change (`--max-depth`; `--focus`/ `--focus-depth` and `--collapse`
+  are both more powerful and to the point for most use cases)
 
 ## Options also available in dependency-cruiser configurations
 


### PR DESCRIPTION
## Description

- hides the following implied options from `--help`:
  - `--no-config` (implied by `--config`)
  - `--no-progress` (implied by `--progress`)
  - `--no-cache` (implied by `--cache`)
- hides `--validate` which is an alias for `--config`
- hides `--max-depth` - which is superseded by the more useful & powerful `--focus`/ `--focus-depth` and `--collapse` options
- lets commander validate of passed values for `--progress` and `--cache-strategy` - which comes with automatic hinting
- lets commander put `"err"` as the default value for the reporter

## Motivation and Context

The `--help` output is becoming  large. Removing implied options and options that have gotten an alias or alternative over time  makes the the output looks less intimidating, and easier to navigate. 

This also means we'll have to _add_ `--no-xxx` options for all boolean options that don't yet have it.

Letting commander validate some of the 'pick one value' options is easier and more user friendly than building it ourselves.

> If this turns out well we might want to remove command line options from the help that better live in the configuration file anyway (`--do-not-follow`, `--ts-config`, `--webpack-confg`, `--ts-pre-compilation-deps`, `--preserve-symlinks`, `--module-systems`.

## How Has This Been Tested?

- [x] green ci
- [x] manually (the updates use functionality of commander.js and it doesn't make sense to duplicate their tests)

## Screenshots

### After
```
Usage: dependency-cruise [options] [files-or-directories]

Validate and visualize dependencies.
Details: https://github.com/sverweij/dependency-cruiser

Options:
  --init [oneshot]               set up dependency-cruiser for use in your environment (<<< recommended!)
  -c, --config [file]            read rules and options from [file] (e.g. .dependency-cruiser.js)
  -T, --output-type <type>       output type; e.g. err, err-html, dot, ddot, archi, flat, baseline or json
                                 (default: "err")
  -m, --metrics                  calculate stability metrics (default: false)
  -f, --output-to <file>         file to write output to; - for stdout (default: "-")
  -I, --include-only <regex>     only include modules matching the regex
  -F, --focus <regex>            only include modules matching the regex + their direct neighbours
  --focus-depth <number>         the depth to focus on - only applied when --focus is passed too. 1= direct
                                 neighbors, 2=neighbours of neighbours etc. (default: 1)
  -R, --reaches <regex>          only include modules matching the regex + all modules that can reach it
  -H, --highlight <regex>        mark modules matching the regex as 'highlighted'
  -x, --exclude <regex>          exclude all modules matching the regex
  -X, --do-not-follow <regex>    include modules matching the regex, but don't follow their dependencies
  --ignore-known [file]          ignore known violations as saved in [file] (default:
                                 .dependency-cruiser-known-violations.json)
  --ts-config [file]             use a TypeScript configuration (e.g. tsconfig.json) or it's JavaScript
                                 counterpart (e.g. jsconfig.json)
  --webpack-config [file]        use a webpack configuration (e.g. webpack.config.js)
  --ts-pre-compilation-deps      detect dependencies that only exist before typescript-to-javascript
                                 compilation (off by default)
  -S, --collapse <regex>         collapse a to a folder depth by passing a single digit (e.g. 2). When passed a
                                 regex collapses to that pattern E.g. ^packages/[^/]+/ would collapse to
                                 modules/ folders directly under your packages folder.
  -p, --progress [type]          show progress while dependency-cruiser is busy (choices: "cli-feedback",
                                 "performance-log", "none")
  -M, --module-systems <items>   list of module systems (default: amd, cjs, es6, tsd)
  -P, --prefix <prefix>          prefix to use for links in the dot and err-html reporters
  -C, --cache [cache-directory]  (experimental) use a cache to speed up execution. The directory defaults to
                                 node_modules/.cache/dependency-cruiser
  --cache-strategy <strategy>    (experimental) strategy to use for detecting changed files in the cache.
                                 (choices: "metadata", "content")
  --preserve-symlinks            leave symlinks unchanged (off by default)
  -i, --info                     shows what languages and extensions dependency-cruiser supports
  -V, --version                  output the version number
  -h, --help                     display help for command
```

### Before
```
Usage: dependency-cruise [options] [files-or-directories]

Validate and visualize dependencies.
Details: https://github.com/sverweij/dependency-cruiser

Options:
  --init [oneshot]               set up dependency-cruiser for use in your environment (<<< recommended!)
  -c, --config [file]            read rules and options from [file] (e.g. .dependency-cruiser.js)
  --no-config                    do not use a configuration file. Overrides any --config option set earlier
  -T, --output-type <type>       output type; e.g. err, err-html, dot, ddot, archi, flat, baseline or json
                                 (default: err)
  -m, --metrics                  calculate stability metrics (default: false)
  -f, --output-to <file>         file to write output to; - for stdout (default: "-")
  -I, --include-only <regex>     only include modules matching the regex
  -F, --focus <regex>            only include modules matching the regex + their direct neighbours
  --focus-depth <number>         the depth to focus on - only applied when --focus is passed too. 1= direct
                                 neighbors, 2=neighbours of neighbours etc. (default: 1)
  -R, --reaches <regex>          only include modules matching the regex + all modules that can reach it
  -H, --highlight <regex>        mark modules matching the regex as 'highlighted'
  -x, --exclude <regex>          exclude all modules matching the regex
  -X, --do-not-follow <regex>    include modules matching the regex, but don't follow their dependencies
  --ignore-known [file]          ignore known violations as saved in [file] (default:
                                 .dependency-cruiser-known-violations.json)
  --ts-config [file]             use a TypeScript configuration (e.g. tsconfig.json) or it's JavaScript
                                 counterpart (e.g. jsconfig.json)
  --webpack-config [file]        use a webpack configuration (e.g. webpack.config.js)
  --ts-pre-compilation-deps      detect dependencies that only exist before typescript-to-javascript
                                 compilation (off by default)
  -S, --collapse <regex>         collapse a to a folder depth by passing a single digit (e.g. 2). When passed a
                                 regex collapses to that pattern E.g. ^packages/[^/]+/ would collapse to
                                 modules/ folders directly under your packages folder.
  -p, --progress [type]          show progress while dependency-cruiser is busy. Possible values: cli-feedback,
                                 performance-log, none
  --no-progress                  Alias of --progress none
  -d, --max-depth <n>            You probably want to use --collapse instead of --max-depth. (max-depth would
                                 limit the cruise depth; 0 <= n <= 99 (default: 0 - no limit)).
  -M, --module-systems <items>   list of module systems (default: amd, cjs, es6, tsd)
  -P, --prefix <prefix>          prefix to use for links in the dot and err-html reporters
  -C, --cache [cache-directory]  (experimental) use a cache to speed up execution. The directory defaults to
                                 node_modules/.cache/dependency-cruiser
  --cache-strategy <strategy>    (experimental) strategy to use for detecting changed files in the cache.
                                 Possible values: metadata (= use git, the default), content
  --no-cache                     switch off caching. Overrides the 'cache' key in .dependency-cruiser.js and
                                 --cache options set earlier on the command line
  --preserve-symlinks            leave symlinks unchanged (off by default)
  -v, --validate [file]          alias for --config
  -i, --info                     shows what languages and extensions dependency-cruiser supports
  -V, --version                  output the version number
  -h, --help                     display help for command
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
