### PR TITLE
refactor: uses qualified imports for imports from node native modules

### DIFF
--- a/src/cache/helpers.mjs
+++ b/src/cache/helpers.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable import/exports-last */
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import path from "node:path";
+import { extname } from "node:path";
 import memoize from "lodash/memoize.js";
 import { filenameMatchesPattern } from "../graph-utl/match-facade.mjs";
 
@@ -69,7 +69,7 @@ export function includeOnlyFilter(pIncludeOnlyFilter) {
  * @returns {(pFileName: string) => boolean}
  */
 export function hasInterestingExtension(pExtensions) {
-  return (pFileName) => pExtensions.has(path.extname(pFileName));
+  return (pFileName) => pExtensions.has(extname(pFileName));
 }
 
 /**

--- a/src/cli/init-config/validators.mjs
+++ b/src/cli/init-config/validators.mjs
@@ -1,10 +1,10 @@
-import fs from "node:fs";
+import { statSync } from "node:fs";
 import { toSourceLocationArray } from "./environment-helpers.mjs";
 
 export function validateLocation(pLocations) {
   for (const lLocation of toSourceLocationArray(pLocations)) {
     try {
-      if (!fs.statSync(lLocation).isDirectory()) {
+      if (!statSync(lLocation).isDirectory()) {
         return `'${lLocation}' doesn't seem to be a folder - please try again`;
       }
     } catch (pError) {

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -1,5 +1,5 @@
-import fs from "node:fs";
-import path from "node:path";
+import { accessSync, R_OK } from "node:fs";
+import { isAbsolute } from "node:path";
 import set from "lodash/set.js";
 import get from "lodash/get.js";
 import has from "lodash/has.js";
@@ -45,7 +45,7 @@ function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
 
 function fileExists(pFileName) {
   try {
-    fs.accessSync(pFileName, fs.R_OK);
+    accessSync(pFileName, R_OK);
     return true;
   } catch (pError) {
     return false;
@@ -129,7 +129,7 @@ async function normalizeValidationOption(pCliOptions) {
   return {
     rulesFile,
     ruleSet: await loadConfig(
-      path.isAbsolute(rulesFile) ? rulesFile : `./${rulesFile}`
+      isAbsolute(rulesFile) ? rulesFile : `./${rulesFile}`
     ),
     validate: true,
   };

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -1,4 +1,4 @@
-import path from "node:path";
+import { dirname } from "node:path";
 import cloneDeep from "lodash/cloneDeep.js";
 import has from "lodash/has.js";
 import { resolve } from "../../extract/resolve/resolve.mjs";
@@ -67,7 +67,7 @@ export default async function extractDepcruiseConfig(
     ),
     "cli"
   );
-  const lBaseDirectory = path.dirname(lResolvedFileName);
+  const lBaseDirectory = dirname(lResolvedFileName);
 
   if (pAlreadyVisited.has(lResolvedFileName)) {
     throw new Error(

--- a/src/config-utl/extract-depcruise-config/merge-configs.mjs
+++ b/src/config-utl/extract-depcruise-config/merge-configs.mjs
@@ -1,5 +1,4 @@
 import { isDeepStrictEqual } from "node:util";
-import get from "lodash/get.js";
 import uniqBy from "lodash/uniqBy.js";
 import uniqWith from "lodash/uniqWith.js";
 
@@ -87,10 +86,8 @@ function mergeOptions(pOptionsExtended, pOptionsBase) {
  * @returns {string} - a string from the SeverityType value set
  */
 function mergeAllowedSeverities(pConfigExtended, pConfigBase) {
-  return get(
-    pConfigExtended,
-    "allowedSeverity",
-    get(pConfigBase, "allowedSeverity", "warn")
+  return (
+    pConfigExtended?.allowedSeverity ?? pConfigBase?.allowedSeverity ?? "warn"
   );
 }
 
@@ -108,18 +105,19 @@ function mergeAllowedSeverities(pConfigExtended, pConfigBase) {
  *
  * @returns {Object} - The merged rule set
  */
+// eslint-disable-next-line complexity
 export default (pConfigExtended, pConfigBase) => {
   const lForbidden = mergeRules(
-    get(pConfigExtended, "forbidden", []),
-    get(pConfigBase, "forbidden", [])
+    pConfigExtended?.forbidden ?? [],
+    pConfigBase?.forbidden ?? []
   );
   const lRequired = mergeRules(
-    get(pConfigExtended, "required", []),
-    get(pConfigBase, "required", [])
+    pConfigExtended?.required ?? [],
+    pConfigBase?.required ?? []
   );
   const lAllowed = mergeAllowedRules(
-    get(pConfigExtended, "allowed", []),
-    get(pConfigBase, "allowed", [])
+    pConfigExtended?.allowed ?? [],
+    pConfigBase?.allowed ?? []
   );
 
   return {
@@ -132,8 +130,8 @@ export default (pConfigExtended, pConfigBase) => {
         }
       : {}),
     options: mergeOptions(
-      get(pConfigExtended, "options", {}),
-      get(pConfigBase, "options", {})
+      pConfigExtended?.options ?? {},
+      pConfigBase?.options ?? {}
     ),
   };
 };

--- a/src/config-utl/extract-ts-config.mjs
+++ b/src/config-utl/extract-ts-config.mjs
@@ -1,4 +1,4 @@
-import path from "node:path";
+import { dirname, resolve } from "node:path";
 import tryImport from "semver-try-require";
 import meta from "../meta.js";
 
@@ -55,7 +55,7 @@ export default function extractTSConfig(pTSConfigFileName) {
     lReturnValue = typescript.parseJsonConfigFileContent(
       lConfig.config,
       typescript.sys,
-      path.dirname(path.resolve(pTSConfigFileName)),
+      dirname(resolve(pTSConfigFileName)),
       {},
       pTSConfigFileName
     );

--- a/src/enrich/derive/folders/aggregate-to-folders.mjs
+++ b/src/enrich/derive/folders/aggregate-to-folders.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable security/detect-object-injection */
-import path from "node:path/posix";
+import { dirname } from "node:path/posix";
 import { calculateInstability, metricsAreCalculable } from "../module-utl.mjs";
 import detectCycles from "../circular.mjs";
 import IndexedModuleGraph from "../../../graph-utl/indexed-module-graph.mjs";
@@ -42,7 +42,7 @@ function upsertFolderAttributes(pAllMetrics, pModule, pDirname) {
 }
 
 function aggregateToFolder(pAllFolders, pModule) {
-  getParentFolders(path.dirname(pModule.source)).forEach((pParentDirectory) =>
+  getParentFolders(dirname(pModule.source)).forEach((pParentDirectory) =>
     upsertFolderAttributes(pAllFolders, pModule, pParentDirectory)
   );
   return pAllFolders;
@@ -56,9 +56,9 @@ function getFolderLevelCouplings(pCouplingArray) {
   return Array.from(
     new Set(
       pCouplingArray.map((pCoupling) =>
-        path.dirname(pCoupling.name) === "."
+        dirname(pCoupling.name) === "."
           ? pCoupling.name
-          : path.dirname(pCoupling.name)
+          : dirname(pCoupling.name)
       )
     )
   ).map((pCoupling) => ({ name: pCoupling }));

--- a/src/enrich/derive/folders/utl.mjs
+++ b/src/enrich/derive/folders/utl.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable security/detect-object-injection */
-import path from "node:path/posix";
+import { sep } from "node:path/posix";
 
 export function findFolderByName(pAllFolders, pName) {
   return pAllFolders.find((pFolder) => pFolder.name === pName);
@@ -7,13 +7,13 @@ export function findFolderByName(pAllFolders, pName) {
 
 export function getAfferentCouplings(pModule, pDirname) {
   return pModule.dependents.filter(
-    (pDependent) => !pDependent.startsWith(pDirname.concat(path.sep))
+    (pDependent) => !pDependent.startsWith(pDirname.concat(sep))
   );
 }
 
 export function getEfferentCouplings(pModule, pDirname) {
   return pModule.dependencies.filter(
-    (pDependency) => !pDependency.resolved.startsWith(pDirname.concat(path.sep))
+    (pDependency) => !pDependency.resolved.startsWith(pDirname.concat(sep))
   );
 }
 

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -1,7 +1,6 @@
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { glob } from "glob";
-import get from "lodash/get.js";
 import { filenameMatchesPattern } from "../graph-utl/match-facade.mjs";
 import getExtension from "../utl/get-extension.mjs";
 import pathToPosix from "../utl/path-to-posix.mjs";
@@ -22,16 +21,16 @@ function fileIsScannable(pOptions, pPathToFile) {
 
 function shouldBeIncluded(pFullPathToFile, pOptions) {
   return (
-    !get(pOptions, "includeOnly.path") ||
+    !pOptions?.includeOnly?.path ||
     filenameMatchesPattern(pFullPathToFile, pOptions.includeOnly.path)
   );
 }
 
 function shouldNotBeExcluded(pFullPathToFile, pOptions) {
   return (
-    (!get(pOptions, "exclude.path") ||
+    (!pOptions?.exclude?.path ||
       !filenameMatchesPattern(pFullPathToFile, pOptions.exclude.path)) &&
-    (!get(pOptions, "doNotFollow.path") ||
+    (!pOptions?.doNotFollow?.path ||
       !filenameMatchesPattern(pFullPathToFile, pOptions.doNotFollow.path))
   );
 }

--- a/src/extract/get-dependencies.mjs
+++ b/src/extract/get-dependencies.mjs
@@ -1,5 +1,4 @@
 import { join, extname, dirname } from "node:path";
-import get from "lodash/get.js";
 import uniqBy from "lodash/uniqBy.js";
 import { intersects } from "../utl/array-util.mjs";
 import resolve from "./resolve/index.mjs";
@@ -235,9 +234,9 @@ export default function getDependencies(
       .map(addResolutionAttributes(pCruiseOptions, pFileName, pResolveOptions))
       .filter(
         ({ resolved }) =>
-          (!get(pCruiseOptions, "exclude.path") ||
+          (!pCruiseOptions?.exclude?.path ||
             !matchesPattern(resolved, pCruiseOptions.exclude.path)) &&
-          (!get(pCruiseOptions, "includeOnly.path") ||
+          (!pCruiseOptions?.includeOnly?.path ||
             matchesPattern(resolved, pCruiseOptions.includeOnly.path))
       );
   } catch (pError) {

--- a/src/main/helpers.mjs
+++ b/src/main/helpers.mjs
@@ -39,7 +39,6 @@ export function normalizeREProperties(
       set(
         lPropertyContainer,
         lProperty,
-
         normalizeToREAsString(get(lPropertyContainer, lProperty))
       );
     }

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import get from "lodash/get.js";
 import has from "lodash/has.js";
 import omit from "lodash/omit.js";
 import enhancedResolve from "enhanced-resolve";
@@ -110,11 +109,8 @@ async function compileResolveOptions(
     ...omit(pResolveOptionsFromDCConfig, "cachedInputFileSystem"),
     ...pResolveOptions,
     ...getNonOverridableResolveOptions(
-      get(
-        pResolveOptionsFromDCConfig,
-        "cachedInputFileSystem.cacheDuration",
+      pResolveOptionsFromDCConfig?.cachedInputFileSystem?.cacheDuration ??
         DEFAULT_CACHE_DURATION
-      )
     ),
   };
 }
@@ -125,12 +121,13 @@ async function compileResolveOptions(
  * @param {import("typescript").ParsedTsconfig} pTSConfig
  * @returns
  */
+// eslint-disable-next-line complexity
 export default async function normalizeResolveOptions(
   pResolveOptions,
   pOptions,
   pTSConfig
 ) {
-  const lRuleSet = get(pOptions, "ruleSet", {});
+  const lRuleSet = pOptions?.ruleSet ?? {};
   // eslint-disable-next-line no-return-await
   return await compileResolveOptions(
     {
@@ -140,20 +137,20 @@ export default async function normalizeResolveOptions(
         symlink === !preserveSymlinks - but using it that way
         breaks backwards compatibility
       */
-      symlinks: get(pOptions, "preserveSymlinks", null),
-      tsConfig: get(pOptions, "ruleSet.options.tsConfig.fileName", null),
+      symlinks: pOptions?.preserveSymlinks ?? null,
+      tsConfig: pOptions?.ruleSet?.options?.tsConfig?.fileName ?? null,
 
       /* squirrel the externalModuleResolutionStrategy and combinedDependencies
          thing into the resolve options
          - they're not for enhanced resolve, but they are for what we consider
          resolve options ...
        */
-      combinedDependencies: get(pOptions, "combinedDependencies", false),
+      combinedDependencies: pOptions?.combinedDependencies ?? false,
       resolveLicenses: ruleSetHasLicenseRule(lRuleSet),
       resolveDeprecations: ruleSetHasDeprecationRule(lRuleSet),
       ...(pResolveOptions || {}),
     },
     pTSConfig || {},
-    get(pOptions, "enhancedResolveOptions", {})
+    pOptions?.enhancedResolveOptions ?? {}
   );
 }

--- a/test/config-utl/extract-depcruise-config/index.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/index.spec.mjs
@@ -1,10 +1,10 @@
 import { fileURLToPath } from "node:url";
-import path from "node:path";
+import { join } from "node:path";
 import { expect } from "chai";
 import loadConfig from "../../../src/config-utl/extract-depcruise-config/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
-const mockDirectory = path.join(__dirname, "__mocks__");
+const mockDirectory = join(__dirname, "__mocks__");
 
 describe("[I] config-utl/extract-depcruise-config", () => {
   it("a rule set without an extends returns just that rule set", async () => {
@@ -15,9 +15,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
       }
     );
     expect(
-      await loadConfig(
-        path.join(mockDirectory, "rules.sub-not-allowed-error.json")
-      )
+      await loadConfig(join(mockDirectory, "rules.sub-not-allowed-error.json"))
     ).to.deep.equal(fixture.default);
   });
 
@@ -26,17 +24,14 @@ describe("[I] config-utl/extract-depcruise-config", () => {
       assert: { type: "json" },
     });
     expect(
-      await loadConfig(path.join(mockDirectory, "extends/extending.json"))
+      await loadConfig(join(mockDirectory, "extends/extending.json"))
     ).to.deep.equal(mergedFixture.default);
   });
 
   it("a rule set with an extends array (0 members) returns that rule set", async () => {
     expect(
       await loadConfig(
-        path.join(
-          mockDirectory,
-          "extends/extending-array-with-zero-members.json"
-        )
+        join(mockDirectory, "extends/extending-array-with-zero-members.json")
       )
     ).to.deep.equal({
       forbidden: [
@@ -58,7 +53,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
     );
     expect(
       await loadConfig(
-        path.join(mockDirectory, "extends/extending-array-with-one-member.json")
+        join(mockDirectory, "extends/extending-array-with-one-member.json")
       )
     ).to.deep.equal(mergedArrayOneFixture.default);
   });
@@ -72,10 +67,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
     );
     expect(
       await loadConfig(
-        path.join(
-          mockDirectory,
-          "extends/extending-array-with-two-members.json"
-        )
+        join(mockDirectory, "extends/extending-array-with-two-members.json")
       )
     ).to.deep.equal(mergedArrayTwoFixture.default);
   });
@@ -83,7 +75,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
   it("a rule set with an extends from node_modules gets merged properly as well", async () => {
     expect(
       await loadConfig(
-        path.join(mockDirectory, "extends/extending-from-node-modules.json")
+        join(mockDirectory, "extends/extending-from-node-modules.json")
       )
     ).to.deep.equal({
       allowed: [
@@ -104,17 +96,17 @@ describe("[I] config-utl/extract-depcruise-config", () => {
   });
 
   it("borks on a circular extends (1 step)", async () => {
-    const lMessageOutTake = `config is circular - ${path.join(
+    const lMessageOutTake = `config is circular - ${join(
       mockDirectory,
       "extends/circular-one.js"
-    )} -> ${path.join(mockDirectory, "extends/circular-two.js")} -> ${path.join(
+    )} -> ${join(mockDirectory, "extends/circular-two.js")} -> ${join(
       mockDirectory,
       "extends/circular-one.js"
     )}.`;
     let lError = "none";
 
     try {
-      await loadConfig(path.join(mockDirectory, "extends/circular-one.js"));
+      await loadConfig(join(mockDirectory, "extends/circular-one.js"));
     } catch (pError) {
       lError = pError.toString();
     }

--- a/test/config-utl/make-absolute.spec.mjs
+++ b/test/config-utl/make-absolute.spec.mjs
@@ -1,4 +1,4 @@
-import path from "node:path";
+import { join } from "node:path";
 import { expect } from "chai";
 import makeAbsolute from "../../src/config-utl/make-absolute.mjs";
 
@@ -10,6 +10,6 @@ describe("[U] cli/utl/makeAbsolute", () => {
   });
 
   it("puts the current working directory in front of non-absolute paths", () => {
-    expect(makeAbsolute("pad")).to.equal(path.join(process.cwd(), "pad"));
+    expect(makeAbsolute("pad")).to.equal(join(process.cwd(), "pad"));
   });
 });

--- a/test/extract/resolve/get-manifest.spec.mjs
+++ b/test/extract/resolve/get-manifest.spec.mjs
@@ -1,11 +1,11 @@
-import fs from "node:fs";
-import path from "node:path";
+import { readFileSync } from "node:fs";
+import { parse, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import { getManifest } from "../../../src/extract/resolve/get-manifest.mjs";
 
 const rootPackageJson = JSON.parse(
-  fs.readFileSync(
+  readFileSync(
     fileURLToPath(new URL("../../../package.json", import.meta.url)),
     "utf8"
   )
@@ -21,32 +21,32 @@ describe("[I] extract/resolve/get-manifest - classic strategy", () => {
 
   it("returns 'null' if the package.json does not exist over there", () => {
     process.chdir("test/extract/resolve/__fixtures__/no-package-json-here");
-    expect(getManifest(path.parse(process.cwd()).root)).to.equal(null);
+    expect(getManifest(parse(process.cwd()).root)).to.equal(null);
   });
 
   it("returns 'null' if the package.json is invalid", () => {
-    expect(getManifest(path.join(FIXTUREDIR, "invalid-package-json"))).to.equal(
+    expect(getManifest(join(FIXTUREDIR, "invalid-package-json"))).to.equal(
       null
     );
   });
 
   it("returns '{}' if the package.json is empty (which is - strictly speaking - not allowed", () => {
-    expect(
-      getManifest(path.join(FIXTUREDIR, "empty-package-json"))
-    ).to.deep.equal({});
+    expect(getManifest(join(FIXTUREDIR, "empty-package-json"))).to.deep.equal(
+      {}
+    );
   });
 
   it("returns an object with the package.json", () => {
-    expect(
-      getManifest(path.join(FIXTUREDIR, "minimal-package-json"))
-    ).to.deep.equal({
-      name: "the-absolute-bare-minimum-package-json",
-      version: "481.0.0",
-    });
+    expect(getManifest(join(FIXTUREDIR, "minimal-package-json"))).to.deep.equal(
+      {
+        name: "the-absolute-bare-minimum-package-json",
+        version: "481.0.0",
+      }
+    );
   });
 
   it("looks up the closest package.json", () => {
-    expect(getManifest(path.join(FIXTUREDIR, "no-package-json"))).to.deep.equal(
+    expect(getManifest(join(FIXTUREDIR, "no-package-json"))).to.deep.equal(
       rootPackageJson
     );
   });
@@ -65,8 +65,8 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
   it("returns 'null' if the package.json is invalid", () => {
     expect(
       getManifest(
-        path.join(FIXTUREDIR, "invalid-package-json"),
-        path.join(FIXTUREDIR),
+        join(FIXTUREDIR, "invalid-package-json"),
+        join(FIXTUREDIR),
         true
       )
     ).to.equal(null);
@@ -85,7 +85,7 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
     process.chdir("test/extract/resolve/__fixtures__/two-level-package-jsons");
     expect(
       getManifest(
-        path.join(process.cwd(), "packages", "subthing"),
+        join(process.cwd(), "packages", "subthing"),
         process.cwd(),
         true
       )
@@ -107,13 +107,7 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
     process.chdir("test/extract/resolve/__fixtures__/two-level-package-jsons");
     expect(
       getManifest(
-        path.join(
-          process.cwd(),
-          "packages",
-          "subthing",
-          "src",
-          "somefunctionality"
-        ),
+        join(process.cwd(), "packages", "subthing", "src", "somefunctionality"),
         process.cwd(),
         true
       )
@@ -145,7 +139,7 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
       "test/extract/resolve/__fixtures__/amok-prevention-bogus-sub"
     );
     expect(() => {
-      getManifest(process.cwd(), `${path.dirname(process.cwd())}/`, true);
+      getManifest(process.cwd(), `${dirname(process.cwd())}/`, true);
     }).to.throw(/Unusual baseDir passed to package reading function/);
   });
 });

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
 import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.mjs";
@@ -16,7 +16,7 @@ describe("[I] typescript transpiler", () => {
     expect(
       normalizeSource(
         typeScriptRegularWrap.transpile(
-          fs.readFileSync(
+          readFileSync(
             "./test/extract/transpile/__mocks__/typescriptscript.ts",
             "utf8"
           )
@@ -24,7 +24,7 @@ describe("[I] typescript transpiler", () => {
       )
     ).to.equal(
       normalizeSource(
-        fs.readFileSync(
+        readFileSync(
           "./test/extract/transpile/__fixtures__/typescriptscript.js",
           "utf8"
         )
@@ -42,12 +42,12 @@ describe("[I] typescript transpiler (tsx)", () => {
     expect(
       normalizeSource(
         typeScriptTsxWrap.transpile(
-          fs.readFileSync("./test/extract/transpile/__mocks__/tsx.tsx", "utf8")
+          readFileSync("./test/extract/transpile/__mocks__/tsx.tsx", "utf8")
         )
       )
     ).to.equal(
       normalizeSource(
-        fs.readFileSync("./test/extract/transpile/__fixtures__/tsx.js", "utf8")
+        readFileSync("./test/extract/transpile/__fixtures__/tsx.js", "utf8")
       )
     );
   });
@@ -62,12 +62,12 @@ describe("[I] typescript transpiler (esm)", () => {
     expect(
       normalizeSource(
         typeScriptESMWrap.transpile(
-          fs.readFileSync("./test/extract/transpile/__mocks__/mts.mts", "utf8")
+          readFileSync("./test/extract/transpile/__mocks__/mts.mts", "utf8")
         )
       )
     ).to.equal(
       normalizeSource(
-        fs.readFileSync("./test/extract/transpile/__fixtures__/mts.mjs", "utf8")
+        readFileSync("./test/extract/transpile/__fixtures__/mts.mjs", "utf8")
       )
     );
   });

--- a/tools/regenerate-main-fixtures.utl.mjs
+++ b/tools/regenerate-main-fixtures.utl.mjs
@@ -1,27 +1,21 @@
 import { fileURLToPath } from "node:url";
-import fs from "node:fs";
-import path from "node:path";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import prettier from "prettier";
 import main from "../src/main/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const WORKING_DIR = process.cwd();
-const MAIN_FIXTURE_DIR = path.join(
-  __dirname,
-  "..",
-  "test",
-  "main",
-  "__fixtures__"
-);
-const MAIN_MOCKS_DIR = path.join(__dirname, "..", "test", "main", "__mocks__");
+const MAIN_FIXTURE_DIR = join(__dirname, "..", "test", "main", "__fixtures__");
+const MAIN_MOCKS_DIR = join(__dirname, "..", "test", "main", "__mocks__");
 
 function barfTheJSON(
   pTargetFileName,
   pResult,
   pTargetDirectory = MAIN_MOCKS_DIR
 ) {
-  fs.writeFileSync(
-    path.join(pTargetDirectory, pTargetFileName),
+  writeFileSync(
+    join(pTargetDirectory, pTargetFileName),
     prettier.format(JSON.stringify(pResult.output), { parser: "json" }),
     {
       encoding: "utf8",

--- a/tools/regenerate-report-fixtures.utl.mjs
+++ b/tools/regenerate-report-fixtures.utl.mjs
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
-import fs from "node:fs";
-import path from "node:path";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import dot from "../src/report/dot/index.mjs";
 import renderTeamcity from "../src/report/teamcity.mjs";
 import renderHTML from "../src/report/html/index.mjs";
@@ -14,9 +14,9 @@ const renderDot = dot("module");
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 function transformJSONtoFile(pInputFileName, pOutputFileName, pFunction) {
-  fs.writeFileSync(
+  writeFileSync(
     pOutputFileName,
-    pFunction(JSON.parse(fs.readFileSync(pInputFileName, "utf8"))).output,
+    pFunction(JSON.parse(readFileSync(pInputFileName, "utf8"))).output,
     "utf8"
   );
 }
@@ -27,12 +27,12 @@ function regenerateReportFixtures(
   pTargetExtension,
   pRelativeTargetDirectory = "../__fixtures__"
 ) {
-  fs.readdirSync(pDirectory)
+  readdirSync(pDirectory)
     .filter((pFileName) => pFileName.endsWith(".json"))
     .map((pFileName) => ({
-      inputFileName: path.join(pDirectory, pFileName),
-      outputFileName: path.join(
-        path.join(pDirectory, pRelativeTargetDirectory),
+      inputFileName: join(pDirectory, pFileName),
+      outputFileName: join(
+        join(pDirectory, pRelativeTargetDirectory),
         pFileName.replace(/\.json$/g, pTargetExtension)
       ),
     }))
@@ -43,11 +43,7 @@ function regenerateReportFixtures(
 
 function transformMJStoFile(pInputFileName, pOutputFileName, pFunction) {
   import(pInputFileName).then((pModule) => {
-    fs.writeFileSync(
-      pOutputFileName,
-      pFunction(pModule.default).output,
-      "utf8"
-    );
+    writeFileSync(pOutputFileName, pFunction(pModule.default).output, "utf8");
   });
 }
 
@@ -57,12 +53,12 @@ function regenerateReportFixturesFromMJS(
   pTargetExtension,
   pRelativeTargetDirectory = "../__fixtures__"
 ) {
-  fs.readdirSync(pDirectory)
+  readdirSync(pDirectory)
     .filter((pFileName) => pFileName.endsWith(".mjs"))
     .map((pFileName) => ({
-      inputFileName: path.join(pDirectory, pFileName),
-      outputFileName: path.join(
-        path.join(pDirectory, pRelativeTargetDirectory),
+      inputFileName: join(pDirectory, pFileName),
+      outputFileName: join(
+        join(pDirectory, pRelativeTargetDirectory),
         pFileName.replace(/\.mjs$/g, pTargetExtension)
       ),
     }))
@@ -73,35 +69,32 @@ function regenerateReportFixturesFromMJS(
 
 function renderBareThemeDot(pResultObject) {
   const lBareTheme = JSON.parse(
-    fs.readFileSync(
-      path.join(__dirname, "../test/report/dot/module-level/bare-theme.json")
+    readFileSync(
+      join(__dirname, "../test/report/dot/module-level/bare-theme.json")
     )
   );
   return renderDot(pResultObject, { theme: lBareTheme });
 }
 
-const CDOT_MOCK_DIR = path.join(
+const CDOT_MOCK_DIR = join(
   __dirname,
   "../test/report/dot/custom-level/__mocks__/"
 );
-const DDOT_MOCK_DIR = path.join(
+const DDOT_MOCK_DIR = join(
   __dirname,
   "../test/report/dot/folder-level/__mocks__/"
 );
-const FDOT_MOCK_DIR = path.join(
+const FDOT_MOCK_DIR = join(
   __dirname,
   "../test/report/dot/flat-level/__mocks__/"
 );
-const DOT_MOCK_DIR = path.join(
+const DOT_MOCK_DIR = join(
   __dirname,
   "../test/report/dot/module-level/__mocks__/"
 );
-const TEAMCITY_MOCK_DIR = path.join(
-  __dirname,
-  "../test/report/teamcity/__mocks__/"
-);
-const HTML_MOCK_DIR = path.join(__dirname, "../test/report/html/__mocks__/");
-const CSV_MOCK_DIR = path.join(__dirname, "../test/report/csv/__mocks__/");
+const TEAMCITY_MOCK_DIR = join(__dirname, "../test/report/teamcity/__mocks__/");
+const HTML_MOCK_DIR = join(__dirname, "../test/report/html/__mocks__/");
+const CSV_MOCK_DIR = join(__dirname, "../test/report/csv/__mocks__/");
 
 regenerateReportFixtures(DDOT_MOCK_DIR, renderDdot, ".dot");
 regenerateReportFixtures(CDOT_MOCK_DIR, renderCdot, ".dot");


### PR DESCRIPTION

## Description

- uses qualified imports for imports from node native modules
- replaces lodash.get statements with optional chaining wherever that improved readability

## Motivation and Context

consistency (hmm - would there be an eslint rule for this? with a fixert?)

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
