### PR TITLE
doc: makes readme backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ a one liner:
 npx depcruise src --include-only "^src" --output-type dot | dot -T svg > dependency-graph.svg
 ```
 
+> <details>
+> <summary>dependency-cruiser v12 and older: add --config option</summary>
+>
+> While not necessary from dependency-cruiser v13, in v12 and older you'll have
+> to pass the --config option to make it find the .dependency-cruiser.js
+> configuration file:
+>
+> ```shell
+> npx depcruise src --include-only "^src" --config --output-type dot | dot -T svg > dependency-graph.svg
+> ```
+
+</details>
+
 - You can read more about what you can do with `--include-only` and other command line
   options in the [command line interface](./doc/cli.md) documentation.
 - _[Real world samples](./doc/real-world-samples.md)_
@@ -109,6 +122,19 @@ Sample rule:
 ```sh
 npx depcruise src
 ```
+
+> <details>
+> <summary>dependency-cruiser v12 and older: add --config option</summary>
+>
+> While not necessary from dependency-cruiser v13, in v12 and older you'll have
+> to pass the --config option to make it find the .dependency-cruiser.js
+> configuration file:
+>
+> ```shell
+> npx depcruise --config .dependency-cruiser.js src
+> ```
+
+</details>
 
 This will validate against your rules and shows any violations in an eslint-like format:
 


### PR DESCRIPTION
## Description

- adds notes on how to run commands with dependency-cruiser v12 

## Motivation and Context

Fixes #798 

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
