### PR TITLE
refactor(cache): converts to esm

### DIFF
--- a/src/cache/cache.mjs
+++ b/src/cache/cache.mjs
@@ -1,9 +1,9 @@
 import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { scannableExtensions } from "../extract/transpile/meta.mjs";
-import optionsCompatible from "./options-compatible.js";
-import MetadataStrategy from "./metadata-strategy.js";
-import ContentStrategy from "./content-strategy.js";
+import { optionsAreCompatible } from "./options-compatible.mjs";
+import MetadataStrategy from "./metadata-strategy.mjs";
+import ContentStrategy from "./content-strategy.mjs";
 
 const CACHE_FILE_NAME = "cache.json";
 
@@ -43,7 +43,7 @@ export default class Cache {
         pCachedCruiseResult.revisionData,
         this.revisionData
       ) &&
-      optionsCompatible.optionsAreCompatible(
+      optionsAreCompatible(
         pCachedCruiseResult.summary.optionsUsed,
         pCruiseOptions
       )

--- a/src/cache/content-strategy.mjs
+++ b/src/cache/content-strategy.mjs
@@ -1,16 +1,16 @@
-const { join } = require("node:path").posix;
-const { isDeepStrictEqual } = require("node:util");
-const findContentChanges = require("./find-content-changes");
-const {
+import { isDeepStrictEqual } from "node:util";
+import { join } from "node:path/posix";
+import findContentChanges from "./find-content-changes.mjs";
+import {
   getFileHash,
   isInterestingChangeType,
   addCheckSumToChange,
   moduleIsInterestingForDiff,
-} = require("./utl");
+} from "./helpers.mjs";
 
 /**
  * @param {string} pBaseDirectory
- * @returns {(pModule: import("../..").IModule) => import("../..").IModule}
+ * @returns {(pModule: import("../../types/dependency-cruiser.js").IModule) => import("../../types/dependency-cruiser.js").IModule}
  */
 function addCheckSumToModule(pBaseDirectory) {
   return (pModule) => {
@@ -25,9 +25,9 @@ function addCheckSumToModule(pBaseDirectory) {
 }
 
 /**
- * @param {import("../..").IRevisionChange[]} pChanges
- * @param {import("../..").IModule[]} pModules
- * @returns {import("../..").IRevisionChange[]}
+ * @param {import("../../types/dependency-cruiser.js").IRevisionChange[]} pChanges
+ * @param {import("../../types/dependency-cruiser.js").IModule[]} pModules
+ * @returns {import("../../types/dependency-cruiser.js").IRevisionChange[]}
  */
 function refreshChanges(pChanges, pModules) {
   return pChanges.filter(
@@ -40,18 +40,18 @@ function refreshChanges(pChanges, pModules) {
   );
 }
 
-module.exports = class ContentStrategy {
+export default class ContentStrategy {
   /**
    * @param {string} pDirectory
-   * @param {import("../..").ICruiseResult} pCachedCruiseResult
-   * @param {import("../../types/strict-options").IStrictCruiseOptions} pCruiseOptions
+   * @param {import("../../types/dependency-cruiser.js").ICruiseResult} pCachedCruiseResult
+   * @param {import("../../types/strict-options.js").IStrictCruiseOptions} pCruiseOptions
    * @param {Object} pOptions
    * @param {Set<string>} pOptions.extensions
    * @param {Set<import("watskeburt").changeTypeType>} pOptions.interestingChangeTypes
    * @param {string} pOptions.baseDir
    * @param {(pString:string) => Array<import("watskeburt").IChange>} pOptions.diffListFn
    * @param {(import("watskeburt").IChange) => import("../..").IRevisionChange} pOptions.checksumFn
-   * @returns {import("../..").IRevisionData}
+   * @returns {import("../../types/dependency-cruiser.js").IRevisionData}
    */
   getRevisionData(pDirectory, pCachedCruiseResult, pCruiseOptions, pOptions) {
     const lOptions = {
@@ -74,8 +74,8 @@ module.exports = class ContentStrategy {
   }
 
   /**
-   * @param {import("../..").IRevisionData} pExistingRevisionData
-   * @param {import("../..").IRevisionData} pNewRevisionData
+   * @param {import("../../types/dependency-cruiser.js").IRevisionData} pExistingRevisionData
+   * @param {import("../../types/dependency-cruiser.js").IRevisionData} pNewRevisionData
    * @returns {boolean}
    */
   revisionDataEqual(pExistingRevisionData, pNewRevisionData) {
@@ -91,9 +91,9 @@ module.exports = class ContentStrategy {
   }
 
   /**
-   * @param {import("../..").ICruiseResult} pCruiseResult
-   * @param {import("../..").IRevisionData} pRevisionData
-   * @returns {import("../..").ICruiseResult}
+   * @param {import("../../types/dependency-cruiser.js").ICruiseResult} pCruiseResult
+   * @param {import("../../types/dependency-cruiser.js").IRevisionData} pRevisionData
+   * @returns {import("../../types/dependency-cruiser.js").ICruiseResult}
    */
   prepareRevisionDataForSaving(pCruiseResult, pRevisionData) {
     const lModulesWithCheckSum = pCruiseResult.modules.map(
@@ -110,4 +110,4 @@ module.exports = class ContentStrategy {
       revisionData: lRevisionData,
     };
   }
-};
+}

--- a/src/cache/find-content-changes.mjs
+++ b/src/cache/find-content-changes.mjs
@@ -1,14 +1,16 @@
-const { join } = require("node:path").posix;
-const bus = require("../utl/bus");
-const { DEBUG } = require("../utl/bus-log-levels");
-const findAllFiles = require("../utl/find-all-files");
-const {
+import { join } from "node:path/posix";
+import bus from "../utl/bus.js";
+import busLogLevels from "../utl/bus-log-levels.js";
+import findAllFiles from "../utl/find-all-files.js";
+import {
   getFileHash,
   excludeFilter,
   includeOnlyFilter,
   hasInterestingExtension,
   moduleIsInterestingForDiff,
-} = require("./utl");
+} from "./helpers.mjs";
+
+const { DEBUG } = busLogLevels;
 
 /**
  * @param {Set<string>} pFileSet
@@ -68,7 +70,7 @@ function diffCachedModuleAgainstFileSet(
  * @param {string} pOptions.baseDir
  * @returns {{source: string; changeType: import("watskeburt").changeTypeType; checksum: string}[]}
  */
-module.exports = function findContentChanges(
+export default function findContentChanges(
   pDirectory,
   pCachedCruiseResult,
   pOptions
@@ -101,4 +103,4 @@ module.exports = function findContentChanges(
 
   bus.emit("progress", "cache: - returning revision data", { level: DEBUG });
   return lDiffCachedVsNew.concat(lDiffNewVsCached);
-};
+}

--- a/src/cache/helpers.mjs
+++ b/src/cache/helpers.mjs
@@ -1,8 +1,11 @@
-const { createHash } = require("node:crypto");
-const { readFileSync } = require("node:fs");
-const path = require("node:path");
-const memoize = require("lodash/memoize");
-const { filenameMatchesPattern } = require("../graph-utl/match-facade");
+/* eslint-disable import/exports-last */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import memoize from "lodash/memoize.js";
+import matchFacade from "../graph-utl/match-facade.js";
+
+const { filenameMatchesPattern } = matchFacade;
 
 /**
  * @param {string} pString
@@ -24,13 +27,13 @@ function _getFileHash(pFileName) {
   }
 }
 
-const getFileHash = memoize(_getFileHash);
+export const getFileHash = memoize(_getFileHash);
 
 /**
  * @param {import("watskeburt").IChange} pChange
- * @param {import("../..").IRevisionChange}
+ * @param {import("../../types/dependency-cruiser.js").IRevisionChange}
  */
-function addCheckSumToChange(pChange) {
+export function addCheckSumToChange(pChange) {
   return {
     ...pChange,
     checksum: getFileHash(pChange.name),
@@ -39,10 +42,10 @@ function addCheckSumToChange(pChange) {
 
 /**
  *
- * @param {import("../../types/strict-filter-types").IStrictExcludeType} pExcludeOption
+ * @param {import("../../types/strict-filter-types.js").IStrictExcludeType} pExcludeOption
  * @returns {(pFileName: string) => boolean}
  */
-function excludeFilter(pExcludeOption) {
+export function excludeFilter(pExcludeOption) {
   return (pFileName) => {
     if (pExcludeOption.path) {
       return !filenameMatchesPattern(pFileName, pExcludeOption.path);
@@ -52,10 +55,10 @@ function excludeFilter(pExcludeOption) {
 }
 
 /**
- * @param {import("../../types/strict-filter-types").IStrictIncludeOnlyType} pIncludeOnlyFilter
+ * @param {import("../../types/strict-filter-types.js").IStrictIncludeOnlyType} pIncludeOnlyFilter
  * @returns {(pFileName: string) => boolean}
  */
-function includeOnlyFilter(pIncludeOnlyFilter) {
+export function includeOnlyFilter(pIncludeOnlyFilter) {
   return (pFileName) => {
     if (pIncludeOnlyFilter) {
       return filenameMatchesPattern(pFileName, pIncludeOnlyFilter.path);
@@ -67,7 +70,7 @@ function includeOnlyFilter(pIncludeOnlyFilter) {
  * @param {Set<string>} pExtensions
  * @returns {(pFileName: string) => boolean}
  */
-function hasInterestingExtension(pExtensions) {
+export function hasInterestingExtension(pExtensions) {
   return (pFileName) => pExtensions.has(path.extname(pFileName));
 }
 
@@ -75,7 +78,7 @@ function hasInterestingExtension(pExtensions) {
  * @param {Set<string>} pExtensions
  * @returns {(pChange: import("watskeburt").IChange) => boolean}
  */
-function changeHasInterestingExtension(pExtensions) {
+export function changeHasInterestingExtension(pExtensions) {
   return (pChange) =>
     hasInterestingExtension(pExtensions)(pChange.name) ||
     (pChange.oldName && hasInterestingExtension(pExtensions)(pChange.oldName));
@@ -96,7 +99,7 @@ const DEFAULT_INTERESTING_CHANGE_TYPES = new Set([
  * @param {Set<import("watskeburt").changeTypeType>} pInterestingChangeTypes
  * @returns {(pChange: import("watskeburt").IChange) => boolean}
  */
-function isInterestingChangeType(pInterestingChangeTypes) {
+export function isInterestingChangeType(pInterestingChangeTypes) {
   return (pChange) =>
     (pInterestingChangeTypes ?? DEFAULT_INTERESTING_CHANGE_TYPES).has(
       pChange.changeType
@@ -106,7 +109,7 @@ function isInterestingChangeType(pInterestingChangeTypes) {
 /**
  * @param {pModule:import("../..").IModule} pModule
  */
-function moduleIsInterestingForDiff(pModule) {
+export function moduleIsInterestingForDiff(pModule) {
   return (
     !pModule.consolidated &&
     !pModule.coreModule &&
@@ -117,14 +120,3 @@ function moduleIsInterestingForDiff(pModule) {
     pModule.followable !== false
   );
 }
-
-module.exports = {
-  getFileHash,
-  excludeFilter,
-  includeOnlyFilter,
-  hasInterestingExtension,
-  changeHasInterestingExtension,
-  isInterestingChangeType,
-  addCheckSumToChange,
-  moduleIsInterestingForDiff,
-};

--- a/src/cache/metadata-strategy.mjs
+++ b/src/cache/metadata-strategy.mjs
@@ -1,25 +1,25 @@
-const { isDeepStrictEqual } = require("node:util");
-const { getSHASync, listSync } = require("watskeburt");
-const {
+import { isDeepStrictEqual } from "node:util";
+import { getSHASync, listSync } from "watskeburt";
+import {
   isInterestingChangeType,
   addCheckSumToChange,
   excludeFilter,
   includeOnlyFilter,
   changeHasInterestingExtension,
-} = require("./utl");
+} from "./helpers.mjs";
 
-module.exports = class MetaDataStrategy {
+export default class MetaDataStrategy {
   /**
    * @param {Set<string>} pExtensions
    * @param {Set<import("watskeburt").changeTypeType>} pInterestingChangeTypes
-   * @param {import("../../types/strict-options").IStrictCruiseOptions} pCruiseOptions
+   * @param {import("../../types/strict-options.js").IStrictCruiseOptions} pCruiseOptions
    * @param {Object} pOptions
    * @param {Set<string>} pOptions.extensions
    * @param {Set<import("watskeburt").changeTypeType>} pOptions.interestingChangeTypes
    * @param {() => string} pOptions.shaRetrievalFn
    * @param {(pString:string) => Array<import("watskeburt").IChange>} pOptions.diffListFn
    * @param {(import("watskeburt").IChange) => import("../..").IRevisionChange} pOptions.checksumFn
-   * @returns {import("../..").IRevisionData}
+   * @returns {import("../../types/dependency-cruiser.js").IRevisionData}
    */
   getRevisionData(pDirectory, pCachedCruiseResult, pCruiseOptions, pOptions) {
     const lOptions = {
@@ -44,16 +44,14 @@ module.exports = class MetaDataStrategy {
       };
     } catch (pError) {
       throw new Error(
-        "The --cache option works in concert with git - and it seems either the " +
-          "current folder isn't version managed or git isn't installed. Error:" +
-          `\n\n          ${pError}\n`
+        `The --cache option works in concert with git - and it seems either the current folder isn't version managed or git isn't installed. Error:${`\n\n          ${pError}\n`}`
       );
     }
   }
 
   /**
-   * @param {import("../..").IRevisionData} pExistingRevisionData
-   * @param {import("../..").IRevisionData} pNewRevisionData
+   * @param {import("../../types/dependency-cruiser.js").IRevisionData} pExistingRevisionData
+   * @param {import("../../types/dependency-cruiser.js").IRevisionData} pNewRevisionData
    * @returns {boolean}
    */
   revisionDataEqual(pExistingRevisionData, pNewRevisionData) {
@@ -66,9 +64,9 @@ module.exports = class MetaDataStrategy {
   }
 
   /**
-   * @param {import("../..").ICruiseResult} pCruiseResult
-   * @param {import("../..").IRevisionData} pRevisionData
-   * @returns {import("../..").ICruiseResult}
+   * @param {import("../../types/dependency-cruiser.js").ICruiseResult} pCruiseResult
+   * @param {import("../../types/dependency-cruiser.js").IRevisionData} pRevisionData
+   * @returns {import("../../types/dependency-cruiser.js").ICruiseResult}
    */
   prepareRevisionDataForSaving(pCruiseResult, pRevisionData) {
     return pRevisionData
@@ -78,4 +76,4 @@ module.exports = class MetaDataStrategy {
         }
       : pCruiseResult;
   }
-};
+}

--- a/src/cache/options-compatible.mjs
+++ b/src/cache/options-compatible.mjs
@@ -1,4 +1,4 @@
-const { isDeepStrictEqual } = require("node:util");
+import { isDeepStrictEqual } from "node:util";
 
 /*
 # command line options
@@ -53,29 +53,29 @@ const { isDeepStrictEqual } = require("node:util");
 - knownViolations
 */
 
-function includeOnlyIsCompatible(pExistingFilter, pNewFilter) {
+export function includeOnlyIsCompatible(pExistingFilter, pNewFilter) {
   return (
     !pExistingFilter || isDeepStrictEqual({ path: pExistingFilter }, pNewFilter)
   );
 }
 
-function filterOptionIsCompatible(pExistingOption, pNewOption) {
+export function filterOptionIsCompatible(pExistingOption, pNewOption) {
   return !pExistingOption || isDeepStrictEqual(pExistingOption, pNewOption);
 }
 
-function optionIsCompatible(pExistingOption, pNewOption) {
+export function optionIsCompatible(pExistingOption, pNewOption) {
   return isDeepStrictEqual(pExistingOption, pNewOption);
 }
 
-function limitIsCompatible(pExistingLimit, pNewLimit) {
+export function limitIsCompatible(pExistingLimit, pNewLimit) {
   return !pExistingLimit || pExistingLimit >= (pNewLimit || pExistingLimit + 1);
 }
 
-function metricsIsCompatible(pExistingMetrics, pNewMetrics) {
+export function metricsIsCompatible(pExistingMetrics, pNewMetrics) {
   return pExistingMetrics || pExistingMetrics === pNewMetrics;
 }
 
-function cacheOptionIsCompatible(pExistingCacheOption, pNewCacheOption) {
+export function cacheOptionIsCompatible(pExistingCacheOption, pNewCacheOption) {
   if (!pExistingCacheOption || !pNewCacheOption) {
     return false;
   }
@@ -92,7 +92,7 @@ function cacheOptionIsCompatible(pExistingCacheOption, pNewCacheOption) {
  * @returns {boolean}
  */
 // eslint-disable-next-line complexity
-function optionsAreCompatible(pOldOptions, pNewOptions) {
+export function optionsAreCompatible(pOldOptions, pNewOptions) {
   return (
     pOldOptions.args === pNewOptions.args &&
     pOldOptions.rulesFile === pNewOptions.rulesFile &&
@@ -131,13 +131,3 @@ function optionsAreCompatible(pOldOptions, pNewOptions) {
     cacheOptionIsCompatible(pOldOptions.cache, pNewOptions.cache)
   );
 }
-
-module.exports = {
-  optionsAreCompatible,
-  filterOptionIsCompatible,
-  optionIsCompatible,
-  limitIsCompatible,
-  metricsIsCompatible,
-  includeOnlyIsCompatible,
-  cacheOptionIsCompatible,
-};

--- a/test/cache/content-strategy.spec.mjs
+++ b/test/cache/content-strategy.spec.mjs
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import ContentStrategy from "../../src/cache/content-strategy.js";
+import ContentStrategy from "../../src/cache/content-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
 const INTERESTING_CHANGE_TYPES = new Set([

--- a/test/cache/find-content-changes.spec.mjs
+++ b/test/cache/find-content-changes.spec.mjs
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import findContentChanges from "../../src/cache/find-content-changes.js";
+import findContentChanges from "../../src/cache/find-content-changes.mjs";
 
 describe("[U] cache/find-content-changes - cached vs new", () => {
   it("returns files not in directory but in cache as 'ignored' when they're not interesting for diffing", () => {

--- a/test/cache/metadata-strategy.spec.mjs
+++ b/test/cache/metadata-strategy.spec.mjs
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import MetaDataStrategy from "../../src/cache/metadata-strategy.js";
+import MetaDataStrategy from "../../src/cache/metadata-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
 const INTERESTING_CHANGE_TYPES = new Set([

--- a/test/cache/options-compatible.spec.mjs
+++ b/test/cache/options-compatible.spec.mjs
@@ -8,7 +8,7 @@ import {
   metricsIsCompatible,
   cacheOptionIsCompatible,
   optionsAreCompatible,
-} from "../../src/cache/options-compatible.js";
+} from "../../src/cache/options-compatible.mjs";
 
 describe("[U] cache/options-compatible - optionIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {


### PR DESCRIPTION
## Description

- converts the cache modules to esm

## Motivation and Context

See other PR's regarding esm conversion

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
