### PR TITLE
feature(config-utl): enables webpack configurations in ESM format BREAKING

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -109,7 +109,9 @@ try {
   const depcruiseConfig: ICruiseOptions = await extractDepcruiseConfig(
     "./.dependency-cruiser.js"
   );
-  const webpackResolveConfig = extractWebpackResolveConfig("./webpack.conf.js");
+  const webpackResolveConfig = await extractWebpackResolveConfig(
+    "./webpack.conf.js"
+  );
   const tsConfig = extractTSConfig("./tsconfig.json");
   // const babelConfig = await extractBabelConfig("./babel.conf.json");
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -451,7 +451,7 @@ your dependencies. This includes any `alias` you might have in there.
 Currently dependency-cruiser supports a reasonable subset of webpack
 config file formats:
 
-- nodejs parsable JavaScript only
+- nodejs parsable JavaScript only (_including_ ESM)
 - webpack 4 compatible and up (although earlier ones _might_ work
   there's no guarantee)
 - exporting either:
@@ -459,9 +459,10 @@ config file formats:
   - a function (webpack 4 style, taking up to two parameters)
   - an array of the above (where dependency-cruiser takes the
     first element in the array)
-
-Support for other formats (promise exports, TypeScript, fancier
-ECMAScript) might come later.
+- other formats (TypeScript, yaml, LiveScript, ...) will work if the function
+  is available that hacks node into understanding it. If you use a format like
+  this for your webpack configuration, it's likely this function is already
+  available.
 
 </details>
 

--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -768,9 +768,9 @@ you can provide the parameters like so:
 - :bulb: If your webpack config exports an array of configurations,
   dependency-cruiser will only use the resolve options of the first
   configuration in that array.
-- :warning: at this time webpack configurations in ES module format (.mjs) are
-  _not_ supported.
-- :bulb: other formats of webpack configurations (TypeScript, yaml, livescript(!),
+- :bulb: Configuration files in the node 'native' formats (.json, .js (both commonjs
+  and ESM), .cjs, .mjs, .node) will load without configuration.
+- :bulb: formats of webpack configurations (TypeScript, yaml, livescript(!),
   json5 etc.) only work when the function is available that hacks nodejs into
   accepting the language type.
   This should already be the case in order for `webpack-cli` to parse the config in

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -23,13 +23,13 @@ import setUpPerformanceLogListener from "./listeners/performance-log/index.mjs";
 import setUpNDJSONListener from "./listeners/ndjson.mjs";
 import initConfig from "./init-config/index.mjs";
 
-function extractResolveOptions(pCruiseOptions) {
+async function extractResolveOptions(pCruiseOptions) {
   let lResolveOptions = {};
   const lWebPackConfigFileName =
     pCruiseOptions?.ruleSet?.options?.webpackConfig?.fileName ?? null;
 
   if (lWebPackConfigFileName) {
-    lResolveOptions = extractWebpackResolveConfig(
+    lResolveOptions = await extractWebpackResolveConfig(
       lWebPackConfigFileName,
       pCruiseOptions?.ruleSet?.options?.webpackConfig?.env ?? null,
       pCruiseOptions?.ruleSet?.options?.webpackConfig?.arguments ?? null
@@ -118,7 +118,7 @@ async function runCruise(pFileDirectoryArray, pCruiseOptions) {
   const lReportingResult = await cruise(
     pFileDirectoryArray,
     lCruiseOptions,
-    extractResolveOptions(lCruiseOptions),
+    await extractResolveOptions(lCruiseOptions),
     {
       tsConfig: extractTSConfigOptions(lCruiseOptions),
       babelConfig: await extractBabelConfigOptions(lCruiseOptions),

--- a/src/config-utl/extract-babel-config.mjs
+++ b/src/config-utl/extract-babel-config.mjs
@@ -7,7 +7,7 @@ import tryImport from "semver-try-require";
 import meta from "../meta.js";
 import makeAbsolute from "./make-absolute.mjs";
 
-async function getCommonJSConfig(pBabelConfigFileName) {
+async function getJSConfig(pBabelConfigFileName) {
   let lReturnValue = {};
 
   try {
@@ -55,9 +55,9 @@ function getJSON5Config(pBabelConfigFileName) {
 
 async function getConfig(pBabelConfigFileName) {
   const lExtensionToParseFunction = {
-    ".js": getCommonJSConfig,
-    ".cjs": getCommonJSConfig,
-    ".mjs": getCommonJSConfig,
+    ".js": getJSConfig,
+    ".cjs": getJSConfig,
+    ".mjs": getJSConfig,
     "": getJSON5Config,
     ".json": getJSON5Config,
     ".json5": getJSON5Config,

--- a/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
@@ -6,35 +6,49 @@ function getFullPath(pRelativePath) {
   return fileURLToPath(new URL(pRelativePath, import.meta.url));
 }
 describe("[I] config-utl/extract-webpack-resolve-config - native formats", () => {
-  it("throws when no config file name is passed", () => {
-    expect(() => loadResolveConfig()).to.throw();
+  it("throws when no config file name is passed", async () => {
+    let lThrown = false;
+    try {
+      await loadResolveConfig();
+    } catch (_pError) {
+      lThrown = true;
+    }
+    expect(lThrown).to.equal(true);
   });
 
-  it("throws when a non-existing config file is passed", () => {
-    expect(() => {
-      loadResolveConfig("config-does-not-exist");
-    }).to.throw();
+  it("throws when a non-existing config file is passed", async () => {
+    let lThrown = false;
+    try {
+      await loadResolveConfig("config-does-not-exist");
+    } catch (_pError) {
+      lThrown = true;
+    }
+    expect(lThrown).to.equal(true);
   });
 
-  it("throws when a config file is passed that does not contain valid javascript", () => {
-    expect(() => {
-      loadResolveConfig(
+  it("throws when a config file is passed that does not contain valid javascript", async () => {
+    let lThrown = false;
+    try {
+      await loadResolveConfig(
         getFullPath("./__mocks__/webpackconfig/invalid.config.js")
       );
-    }).to.throw();
+    } catch (_pError) {
+      lThrown = true;
+    }
+    expect(lThrown).to.equal(true);
   });
 
-  it("returns an empty object when a config file is passed without a 'resolve' section", () => {
+  it("returns an empty object when a config file is passed without a 'resolve' section", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         getFullPath("./__mocks__/webpackconfig/noresolve.config.js")
       )
     ).to.deep.equal({});
   });
 
-  it("returns the resolve section of the webpack config if there's any", () => {
+  it("returns the resolve section of the webpack config if there's any", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         getFullPath("./__mocks__/webpackconfig/hasaresolve.config.js")
       )
     ).to.deep.equal({
@@ -45,9 +59,22 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     });
   });
 
-  it("returns the production resolve section of the webpack config if that's an environment specific", () => {
+  it("returns the resolve section of the webpack config if there's any (.mjs variant)", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
+        getFullPath("./__mocks__/webpackconfig/webpack.config.mjs")
+      )
+    ).to.deep.equal({
+      alias: {
+        config: "src/config",
+        magic$: "src/merlin/browserify/magic",
+      },
+    });
+  });
+
+  it("returns the production resolve section of the webpack config if that's an environment specific", async () => {
+    expect(
+      await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/hastwoseparateresolves.config.js"
         ),
@@ -61,9 +88,9 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     });
   });
 
-  it("returns the 'other' resolve section of the webpack config if development environment is requested", () => {
+  it("returns the 'other' resolve section of the webpack config if development environment is requested", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/hastwoseparateresolves.config.js"
         ),
@@ -77,9 +104,9 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     });
   });
 
-  it("returns the resolve section of the function returning webpack config if there's any", () => {
+  it("returns the resolve section of the function returning webpack config if there's any", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/aliassy/webpack.functionexport.config.js"
         )
@@ -92,9 +119,9 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     });
   });
 
-  it("returns the resolve section of the first element of the array returning webpack config if there's any", () => {
+  it("returns the resolve section of the first element of the array returning webpack config if there's any", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/aliassy/webpack.arrayexport.config.js"
         )
@@ -107,9 +134,9 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     });
   });
 
-  it("returns the resolve section of the result of the first element of the array if that's a function", () => {
+  it("returns the resolve section of the result of the first element of the array if that's a function", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/aliassy/webpack.functionarrayexport.config.js"
         )

--- a/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
@@ -6,53 +6,56 @@ import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-conf
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("[I] config-utl/extract-webpack-resolve-config - non-native formats", () => {
-  it("throws an error when the config is .mjs ", () => {
-    expect(() =>
-      loadResolveConfig(
-        join(__dirname, "__mocks__", "webpackconfig", "webpack.config.mjs")
-      )
-    ).to.throw(
-      /dependency-cruiser currently does not support webpack configurations/
-    );
-  });
-
-  it("throws an error when interpret doesn't know a loader for it", () => {
+  it("throws an error when interpret doesn't know a loader for it", async () => {
     /* keeping the throw expectancy minimal as the throw is done by rechoir and may
        be susceptible to change
      */
-    expect(() =>
-      loadResolveConfig(
+    let lThrown = false;
+    try {
+      await loadResolveConfig(
         join(
           __dirname,
           "__mocks__",
           "webpackconfig",
           "webpack.config.unknown-extension"
         )
-      )
-    ).to.throw();
+      );
+    } catch (_pError) {
+      lThrown = true;
+    }
+    expect(lThrown).to.equal(true);
   });
 
-  it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (livescript)", () => {
-    expect(() =>
-      loadResolveConfig(
+  it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (livescript)", async () => {
+    let lThrownError = "none";
+    try {
+      await loadResolveConfig(
         join(__dirname, "__mocks__", "webpackconfig", "webpack.config.ls")
-      )
-    ).to.throw(/No module loader found for ".ls"/m);
+      );
+    } catch (pError) {
+      lThrownError = pError.toString();
+    }
+    expect(lThrownError).to.match(/No module loader found for ".ls"/m);
   });
 
-  it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (yaml)", () => {
+  it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (yaml)", async () => {
     // yml is special as there's only one loader for it and 'interpret' then
     // doesn't put it in an array, but in a literal
-    expect(() =>
-      loadResolveConfig(
+
+    let lThrownError = "none";
+    try {
+      await loadResolveConfig(
         join(__dirname, "__mocks__", "webpackconfig", "webpack.config.yml")
-      )
-    ).to.throw(/Unable to use specified module loader/m);
+      );
+    } catch (pError) {
+      lThrownError = pError.toString();
+    }
+    expect(lThrownError).to.match(/Unable to use specified module loader/m);
   });
 
-  it("returns contents of the webpack config when the non-native extension _is_ registered", () => {
+  it("returns contents of the webpack config when the non-native extension _is_ registered", async () => {
     expect(
-      loadResolveConfig(
+      await loadResolveConfig(
         join(__dirname, "__mocks__", "webpackconfig", "webpack.config.json5")
       )
     ).to.deep.equal({


### PR DESCRIPTION
## Description

- uses `import` instead of require for webpack configurations that look like they can be loaded natively.
- still uses the `require` hack with rechoir/ interpret for configurations that look different.

This makes the config util that loads webpack configurations asynchronous which is 🚨 BREAKING.

## Motivation and Context

- to remain consistent with the formats we support for babel and dependency-cruiser itself.
- because it's possible now.

## How Has This Been Tested?

- [x] green ci
- [x] updated automated integration tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
