### PR TITLE
refactor(extract): removes default export from meta

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -80,7 +80,7 @@
           "$1",
           "^node_modules",
           "^\\.yarn/cache",
-          "^(path|fs|module|os)$",
+          "^(path|path/posix|fs|module|os)$",
           "^src/meta\\.js$",
           "^src/graph-utl",
           "^src/utl"

--- a/configs/.dependency-cruiser-show-metrics-config.mjs
+++ b/configs/.dependency-cruiser-show-metrics-config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('../').IConfiguration} */
 export default {
-  $schema: "../src/schema/configuration.schema.json",
   extends: "../.dependency-cruiser.json",
   forbidden: [
     {

--- a/src/cache/cache.mjs
+++ b/src/cache/cache.mjs
@@ -1,6 +1,6 @@
 import { readFileSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import meta from "../extract/transpile/meta.mjs";
+import { scannableExtensions } from "../extract/transpile/meta.mjs";
 import optionsCompatible from "./options-compatible.js";
 import MetadataStrategy from "./metadata-strategy.js";
 import ContentStrategy from "./content-strategy.js";
@@ -34,9 +34,7 @@ export default class Cache {
         pCruiseOptions,
         {
           extensions: new Set(
-            meta.scannableExtensions.concat(
-              pCruiseOptions.extraExtensionsToScan
-            )
+            scannableExtensions.concat(pCruiseOptions.extraExtensionsToScan)
           ),
         }
       );

--- a/src/cli/format-meta-info.mjs
+++ b/src/cli/format-meta-info.mjs
@@ -1,22 +1,20 @@
 import chalk from "chalk";
 import figures from "figures";
 
-import main from "../main/index.mjs";
+import { getAvailableTranspilers, allExtensions } from "../main/index.mjs";
 
 function bool2Symbol(pBool) {
   return pBool ? chalk.green(figures.tick) : chalk.red(figures.cross);
 }
 
 function formatTranspilers() {
-  return main
-    .getAvailableTranspilers()
-    .reduce(
-      (pAll, pThis) =>
-        `${pAll}    ${bool2Symbol(pThis.available)} ${pThis.name} (${
-          pThis.version
-        })\n`,
-      `    ${bool2Symbol(true)} javascript (>es1)\n`
-    );
+  return getAvailableTranspilers().reduce(
+    (pAll, pThis) =>
+      `${pAll}    ${bool2Symbol(pThis.available)} ${pThis.name} (${
+        pThis.version
+      })\n`,
+    `    ${bool2Symbol(true)} javascript (>es1)\n`
+  );
 }
 
 function formatExtensions(pExtensions) {
@@ -42,7 +40,7 @@ export default function formatMetaInfo() {
 ${formatTranspilers()}
   Extensions:
 
-${formatExtensions(main.allExtensions)}
+${formatExtensions(allExtensions)}
 `;
 }
 

--- a/src/cli/init-config/find-extensions.mjs
+++ b/src/cli/init-config/find-extensions.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 /* eslint-disable security/detect-object-injection */
 import getExtension from "../../utl/get-extension.js";
-import meta from "../../extract/transpile/meta.mjs";
+import { scannableExtensions } from "../../extract/transpile/meta.mjs";
 import findAllFiles from "../../utl/find-all-files.js";
 
 /**
@@ -31,7 +31,7 @@ function compareByCount(pCountsObject) {
 export default function findExtensions(pDirectories, pOptions) {
   const lOptions = {
     baseDir: process.cwd(),
-    scannableExtensions: meta.scannableExtensions,
+    scannableExtensions,
     ...pOptions,
   };
 

--- a/src/extract/clear-caches.mjs
+++ b/src/extract/clear-caches.mjs
@@ -1,7 +1,7 @@
 import toTypescriptAST from "./parse/to-typescript-ast.mjs";
 import toJavascriptAST from "./parse/to-javascript-ast.mjs";
 import toSwcAST from "./parse/to-swc-ast.mjs";
-import localNpmHelpers from "./resolve/external-module-helpers.mjs";
+import { clearCache as externalModuleHelpers_clearCache } from "./resolve/external-module-helpers.mjs";
 import { clearCache as getManifest_clearCache } from "./resolve/get-manifest.mjs";
 import { clearCache as resolveAMD_clearCache } from "./resolve/resolve-amd.mjs";
 import { clearCache as resolve_clearCache } from "./resolve/resolve.mjs";
@@ -10,7 +10,7 @@ export default function clearCaches() {
   toTypescriptAST.clearCache();
   toJavascriptAST.clearCache();
   toSwcAST.clearCache();
-  localNpmHelpers.clearCache();
+  externalModuleHelpers_clearCache();
   getManifest_clearCache();
   resolveAMD_clearCache();
   resolve_clearCache();

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -1,11 +1,11 @@
-import fs from "fs";
-import path from "path";
+import { readdirSync, statSync } from "fs";
+import { join } from "path";
 import { glob } from "glob";
 import get from "lodash/get.js";
 import { filenameMatchesPattern } from "../graph-utl/match-facade.js";
 import getExtension from "../utl/get-extension.js";
 import pathToPosix from "../utl/path-to-posix.js";
-import transpileMeta from "./transpile/meta.mjs";
+import { scannableExtensions } from "./transpile/meta.mjs";
 
 /**
  *
@@ -13,9 +13,7 @@ import transpileMeta from "./transpile/meta.mjs";
  * @returns {string[]}
  */
 function getScannableExtensions(pOptions) {
-  return transpileMeta.scannableExtensions.concat(
-    pOptions.extraExtensionsToScan
-  );
+  return scannableExtensions.concat(pOptions.extraExtensionsToScan);
 }
 
 function fileIsScannable(pOptions, pPathToFile) {
@@ -45,14 +43,13 @@ function shouldNotBeExcluded(pFullPathToFile, pOptions) {
  * @returns {string[]}
  */
 function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
-  return fs
-    .readdirSync(path.join(pOptions.baseDir, pDirectoryName))
-    .map((pFileName) => path.join(pDirectoryName, pFileName))
+  return readdirSync(join(pOptions.baseDir, pDirectoryName))
+    .map((pFileName) => join(pDirectoryName, pFileName))
     .filter((pFullPathToFile) =>
       shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions)
     )
     .reduce((pSum, pFullPathToFile) => {
-      let lStat = fs.statSync(path.join(pOptions.baseDir, pFullPathToFile), {
+      let lStat = statSync(join(pOptions.baseDir, pFullPathToFile), {
         throwIfNoEntry: false,
       });
 
@@ -105,9 +102,7 @@ export default function gatherInitialSources(pFileAndDirectoryArray, pOptions) {
       []
     )
     .reduce((pAll, pFileOrDirectory) => {
-      if (
-        fs.statSync(path.join(lOptions.baseDir, pFileOrDirectory)).isDirectory()
-      ) {
+      if (statSync(join(lOptions.baseDir, pFileOrDirectory)).isDirectory()) {
         return pAll.concat(
           gatherScannableFilesFromDirectory(pFileOrDirectory, lOptions)
         );

--- a/src/extract/get-dependencies.mjs
+++ b/src/extract/get-dependencies.mjs
@@ -1,4 +1,4 @@
-import path from "path";
+import { join, extname, dirname } from "path";
 import get from "lodash/get.js";
 import uniqBy from "lodash/uniqBy.js";
 import { intersects } from "../utl/array-util.js";
@@ -18,7 +18,7 @@ import {
 
 function extractFromSwcAST({ baseDir, exoticRequireStrings }, pFileName) {
   return extractSwcDeps(
-    toSwcAST.getASTCached(path.join(baseDir, pFileName)),
+    toSwcAST.getASTCached(join(baseDir, pFileName)),
     exoticRequireStrings
   );
 }
@@ -29,10 +29,7 @@ function extractFromTypeScriptAST(
   pTranspileOptions
 ) {
   return extractTypeScriptDeps(
-    toTypescriptAST.getASTCached(
-      path.join(baseDir, pFileName),
-      pTranspileOptions
-    ),
+    toTypescriptAST.getASTCached(join(baseDir, pFileName), pTranspileOptions),
     exoticRequireStrings
   );
 }
@@ -47,7 +44,7 @@ function isTypeScriptCompatible(pFileName) {
     ".mjs",
     ".cjs",
     ".vue",
-  ].includes(path.extname(pFileName));
+  ].includes(extname(pFileName));
 }
 
 function shouldUseTsc({ tsPreCompilationDeps, parser }, pFileName) {
@@ -73,7 +70,7 @@ function extractFromJavaScriptAST(
 ) {
   let lDependencies = [];
   const lAST = toJavascriptAST.getASTCached(
-    path.join(baseDir, pFileName),
+    join(baseDir, pFileName),
     pTranspileOptions
   );
 
@@ -125,7 +122,7 @@ function extractDependencies(pCruiseOptions, pFileName, pTranspileOptions) {
   /** @type import('../../types/cruise-result.js').IDependency[] */
   let lDependencies = [];
 
-  if (!pCruiseOptions.extraExtensionsToScan.includes(path.extname(pFileName))) {
+  if (!pCruiseOptions.extraExtensionsToScan.includes(extname(pFileName))) {
     if (shouldUseSwc(pCruiseOptions, pFileName)) {
       lDependencies = extractWithSwc(pCruiseOptions, pFileName);
     } else if (shouldUseTsc(pCruiseOptions, pFileName)) {
@@ -169,7 +166,7 @@ function addResolutionAttributes(
     const lResolved = resolve(
       pDependency,
       baseDir,
-      path.join(baseDir, path.dirname(pFileName)),
+      join(baseDir, dirname(pFileName)),
       pResolveOptions
     );
     const lMatchesDoNotFollow = matchesDoNotFollow(lResolved, doNotFollow);

--- a/src/extract/parse/to-javascript-ast.mjs
+++ b/src/extract/parse/to-javascript-ast.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/exports-last */
-import fs from "fs";
+import { readFileSync } from "fs";
 import { Parser as acornParser, parse as acornParse } from "acorn";
 import { parse as acornLooseParse } from "acorn-loose";
 import acornJsx from "acorn-jsx";
@@ -66,7 +66,7 @@ export function getASTFromSource(pFileRecord, pTranspileOptions) {
 function getAST(pFileName, pTranspileOptions) {
   return getASTFromSource(
     {
-      source: fs.readFileSync(pFileName, "utf8"),
+      source: readFileSync(pFileName, "utf8"),
       extension: getExtension(pFileName),
       filename: pFileName,
     },

--- a/src/extract/parse/to-typescript-ast.mjs
+++ b/src/extract/parse/to-typescript-ast.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/exports-last */
-import fs from "fs";
+import { readFileSync } from "fs";
 import tryImport from "semver-try-require";
 import memoize from "lodash/memoize.js";
 import meta from "../../meta.js";
@@ -46,7 +46,7 @@ export function getASTFromSource(pFileRecord, pTranspileOptions) {
 function getAST(pFileName, pTranspileOptions) {
   return getASTFromSource(
     {
-      source: fs.readFileSync(pFileName, "utf8"),
+      source: readFileSync(pFileName, "utf8"),
       extension: getExtension(pFileName),
       filename: pFileName,
     },

--- a/src/extract/resolve/determine-dependency-types.mjs
+++ b/src/extract/resolve/determine-dependency-types.mjs
@@ -1,9 +1,14 @@
-import path from "path";
+import { join } from "path/posix";
 import has from "lodash/has.js";
-import moduleClassifiers from "./module-classifiers.mjs";
-import externalModuleHelpers from "./external-module-helpers.mjs";
-
-const { isRelativeModuleName, isExternalModule, isAliassy } = moduleClassifiers;
+import {
+  isRelativeModuleName,
+  isExternalModule,
+  isAliassy,
+} from "./module-classifiers.mjs";
+import {
+  dependencyIsDeprecated,
+  getPackageRoot,
+} from "./external-module-helpers.mjs";
 
 function dependencyKeyHasModuleName(
   pPackageDependencies,
@@ -12,7 +17,7 @@ function dependencyKeyHasModuleName(
 ) {
   return (pKey) =>
     pKey.includes("ependencies") &&
-    has(pPackageDependencies[pKey], path.posix.join(pPrefix, pModuleName));
+    has(pPackageDependencies[pKey], join(pPrefix, pModuleName));
 }
 
 const NPM2DEP_TYPE = {
@@ -105,17 +110,13 @@ function determineNodeModuleDependencyTypes(
 ) {
   /** @type {import("../../../types/shared-types.js").DependencyType[]} */
   let lReturnValue = determineManifestDependencyTypes(
-    externalModuleHelpers.getPackageRoot(pModuleName),
+    getPackageRoot(pModuleName),
     pPackageDeps,
     pResolveOptions.modules
   );
   if (
     pResolveOptions.resolveDeprecations &&
-    externalModuleHelpers.dependencyIsDeprecated(
-      pModuleName,
-      pFileDirectory,
-      pResolveOptions
-    )
+    dependencyIsDeprecated(pModuleName, pFileDirectory, pResolveOptions)
   ) {
     lReturnValue.push("deprecated");
   }

--- a/src/extract/resolve/external-module-helpers.mjs
+++ b/src/extract/resolve/external-module-helpers.mjs
@@ -1,12 +1,10 @@
 /* eslint-disable import/exports-last */
-import fs from "fs";
-import path from "path";
+import { readFileSync } from "fs";
+import { join } from "path";
 import memoize from "lodash/memoize.js";
 import has from "lodash/has.js";
 import { resolve } from "./resolve.mjs";
-import moduleClassifiers from "./module-classifiers.mjs";
-
-const { isScoped, isRelativeModuleName } = moduleClassifiers;
+import { isScoped, isRelativeModuleName } from "./module-classifiers.mjs";
 
 /**
  * Returns the 'root' of the package - the spot where we can probably find
@@ -81,7 +79,7 @@ function bareGetPackageJson(pModuleName, pFileDirectory, pResolveOptions) {
 
   try {
     const lPackageJsonFilename = resolve(
-      path.join(getPackageRoot(pModuleName), "package.json"),
+      join(getPackageRoot(pModuleName), "package.json"),
       pFileDirectory ? pFileDirectory : process.cwd(),
       {
         ...pResolveOptions,
@@ -102,7 +100,7 @@ function bareGetPackageJson(pModuleName, pFileDirectory, pResolveOptions) {
       // and an array of extensions
       "manifest-resolution"
     );
-    lReturnValue = JSON.parse(fs.readFileSync(lPackageJsonFilename, "utf8"));
+    lReturnValue = JSON.parse(readFileSync(lPackageJsonFilename, "utf8"));
   } catch (pError) {
     // left empty on purpose
   }
@@ -170,11 +168,3 @@ export function getLicense(pModuleName, pFileDirectory, pResolveOptions) {
 export function clearCache() {
   getPackageJson.cache.clear();
 }
-
-export default {
-  getPackageRoot,
-  getPackageJson,
-  dependencyIsDeprecated,
-  getLicense,
-  clearCache,
-};

--- a/src/extract/resolve/get-manifest.mjs
+++ b/src/extract/resolve/get-manifest.mjs
@@ -1,5 +1,5 @@
-import path from "path";
-import fs from "fs";
+import { join, dirname, sep } from "path";
+import { readFileSync } from "fs";
 import memoize from "lodash/memoize.js";
 import mergePackages from "./merge-manifests.mjs";
 
@@ -21,8 +21,8 @@ const getSingleManifest = memoize((pFileDirectory) => {
 
   try {
     // find the closest package.json from pFileDirectory
-    const lPackageContent = fs.readFileSync(
-      path.join(pFileDirectory, "package.json"),
+    const lPackageContent = readFileSync(
+      join(pFileDirectory, "package.json"),
       "utf8"
     );
 
@@ -32,7 +32,7 @@ const getSingleManifest = memoize((pFileDirectory) => {
       // left empty on purpose
     }
   } catch (pError) {
-    const lNextDirectory = path.dirname(pFileDirectory);
+    const lNextDirectory = dirname(pFileDirectory);
 
     if (lNextDirectory !== pFileDirectory) {
       // not yet reached root directory
@@ -46,8 +46,8 @@ function maybeReadPackage(pFileDirectory) {
   let lReturnValue = {};
 
   try {
-    const lPackageContent = fs.readFileSync(
-      path.join(pFileDirectory, "package.json"),
+    const lPackageContent = readFileSync(
+      join(pFileDirectory, "package.json"),
       "utf8"
     );
 
@@ -71,10 +71,10 @@ function getIntermediatePaths(pFileDirectory, pBaseDirectory) {
     // safety hatch in case pBaseDirectory is either not a part of
     // pFileDirectory or not something uniquely comparable to a
     // dirname
-    lIntermediate !== path.dirname(lIntermediate)
+    lIntermediate !== dirname(lIntermediate)
   ) {
     lReturnValue.push(lIntermediate);
-    lIntermediate = path.dirname(lIntermediate);
+    lIntermediate = dirname(lIntermediate);
   }
   lReturnValue.push(pBaseDirectory);
   return lReturnValue;
@@ -89,7 +89,7 @@ const getCombinedManifests = memoize((pFileDirectory, pBaseDirectory) => {
   // something gone terribly awry
   if (
     !pFileDirectory.startsWith(pBaseDirectory) ||
-    pBaseDirectory.endsWith(path.sep)
+    pBaseDirectory.endsWith(sep)
   ) {
     throw new Error(
       `Unexpected Error: Unusual baseDir passed to package reading function: '${pBaseDirectory}'\n` +

--- a/src/extract/resolve/module-classifiers.mjs
+++ b/src/extract/resolve/module-classifiers.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/exports-last */
-import path from "path";
+import { isAbsolute, resolve as path_resolve } from "path";
 import getExtension from "../../utl/get-extension.js";
 
 let gFollowableExtensionsCache = new Set();
@@ -36,10 +36,10 @@ export function isExternalModule(
       // hence we'll have to test for them in different fashion as well.
       // reference: https://webpack.js.org/configuration/resolve/#resolve-modules
       (pModuleFolderName) => {
-        if (path.isAbsolute(pModuleFolderName)) {
-          return path
-            .resolve(pBaseDirectory, pResolvedModuleName)
-            .startsWith(pModuleFolderName);
+        if (isAbsolute(pModuleFolderName)) {
+          return path_resolve(pBaseDirectory, pResolvedModuleName).startsWith(
+            pModuleFolderName
+          );
         }
         return pResolvedModuleName.includes(pModuleFolderName);
       }
@@ -116,11 +116,3 @@ export function isAliassy(pModuleName, pResolvedModuleName, pResolveOptions) {
     isLikelyTSAliased(pModuleName, pResolvedModuleName, pResolveOptions)
   );
 }
-
-export default {
-  isScoped,
-  isRelativeModuleName,
-  isExternalModule,
-  isFollowable,
-  isAliassy,
-};

--- a/src/extract/resolve/resolve-amd.mjs
+++ b/src/extract/resolve/resolve-amd.mjs
@@ -1,12 +1,12 @@
-import fs from "fs";
-import path from "path";
+import { accessSync, R_OK } from "fs";
+import { relative, join } from "path";
 import { builtinModules } from "module";
 import memoize from "lodash/memoize.js";
 import pathToPosix from "../../utl/path-to-posix.js";
 
 const fileExists = memoize((pFile) => {
   try {
-    fs.accessSync(pFile, fs.R_OK);
+    accessSync(pFile, R_OK);
   } catch (pError) {
     return false;
   }
@@ -16,10 +16,7 @@ const fileExists = memoize((pFile) => {
 
 function guessPath(pBaseDirectory, pFileDirectory, pStrippedModuleName) {
   return pathToPosix(
-    path.relative(
-      pBaseDirectory,
-      path.join(pFileDirectory, pStrippedModuleName)
-    )
+    relative(pBaseDirectory, join(pFileDirectory, pStrippedModuleName))
   );
 }
 

--- a/src/extract/resolve/resolve-cjs.mjs
+++ b/src/extract/resolve/resolve-cjs.mjs
@@ -1,10 +1,8 @@
-import path from "path";
+import { relative } from "path";
 import { builtinModules } from "module";
 import pathToPosix from "../../utl/path-to-posix.js";
-import moduleClassifiers from "./module-classifiers.mjs";
+import { isFollowable } from "./module-classifiers.mjs";
 import { resolve } from "./resolve.mjs";
-
-const { isFollowable } = moduleClassifiers;
 
 function addResolutionAttributes(
   pBaseDirectory,
@@ -19,7 +17,7 @@ function addResolutionAttributes(
   } else {
     try {
       lReturnValue.resolved = pathToPosix(
-        path.relative(
+        relative(
           pBaseDirectory,
           resolve(pModuleName, pFileDirectory, pResolveOptions)
         )

--- a/src/extract/resolve/resolve-helpers.mjs
+++ b/src/extract/resolve/resolve-helpers.mjs
@@ -1,31 +1,30 @@
 import { getLicense } from "./external-module-helpers.mjs";
-import moduleClassifiers from "./module-classifiers.mjs";
+import { isExternalModule } from "./module-classifiers.mjs";
 
-export default {
-  addLicenseAttribute(
-    pModuleName,
-    pResolvedModuleName,
-    { baseDirectory, fileDirectory },
-    pResolveOptions
+export function addLicenseAttribute(
+  pModuleName,
+  pResolvedModuleName,
+  { baseDirectory, fileDirectory },
+  pResolveOptions
+) {
+  let lReturnValue = {};
+  if (
+    pResolveOptions.resolveLicenses &&
+    isExternalModule(
+      pResolvedModuleName,
+      pResolveOptions.modules,
+      baseDirectory
+    )
   ) {
-    let lReturnValue = {};
-    if (
-      pResolveOptions.resolveLicenses &&
-      moduleClassifiers.isExternalModule(
-        pResolvedModuleName,
-        pResolveOptions.modules,
-        baseDirectory
-      )
-    ) {
-      const lLicense = getLicense(pModuleName, fileDirectory, pResolveOptions);
+    const lLicense = getLicense(pModuleName, fileDirectory, pResolveOptions);
 
-      if (Boolean(lLicense)) {
-        lReturnValue.license = lLicense;
-      }
+    if (Boolean(lLicense)) {
+      lReturnValue.license = lLicense;
     }
-    return lReturnValue;
-  },
-  stripToModuleName(pUnstrippedModuleName) {
-    return pUnstrippedModuleName.split("!").pop();
-  },
-};
+  }
+  return lReturnValue;
+}
+
+export function stripToModuleName(pUnstrippedModuleName) {
+  return pUnstrippedModuleName.split("!").pop();
+}

--- a/src/extract/transpile/index.mjs
+++ b/src/extract/transpile/index.mjs
@@ -1,4 +1,4 @@
-import meta from "./meta.mjs";
+import { getWrapper } from "./meta.mjs";
 
 /**
  * Transpiles the string pFile with the transpiler configured for extension
@@ -22,7 +22,7 @@ export default function transpile(
   { extension, source, filename },
   pTranspilerOptions
 ) {
-  const lWrapper = meta.getWrapper(extension, pTranspilerOptions);
+  const lWrapper = getWrapper(extension, pTranspilerOptions);
 
   if (lWrapper.isAvailable()) {
     return lWrapper.transpile(source, filename, pTranspilerOptions);

--- a/src/extract/transpile/meta.mjs
+++ b/src/extract/transpile/meta.mjs
@@ -1,3 +1,4 @@
+/* eslint security/detect-object-injection : 0*/
 import meta from "../../meta.js";
 import swc from "../parse/to-swc-ast.mjs";
 import javaScriptWrap from "./javascript-wrap.mjs";
@@ -135,11 +136,3 @@ export function getAvailableTranspilers() {
     available: TRANSPILER2WRAPPER[pTranspiler].isAvailable(),
   }));
 }
-
-export default {
-  getWrapper,
-  allExtensions,
-  scannableExtensions,
-  getAvailableTranspilers,
-};
-/* eslint security/detect-object-injection : 0*/

--- a/src/main/index.mjs
+++ b/src/main/index.mjs
@@ -5,9 +5,12 @@ import Ajv from "ajv";
 import extract from "../extract/index.mjs";
 import enrich from "../enrich/index.js";
 import cruiseResultSchema from "../schema/cruise-result.schema.js";
-import meta from "../extract/transpile/meta.mjs";
 import bus from "../utl/bus.js";
 import Cache from "../cache/cache.mjs";
+import {
+  allExtensions,
+  getAvailableTranspilers,
+} from "../extract/transpile/meta.mjs";
 import normalizeFilesAndDirectories from "./files-and-dirs/normalize.js";
 import validateRuleSet from "./rule-set/validate.js";
 import normalizeRuleSet from "./rule-set/normalize.js";
@@ -121,12 +124,14 @@ export async function cruise(
   return reportWrap(lCruiseResult, lCruiseOptions);
 }
 
-export const allExtensions = meta.allExtensions;
-export const getAvailableTranspilers = meta.getAvailableTranspilers;
+export {
+  allExtensions,
+  getAvailableTranspilers,
+} from "../extract/transpile/meta.mjs";
 
 export default {
   cruise,
   format,
-  allExtensions: meta.allExtensions,
-  getAvailableTranspilers: meta.getAvailableTranspilers,
+  allExtensions,
+  getAvailableTranspilers,
 };

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -3,7 +3,7 @@ import get from "lodash/get.js";
 import has from "lodash/has.js";
 import omit from "lodash/omit.js";
 import enhancedResolve from "enhanced-resolve";
-import transpileMeta from "../../extract/transpile/meta.mjs";
+import { scannableExtensions } from "../../extract/transpile/meta.mjs";
 import ruleSet from "../../graph-utl/rule-set.js";
 
 const DEFAULT_CACHE_DURATION = 4000;
@@ -22,7 +22,7 @@ const DEFAULT_RESOLVE_OPTIONS = {
   // anyway, that works well in most circumstances.
   // Note that if extract/transpile/index gets an unknown extension
   // passed, it'll fall back to the javascript parser
-  extensions: transpileMeta.scannableExtensions,
+  extensions: scannableExtensions,
   // for typescript projects that import stuff that's only in
   // node_modules/@types we need:
   // - the inclusion of .d.ts to the extensions (see above)

--- a/test/extract/resolve/resolve-helpers.spec.mjs
+++ b/test/extract/resolve/resolve-helpers.spec.mjs
@@ -1,37 +1,27 @@
 import { expect } from "chai";
-import resolveHelpers from "../../../src/extract/resolve/resolve-helpers.mjs";
+import { stripToModuleName } from "../../../src/extract/resolve/resolve-helpers.mjs";
 
 describe("[U] extract/resolve/resolveHelpers - stripToModuleName", () => {
   it("yields the empty string when stripping the empty string", () => {
-    expect(resolveHelpers.stripToModuleName("")).to.equal("");
+    expect(stripToModuleName("")).to.equal("");
   });
   it("leaves imports without inline loaders alone", () => {
-    expect(resolveHelpers.stripToModuleName("some_module")).to.equal(
-      "some_module"
-    );
-    expect(resolveHelpers.stripToModuleName("./local/module")).to.equal(
-      "./local/module"
-    );
-    expect(resolveHelpers.stripToModuleName("@some/module")).to.equal(
-      "@some/module"
-    );
-    expect(resolveHelpers.stripToModuleName("/abso/lute/path")).to.equal(
-      "/abso/lute/path"
-    );
+    expect(stripToModuleName("some_module")).to.equal("some_module");
+    expect(stripToModuleName("./local/module")).to.equal("./local/module");
+    expect(stripToModuleName("@some/module")).to.equal("@some/module");
+    expect(stripToModuleName("/abso/lute/path")).to.equal("/abso/lute/path");
   });
   it("takes the name after the last ! when there's inline loaders involved", () => {
-    expect(resolveHelpers.stripToModuleName("!some_module")).to.equal(
-      "some_module"
-    );
-    expect(resolveHelpers.stripToModuleName("hello!./local/module")).to.equal(
+    expect(stripToModuleName("!some_module")).to.equal("some_module");
+    expect(stripToModuleName("hello!./local/module")).to.equal(
       "./local/module"
     );
-    expect(
-      resolveHelpers.stripToModuleName("wim!zus!jet!@some/module")
-    ).to.equal("@some/module");
-    expect(
-      resolveHelpers.stripToModuleName("!!taa!tuu!taa!tuu!!!./thing.js")
-    ).to.equal("./thing.js");
-    expect(resolveHelpers.stripToModuleName("edge-case!!")).to.equal("");
+    expect(stripToModuleName("wim!zus!jet!@some/module")).to.equal(
+      "@some/module"
+    );
+    expect(stripToModuleName("!!taa!tuu!taa!tuu!!!./thing.js")).to.equal(
+      "./thing.js"
+    );
+    expect(stripToModuleName("edge-case!!")).to.equal("");
   });
 });

--- a/test/extract/transpile/meta.spec.mjs
+++ b/test/extract/transpile/meta.spec.mjs
@@ -1,13 +1,17 @@
 import { expect } from "chai";
-import meta from "../../../src/extract/transpile/meta.mjs";
+import {
+  getAvailableTranspilers,
+  getWrapper,
+  scannableExtensions,
+} from "../../../src/extract/transpile/meta.mjs";
 import jsWrap from "../../../src/extract/transpile/javascript-wrap.mjs";
 import lsWrap from "../../../src/extract/transpile/livescript-wrap.mjs";
 import babelWrap from "../../../src/extract/transpile/babel-wrap.mjs";
 import vueTemplateWrap from "../../../src/extract/transpile/vue-template-wrap.cjs";
 
 describe("[U] extract/transpile/meta", () => {
-  it("tells which extensio ns can be scanned", () => {
-    expect(meta.scannableExtensions).to.deep.equal([
+  it("tells which extensions can be scanned", () => {
+    expect(scannableExtensions).to.deep.equal([
       ".js",
       ".cjs",
       ".mjs",
@@ -30,53 +34,53 @@ describe("[U] extract/transpile/meta", () => {
   });
 
   it("returns the 'js' wrapper for unknown extensions", () => {
-    expect(meta.getWrapper("")).to.deep.equal(jsWrap);
+    expect(getWrapper("")).to.deep.equal(jsWrap);
   });
 
   it("returns the 'ls' wrapper for livescript", () => {
-    expect(meta.getWrapper(".ls")).to.deep.equal(lsWrap);
+    expect(getWrapper(".ls")).to.deep.equal(lsWrap);
   });
 
   it("returns the 'javascript' wrapper for javascript when the babel config is not passed", () => {
-    expect(meta.getWrapper(".js", {})).to.deep.equal(jsWrap);
+    expect(getWrapper(".js", {})).to.deep.equal(jsWrap);
   });
 
   it("returns the 'javascript' wrapper for javascript when there's just a typscript config", () => {
-    expect(meta.getWrapper(".js", { tsConfig: {} })).to.deep.equal(jsWrap);
+    expect(getWrapper(".js", { tsConfig: {} })).to.deep.equal(jsWrap);
   });
 
   it("returns the 'babel' wrapper for javascript when the babel config is empty", () => {
-    expect(meta.getWrapper(".js", { babelConfig: {} })).to.deep.equal(jsWrap);
+    expect(getWrapper(".js", { babelConfig: {} })).to.deep.equal(jsWrap);
   });
 
   it("returns the 'babel' wrapper for javascript when the babel config is not empty", () => {
     expect(
-      meta.getWrapper(".js", { babelConfig: { babelrc: false } })
+      getWrapper(".js", { babelConfig: { babelrc: false } })
     ).to.deep.equal(babelWrap);
   });
 
   it("returns the 'babel' wrapper for typescript when the babel config is not empty", () => {
     expect(
-      meta.getWrapper(".ts", { babelConfig: { babelrc: false } })
+      getWrapper(".ts", { babelConfig: { babelrc: false } })
     ).to.deep.equal(babelWrap);
   });
 
   it("returns the 'vue' wrapper for vue templates even when the babel config is not empty", () => {
     expect(
-      meta.getWrapper(".vue", { babelConfig: { babelrc: false } })
+      getWrapper(".vue", { babelConfig: { babelrc: false } })
     ).to.deep.equal(vueTemplateWrap);
   });
 
   it("returns the 'svelte' wrapper for svelte even when the babel config is not empty", () => {
     expect(
-      meta
-        .getWrapper(".svelte", { babelConfig: { babelrc: false } })
-        .transpile.toString()
+      getWrapper(".svelte", {
+        babelConfig: { babelrc: false },
+      }).transpile.toString()
     ).to.contains("svelte");
   });
 
   it("returns me the available transpilers", () => {
-    expect(meta.getAvailableTranspilers()).to.deep.equal([
+    expect(getAvailableTranspilers()).to.deep.equal([
       {
         name: "babel",
         version: ">=7.0.0 <8.0.0",


### PR DESCRIPTION
## Description

- removes the default export from extract/ meta

(I think its usage is clearer now)

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
