### PR TITLE
feature(cli): makes cli help output more focused

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -105,7 +105,8 @@
           "^src/cli",
           "^node_modules",
           "^\\.yarn/cache",
-          "^src/meta\\.js$"
+          "^src/meta\\.js$",
+          "^os$"
         ]
       }
     },

--- a/bin/dependency-cruise.js
+++ b/bin/dependency-cruise.js
@@ -8,6 +8,7 @@ try {
   // error. Otherwise, on unsupported platforms we would show a stack trace, which is
   // not so nice
   /* eslint-disable node/global-require */
+  const { EOL } = require("os");
   const program = require("commander");
   const { version } = require("../src/meta.js");
   const cli = require("../src/cli");
@@ -15,7 +16,7 @@ try {
   /** @type {import('commander')} */
   program
     .description(
-      "Validate and visualize dependencies.\nDetails: https://github.com/sverweij/dependency-cruiser"
+      `Validate and visualize dependencies.${EOL}Details: https://github.com/sverweij/dependency-cruiser`
     )
     .option(
       "--init [oneshot]",
@@ -76,18 +77,24 @@ try {
       "ignore known violations as saved in [file] (default: .dependency-cruiser-known-violations.json)"
     )
     .addOption(new program.Option("--no-ignore-known").hideHelp(true))
-    .option(
-      "--ts-config [file]",
-      "use a TypeScript configuration (e.g. tsconfig.json) or it's JavaScript counterpart (e.g. jsconfig.json)"
+    .addOption(
+      new program.Option(
+        "--ts-config [file]",
+        "use a TypeScript configuration (e.g. tsconfig.json) or it's JavaScript counterpart (e.g. jsconfig.json)"
+      ).hideHelp(true)
     )
-    .option(
-      "--webpack-config [file]",
-      "use a webpack configuration (e.g. webpack.config.js)"
+    .addOption(
+      new program.Option(
+        "--webpack-config [file]",
+        "use a webpack configuration (e.g. webpack.config.js)"
+      ).hideHelp(true)
     )
-    .option(
-      "--ts-pre-compilation-deps",
-      "detect dependencies that only exist before typescript-to-javascript " +
-        "compilation (off by default)"
+    .addOption(
+      new program.Option(
+        "--ts-pre-compilation-deps",
+        "detect dependencies that only exist before typescript-to-javascript " +
+          "compilation (off by default)"
+      ).hideHelp(true)
     )
     .option(
       "-S, --collapse <regex>",
@@ -99,7 +106,7 @@ try {
       new program.Option(
         "-p, --progress [type]",
         "show progress while dependency-cruiser is busy"
-      ).choices(["cli-feedback", "performance-log", "none"])
+      ).choices(["cli-feedback", "performance-log", "ndjson", "none"])
     )
     .addOption(
       new program.Option("--no-progress", "Alias of --progress none").hideHelp(
@@ -113,9 +120,11 @@ try {
           "(max-depth would limit the cruise depth; 0 <= n <= 99 (default: 0 - no limit))."
       ).hideHelp(true)
     )
-    .option(
-      "-M, --module-systems <items>",
-      "list of module systems (default: amd, cjs, es6, tsd)"
+    .addOption(
+      new program.Option(
+        "-M, --module-systems <items>",
+        "list of module systems (default: amd, cjs, es6, tsd)"
+      ).hideHelp(true)
     )
     .option(
       "-P, --prefix <prefix>",
@@ -139,7 +148,12 @@ try {
           "and --cache options set earlier on the command line"
       ).hideHelp(true)
     )
-    .option("--preserve-symlinks", `leave symlinks unchanged (off by default)`)
+    .addOption(
+      new program.Option(
+        "--preserve-symlinks",
+        "leave symlinks unchanged (off by default)"
+      ).hideHelp(true)
+    )
     .addOption(
       new program.Option(
         "-v, --validate [file]",
@@ -149,6 +163,11 @@ try {
     .option(
       "-i, --info",
       "shows what languages and extensions dependency-cruiser supports"
+    )
+    .addHelpText(
+      "after",
+      `${EOL}Other options:` +
+        `${EOL}    see https://github.com/sverweij/dependency-cruiser/blob/master/doc/cli.md${EOL}`
     )
     .version(version)
     .arguments("[files-or-directories]")

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -854,12 +854,16 @@ options documented here in order to keep it inviting to use. The ones left out
 are:
 
 - the _implied_ ones (e.g. `--config` implies the existence of
-  a `--no-config` option)
+  a `--no-config` option).
 - ones that have an _alias_ to prevent a breaking change
-  (`--validate` is an alias for `--config`)
-- ones that have been superseded by better options but were left in to prevent
-  a breaking change (`--max-depth`; `--focus`/ `--focus-depth` and `--collapse`
-  are both more powerful and to the point for most use cases)
+  (`--validate` is an alias for `--config`).
+- ones that have been superseded by better options but were left in for
+  backwards compatibility. E.g. `--max-depth` has been superseded by the
+  `--focus`/ `--focus-depth` and `--collapse` which are both more powerful
+  and mor to the point for most use cases.
+- those that better live in the configuration file, but are still cli
+  options for backwards compatibility (e.g. `--ts-config`, `--webpack-config`,
+  `--ts-pre-compilation-deps`, `--module-systems`, `--preserve-symlinks`)
 
 ## Options also available in dependency-cruiser configurations
 


### PR DESCRIPTION
## Description

- hides the following options in the command line help:
  - `--ts-config`
  - `--webpack-config`
  - `--ts-pre-compilation-deps`
  - `--module-systems`
  - `--preserve-symlinks`
- adds `ndjson` to the choices possible for the `--progress` option (actually a bugfix)
- adds a link to the full documentation

## Motivation and Context

For the now hidden options it makes more sense to specify them in a .dependency-cruiser.js - they are part of the command line options for backwards compatibility only. Keeping them in the cli help would stimulate sub-optimal use of dependency-cruiser + without them the help text is _much_ shorter.

## How Has This Been Tested?

- [x] green ci
- [x] manual checks (the changes involves configuring commander - I presume commander itself is already covered with sufficient automated tests).

## After and before

### After
```
Usage: dependency-cruise [options] [files-or-directories]

Validate and visualize dependencies.
Details: https://github.com/sverweij/dependency-cruiser

Options:
  --init [oneshot]               set up dependency-cruiser for use in your environment (<<<
                                 recommended!)
  -c, --config [file]            read rules and options from [file] (e.g. .dependency-cruiser.js)
  -T, --output-type <type>       output type; e.g. err, err-html, dot, ddot, archi, flat,
                                 baseline or json (default: "err")
  -m, --metrics                  calculate stability metrics (default: false)
  -f, --output-to <file>         file to write output to; - for stdout (default: "-")
  -I, --include-only <regex>     only include modules matching the regex
  -F, --focus <regex>            only include modules matching the regex + their direct
                                 neighbours
  --focus-depth <number>         the depth to focus on - only applied when --focus is passed too.
                                 1= direct neighbors, 2=neighbours of neighbours etc. (default:
                                 1)
  -R, --reaches <regex>          only include modules matching the regex + all modules that can
                                 reach it
  -H, --highlight <regex>        mark modules matching the regex as 'highlighted'
  -x, --exclude <regex>          exclude all modules matching the regex
  -X, --do-not-follow <regex>    include modules matching the regex, but don't follow their
                                 dependencies
  --ignore-known [file]          ignore known violations as saved in [file] (default:
                                 .dependency-cruiser-known-violations.json)
  -S, --collapse <regex>         collapse a to a folder depth by passing a single digit (e.g. 2).
                                 When passed a regex collapses to that pattern E.g.
                                 ^packages/[^/]+/ would collapse to modules/ folders directly
                                 under your packages folder.
  -p, --progress [type]          show progress while dependency-cruiser is busy (choices:
                                 "cli-feedback", "performance-log", "ndjson", "none")
  -P, --prefix <prefix>          prefix to use for links in the dot and err-html reporters
  -C, --cache [cache-directory]  (experimental) use a cache to speed up execution. The directory
                                 defaults to node_modules/.cache/dependency-cruiser
  --cache-strategy <strategy>    (experimental) strategy to use for detecting changed files in
                                 the cache.  (choices: "metadata", "content")
  -i, --info                     shows what languages and extensions dependency-cruiser supports
  -V, --version                  output the version number
  -h, --help                     display help for command

Other options:
    see https://github.com/sverweij/dependency-cruiser/blob/master/doc/cli.md

```

### Before

```
Usage: dependency-cruise [options] [files-or-directories]

Validate and visualize dependencies.
Details: https://github.com/sverweij/dependency-cruiser

Options:
  --init [oneshot]               set up dependency-cruiser for use in your environment (<<<
                                 recommended!)
  -c, --config [file]            read rules and options from [file] (e.g. .dependency-cruiser.js)
  -T, --output-type <type>       output type; e.g. err, err-html, dot, ddot, archi, flat,
                                 baseline or json (default: "err")
  -m, --metrics                  calculate stability metrics (default: false)
  -f, --output-to <file>         file to write output to; - for stdout (default: "-")
  -I, --include-only <regex>     only include modules matching the regex
  -F, --focus <regex>            only include modules matching the regex + their direct
                                 neighbours
  --focus-depth <number>         the depth to focus on - only applied when --focus is passed too.
                                 1= direct neighbors, 2=neighbours of neighbours etc. (default:
                                 1)
  -R, --reaches <regex>          only include modules matching the regex + all modules that can
                                 reach it
  -H, --highlight <regex>        mark modules matching the regex as 'highlighted'
  -x, --exclude <regex>          exclude all modules matching the regex
  -X, --do-not-follow <regex>    include modules matching the regex, but don't follow their
                                 dependencies
  --ignore-known [file]          ignore known violations as saved in [file] (default:
                                 .dependency-cruiser-known-violations.json)
  --ts-config [file]             use a TypeScript configuration (e.g. tsconfig.json) or it's
                                 JavaScript counterpart (e.g. jsconfig.json)
  --webpack-config [file]        use a webpack configuration (e.g. webpack.config.js)
  --ts-pre-compilation-deps      detect dependencies that only exist before
                                 typescript-to-javascript compilation (off by default)
  -S, --collapse <regex>         collapse a to a folder depth by passing a single digit (e.g. 2).
                                 When passed a regex collapses to that pattern E.g.
                                 ^packages/[^/]+/ would collapse to modules/ folders directly
                                 under your packages folder.
  -p, --progress [type]          show progress while dependency-cruiser is busy (choices:
                                 "cli-feedback", "performance-log", "none")
  -M, --module-systems <items>   list of module systems (default: amd, cjs, es6, tsd)
  -P, --prefix <prefix>          prefix to use for links in the dot and err-html reporters
  -C, --cache [cache-directory]  (experimental) use a cache to speed up execution. The directory
                                 defaults to node_modules/.cache/dependency-cruiser
  --cache-strategy <strategy>    (experimental) strategy to use for detecting changed files in
                                 the cache.  (choices: "metadata", "content")
  --preserve-symlinks            leave symlinks unchanged (off by default)
  -i, --info                     shows what languages and extensions dependency-cruiser supports
  -V, --version                  output the version number
  -h, --help                     display help for command
```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
