### PR TITLE
perf(cli): reads webpack, typescript  and babel config options in parallel

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -41,7 +41,7 @@
           "^node_modules",
           "^\\.yarn/cache",
           "^os$",
-          "^fs$",
+          "^fs(/promises)?$",
           "^path$",
           "^url$",
           "$1",

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -118,14 +118,16 @@ async function runCruise(pFileDirectoryArray, pCruiseOptions) {
   setUpListener(lCruiseOptions);
 
   bus.emit("start");
+  const [lResolveOptions, tsConfig, babelConfig] = await Promise.all([
+    extractResolveOptions(lCruiseOptions),
+    extractTSConfigOptions(lCruiseOptions),
+    extractBabelConfigOptions(lCruiseOptions),
+  ]);
   const lReportingResult = await cruise(
     pFileDirectoryArray,
     lCruiseOptions,
-    await extractResolveOptions(lCruiseOptions),
-    {
-      tsConfig: await extractTSConfigOptions(lCruiseOptions),
-      babelConfig: await extractBabelConfigOptions(lCruiseOptions),
-    }
+    lResolveOptions,
+    { tsConfig, babelConfig }
   );
 
   bus.emit("progress", "cli: writing results", { complete: 1 });

--- a/src/cli/tools/wrap-stream-in-html.mjs
+++ b/src/cli/tools/wrap-stream-in-html.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const HEADER_FILE = fileURLToPath(
@@ -25,10 +25,13 @@ const FOOTER_FILE = fileURLToPath(
  * @param {readStream} pStream stream whose characters are to be slapped between header and footer
  * @param {writeStream} pOutStream stream to write to
  */
-export default function wrap(pInStream, pOutStream) {
-  const lHeader = readFileSync(HEADER_FILE, "utf8");
-  const lScript = readFileSync(SCRIPT_FILE, "utf8");
-  const lEnd = readFileSync(FOOTER_FILE, "utf8");
+export default async function wrap(pInStream, pOutStream) {
+  const [lHeader, lScript, lEnd] = await Promise.all([
+    readFile(HEADER_FILE, "utf8"),
+    readFile(SCRIPT_FILE, "utf8"),
+    readFile(FOOTER_FILE, "utf8"),
+  ]);
+
   const lFooter = `<script>${lScript}</script>${lEnd}`;
 
   pOutStream.write(lHeader);


### PR DESCRIPTION
## Description

- runs reading & processing webpack, typescript and babel configurations in parallel

## Motivation and Context

- likely slightly faster in case more than one of these is provided
- more idiomatic way to call a bunch of independent async functions => easier to maintain

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
