### PR TITLE
feature(cli|cache): adds --no-ignore-known option

### DIFF
--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -74,6 +74,7 @@ try {
       "--ignore-known [file]",
       "ignore known violations as saved in [file] (default: .dependency-cruiser-known-violations.json)"
     )
+    .addOption(new program.Option("--no-ignore-known").hideHelp(true))
     .option(
       "--ts-config [file]",
       "use a TypeScript configuration (e.g. tsconfig.json) or it's JavaScript counterpart (e.g. jsconfig.json)"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -23,6 +23,7 @@ available in dependency-cruiser configurations.
 1. [`--metrics`: calculate stability metrics](#--metrics)
 1. [`--info`: show what alt-js are supported](#--info-showing-what-alt-js-are-supported)
 1. [`--ignore-known`: ignore known violations](#--ignore-known-ignore-known-violations)
+1. [`--no-ignore-known`: don't ignore known violations](#--no-ignore-known)
 1. [`--help`/ no parameters: get help](#--help--no-parameters)
 
 ### Options also available in dependency-cruiser configurations
@@ -833,6 +834,11 @@ you already decided to fix later - possibly burying any new violations (which
 you probably want to avoid).
 
 With this option you can avoid that.
+
+### `--no-ignore-known`
+
+Don't ignore known violations. Use this if you want to override an `--ignore-known`
+option set earlier on the command line.
 
 ### `--help` / no parameters
 

--- a/src/cache/options-compatible.js
+++ b/src/cache/options-compatible.js
@@ -58,8 +58,13 @@ function includeOnlyIsCompatible(pExistingFilter, pNewFilter) {
     !pExistingFilter || isDeepStrictEqual({ path: pExistingFilter }, pNewFilter)
   );
 }
-function optionIsCompatible(pExistingOption, pNewOption) {
+
+function filterOptionIsCompatible(pExistingOption, pNewOption) {
   return !pExistingOption || isDeepStrictEqual(pExistingOption, pNewOption);
+}
+
+function optionIsCompatible(pExistingOption, pNewOption) {
+  return isDeepStrictEqual(pExistingOption, pNewOption);
 }
 
 function limitIsCompatible(pExistingLimit, pNewLimit) {
@@ -97,13 +102,19 @@ function optionsAreCompatible(pOldOptions, pNewOptions) {
     metricsIsCompatible(pOldOptions.metrics, pNewOptions.metrics) &&
     // includeOnly suffers from a backwards compatibility disease
     includeOnlyIsCompatible(pOldOptions.includeOnly, pNewOptions.includeOnly) &&
-    optionIsCompatible(pOldOptions.doNotFollow, pNewOptions.doNotFollow) &&
-    optionIsCompatible(pOldOptions.moduleSystems, pNewOptions.moduleSystems) &&
-    optionIsCompatible(pOldOptions.exclude, pNewOptions.exclude) &&
-    optionIsCompatible(pOldOptions.focus, pNewOptions.focus) &&
-    optionIsCompatible(pOldOptions.reaches, pNewOptions.reaches) &&
-    optionIsCompatible(pOldOptions.highlight, pNewOptions.highlight) &&
-    optionIsCompatible(pOldOptions.collapse, pNewOptions.collapse) &&
+    filterOptionIsCompatible(
+      pOldOptions.doNotFollow,
+      pNewOptions.doNotFollow
+    ) &&
+    filterOptionIsCompatible(
+      pOldOptions.moduleSystems,
+      pNewOptions.moduleSystems
+    ) &&
+    filterOptionIsCompatible(pOldOptions.exclude, pNewOptions.exclude) &&
+    filterOptionIsCompatible(pOldOptions.focus, pNewOptions.focus) &&
+    filterOptionIsCompatible(pOldOptions.reaches, pNewOptions.reaches) &&
+    filterOptionIsCompatible(pOldOptions.highlight, pNewOptions.highlight) &&
+    filterOptionIsCompatible(pOldOptions.collapse, pNewOptions.collapse) &&
     limitIsCompatible(pOldOptions.maxDepth, pNewOptions.maxDepth) &&
     optionIsCompatible(
       pOldOptions.knownViolations,
@@ -123,6 +134,7 @@ function optionsAreCompatible(pOldOptions, pNewOptions) {
 
 module.exports = {
   optionsAreCompatible,
+  filterOptionIsCompatible,
   optionIsCompatible,
   limitIsCompatible,
   metricsIsCompatible,

--- a/src/cli/normalize-cli-options.js
+++ b/src/cli/normalize-cli-options.js
@@ -97,7 +97,7 @@ function validateAndGetKnownViolationsFileName(pKnownViolations) {
 }
 
 function normalizeKnownViolationsOption(pCliOptions) {
-  if (!has(pCliOptions, "ignoreKnown")) {
+  if (!has(pCliOptions, "ignoreKnown") || pCliOptions.ignoreKnown === false) {
     return {};
   }
   return {

--- a/test/cache/options-compatible.spec.mjs
+++ b/test/cache/options-compatible.spec.mjs
@@ -2,6 +2,7 @@
 import { expect } from "chai";
 import {
   optionIsCompatible,
+  filterOptionIsCompatible,
   includeOnlyIsCompatible,
   limitIsCompatible,
   metricsIsCompatible,
@@ -14,13 +15,14 @@ describe("[U] cache/options-compatible - optionIsCompatible", () => {
     expect(optionIsCompatible()).to.equal(true);
   });
 
-  it("if the old filter doesn't exist, the new one is compatible, whatever it is", () => {
+  it("if the old option doesn't exist, the new one is not compatible, whatever it is", () => {
     expect(
-      optionIsCompatible(null, { path: ["aap", "noot", "mies"] })
-    ).to.equal(true);
+      // eslint-disable-next-line no-undefined
+      optionIsCompatible(undefined, { path: ["aap", "noot", "mies"] })
+    ).to.equal(false);
   });
 
-  it("if the old filter exists, the new one is compatible when it's _exactly_ the same", () => {
+  it("if the old option exists, the new one is compatible when it's _exactly_ the same", () => {
     expect(
       optionIsCompatible(
         { path: ["aap", "noot", "mies"] },
@@ -29,19 +31,78 @@ describe("[U] cache/options-compatible - optionIsCompatible", () => {
     ).to.equal(true);
   });
 
-  it("if the old filter exists, the new one is _not_ compatible when it doesn't exist", () => {
+  it("if the old option exists, the new one is _not_ compatible when it doesn't exist", () => {
     expect(
       optionIsCompatible({ path: ["aap", "noot", "mies"] }, null)
     ).to.equal(false);
   });
 
-  it("if the old filter exists, the new one is _not_ compatible when it isn't exactly the same", () => {
+  it("if the old option exists, the new one is _not_ compatible when it isn't exactly the same", () => {
     expect(
       optionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "mies"] }
       )
     ).to.equal(false);
+  });
+
+  it("if the old option equals false and the new one is as well, they're compatible", () => {
+    expect(optionIsCompatible(false, false)).to.equal(true);
+  });
+
+  it("if the old option equals false and the new one is true, they're _not_ compatible", () => {
+    expect(optionIsCompatible(false, true)).to.equal(false);
+  });
+});
+
+describe("[U] cache/options-compatible - filterOptionIsCompatible", () => {
+  it("if neither filter exists they're compatible", () => {
+    expect(filterOptionIsCompatible()).to.equal(true);
+  });
+
+  it("if the old (filter) option doesn't exist, the new one is compatible, whatever it is", () => {
+    expect(
+      // eslint-disable-next-line no-undefined
+      filterOptionIsCompatible(undefined, { path: ["aap", "noot", "mies"] })
+    ).to.equal(true);
+  });
+
+  it("if the old (filter) option is null, the new one is compatible, whatever it is", () => {
+    expect(
+      filterOptionIsCompatible(null, { path: ["aap", "noot", "mies"] })
+    ).to.equal(true);
+  });
+
+  it("if the old (filter) option exists, the new one is compatible when it's _exactly_ the same", () => {
+    expect(
+      filterOptionIsCompatible(
+        { path: ["aap", "noot", "mies"] },
+        { path: ["aap", "noot", "mies"] }
+      )
+    ).to.equal(true);
+  });
+
+  it("if the old (filter) option exists, the new one is _not_ compatible when it doesn't exist", () => {
+    expect(
+      filterOptionIsCompatible({ path: ["aap", "noot", "mies"] }, null)
+    ).to.equal(false);
+  });
+
+  it("if the old (filter) option exists, the new one is _not_ compatible when it isn't exactly the same", () => {
+    expect(
+      filterOptionIsCompatible(
+        { path: ["aap", "noot", "mies"] },
+        { path: ["aap", "mies"] }
+      )
+    ).to.equal(false);
+  });
+
+  it("if the old (filter) option equals false and the new one is as well, they're compatible", () => {
+    expect(filterOptionIsCompatible(false, false)).to.equal(true);
+  });
+
+  it("if the old (filter) option equals false and the new one is true, they're compatible", () => {
+    expect(filterOptionIsCompatible(false, true)).to.equal(true);
   });
 });
 


### PR DESCRIPTION
## Description

- adds a `--no-ignore-known` option to the cli (which doesn't show up in --help as it can be considered as implied by the existence of the `--ignore-known` option)
- fixes a bug in the option compatibility check for caching (for non-filter options, if previous option wasn't there, the presence of a new option now correctly implies a dirty cache).


## Motivation and Context

- to remain symmetric with other options that can have a boolean value


## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
