### PR TITLE
refactor: replaces cruise function with signature from futureCruise BREAKING

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -98,30 +98,35 @@ try {
 
 ### Utility functions
 
-> Exposition of `extract-xxx` functions is _experimental_. It also will only
-> work on node ^12.19 || >=14.7 as those are versions that support the `exports`
-> entry points feature in package.json.
-
 ```typescript
-import { cruise, ICruiseOptions, IReporterOutput } from ".";
-import extractDepcruiseConfig from "./src/config-utl/extract-depcruise-config";
-import extractTSConfig from "./src/config-utl/extract-ts-config";
-import extractWebpackResolveConfig from "./src/config-utl/extract-webpack-resolve-config";
+import { cruise, ICruiseOptions, IReporterOutput } from "dependency-cruiser";
+import extractDepcruiseConfig from "dependency-cruiser/config-utl/extract-depcruise-config";
+import extractTSConfig from "dependency-cruiser/config-utl/extract-ts-config";
+import extractWebpackResolveConfig from "dependency-cruiser/config-utl/extract-webpack-resolve-config";
+import extractBabelConfig from "dependency-cruiser/config-utl/extract-babel-config";
 
 try {
   const ARRAY_OF_FILES_AND_DIRS_TO_CRUISE = ["src"];
 
-  const depcruiseConfig: ICruiseOptions = extractDepcruiseConfig(
+  const depcruiseConfig: ICruiseOptions = await extractDepcruiseConfig(
     "./.dependency-cruiser.js"
   );
   const webpackResolveConfig = extractWebpackResolveConfig("./webpack.conf.js");
   const tsConfig = extractTSConfig("./tsconfig.json");
+  // const babelConfig = await extractBabelConfig("./babel.conf.json");
 
   const cruiseResult: IReporterOutput = cruise(
     ARRAY_OF_FILES_AND_DIRS_TO_CRUISE,
     depcruiseConfig,
     webpackResolveConfig,
-    tsConfig
+    //   change since v13: in stead of passing the tsConfig directly, like so:
+    // tsconfig
+    //   you now pass it into an object that also supports other types of
+    //   compiler options, like those for babel:
+    {
+      tsConfig: tsConfig,
+      // babelConfig: babelConfig,
+    }
   );
 
   console.dir(cruiseResult.output, { depth: 10 });

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -115,7 +115,7 @@ async function runCruise(pFileDirectoryArray, pCruiseOptions) {
   setUpListener(lCruiseOptions);
 
   bus.emit("start");
-  const lReportingResult = main.futureCruise(
+  const lReportingResult = main.cruise(
     pFileDirectoryArray,
     lCruiseOptions,
     extractResolveOptions(lCruiseOptions),

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,9 +46,9 @@ function c(pComplete, pTotal = TOTAL_STEPS) {
   return { complete: pComplete / pTotal };
 }
 
-/** @type {import("../..").futureCruise} */
+/** @type {import("../..").cruise} */
 // eslint-disable-next-line max-lines-per-function, max-statements
-function futureCruise(
+function cruise(
   pFileAndDirectoryArray,
   pCruiseOptions,
   pResolveOptions,
@@ -93,7 +93,7 @@ function futureCruise(
   const lNormalizedResolveOptions = normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
-    pTranspileOptions.tsConfig
+    pTranspileOptions?.tsConfig
   );
 
   bus.emit("progress", "reading files", c(5));
@@ -120,18 +120,8 @@ function futureCruise(
   return reportWrap(lCruiseResult, lCruiseOptions);
 }
 
-// see [api.md](../../doc/api.md) and/ or the
-// [type definition](../../types/dependency-cruiser.d.ts) for details
-/** @type {import("../..").cruise} */
-function cruise(pFileAndDirectoryArray, pOptions, pResolveOptions, pTSConfig) {
-  return futureCruise(pFileAndDirectoryArray, pOptions, pResolveOptions, {
-    tsConfig: pTSConfig,
-  });
-}
-
 module.exports = {
   cruise,
-  futureCruise,
   format,
   allExtensions: meta.allExtensions,
   getAvailableTranspilers: meta.getAvailableTranspilers,

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -2,7 +2,7 @@ import { rmSync } from "fs";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
-import { futureCruise } from "../../src/main/index.js";
+import { cruise } from "../../src/main/index.js";
 import Cache from "../../src/cache/cache.js";
 
 use(chaiJSONSchema);
@@ -19,7 +19,7 @@ describe("[E] main.cruise - cache", () => {
   });
 
   it("cruising fills the cache", () => {
-    const lResult = futureCruise(
+    const lResult = cruise(
       ["test/main/__mocks__/cache"],
       {
         cache: CACHE_FOLDER,
@@ -35,7 +35,7 @@ describe("[E] main.cruise - cache", () => {
   });
 
   it("cruising twice yields the same result (minus 'revisionData')", () => {
-    const lResult = futureCruise(
+    const lResult = cruise(
       ["test/main/__mocks__/cache"],
       {
         cache: CACHE_FOLDER,
@@ -48,7 +48,7 @@ describe("[E] main.cruise - cache", () => {
 
     expect(lResult.output).to.deep.equal(lCache);
 
-    const lResultTwo = futureCruise(
+    const lResultTwo = cruise(
       ["test/main/__mocks__/cache"],
       {
         cache: CACHE_FOLDER,
@@ -62,7 +62,7 @@ describe("[E] main.cruise - cache", () => {
   });
 
   it("cruising twice with non-compatible arguments yields different results", () => {
-    const lResult = futureCruise(
+    const lResult = cruise(
       ["test/main/__mocks__/cache"],
       {
         cache: CACHE_FOLDER,
@@ -75,7 +75,7 @@ describe("[E] main.cruise - cache", () => {
 
     expect(lResult.output).to.deep.equal(lOldCache);
 
-    const lResultTwo = futureCruise(
+    const lResultTwo = cruise(
       ["test/main/__mocks__/cache test/main/__mocks__/cache-too "],
       {
         cache: CACHE_FOLDER,

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,7 +1,7 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
-import main from "../../src/main/index.js";
+import { cruise } from "../../src/main/index.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
@@ -34,7 +34,7 @@ describe("[E] main.cruise - dynamic imports", () => {
 
   it("detects dynamic dependencies in es", () => {
     process.chdir("test/main/__mocks__/dynamic-imports/es");
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["src"],
       {
         ruleSet: {
@@ -69,7 +69,7 @@ describe("[E] main.cruise - dynamic imports", () => {
 
   it("detects dynamic dependencies in typescript", () => {
     process.chdir("test/main/__mocks__/dynamic-imports/typescript");
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["src"],
       {
         ruleSet: {
@@ -104,7 +104,7 @@ describe("[E] main.cruise - dynamic imports", () => {
 
   it("detects dynamic dependencies in typescript when using tsPreCompilationDeps", () => {
     process.chdir("test/main/__mocks__/dynamic-imports/typescript");
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["src"],
       {
         ruleSet: {

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -5,7 +5,7 @@ import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import pathToPosix from "../../src/utl/path-to-posix.js";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";
-import main from "../../src/main/index.js";
+import { cruise } from "../../src/main/index.js";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
 
@@ -31,14 +31,14 @@ function pathPosixify(pOutput) {
 
 describe("[E] main.cruise - main", () => {
   it("Returns an object when no options are passed", () => {
-    const lResult = main.cruise(["test/main/__mocks__/ts"]);
+    const lResult = cruise(["test/main/__mocks__/ts"]);
 
     expect(pathPosixify(lResult.output)).to.deep.equal(tsFixture);
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
 
   it("Returns an object when no options are passed (absolute path)", () => {
-    const lResult = main.cruise(
+    const lResult = cruise(
       [path.join(__dirname, "__mocks__", "ts")],
       {},
       { bustTheCache: true }
@@ -49,7 +49,7 @@ describe("[E] main.cruise - main", () => {
   });
 
   it("processes tsx correctly", () => {
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["test/main/__mocks__/tsx"],
       {},
       { bustTheCache: true }
@@ -60,7 +60,7 @@ describe("[E] main.cruise - main", () => {
   });
 
   it("processes jsx correctly", () => {
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["test/main/__mocks__/jsx"],
       {},
       { bustTheCache: true }
@@ -70,7 +70,7 @@ describe("[E] main.cruise - main", () => {
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
   it("process rulesets in the form a an object instead of json", () => {
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["test/main/__mocks__/jsx"],
       {
         ruleSet: {},
@@ -82,7 +82,7 @@ describe("[E] main.cruise - main", () => {
     expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
   });
   it("Collapses to a pattern when a collapse pattern is passed", () => {
-    const lResult = main.cruise(
+    const lResult = cruise(
       ["test/main/__mocks__/collapse-after-cruise"],
       {
         ruleSet: {},

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -34,9 +34,11 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
       { bustTheCache: true },
       {
-        options: {
-          baseUrl: ".",
-          module: "commonjs",
+        tsConfig: {
+          options: {
+            baseUrl: ".",
+            module: "commonjs",
+          },
         },
       }
     );
@@ -55,9 +57,11 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
       { bustTheCache: true },
       {
-        options: {
-          baseUrl: ".",
-          module: "es6",
+        tsConfig: {
+          options: {
+            baseUrl: ".",
+            module: "es6",
+          },
         },
       }
     );
@@ -76,9 +80,11 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
       { bustTheCache: true },
       {
-        options: {
-          baseUrl: ".",
-          module: "commonjs",
+        tsConfig: {
+          options: {
+            baseUrl: ".",
+            module: "commonjs",
+          },
         },
       }
     );
@@ -97,9 +103,11 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
       { bustTheCache: true },
       {
-        options: {
-          baseUrl: ".",
-          module: "es6",
+        tsConfig: {
+          options: {
+            baseUrl: ".",
+            module: "es6",
+          },
         },
       }
     );

--- a/types/dependency-cruiser.d.ts
+++ b/types/dependency-cruiser.d.ts
@@ -57,29 +57,6 @@ export interface IReporterOutput {
   exitCode: number;
 }
 
-/**
- * Cruises the specified files and files with supported extensions in
- * the specified directories in the pFileDirArray and returns the result
- * in an object.
- *
- * @param pFileAndDirectoryArray  An array of (names of) files, directories and/ or glob patterns
- *                        to start the cruise with
- * @param pCruiseOptions  Options that influence the way the dependencies are cruised - and
- *                        how they are returned.
- * @param pResolveOptions Options that influence how dependency references are resolved to disk.
- *                        See https://webpack.js.org/configuration/resolve/ for the details.
- * @param pTSConfig       An object with with a typescript config object. Note that the
- *                        API will not take any 'extends' keys there into account, so
- *                        before calling make sure to flatten them out if you want them
- *                        used (e.g. with 'dependency-cruiser/config-utl/extract-ts-config')
- */
-export function cruise(
-  pFileAndDirectoryArray: string[],
-  pCruiseOptions?: ICruiseOptions,
-  pResolveOptions?: IResolveOptions,
-  pTSConfig?: any
-): IReporterOutput;
-
 export interface ITranspileOptions {
   /**
    * An object with with a typescript config object. Note that the
@@ -97,9 +74,6 @@ export interface ITranspileOptions {
 }
 
 /**
- * /!\ Beta cruise function. Supports slightly more stuff (i.e. babel), but
- * the function signature might change without notice. /!\
- *
  * Cruises the specified files and files with supported extensions in
  * the specified directories in the pFileDirArray and returns the result
  * in an object.
@@ -113,7 +87,7 @@ export interface ITranspileOptions {
  * @param pTranspileOptions Object to hold options to pass to underlying transpilers
  *                        like TypeScript or Babel
  */
-export function futureCruise(
+export function cruise(
   pFileAndDirectoryArray: string[],
   pCruiseOptions?: ICruiseOptions,
   pResolveOptions?: IResolveOptions,


### PR DESCRIPTION
## Description

- replaces the `cruise` interface with the more generic `futureCruise`

## Motivation and Context

Enables more types of transpiler options to be passed - a thing already in use for babel configuration options. 

Before:

```javascript
import { cruise } from 'dependency-cruiser';
import extractDepcruiseConfig from "dependency-cruiser/config-utl/extract-depcruise-config";
import extractTSConfig from "dependency-cruiser/config-utl/extract-ts-config";
import extractWebpackResolveConfig from "dependency-cruiser/config-utl/extract-webpack-resolve-config"
import extractBabelConfig from "dependency-cruiser/config-utl/extract-babel-config";

const lCruiseOptions = {
  // ...
};

const lResult = main.cruise(
  ["src", "test"],
  await extractDepcruiseConfig("./.dependency-cruiser.js"),
  extractWebpackResolveConfig("webpack.config.js"),
  extractTSConfig("./tsconfig.json"),
  // not possible to pass a babel configuration
  }
);
```

After: 
```javascript
import { cruise } from 'dependency-cruiser';
import extractDepcruiseConfig from "dependency-cruiser/config-utl/extract-depcruise-config";
import extractTSConfig from "dependency-cruiser/config-utl/extract-ts-config";
import extractWebpackResolveConfig from "dependency-cruiser/config-utl/extract-webpack-resolve-config"
import extractBabelConfig from "dependency-cruiser/config-utl/extract-babel-config";

const lResult = main.cruise(
  ["src", "test"],
  await extractDepcruiseConfig("./.dependency-cruiser.js"),
  extractWebpackResolveConfig("webpack.config.js"),
  {
   tsConfig: extractTSConfig("./tsconfig.json"),
   babelConfig: await extractBabelConfig("./babel.conf.json")
  }
);
```

## How Has This Been Tested?

- [x] green ci
- [x] adapted unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
