### PR TITLE
feature(extract): adds support for TypeScript (>= 5) type only re-exports

### DIFF
--- a/src/extract/ast-extractors/extract-typescript-deps.js
+++ b/src/extract/ast-extractors/extract-typescript-deps.js
@@ -4,6 +4,19 @@ const { supportedTranspilers } = require("../../../src/meta.js");
 
 const typescript = tryRequire("typescript", supportedTranspilers.typescript);
 
+function isTypeOnly(pStatement) {
+  return (
+    (pStatement.importClause && pStatement.importClause.isTypeOnly) ||
+    // for some weird reason the isTypeOnly indicator is on _statement_ level
+    // and not in exportClause as it is in the importClause ¯\_ (ツ)_/¯.
+    // Also in the case of the omission of an alias the exportClause
+    // is not there entirely. So regardless whether there is a
+    // pStatement.exportClause or not, we can directly test for the
+    // isTypeOnly attribute.
+    pStatement.isTypeOnly
+  );
+}
+
 /*
  * Both extractImport* assume the imports/ exports can only occur at
  * top level. AFAIK this the only place they're allowed, so we should
@@ -30,9 +43,7 @@ function extractImportsAndExports(pAST) {
       module: pStatement.moduleSpecifier.text,
       moduleSystem: "es6",
       exoticallyRequired: false,
-      ...(pStatement.importClause && pStatement.importClause.isTypeOnly
-        ? { dependencyTypes: ["type-only"] }
-        : {}),
+      ...(isTypeOnly(pStatement) ? { dependencyTypes: ["type-only"] } : {}),
     }));
 }
 

--- a/test/extract/ast-extractors/extract-typescript-type-imports-and-exports.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-type-imports-and-exports.spec.mjs
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
-describe("[U] ast-extractors/extract-typescript - type imports", () => {
+describe("[U] ast-extractors/extract-typescript - type imports and exports", () => {
   it("extracts type imports in const declarations", () => {
     expect(
       extractTypescript("const tiepetjes: import('./types').T;")
@@ -115,5 +115,33 @@ describe("[U] ast-extractors/extract-typescript - type imports", () => {
         dependencyTypes: ["type-only"],
       },
     ]);
+  });
+
+  it("extracts re-exports that explicitly state they only re-export a type", () => {
+    expect(
+      extractTypescript("export type * as vehicles from './vehicles';")
+    ).to.deep.equal([
+      {
+        module: "./vehicles",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+        dependencyTypes: ["type-only"],
+      },
+    ]);
+  });
+
+  it("extracts re-exports that explicitly state they only re-export a type (without aliases)", () => {
+    expect(extractTypescript("export type * from './vehicles';")).to.deep.equal(
+      [
+        {
+          module: "./vehicles",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: ["type-only"],
+        },
+      ]
+    );
   });
 });


### PR DESCRIPTION
## Description

- adds support for type only re-exports 

```typescript
export type * as vehicles from './vehicles';
export type * from './roads';
```

> - As with other type only stuff, this only works with `tsPreCompilationDeps: true`, or with a 
> TypeScript capable parser.
> - Different from other type only stuff this _does not_ work with the `swc` `parser`, as it looks like `swc` doesn't support this yet. Which is not that weird, as TypeScript has only been out for a few days. When swc starts supports it I'll open a PR for it (unless somebody else does it).


## Motivation and Context

This was added in TypeScript 5 - see [TypeScript 5 release notes]( https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#support-for-export-type)

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
