### PR TITLE
refactor(report): makes csv, error and text reporters less OS dependent

### DIFF
--- a/src/report/csv.mjs
+++ b/src/report/csv.mjs
@@ -1,3 +1,4 @@
+import { EOL } from "node:os";
 import dependencyToIncidenceTransformer from "./utl/dependency-to-incidence-transformer.mjs";
 
 function renderHeader(pModules) {
@@ -9,15 +10,15 @@ function mapIncidences(pIncidences) {
 }
 
 function renderBody(pModules) {
-  return pModules.reduce(
-    (pAll, pModule) =>
-      `${pAll}\n"${pModule.source}",${mapIncidences(pModule.incidences)},""`,
-    ""
-  );
+  return pModules
+    .map(
+      (pModule) => `"${pModule.source}",${mapIncidences(pModule.incidences)},""`
+    )
+    .join(EOL);
 }
 
 function report(pModules) {
-  return `"",${renderHeader(pModules)},""${renderBody(pModules)}\n`;
+  return `"",${renderHeader(pModules)},""${EOL}${renderBody(pModules)}${EOL}`;
 }
 
 /**

--- a/src/report/error.mjs
+++ b/src/report/error.mjs
@@ -1,3 +1,4 @@
+import { EOL } from "node:os";
 import chalk from "chalk";
 import figures from "figures";
 import { findRuleByName } from "../graph-utl/rule-set.mjs";
@@ -17,9 +18,9 @@ const SEVERITY2CHALK = {
 const EXTRA_PATH_INFORMATION_INDENT = 6;
 
 function formatExtraPathInformation(pExtra) {
-  return "\n".concat(
+  return EOL.concat(
     wrapAndIndent(
-      pExtra.join(` ${figures.arrowRight} \n`),
+      pExtra.join(` ${figures.arrowRight} ${EOL}`),
       EXTRA_PATH_INFORMATION_INDENT
     )
   );
@@ -48,7 +49,7 @@ function formatReachabilityViolation(pViolation) {
 }
 
 function formatInstabilityViolation(pViolation) {
-  return `${formatDependencyViolation(pViolation)}\n${wrapAndIndent(
+  return `${formatDependencyViolation(pViolation)}${EOL}${wrapAndIndent(
     chalk.dim(
       `instability: ${formatPercentage(pViolation.metrics.from.instability)} ${
         figures.arrowRight
@@ -78,7 +79,7 @@ function formatViolation(pViolation) {
     }: ${lFormattedViolators}` +
     `${
       pViolation.comment
-        ? `\n${wrapAndIndent(chalk.dim(pViolation.comment))}\n`
+        ? `${EOL}${wrapAndIndent(chalk.dim(pViolation.comment))}${EOL}`
         : ""
     }`
   );
@@ -93,11 +94,11 @@ function sumMeta(pMeta) {
 }
 
 function formatSummary(pSummary) {
-  let lMessage = `\n${figures.cross} ${sumMeta(
+  let lMessage = `${EOL}${figures.cross} ${sumMeta(
     pSummary
   )} dependency violations (${formatMeta(pSummary)}). ${
     pSummary.totalCruised
-  } modules, ${pSummary.totalDependenciesCruised} dependencies cruised.\n`;
+  } modules, ${pSummary.totalDependenciesCruised} dependencies cruised.${EOL}`;
 
   return pSummary.error > 0 ? chalk.red(lMessage) : lMessage;
 }
@@ -114,7 +115,7 @@ function addExplanation(pRuleSet, pLong) {
 function formatIgnoreWarning(pNumberOfIgnoredViolations) {
   if (pNumberOfIgnoredViolations > 0) {
     return chalk.yellow(
-      `${figures.warning} ${pNumberOfIgnoredViolations} known violations ignored. Run with --no-ignore-known to see them.\n`
+      `${figures.warning} ${pNumberOfIgnoredViolations} known violations ignored. Run with --no-ignore-known to see them.${EOL}`
     );
   }
   return "";
@@ -126,22 +127,24 @@ function report(pResults, pLong) {
   );
 
   if (lNonIgnorableViolations.length === 0) {
-    return `\n${chalk.green(figures.tick)} no dependency violations found (${
+    return `${EOL}${chalk.green(
+      figures.tick
+    )} no dependency violations found (${
       pResults.summary.totalCruised
     } modules, ${
       pResults.summary.totalDependenciesCruised
-    } dependencies cruised)\n${formatIgnoreWarning(
+    } dependencies cruised)${EOL}${formatIgnoreWarning(
       pResults.summary.ignore
-    )}\n\n`;
+    )}${EOL}`;
   }
 
   return lNonIgnorableViolations
     .reverse()
     .map(addExplanation(pResults.summary.ruleSetUsed, pLong))
-    .reduce((pAll, pThis) => `${pAll}  ${formatViolation(pThis)}\n`, "\n")
+    .reduce((pAll, pThis) => `${pAll}  ${formatViolation(pThis)}${EOL}`, EOL)
     .concat(formatSummary(pResults.summary))
     .concat(formatIgnoreWarning(pResults.summary.ignore))
-    .concat(`\n`);
+    .concat(EOL);
 }
 
 /**

--- a/src/report/text.mjs
+++ b/src/report/text.mjs
@@ -1,3 +1,4 @@
+import { EOL } from "node:os";
 import figures from "figures";
 import chalk from "chalk";
 
@@ -72,7 +73,7 @@ function report(pResults, pOptions) {
     getModulesInFocus(pResults.modules),
     lOptions.highlightFocused === true
   ).reduce(
-    (pAll, pDependency) => pAll.concat(stringify(pDependency)).concat("\n"),
+    (pAll, pDependency) => pAll.concat(stringify(pDependency)).concat(EOL),
     ""
   );
 }

--- a/test/cli/asserthelpers.utl.mjs
+++ b/test/cli/asserthelpers.utl.mjs
@@ -1,10 +1,13 @@
 import { readFileSync } from "node:fs";
 import { expect } from "chai";
+import normalizeNewline from "normalize-newline";
 import normBaseDirectory from "../main/norm-base-directory.utl.mjs";
 
 export function assertFileEqual(pActualFileName, pExpectedFileName) {
-  expect(readFileSync(pActualFileName, { encoding: "utf8" })).to.equal(
-    readFileSync(pExpectedFileName, { encoding: "utf8" })
+  expect(
+    normalizeNewline(readFileSync(pActualFileName, { encoding: "utf8" }))
+  ).to.equal(
+    normalizeNewline(readFileSync(pExpectedFileName, { encoding: "utf8" }))
   );
 }
 export function assertJSONFileEqual(pActualFileName, pExpectedFileName) {

--- a/test/report/csv/csv.spec.mjs
+++ b/test/report/csv/csv.spec.mjs
@@ -1,21 +1,24 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect } from "chai";
+import normalizeNewline from "normalize-newline";
 import render from "../../../src/report/csv.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
 
-const elementFixture = readFileSync(
-  fileURLToPath(
-    new URL("__mocks__/cjs-no-dependency-valid.csv", import.meta.url)
-  ),
-  "utf8"
+const elementFixture = normalizeNewline(
+  readFileSync(
+    fileURLToPath(
+      new URL("__mocks__/cjs-no-dependency-valid.csv", import.meta.url)
+    ),
+    "utf8"
+  )
 );
 
 describe("[I] report/csv reporter", () => {
   it("renders csv", () => {
     const lReturnValue = render(deps);
 
-    expect(lReturnValue.output).to.deep.equal(elementFixture);
+    expect(normalizeNewline(lReturnValue.output)).to.deep.equal(elementFixture);
     expect(lReturnValue.exitCode).to.equal(0);
   });
 });

--- a/test/report/error/error-long.spec.mjs
+++ b/test/report/error/error-long.spec.mjs
@@ -1,12 +1,13 @@
 /* eslint-disable no-magic-numbers */
+import { EOL } from "node:os";
 import { expect } from "chai";
 import chalk from "chalk";
 import render from "../../../src/report/error-long.mjs";
-import okdeps from "./__mocks__/everything-fine.mjs";
+import okDeps from "./__mocks__/everything-fine.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
-import warndeps from "./__mocks__/err-only-warnings.mjs";
-import erradds from "./__mocks__/err-with-additional-information.mjs";
-import orphanerrs from "./__mocks__/orphan-deps.mjs";
+import warnDeps from "./__mocks__/err-only-warnings.mjs";
+import errorsAdditionalInfo from "./__mocks__/err-with-additional-information.mjs";
+import orphanErrs from "./__mocks__/orphan-deps.mjs";
 
 describe("[I] report/error-long", () => {
   let chalkLevel = chalk.level;
@@ -18,7 +19,7 @@ describe("[I] report/error-long", () => {
     chalk.level = chalkLevel;
   });
   it("says everything fine", () => {
-    const lResult = render(okdeps);
+    const lResult = render(okDeps);
 
     expect(lResult.output).to.contain("no dependency violations found");
     expect(lResult.exitCode).to.equal(0);
@@ -26,7 +27,7 @@ describe("[I] report/error-long", () => {
   it("renders a bunch of errors", () => {
     const lResult = render(deps);
 
-    expect(lResult.output).to.contain("error no-leesplank: aap → noot\n");
+    expect(lResult.output).to.contain(`error no-leesplank: aap → noot${EOL}`);
     expect(lResult.output).to.contain(
       "2 dependency violations (2 errors, 0 warnings). 33 modules, 333 dependencies cruised."
     );
@@ -34,7 +35,7 @@ describe("[I] report/error-long", () => {
     expect(lResult.exitCode).to.equal(2);
   });
   it("renders a bunch of warnings", () => {
-    const lResult = render(warndeps);
+    const lResult = render(warnDeps);
 
     expect(lResult.output).to.contain(
       "1 dependency violations (0 errors, 1 warnings)"
@@ -42,16 +43,16 @@ describe("[I] report/error-long", () => {
     expect(lResult.exitCode).to.equal(0);
   });
   it("renders module only violations as module only", () => {
-    const lResult = render(orphanerrs);
+    const lResult = render(orphanErrs);
 
-    expect(lResult.output).to.contain("error no-orphans: remi.js\n");
+    expect(lResult.output).to.contain(`error no-orphans: remi.js${EOL}`);
     expect(lResult.output).to.contain(
       "1 dependency violations (1 errors, 0 warnings). 1 modules, 0 dependencies cruised."
     );
     expect(lResult.exitCode).to.equal(1);
   });
   it("renders a '-' for comment if it couldn't find the rule", () => {
-    const lResult = render(erradds);
+    const lResult = render(errorsAdditionalInfo);
 
     expect(lResult.output).to.contain("    -");
   });

--- a/test/report/error/error.spec.mjs
+++ b/test/report/error/error.spec.mjs
@@ -1,16 +1,17 @@
 /* eslint-disable no-magic-numbers */
+import { EOL } from "node:os";
 import { expect } from "chai";
 import chalk from "chalk";
 import render from "../../../src/report/error.mjs";
 import okdeps from "./__mocks__/everything-fine.mjs";
 import dependencies from "./__mocks__/cjs-no-dependency-valid.mjs";
-import onlywarningdependencies from "./__mocks__/err-only-warnings.mjs";
-import orphanerrs from "./__mocks__/orphan-deps.mjs";
-import circularerrs from "./__mocks__/circular-deps.mjs";
-import viaerrs from "./__mocks__/via-deps.mjs";
-import sdperrors from "./__mocks__/sdp-errors.mjs";
-import ignoredviolations from "./__mocks__/ignored-violations.mjs";
-import ignoredandrealviolations from "./__mocks__/ignored-and-real-violations.mjs";
+import onlyWarningDependencies from "./__mocks__/err-only-warnings.mjs";
+import orphanErrs from "./__mocks__/orphan-deps.mjs";
+import circularErrs from "./__mocks__/circular-deps.mjs";
+import viaErrs from "./__mocks__/via-deps.mjs";
+import sdpErrors from "./__mocks__/sdp-errors.mjs";
+import ignoredViolations from "./__mocks__/ignored-violations.mjs";
+import ignoredAndRealViolations from "./__mocks__/ignored-and-real-violations.mjs";
 import missingViolationType from "./__mocks__/missing-violation-type.mjs";
 import unknownViolationType from "./__mocks__/unknown-violation-type.mjs";
 
@@ -32,7 +33,7 @@ describe("[I] report/error", () => {
   it("renders a bunch of errors", () => {
     const lResult = render(dependencies);
 
-    expect(lResult.output).to.contain("error no-leesplank: aap → noot\n");
+    expect(lResult.output).to.contain(`error no-leesplank: aap → noot${EOL}`);
     expect(lResult.output).to.contain(
       "2 dependency violations (2 errors, 0 warnings). 33 modules, 333 dependencies cruised."
     );
@@ -40,7 +41,7 @@ describe("[I] report/error", () => {
     expect(lResult.exitCode).to.equal(2);
   });
   it("renders a bunch of warnings", () => {
-    const lResult = render(onlywarningdependencies);
+    const lResult = render(onlyWarningDependencies);
 
     expect(lResult.output).to.contain(
       "1 dependency violations (0 errors, 1 warnings)"
@@ -48,62 +49,65 @@ describe("[I] report/error", () => {
     expect(lResult.exitCode).to.equal(0);
   });
   it("renders module only violations as module only", () => {
-    const lResult = render(orphanerrs);
+    const lResult = render(orphanErrs);
 
-    expect(lResult.output).to.contain("error no-orphans: remi.js\n");
+    expect(lResult.output).to.contain(`error no-orphans: remi.js${EOL}`);
     expect(lResult.output).to.contain(
       "1 dependency violations (1 errors, 0 warnings). 1 modules, 0 dependencies cruised."
     );
     expect(lResult.exitCode).to.equal(1);
   });
   it("renders circular violations as circulars", () => {
-    const lResult = render(circularerrs);
+    const lResult = render(circularErrs);
 
     expect(lResult.output).to.contain(
-      "error no-circular: src/some/folder/nested/center.js → \n"
+      `error no-circular: src/some/folder/nested/center.js → ${EOL}`
     );
+    // these `\n` look odd - they're a side effect of the wrap-ansi module
+    // which replaces `\r\n` with `\n` as part of its parse/ split/ re-assemble
+    // operation
     expect(lResult.output).to.contain(
-      "      src/some/folder/loop-a.js →\n      src/some/folder/loop-b.js →\n      src/some/folder/nested/center.js"
+      `      src/some/folder/loop-a.js →\n      src/some/folder/loop-b.js →\n      src/some/folder/nested/center.js`
     );
     expect(lResult.exitCode).to.equal(3);
   });
   it("renders via violations as vias", () => {
-    const lResult = render(viaerrs);
+    const lResult = render(viaErrs);
 
     expect(lResult.output).to.contain(
-      "error some-via-rule: src/extract/index.js → src/utl/find-rule-by-name.js\n"
+      `error some-via-rule: src/extract/index.js → src/utl/find-rule-by-name.js${EOL}`
     );
     expect(lResult.output).to.contain(
-      "error some-via-rule: src/extract/index.js → src/utl/array-util.js\n"
+      `error some-via-rule: src/extract/index.js → src/utl/array-util.js${EOL}`
     );
     expect(lResult.output).to.contain("      (via via)");
     expect(lResult.exitCode).to.equal(4);
   });
   it("renders moreUnstable violations with the module & dependents violations", () => {
-    const lResult = render(sdperrors);
+    const lResult = render(sdpErrors);
 
     expect(lResult.output).to.contain(
-      "warn sdp: src/more-stable.js → src/less-stable.js\n      instability: 42% → 100%\n"
+      `warn sdp: src/more-stable.js → src/less-stable.js${EOL}      instability: 42% → 100%${EOL}`
     );
   });
   it("renders a violation as a dependency-violation when the violation.type ain't there", () => {
     const lResult = render(missingViolationType);
-    expect(lResult.output).to.contain("warn missing-type: a.js → b.js\n");
+    expect(lResult.output).to.contain(`warn missing-type: a.js → b.js${EOL}`);
   });
 
   it("renders a violation as a dependency-violation when the violation.type is yet unknown", () => {
     const lResult = render(unknownViolationType);
-    expect(lResult.output).to.contain("warn unknown-type: a.js → b.js\n");
+    expect(lResult.output).to.contain(`warn unknown-type: a.js → b.js${EOL}`);
   });
   it("emits a warning when there's > 1 ignored violation and no other violations", () => {
-    const lResult = render(ignoredviolations);
+    const lResult = render(ignoredViolations);
     expect(lResult.output).to.contain("no dependency violations found");
     expect(lResult.output).to.contain(
       "11 known violations ignored. Run with --no-ignore-known to see them."
     );
   });
   it("emits a warning when there's > 1 ignored violation and at least one other violation", () => {
-    const lResult = render(ignoredandrealviolations);
+    const lResult = render(ignoredAndRealViolations);
 
     expect(lResult.output).to.contain(
       "warn no-orphans: test/extract/ast-extractors/typescript2.8-union-types-ast.json"

--- a/test/report/text/text.spec.mjs
+++ b/test/report/text/text.spec.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect } from "chai";
 import chalk from "chalk";
+import normalizeNewline from "normalize-newline";
 import renderText from "../../../src/report/text.mjs";
 import dependencies from "./__mocks__/dependencies.mjs";
 import cruiseResultWithFocus from "./__mocks__/cruise-result-with-focus.mjs";
@@ -19,12 +20,16 @@ describe("[I] report/text", () => {
 
   it("renders a bunch of dependencies", () => {
     const lResult = renderText(dependencies);
-    const lExpectedOutput = readFileSync(
-      fileURLToPath(new URL("__fixtures__/dependencies.txt", import.meta.url)),
-      "utf8"
+    const lExpectedOutput = normalizeNewline(
+      readFileSync(
+        fileURLToPath(
+          new URL("__fixtures__/dependencies.txt", import.meta.url)
+        ),
+        "utf8"
+      )
     );
 
-    expect(lResult.output).to.equal(lExpectedOutput);
+    expect(normalizeNewline(lResult.output)).to.equal(lExpectedOutput);
     expect(lResult.exitCode).to.equal(0);
   });
 
@@ -41,7 +46,7 @@ describe("[I] report/text", () => {
       "test/enrich/derive/reachable/index.spec.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n" +
       "test/main/rule-set/normalize.spec.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n" +
       "test/validate/parse-ruleset.utl.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n";
-    expect(lResult.output).to.equal(lExpectedOutput);
+    expect(normalizeNewline(lResult.output)).to.equal(lExpectedOutput);
   });
 
   it("renders dependencies - no highlights when highlightFocused === false", () => {
@@ -57,6 +62,6 @@ describe("[I] report/text", () => {
       "test/enrich/derive/reachable/index.spec.mjs → src/main/rule-set/normalize.js\n" +
       "test/main/rule-set/normalize.spec.mjs → src/main/rule-set/normalize.js\n" +
       "test/validate/parse-ruleset.utl.mjs → src/main/rule-set/normalize.js\n";
-    expect(lResult.output).to.equal(lExpectedOutput);
+    expect(normalizeNewline(lResult.output)).to.equal(lExpectedOutput);
   });
 });


### PR DESCRIPTION
## Description

- uses os.EOL in stead of hard coded `\n` so it's emitting the 'correct' eol on mswindows as wel
- 🏕️ in the csv reporter replaces reduce with a map + join for readability

## How Has This Been Tested?

- [x] green ci
- [x] adapted unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
