### PR TITLE
refactor(cli): converts hbs calling code in init-config to esm

### DIFF
--- a/src/cli/init-config/build-config.mjs
+++ b/src/cli/init-config/build-config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
-const Handlebars = require("handlebars/runtime");
-const { folderNameArrayToRE } = require("./utl.cjs");
+import Handlebars from "handlebars/runtime.js";
+import { folderNameArrayToRE } from "./utl.mjs";
 
 /* eslint import/no-unassigned-import: 0 */
-require("./config.js.template");
+await import("./config.js.template.js");
 
 /**
  * @param {string} pString
@@ -28,12 +28,12 @@ function extensionsToString(pExtensions) {
  * Creates a .dependency-cruiser config with a set of basic validations
  * to the current directory.
  *
- * @param {import("./types").IInitConfig} pNormalizedInitOptions Options that influence the shape of
+ * @param {import("./types.js").IInitConfig} pNormalizedInitOptions Options that influence the shape of
  *                  the configuration
  * @returns {string} the configuration as a string
  */
 
-module.exports = function buildConfig(pNormalizedInitOptions) {
+export default function buildConfig(pNormalizedInitOptions) {
   return Handlebars.templates["config.js.template.hbs"]({
     ...pNormalizedInitOptions,
 
@@ -45,4 +45,4 @@ module.exports = function buildConfig(pNormalizedInitOptions) {
       pNormalizedInitOptions.resolutionExtensions
     ),
   });
-};
+}

--- a/src/cli/init-config/index.mjs
+++ b/src/cli/init-config/index.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { PACKAGE_MANIFEST as _PACKAGE_MANIFEST } from "../defaults.mjs";
 import normalizeInitOptions from "./normalize-init-options.mjs";
-import buildConfig from "./build-config.cjs";
+import buildConfig from "./build-config.mjs";
 import writeConfig from "./write-config.mjs";
 import getUserInput from "./get-user-input.mjs";
 import {

--- a/src/cli/init-config/utl.cjs
+++ b/src/cli/init-config/utl.cjs
@@ -1,6 +1,0 @@
-function folderNameArrayToRE(pArrayOfStrings) {
-  return `^(${pArrayOfStrings.join("|")})`;
-}
-module.exports = {
-  folderNameArrayToRE,
-};

--- a/src/cli/init-config/utl.mjs
+++ b/src/cli/init-config/utl.mjs
@@ -1,0 +1,3 @@
+export function folderNameArrayToRE(pArrayOfStrings) {
+  return `^(${pArrayOfStrings.join("|")})`;
+}

--- a/src/cli/init-config/write-run-scripts-to-manifest.mjs
+++ b/src/cli/init-config/write-run-scripts-to-manifest.mjs
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import wrapAndIndent from "../../utl/wrap-and-indent.mjs";
 import { PACKAGE_MANIFEST as _PACKAGE_MANIFEST } from "../defaults.mjs";
 import { readManifest } from "./environment-helpers.mjs";
-import { folderNameArrayToRE } from "./utl.cjs";
+import { folderNameArrayToRE } from "./utl.mjs";
 
 const PACKAGE_MANIFEST = `./${_PACKAGE_MANIFEST}`;
 

--- a/test/cli/init-config/create-config.spec.mjs
+++ b/test/cli/init-config/create-config.spec.mjs
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path/posix";
 import { expect, use } from "chai";
 import chaiJsonSchema from "chai-json-schema";
-import buildConfig from "../../../src/cli/init-config/build-config.cjs";
+import buildConfig from "../../../src/cli/init-config/build-config.mjs";
 import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";
 import configurationSchema from "../../../src/schema/configuration.schema.mjs";
 import deleteDammit from "../delete-dammit.utl.cjs";

--- a/test/cli/init-config/utl.spec.mjs
+++ b/test/cli/init-config/utl.spec.mjs
@@ -1,15 +1,15 @@
 import { expect } from "chai";
-import utl from "../../../src/cli/init-config/utl.cjs";
+import { folderNameArrayToRE } from "../../../src/cli/init-config/utl.mjs";
 
 describe("[U] cli/init-config/utl - folderNameArrayToRE", () => {
   it("transforms an array of folder names into a regex string - empty", () => {
-    expect(utl.folderNameArrayToRE([])).to.equal("^()");
+    expect(folderNameArrayToRE([])).to.equal("^()");
   });
   it("transforms an array of folder names into a regex string - one entry", () => {
-    expect(utl.folderNameArrayToRE(["src"])).to.equal("^(src)");
+    expect(folderNameArrayToRE(["src"])).to.equal("^(src)");
   });
   it("transforms an array of folder names into a regex string - more than one entry", () => {
-    expect(utl.folderNameArrayToRE(["bin", "src", "lib"])).to.equal(
+    expect(folderNameArrayToRE(["bin", "src", "lib"])).to.equal(
       "^(bin|src|lib)"
     );
   });


### PR DESCRIPTION
## Description

- converts stuff that calls (mandatorily commonjs) handlebars code to esm as well

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
