### PR TITLE
feature(cli): adds --no-metrics option

### DIFF
--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -38,6 +38,7 @@ try {
       "err"
     )
     .option("-m, --metrics", "calculate stability metrics", false)
+    .addOption(new program.Option("--no-metrics").hideHelp(true))
     .option(
       "-f, --output-to <file>",
       "file to write output to; - for stdout",

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -21,6 +21,7 @@ available in dependency-cruiser configurations.
 1. [`--no-config`: do not use a configuration file](#--no-config)
 1. [`--init`](#--init)
 1. [`--metrics`: calculate stability metrics](#--metrics)
+1. [`--no-metrics`: do not calculate stability metrics](#--no-metrics)
 1. [`--info`: show what alt-js are supported](#--info-showing-what-alt-js-are-supported)
 1. [`--ignore-known`: ignore known violations](#--ignore-known-ignore-known-violations)
 1. [`--no-ignore-known`: don't ignore known violations](#--no-ignore-known)
@@ -738,6 +739,12 @@ Currently this output is only reflected in the `json` and the
   need to specify it there.
 - Not on by default as it's relatively resource intensive (especially when
   dependency-cruiser doesn't already derives dependents of folders.)
+
+### `--no-metrics`
+
+Do not calculate metrics. You can use this to override an earlier set `--metrics`
+command line option or `metrics` option in a .dependency-cruiser.js configuration
+file.
 
 ### `--info` showing what alt-js are supported
 


### PR DESCRIPTION
## Description

- adds a `--no-metrics` option to the cli. 

It won't show up in `--help` as it's implied to exist by `--metrics`

## Motivation and Context

Consistency with other semi-boolean command line options

## How Has This Been Tested?

- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
