### PR TITLE
perf(cli): don't load init-config code when not used

### DIFF
--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -21,7 +21,6 @@ import formatMetaInfo from "./format-meta-info.mjs";
 import setUpCliFeedbackListener from "./listeners/cli-feedback.mjs";
 import setUpPerformanceLogListener from "./listeners/performance-log/index.mjs";
 import setUpNDJSONListener from "./listeners/ndjson.mjs";
-import initConfig from "./init-config/index.mjs";
 
 function extractResolveOptions(pCruiseOptions) {
   let lResolveOptions = {};
@@ -161,6 +160,7 @@ export default async function executeCli(pFileDirectoryArray, pCruiseOptions) {
     if (lCruiseOptions.info === true) {
       process.stdout.write(formatMetaInfo());
     } else if (lCruiseOptions.init) {
+      const initConfig = await import("./init-config/index.mjs");
       initConfig(lCruiseOptions.init);
     } else {
       lExitCode = await runCruise(pFileDirectoryArray, lCruiseOptions);


### PR DESCRIPTION
## Description

- only loads the `init-config` modules when asked for

## Motivation and Context

Loading modules takes time - if it's not used, better to not do it. In the commonjs variant of this code we used to do this as well.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
