### PR TITLE
refactor: uses node: protocol for all node native module imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,9 +13,7 @@ module.exports = {
     "budapestian/global-constant-pattern": "off", // currently does not work with the AST as emitted @typescript-eslint parser (FIXME)
     "no-param-reassign": "error",
     "security/detect-non-literal-fs-filename": "off",
-    "unicorn/prefer-top-level-await": "off", // only works as of node 16
     "unicorn/no-useless-fallback-in-spread": "off", // useful, probably. We'll try it later, though
-    "unicorn/prefer-node-protocol": "off", // yarn 1 pnp doesn't understand node: protocol, and as we still support yarn 1 pnp we're not doing this
   },
   overrides: [
     {

--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -70,13 +70,10 @@ try {
     .parse(process.argv);
 
   if (program.args[0]) {
-    format(program.args[0], program.opts())
-      .then((pExitCode) => {
-        if (program.opts().exitCode) {
-          process.exitCode = pExitCode;
-        }
-      })
-      .catch(formatError);
+    const lExitCode = await format(program.args[0], program.opts());
+    if (program.opts().exitCode) {
+      process.exitCode = lExitCode;
+    }
   } else {
     program.help();
   }

--- a/bin/dependency-cruise.mjs
+++ b/bin/dependency-cruise.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { EOL } from "os";
+import { EOL } from "node:os";
 import { program } from "commander";
 import validateNodeEnvironment from "../src/cli/validate-node-environment.mjs";
 import meta from "../src/meta.js";

--- a/configs/plugins/3d-reporter-plugin.js
+++ b/configs/plugins/3d-reporter-plugin.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 const figures = require("figures");
 
 const TEMPLATE = `

--- a/src/cache/cache.mjs
+++ b/src/cache/cache.mjs
@@ -1,5 +1,5 @@
-import { readFileSync, mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { scannableExtensions } from "../extract/transpile/meta.mjs";
 import optionsCompatible from "./options-compatible.js";
 import MetadataStrategy from "./metadata-strategy.js";

--- a/src/cache/content-strategy.js
+++ b/src/cache/content-strategy.js
@@ -1,5 +1,5 @@
-const { join } = require("path").posix;
-const { isDeepStrictEqual } = require("util");
+const { join } = require("node:path").posix;
+const { isDeepStrictEqual } = require("node:util");
 const findContentChanges = require("./find-content-changes");
 const {
   getFileHash,

--- a/src/cache/find-content-changes.js
+++ b/src/cache/find-content-changes.js
@@ -1,4 +1,4 @@
-const { join } = require("path").posix;
+const { join } = require("node:path").posix;
 const bus = require("../utl/bus");
 const { DEBUG } = require("../utl/bus-log-levels");
 const findAllFiles = require("../utl/find-all-files");

--- a/src/cache/metadata-strategy.js
+++ b/src/cache/metadata-strategy.js
@@ -1,4 +1,4 @@
-const { isDeepStrictEqual } = require("util");
+const { isDeepStrictEqual } = require("node:util");
 const { getSHASync, listSync } = require("watskeburt");
 const {
   isInterestingChangeType,

--- a/src/cache/options-compatible.js
+++ b/src/cache/options-compatible.js
@@ -1,4 +1,4 @@
-const { isDeepStrictEqual } = require("util");
+const { isDeepStrictEqual } = require("node:util");
 
 /*
 # command line options

--- a/src/cache/utl.js
+++ b/src/cache/utl.js
@@ -1,6 +1,6 @@
-const { createHash } = require("crypto");
-const { readFileSync } = require("fs");
-const path = require("path");
+const { createHash } = require("node:crypto");
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
 const memoize = require("lodash/memoize");
 const { filenameMatchesPattern } = require("../graph-utl/match-facade");
 

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/max-dependencies */
-import { join } from "path";
+import { join } from "node:path";
 import { glob } from "glob";
 import cloneDeep from "lodash/cloneDeep.js";
 import set from "lodash/set.js";

--- a/src/cli/init-config/environment-helpers.mjs
+++ b/src/cli/init-config/environment-helpers.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable import/exports-last */
 // @ts-check
-import { readFileSync, readdirSync, accessSync, statSync, R_OK } from "fs";
-import { join } from "path";
+import { readFileSync, readdirSync, accessSync, statSync, R_OK } from "node:fs";
+import { join } from "node:path";
 import has from "lodash/has.js";
 import { DEFAULT_CONFIG_FILE_NAME } from "../defaults.mjs";
 

--- a/src/cli/init-config/validators.mjs
+++ b/src/cli/init-config/validators.mjs
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import { toSourceLocationArray } from "./environment-helpers.mjs";
 
 export function validateLocation(pLocations) {

--- a/src/cli/init-config/write-config.mjs
+++ b/src/cli/init-config/write-config.mjs
@@ -1,4 +1,4 @@
-import { writeFileSync } from "fs";
+import { writeFileSync } from "node:fs";
 import figures from "figures";
 import chalk from "chalk";
 import {

--- a/src/cli/listeners/ndjson.mjs
+++ b/src/cli/listeners/ndjson.mjs
@@ -1,4 +1,4 @@
-import { EOL } from "os";
+import { EOL } from "node:os";
 import busLogLevels from "../../utl/bus-log-levels.js";
 
 const MICRO_SECONDS_PER_SECOND = 1000000;

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import set from "lodash/set.js";
 import get from "lodash/get.js";
 import has from "lodash/has.js";

--- a/src/cli/tools/wrap-stream-in-html.mjs
+++ b/src/cli/tools/wrap-stream-in-html.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const HEADER_FILE = fileURLToPath(
   new URL("svg-in-html-snippets/header.snippet.html", import.meta.url)

--- a/src/cli/utl/io.mjs
+++ b/src/cli/utl/io.mjs
@@ -1,4 +1,4 @@
-import { writeFileSync, createReadStream } from "fs";
+import { writeFileSync, createReadStream } from "node:fs";
 
 const PIPE_BUFFER_SIZE = 512;
 

--- a/src/cli/utl/validate-file-existence.mjs
+++ b/src/cli/utl/validate-file-existence.mjs
@@ -1,4 +1,4 @@
-import { accessSync, R_OK } from "fs";
+import { accessSync, R_OK } from "node:fs";
 
 export default function validateFileExistence(pDirectoryOrFile) {
   try {

--- a/src/config-utl/extract-babel-config.mjs
+++ b/src/config-utl/extract-babel-config.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 
-import { extname } from "path";
+import { extname } from "node:path";
 import json5 from "json5";
 import has from "lodash/has.js";
 import tryImport from "semver-try-require";

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import cloneDeep from "lodash/cloneDeep.js";
 import has from "lodash/has.js";
 import { resolve } from "../../extract/resolve/resolve.mjs";

--- a/src/config-utl/extract-depcruise-config/merge-configs.mjs
+++ b/src/config-utl/extract-depcruise-config/merge-configs.mjs
@@ -1,4 +1,4 @@
-import { isDeepStrictEqual } from "util";
+import { isDeepStrictEqual } from "node:util";
 import get from "lodash/get.js";
 import uniqBy from "lodash/uniqBy.js";
 import uniqWith from "lodash/uniqWith.js";

--- a/src/config-utl/extract-depcruise-config/read-config.mjs
+++ b/src/config-utl/extract-depcruise-config/read-config.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { extname } from "path";
+import { readFileSync } from "node:fs";
+import { extname } from "node:path";
 import json5 from "json5";
 
 export default async function readConfig(pAbsolutePathToConfigFile) {

--- a/src/config-utl/extract-known-violations.mjs
+++ b/src/config-utl/extract-known-violations.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import json5 from "json5";
 import makeAbsolute from "./make-absolute.mjs";
 

--- a/src/config-utl/extract-ts-config.mjs
+++ b/src/config-utl/extract-ts-config.mjs
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import tryImport from "semver-try-require";
 import meta from "../meta.js";
 

--- a/src/config-utl/extract-webpack-resolve-config.mjs
+++ b/src/config-utl/extract-webpack-resolve-config.mjs
@@ -1,5 +1,5 @@
-import { extname } from "path";
-import { createRequire } from "module";
+import { extname } from "node:path";
+import { createRequire } from "node:module";
 import makeAbsolute from "./make-absolute.mjs";
 
 const require = createRequire(import.meta.url);

--- a/src/config-utl/make-absolute.mjs
+++ b/src/config-utl/make-absolute.mjs
@@ -1,4 +1,4 @@
-import { join, isAbsolute } from "path";
+import { join, isAbsolute } from "node:path";
 
 export default function makeAbsolute(pFilename) {
   let lReturnValue = pFilename;

--- a/src/enrich/derive/folders/aggregate-to-folders.js
+++ b/src/enrich/derive/folders/aggregate-to-folders.js
@@ -1,5 +1,5 @@
 /* eslint-disable security/detect-object-injection */
-const path = require("path").posix;
+const path = require("node:path").posix;
 const { calculateInstability, metricsAreCalculable } = require("../module-utl");
 const detectCycles = require("../circular");
 const IndexedModuleGraph = require("../../../graph-utl/indexed-module-graph");

--- a/src/enrich/derive/folders/utl.js
+++ b/src/enrich/derive/folders/utl.js
@@ -1,5 +1,5 @@
 /* eslint-disable security/detect-object-injection */
-const path = require("path").posix;
+const path = require("node:path").posix;
 
 function findFolderByName(pAllFolders, pName) {
   return pAllFolders.find((pFolder) => pFolder.name === pName);

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -1,5 +1,5 @@
-import { readdirSync, statSync } from "fs";
-import { join } from "path";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { glob } from "glob";
 import get from "lodash/get.js";
 import { filenameMatchesPattern } from "../graph-utl/match-facade.js";

--- a/src/extract/get-dependencies.mjs
+++ b/src/extract/get-dependencies.mjs
@@ -1,4 +1,4 @@
-import { join, extname, dirname } from "path";
+import { join, extname, dirname } from "node:path";
 import get from "lodash/get.js";
 import uniqBy from "lodash/uniqBy.js";
 import { intersects } from "../utl/array-util.js";

--- a/src/extract/parse/to-javascript-ast.mjs
+++ b/src/extract/parse/to-javascript-ast.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/exports-last */
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { Parser as acornParser, parse as acornParse } from "acorn";
 import { parse as acornLooseParse } from "acorn-loose";
 import acornJsx from "acorn-jsx";

--- a/src/extract/parse/to-typescript-ast.mjs
+++ b/src/extract/parse/to-typescript-ast.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/exports-last */
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import tryImport from "semver-try-require";
 import memoize from "lodash/memoize.js";
 import meta from "../../meta.js";

--- a/src/extract/resolve/determine-dependency-types.mjs
+++ b/src/extract/resolve/determine-dependency-types.mjs
@@ -1,4 +1,4 @@
-import { join } from "path/posix";
+import { join } from "node:path/posix";
 import has from "lodash/has.js";
 import {
   isRelativeModuleName,

--- a/src/extract/resolve/external-module-helpers.mjs
+++ b/src/extract/resolve/external-module-helpers.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable import/exports-last */
-import { readFileSync } from "fs";
-import { join } from "path";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import memoize from "lodash/memoize.js";
 import has from "lodash/has.js";
 import { resolve } from "./resolve.mjs";

--- a/src/extract/resolve/get-manifest.mjs
+++ b/src/extract/resolve/get-manifest.mjs
@@ -1,5 +1,5 @@
-import { join, dirname, sep } from "path";
-import { readFileSync } from "fs";
+import { join, dirname, sep } from "node:path";
+import { readFileSync } from "node:fs";
 import memoize from "lodash/memoize.js";
 import mergePackages from "./merge-manifests.mjs";
 

--- a/src/extract/resolve/index.mjs
+++ b/src/extract/resolve/index.mjs
@@ -1,6 +1,6 @@
-import { realpathSync } from "fs";
-import { extname, resolve as path_resolve, relative } from "path";
-import monkeyPatchedModule from "module";
+import { realpathSync } from "node:fs";
+import { extname, resolve as path_resolve, relative } from "node:path";
+import monkeyPatchedModule from "node:module";
 import pathToPosix from "../../utl/path-to-posix.js";
 import { isRelativeModuleName } from "./module-classifiers.mjs";
 import { resolveAMD } from "./resolve-amd.mjs";

--- a/src/extract/resolve/module-classifiers.mjs
+++ b/src/extract/resolve/module-classifiers.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/exports-last */
-import { isAbsolute, resolve as path_resolve } from "path";
+import { isAbsolute, resolve as path_resolve } from "node:path";
 import getExtension from "../../utl/get-extension.js";
 
 let gFollowableExtensionsCache = new Set();

--- a/src/extract/resolve/resolve-amd.mjs
+++ b/src/extract/resolve/resolve-amd.mjs
@@ -1,6 +1,6 @@
-import { accessSync, R_OK } from "fs";
-import { relative, join } from "path";
-import { builtinModules } from "module";
+import { accessSync, R_OK } from "node:fs";
+import { relative, join } from "node:path";
+import { builtinModules } from "node:module";
 import memoize from "lodash/memoize.js";
 import pathToPosix from "../../utl/path-to-posix.js";
 

--- a/src/extract/resolve/resolve-cjs.mjs
+++ b/src/extract/resolve/resolve-cjs.mjs
@@ -1,5 +1,5 @@
-import { relative } from "path";
-import { builtinModules } from "module";
+import { relative } from "node:path";
+import { builtinModules } from "node:module";
 import pathToPosix from "../../utl/path-to-posix.js";
 import { isFollowable } from "./module-classifiers.mjs";
 import { resolve } from "./resolve.mjs";

--- a/src/graph-utl/consolidate-to-folder.js
+++ b/src/graph-utl/consolidate-to-folder.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 const consolidateModules = require("./consolidate-modules");
 const consolidateModuleDependencies = require("./consolidate-module-dependencies");
 

--- a/src/main/files-and-dirs/normalize.js
+++ b/src/main/files-and-dirs/normalize.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 /**
  *
  * @param {string} pFileDirectory

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import get from "lodash/get.js";
 import has from "lodash/has.js";
 import omit from "lodash/omit.js";

--- a/src/report/dot/module-utl.js
+++ b/src/report/dot/module-utl.js
@@ -1,4 +1,4 @@
-const path = require("path").posix;
+const path = require("node:path").posix;
 const has = require("lodash/has");
 const utl = require("../utl/index.js");
 const theming = require("./theming");

--- a/src/report/metrics.js
+++ b/src/report/metrics.js
@@ -1,4 +1,4 @@
-const { EOL } = require("os");
+const { EOL } = require("node:os");
 const chalk = require("chalk");
 const utl = require("./utl");
 

--- a/src/utl/bus.js
+++ b/src/utl/bus.js
@@ -1,4 +1,4 @@
-const EventEmitter = require("events");
+const EventEmitter = require("node:events");
 
 const gBus = new EventEmitter();
 

--- a/src/utl/find-all-files.js
+++ b/src/utl/find-all-files.js
@@ -1,5 +1,5 @@
-const { readdirSync, statSync, readFileSync } = require("fs");
-const { join } = require("path");
+const { readdirSync, statSync, readFileSync } = require("node:fs");
+const { join } = require("node:path");
 const ignore = require("ignore");
 const pathToPosix = require("./path-to-posix");
 

--- a/src/utl/get-extension.js
+++ b/src/utl/get-extension.js
@@ -1,5 +1,5 @@
 // @ts-check
-const path = require("path");
+const path = require("node:path");
 
 const EXTENSION_RE = /(?<extension>((\.d\.(c|m)?ts)|\.coffee\.md)$)/;
 

--- a/src/utl/path-to-posix.js
+++ b/src/utl/path-to-posix.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 
 /**
  * On win32 platforms transform win32 type paths into posix paths

--- a/test/backwards.utl.mjs
+++ b/test/backwards.utl.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import JSON5 from "json5";
 
 export function createRequireJSON(pBaseURL) {

--- a/test/cache/cache.spec.mjs
+++ b/test/cache/cache.spec.mjs
@@ -1,5 +1,5 @@
-import { rmSync } from "fs";
-import { join } from "path";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
 import { expect } from "chai";
 import { describe } from "mocha";
 import Cache from "../../src/cache/cache.mjs";

--- a/test/cli/asserthelpers.utl.mjs
+++ b/test/cli/asserthelpers.utl.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import normBaseDirectory from "../main/norm-base-directory.utl.mjs";
 

--- a/test/cli/delete-dammit.utl.cjs
+++ b/test/cli/delete-dammit.utl.cjs
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const fs = require("node:fs");
 
 module.exports = (pFileName) => {
   try {

--- a/test/cli/format.spec.mjs
+++ b/test/cli/format.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import format from "../../src/cli/format.mjs";
 import deleteDammit from "./delete-dammit.utl.cjs";

--- a/test/cli/index.spec.mjs
+++ b/test/cli/index.spec.mjs
@@ -1,7 +1,7 @@
-import { unlinkSync, readFileSync } from "fs";
+import { unlinkSync, readFileSync } from "node:fs";
 // path.posix instead of path because otherwise on win32 the resulting
 // outputTo would contain \\ instead of / which for this unit test doesn't matter
-import { join, posix as path } from "path";
+import { join, posix as path } from "node:path";
 import { expect } from "chai";
 import intercept from "intercept-stdout";
 import chalk from "chalk";

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -1,5 +1,5 @@
-import { writeFileSync, readFileSync } from "fs";
-import { join } from "path";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { use, expect } from "chai";
 import chaiJsonSchema from "chai-json-schema";
 import deleteDammit from "../delete-dammit.utl.cjs";

--- a/test/cli/init-config/write-config.spec.mjs
+++ b/test/cli/init-config/write-config.spec.mjs
@@ -1,5 +1,5 @@
-import { writeFileSync, readFileSync } from "fs";
-import { join } from "path";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect } from "chai";
 import deleteDammit from "../delete-dammit.utl.cjs";
 import writeConfig from "../../../src/cli/init-config/write-config.mjs";

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import normalizeCliOptions, {
   determineRulesFileName,

--- a/test/cli/tools/wrap-stream-in-html.spec.mjs
+++ b/test/cli/tools/wrap-stream-in-html.spec.mjs
@@ -1,5 +1,5 @@
-import { createReadStream } from "fs";
-import { Writable } from "stream";
+import { createReadStream } from "node:fs";
+import { Writable } from "node:stream";
 import { expect } from "chai";
 import wrapStreamInHTML from "../../../src/cli/tools/wrap-stream-in-html.mjs";
 

--- a/test/cli/utl/io.spec.mjs
+++ b/test/cli/utl/io.spec.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
-import { ReadStream } from "fs";
-import { Readable } from "stream";
-import { fileURLToPath } from "url";
+import { ReadStream } from "node:fs";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import { getInStream } from "../../../src/cli/utl/io.mjs";
 

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 import omit from "lodash/omit.js";
 import { expect } from "chai";
 import pathToPosix from "../../src/utl/path-to-posix.js";

--- a/test/config-utl/extract-depcruise-config/read-config.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/read-config.spec.mjs
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import readConfig from "../../../src/config-utl/extract-depcruise-config/read-config.mjs";
 

--- a/test/config-utl/extract-ts-config.spec.mjs
+++ b/test/config-utl/extract-ts-config.spec.mjs
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import loadTSConfig from "../../src/config-utl/extract-ts-config.mjs";
 import pathToPosix from "../../src/utl/path-to-posix.js";

--- a/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
 

--- a/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
 

--- a/test/config-utl/make-absolute.spec.mjs
+++ b/test/config-utl/make-absolute.spec.mjs
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import { expect } from "chai";
 import makeAbsolute from "../../src/config-utl/make-absolute.mjs";
 

--- a/test/extract/ast-extractors/extract-typescript-others.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-others.spec.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import extractTypescriptFromAST from "../../../src/extract/ast-extractors/extract-typescript-deps.mjs";
 

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -1,4 +1,4 @@
-import { lstatSync } from "fs";
+import { lstatSync } from "node:fs";
 import { expect } from "chai";
 import gatherInitialSources from "../../src/extract/gather-initial-sources.mjs";
 import p2p from "../../src/utl/path-to-posix.js";

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -1,6 +1,6 @@
-import { join } from "path";
-import { unlinkSync } from "fs";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { unlinkSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import symlinkDir from "symlink-dir";
 import { expect } from "chai";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -1,6 +1,6 @@
-import { join } from "path";
-import { unlinkSync } from "fs";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { unlinkSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import symlinkDir from "symlink-dir";
 import { expect } from "chai";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -1,4 +1,4 @@
-import { renameSync } from "fs";
+import { renameSync } from "node:fs";
 import { expect } from "chai";
 import extract from "../../src/extract/index.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";

--- a/test/extract/resolve/determine-dependency-types.spec.mjs
+++ b/test/extract/resolve/determine-dependency-types.spec.mjs
@@ -1,5 +1,5 @@
-import { resolve } from "path";
-import { fileURLToPath } from "url";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import determineDependencyTypes from "../../../src/extract/resolve/determine-dependency-types.mjs";
 

--- a/test/extract/resolve/get-manifest.spec.mjs
+++ b/test/extract/resolve/get-manifest.spec.mjs
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import { getManifest } from "../../../src/extract/resolve/get-manifest.mjs";
 

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import extractTSConfig from "../../../src/config-utl/extract-ts-config.mjs";
 import resolve from "../../../src/extract/resolve/index.mjs";

--- a/test/extract/resolve/index.typescript.spec.mjs
+++ b/test/extract/resolve/index.typescript.spec.mjs
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/transpile/babel-wrap.spec.mjs
+++ b/test/extract/transpile/babel-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
 import wrap from "../../../src/extract/transpile/babel-wrap.mjs";

--- a/test/extract/transpile/coffeescript-wrap.spec.mjs
+++ b/test/extract/transpile/coffeescript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import normalizeNewline from "normalize-newline";
 import coffeescriptWrap from "../../../src/extract/transpile/coffeescript-wrap.mjs";

--- a/test/extract/transpile/index.spec.mjs
+++ b/test/extract/transpile/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import transpile from "../../../src/extract/transpile/index.mjs";
 import normalizeSource from "../normalize-source.utl.mjs";

--- a/test/extract/transpile/javascript-wrap.spec.mjs
+++ b/test/extract/transpile/javascript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import wrap from "../../../src/extract/transpile/javascript-wrap.mjs";
 

--- a/test/extract/transpile/svelte-wrap.spec.mjs
+++ b/test/extract/transpile/svelte-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { promises as fsPromise } from "fs";
+import { promises as fsPromise } from "node:fs";
 import { expect } from "chai";
 import svelteWrap from "../../../src/extract/transpile/svelte-wrap.js";
 import normalizeSource from "../normalize-source.utl.mjs";

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
 import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.mjs";

--- a/test/extract/transpile/vue-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue-template-wrap.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import normalizeNewline from "normalize-newline";
 import wrap from "../../../src/extract/transpile/vue-template-wrap.cjs";

--- a/test/extract/transpile/vue3-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue3-template-wrap.spec.mjs
@@ -1,7 +1,7 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { createRequire } from "module";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import normalizeNewline from "normalize-newline";
 

--- a/test/main/files-and-dirs/normalize.spec.mjs
+++ b/test/main/files-and-dirs/normalize.spec.mjs
@@ -1,5 +1,5 @@
-import { win32, posix } from "path";
-import { fileURLToPath } from "url";
+import { win32, posix } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import normalizeFilesAndDirectories from "../../../src/main/files-and-dirs/normalize.js";
 

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -1,4 +1,4 @@
-import { rmSync } from "fs";
+import { rmSync } from "node:fs";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.js";

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "node:path";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import { cruise } from "../../src/main/index.mjs";

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -1,6 +1,6 @@
-import { posix as path } from "path";
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { posix as path } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import pathToPosix from "../../src/utl/path-to-posix.js";

--- a/test/main/norm-base-directory.utl.mjs
+++ b/test/main/norm-base-directory.utl.mjs
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "node:path";
 import cloneDeep from "lodash/cloneDeep.js";
 
 export default function normBaseDirectory(

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import normalize from "../../../src/main/options/normalize.js";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";

--- a/test/main/rule-set/validate.spec.mjs
+++ b/test/main/rule-set/validate.spec.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import validate from "../../../src/main/rule-set/validate.js";
 

--- a/test/report/csv/csv.spec.mjs
+++ b/test/report/csv/csv.spec.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import render from "../../../src/report/csv.js";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";

--- a/test/report/dot/custom-level/index.spec.mjs
+++ b/test/report/dot/custom-level/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/dot/flat-level/index.spec.mjs
+++ b/test/report/dot/flat-level/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/dot/folder-level/folder-level.spec.mjs
+++ b/test/report/dot/folder-level/folder-level.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/dot/module-level/index.spec.mjs
+++ b/test/report/dot/module-level/index.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import defaultTheme from "../../../../src/report/dot/default-theme.js";
 import dot from "../../../../src/report/dot/index.js";

--- a/test/report/html/html.spec.mjs
+++ b/test/report/html/html.spec.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import render from "../../../src/report/html/index.js";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 // eslint-plugins import and node don't yet understand these 'self references'
 // eslint-disable-next-line import/no-unresolved, node/no-missing-import

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -1,4 +1,4 @@
-import { EOL } from "os";
+import { EOL } from "node:os";
 import { expect } from "chai";
 import metrics from "../../../src/report/metrics.js";
 import cruiseResultWithMetricsForModulesAndFolders from "./__mocks/cruise-result-with-metrics-for-modules-and-folders.mjs";

--- a/test/report/teamcity/teamcity.spec.mjs
+++ b/test/report/teamcity/teamcity.spec.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import render from "../../../src/report/teamcity.js";
 import okdeps from "./__mocks__/everything-fine.mjs";

--- a/test/report/text/text.spec.mjs
+++ b/test/report/text/text.spec.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import chalk from "chalk";
 import renderText from "../../../src/report/text.js";

--- a/test/utl/path-to-posix.spec.mjs
+++ b/test/utl/path-to-posix.spec.mjs
@@ -1,4 +1,4 @@
-import { win32, posix } from "path";
+import { win32, posix } from "node:path";
 import { expect } from "chai";
 import pathToPosix from "../../src/utl/path-to-posix.js";
 


### PR DESCRIPTION
## Description

- uses node: protocol for all node native module imports
- also starts using top-level await in the _format_ cli which we can do because we don't have to support node 14 anymore.

## Motivation and Context

It's a more clear way of doing this. Standard in our linting tool chain as well. We didn't do this so far because yarn 1 pnp didn't support it, but as we de-supported that, we can now use it.

## How Has This Been Tested?

- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
