### PR TITLE
perf(main): splits off cruise & format in their own modules

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -373,10 +373,6 @@
               }
             },
             {
-              "criteria": { "dynamic": true },
-              "attributes": { "style": "dashed" }
-            },
-            {
               "criteria": { "source": "^src/cli" },
               "attributes": { "fillcolor": "#ccccff" }
             },
@@ -442,6 +438,10 @@
             {
               "criteria": { "valid": false },
               "attributes": { "fontcolor": "red", "color": "red" }
+            },
+            {
+              "criteria": { "dynamic": true },
+              "attributes": { "style": "dashed" }
             },
             {
               "criteria": { "resolved": "^src/cli" },

--- a/src/cli/format.mjs
+++ b/src/cli/format.mjs
@@ -1,5 +1,5 @@
 import getStream from "get-stream";
-import { format as _format } from "../main/index.mjs";
+import _format from "../main/format.mjs";
 import validateFileExistence from "./utl/validate-file-existence.mjs";
 import normalizeOptions from "./normalize-cli-options.mjs";
 import { getInStream, write } from "./utl/io.mjs";

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -23,10 +23,10 @@ async function extractResolveOptions(pCruiseOptions) {
     pCruiseOptions?.ruleSet?.options?.webpackConfig?.fileName ?? null;
 
   if (lWebPackConfigFileName) {
-    const extractWebpackResolveConfig = await import(
+    const { default: extractWebpackResolveConfig } = await import(
       "../config-utl/extract-webpack-resolve-config.mjs"
     );
-    lResolveOptions = await extractWebpackResolveConfig.default(
+    lResolveOptions = await extractWebpackResolveConfig(
       lWebPackConfigFileName,
       pCruiseOptions?.ruleSet?.options?.webpackConfig?.env ?? null,
       pCruiseOptions?.ruleSet?.options?.webpackConfig?.arguments ?? null
@@ -37,10 +37,10 @@ async function extractResolveOptions(pCruiseOptions) {
 
 async function addKnownViolations(pCruiseOptions) {
   if (pCruiseOptions.knownViolationsFile) {
-    const extractKnownViolations = await import(
+    const { default: extractKnownViolations } = await import(
       "../config-utl/extract-known-violations.mjs"
     );
-    const lKnownViolations = extractKnownViolations.default(
+    const lKnownViolations = extractKnownViolations(
       pCruiseOptions.knownViolationsFile
     );
 
@@ -59,8 +59,10 @@ async function extractTSConfigOptions(pCruiseOptions) {
     pCruiseOptions?.ruleSet?.options?.tsConfig?.fileName ?? null;
 
   if (lTSConfigFileName) {
-    const extractTSConfig = await import("../config-utl/extract-ts-config.mjs");
-    lReturnValue = extractTSConfig.default(lTSConfigFileName);
+    const { default: extractTSConfig } = await import(
+      "../config-utl/extract-ts-config.mjs"
+    );
+    lReturnValue = extractTSConfig(lTSConfigFileName);
   }
 
   return lReturnValue;
@@ -71,10 +73,10 @@ async function extractBabelConfigOptions(pCruiseOptions) {
   const lBabelConfigFileName =
     pCruiseOptions?.ruleSet?.options?.babelConfig?.fileName ?? null;
   if (lBabelConfigFileName) {
-    const extractBabelConfig = await import(
+    const { default: extractBabelConfig } = await import(
       "../config-utl/extract-babel-config.mjs"
     );
-    lReturnValue = extractBabelConfig.default(lBabelConfigFileName);
+    lReturnValue = extractBabelConfig(lBabelConfigFileName);
   }
 
   return lReturnValue;
@@ -164,11 +166,13 @@ export default async function executeCli(pFileDirectoryArray, pCruiseOptions) {
     }
     /* c8 ignore stop */
     if (lCruiseOptions.info === true) {
-      const formatMetaInfo = await import("./format-meta-info.mjs");
-      process.stdout.write(await formatMetaInfo.default());
+      const { default: formatMetaInfo } = await import(
+        "./format-meta-info.mjs"
+      );
+      process.stdout.write(await formatMetaInfo());
     } else if (lCruiseOptions.init) {
-      const initConfig = await import("./init-config/index.mjs");
-      initConfig.default(lCruiseOptions.init);
+      const { default: initConfig } = await import("./init-config/index.mjs");
+      initConfig(lCruiseOptions.init);
     } else {
       lExitCode = await runCruise(pFileDirectoryArray, lCruiseOptions);
     }

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -6,7 +6,7 @@ import set from "lodash/set.js";
 import isInstalledGlobally from "is-installed-globally";
 import chalk from "chalk";
 
-import { cruise } from "../main/index.mjs";
+import cruise from "../main/cruise.mjs";
 import bus from "../utl/bus.mjs";
 
 import busLogLevels from "../utl/bus-log-levels.mjs";

--- a/src/config-utl/extract-babel-config.mjs
+++ b/src/config-utl/extract-babel-config.mjs
@@ -11,10 +11,10 @@ async function getJSConfig(pBabelConfigFileName) {
   let lReturnValue = {};
 
   try {
-    const lModule = await import(
+    const { default: lModule } = await import(
       `file://${makeAbsolute(pBabelConfigFileName)}`
     );
-    lReturnValue = lModule.default;
+    lReturnValue = lModule;
   } catch (pError) {
     throw new Error(
       `${

--- a/src/config-utl/extract-depcruise-config/read-config.mjs
+++ b/src/config-utl/extract-depcruise-config/read-config.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
 import json5 from "json5";
 
@@ -6,8 +6,11 @@ export default async function readConfig(pAbsolutePathToConfigFile) {
   if (
     [".js", ".cjs", ".mjs", ""].includes(extname(pAbsolutePathToConfigFile))
   ) {
-    const lConfig = await import(`file://${pAbsolutePathToConfigFile}`);
-    return lConfig.default;
+    const { default: config } = await import(
+      `file://${pAbsolutePathToConfigFile}`
+    );
+    return config;
   }
-  return json5.parse(readFileSync(pAbsolutePathToConfigFile, "utf8"));
+  const lConfig = await readFile(pAbsolutePathToConfigFile, "utf8");
+  return json5.parse(lConfig);
 }

--- a/src/config-utl/extract-webpack-resolve-config.mjs
+++ b/src/config-utl/extract-webpack-resolve-config.mjs
@@ -78,8 +78,10 @@ function isNativelySupported(pWebpackConfigFilename) {
 async function attemptImport(pAbsoluteWebpackConfigFileName) {
   try {
     if (isNativelySupported(pAbsoluteWebpackConfigFileName)) {
-      const lModule = await import(`file://${pAbsoluteWebpackConfigFileName}`);
-      return lModule.default;
+      const { default: lModule } = await import(
+        `file://${pAbsoluteWebpackConfigFileName}`
+      );
+      return lModule;
     } else {
       tryRegisterNonNative(pAbsoluteWebpackConfigFileName);
       /* we're using still using require instead of dynamic imports here because

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -1,0 +1,107 @@
+/* eslint-disable no-return-await */
+/* eslint-disable no-magic-numbers */
+
+import bus from "../utl/bus.mjs";
+import { validateCruiseOptions } from "./options/validate.mjs";
+import { normalizeCruiseOptions } from "./options/normalize.mjs";
+import reportWrap from "./report-wrap.mjs";
+
+const TOTAL_STEPS = 9;
+
+export function c(pComplete, pTotal = TOTAL_STEPS) {
+  return { complete: pComplete / pTotal };
+}
+
+/** @type {import("../../types/dependency-cruiser.js").cruise} */
+// eslint-disable-next-line max-lines-per-function, max-statements
+export default async function cruise(
+  pFileAndDirectoryArray,
+  pCruiseOptions,
+  pResolveOptions,
+  pTranspileOptions
+) {
+  bus.emit("progress", "parsing options", c(1));
+  /** @type {import("../../types/strict-options.js").IStrictCruiseOptions} */
+  let lCruiseOptions = normalizeCruiseOptions(
+    validateCruiseOptions(pCruiseOptions),
+    pFileAndDirectoryArray
+  );
+  let lCache = null;
+
+  if (lCruiseOptions.cache) {
+    bus.emit(
+      "progress",
+      `cache: check freshness with ${lCruiseOptions.cache.strategy}`,
+      c(2)
+    );
+
+    const Cache = await import("../cache/cache.mjs");
+    // eslint-disable-next-line new-cap
+    lCache = new Cache.default(lCruiseOptions.cache.strategy);
+    const lCachedResults = lCache.read(lCruiseOptions.cache.folder);
+
+    if (lCache.canServeFromCache(lCruiseOptions, lCachedResults)) {
+      bus.emit("progress", "cache: reporting from cache", c(8));
+      return await reportWrap(lCachedResults, lCruiseOptions);
+    }
+  }
+
+  const [
+    normalizeRuleSet,
+    validateRuleSet,
+    normalizeFilesAndDirectories,
+    normalizeResolveOptions,
+    extract,
+    enrich,
+  ] = await Promise.all([
+    // despite rule set parsing being behind an if, it's the 'normal' use case
+    // for dependency-cruiser, so import it unconditionally nonetheless
+    import("./rule-set/normalize.mjs"),
+    import("./rule-set/validate.mjs"),
+    import("./files-and-dirs/normalize.mjs"),
+    import("./resolve-options/normalize.mjs"),
+    import("../extract/index.mjs"),
+    import("../enrich/index.mjs"),
+  ]);
+
+  if (Boolean(lCruiseOptions.ruleSet)) {
+    bus.emit("progress", "parsing rule set", c(3));
+    lCruiseOptions.ruleSet = normalizeRuleSet.default(
+      validateRuleSet.default(lCruiseOptions.ruleSet)
+    );
+  }
+
+  const lNormalizedFileAndDirectoryArray = normalizeFilesAndDirectories.default(
+    pFileAndDirectoryArray
+  );
+
+  bus.emit("progress", "determining how to resolve", c(4));
+  const lNormalizedResolveOptions = await normalizeResolveOptions.default(
+    pResolveOptions,
+    lCruiseOptions,
+    pTranspileOptions?.tsConfig
+  );
+
+  bus.emit("progress", "reading files", c(5));
+  const lExtractionResult = extract.default(
+    lNormalizedFileAndDirectoryArray,
+    lCruiseOptions,
+    lNormalizedResolveOptions,
+    pTranspileOptions
+  );
+
+  bus.emit("progress", "analyzing", c(6));
+  const lCruiseResult = enrich.default(
+    lExtractionResult,
+    lCruiseOptions,
+    lNormalizedFileAndDirectoryArray
+  );
+
+  if (lCruiseOptions.cache) {
+    bus.emit("progress", "cache: save", c(7));
+    lCache.write(lCruiseOptions.cache.folder, lCruiseResult);
+  }
+
+  bus.emit("progress", "reporting", c(8));
+  return await reportWrap(lCruiseResult, lCruiseOptions);
+}

--- a/src/main/format.mjs
+++ b/src/main/format.mjs
@@ -1,0 +1,25 @@
+import Ajv from "ajv";
+
+import cruiseResultSchema from "../schema/cruise-result.schema.mjs";
+import { validateFormatOptions } from "./options/validate.mjs";
+import { normalizeFormatOptions } from "./options/normalize.mjs";
+import reportWrap from "./report-wrap.mjs";
+
+function validateResultAgainstSchema(pResult) {
+  const ajv = new Ajv();
+
+  if (!ajv.validate(cruiseResultSchema, pResult)) {
+    throw new Error(
+      `The supplied dependency-cruiser result is not valid: ${ajv.errorsText()}.\n`
+    );
+  }
+}
+/** @type {import("../../types/dependency-cruiser.js").format} */
+export default async function format(pResult, pFormatOptions = {}) {
+  const lFormatOptions = normalizeFormatOptions(pFormatOptions);
+  validateFormatOptions(lFormatOptions);
+
+  validateResultAgainstSchema(pResult);
+
+  return await reportWrap(pResult, lFormatOptions);
+}

--- a/src/main/index.mjs
+++ b/src/main/index.mjs
@@ -1,141 +1,16 @@
-/* eslint-disable no-return-await */
-/* eslint-disable no-magic-numbers */
-
-import Ajv from "ajv";
-
-import cruiseResultSchema from "../schema/cruise-result.schema.mjs";
-import bus from "../utl/bus.mjs";
 import {
   allExtensions,
   getAvailableTranspilers,
 } from "../extract/transpile/meta.mjs";
-import normalizeFilesAndDirectories from "./files-and-dirs/normalize.mjs";
-import validateRuleSet from "./rule-set/validate.mjs";
-import {
-  validateCruiseOptions,
-  validateFormatOptions,
-} from "./options/validate.mjs";
-import {
-  normalizeCruiseOptions,
-  normalizeFormatOptions,
-} from "./options/normalize.mjs";
-import reportWrap from "./report-wrap.mjs";
-
-const TOTAL_STEPS = 9;
-
-function c(pComplete, pTotal = TOTAL_STEPS) {
-  return { complete: pComplete / pTotal };
-}
-
-function validateResultAgainstSchema(pResult) {
-  const ajv = new Ajv();
-
-  if (!ajv.validate(cruiseResultSchema, pResult)) {
-    throw new Error(
-      `The supplied dependency-cruiser result is not valid: ${ajv.errorsText()}.\n`
-    );
-  }
-}
-/** @type {import("../../types/dependency-cruiser.js").format} */
-export async function format(pResult, pFormatOptions = {}) {
-  const lFormatOptions = normalizeFormatOptions(pFormatOptions);
-  validateFormatOptions(lFormatOptions);
-
-  validateResultAgainstSchema(pResult);
-
-  return await reportWrap(pResult, lFormatOptions);
-}
-
-/** @type {import("../../types/dependency-cruiser.js").cruise} */
-// eslint-disable-next-line max-lines-per-function, max-statements
-export async function cruise(
-  pFileAndDirectoryArray,
-  pCruiseOptions,
-  pResolveOptions,
-  pTranspileOptions
-) {
-  bus.emit("progress", "parsing options", c(1));
-  /** @type {import("../../types/strict-options.js").IStrictCruiseOptions} */
-  let lCruiseOptions = normalizeCruiseOptions(
-    validateCruiseOptions(pCruiseOptions),
-    pFileAndDirectoryArray
-  );
-  let lCache = null;
-
-  if (lCruiseOptions.cache) {
-    bus.emit(
-      "progress",
-      `cache: check freshness with ${lCruiseOptions.cache.strategy}`,
-      c(2)
-    );
-
-    const Cache = await import("../cache/cache.mjs");
-    // eslint-disable-next-line new-cap
-    lCache = new Cache.default(lCruiseOptions.cache.strategy);
-    const lCachedResults = lCache.read(lCruiseOptions.cache.folder);
-
-    if (lCache.canServeFromCache(lCruiseOptions, lCachedResults)) {
-      bus.emit("progress", "cache: reporting from cache", c(8));
-      return await reportWrap(lCachedResults, lCruiseOptions);
-    }
-  }
-
-  const [normalizeRuleSet, normalizeResolveOptions, extract, enrich] =
-    await Promise.all([
-      // despite rule set parsing being behind an if, it's the 'normal' use case
-      // for dependency-cruiser, so import it unconditionally nonetheless
-      import("./rule-set/normalize.mjs"),
-      import("./resolve-options/normalize.mjs"),
-      import("../extract/index.mjs"),
-      import("../enrich/index.mjs"),
-    ]);
-
-  if (Boolean(lCruiseOptions.ruleSet)) {
-    bus.emit("progress", "parsing rule set", c(3));
-    lCruiseOptions.ruleSet = normalizeRuleSet.default(
-      validateRuleSet(lCruiseOptions.ruleSet)
-    );
-  }
-
-  const lNormalizedFileAndDirectoryArray = normalizeFilesAndDirectories(
-    pFileAndDirectoryArray
-  );
-
-  bus.emit("progress", "determining how to resolve", c(4));
-  const lNormalizedResolveOptions = await normalizeResolveOptions.default(
-    pResolveOptions,
-    lCruiseOptions,
-    pTranspileOptions?.tsConfig
-  );
-
-  bus.emit("progress", "reading files", c(5));
-  const lExtractionResult = extract.default(
-    lNormalizedFileAndDirectoryArray,
-    lCruiseOptions,
-    lNormalizedResolveOptions,
-    pTranspileOptions
-  );
-
-  bus.emit("progress", "analyzing", c(6));
-  const lCruiseResult = enrich.default(
-    lExtractionResult,
-    lCruiseOptions,
-    lNormalizedFileAndDirectoryArray
-  );
-
-  if (lCruiseOptions.cache) {
-    bus.emit("progress", "cache: save", c(7));
-    lCache.write(lCruiseOptions.cache.folder, lCruiseResult);
-  }
-
-  bus.emit("progress", "reporting", c(8));
-  return await reportWrap(lCruiseResult, lCruiseOptions);
-}
+import format from "./format.mjs";
+import cruise from "./cruise.mjs";
 
 export {
   allExtensions,
   getAvailableTranspilers,
 } from "../extract/transpile/meta.mjs";
+export { default as cruise } from "./cruise.mjs";
+export { default as format } from "./format.mjs";
 
 export default {
   cruise,

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -84,10 +84,9 @@ async function compileResolveOptions(
   // Also: requiring the plugin only when it's necessary will save some
   // startup time (especially on a cold require cache)
   if (pResolveOptions.tsConfig && isTsConfigPathsEligible(pTSConfig)) {
-    const TsConfigPathsPluginModule = await import(
+    const { default: TsConfigPathsPlugin } = await import(
       "tsconfig-paths-webpack-plugin"
     );
-    const TsConfigPathsPlugin = TsConfigPathsPluginModule.default;
     lResolveOptions.plugins = pushPlugin(
       lResolveOptions.plugins,
       // @ts-expect-error TS2351 "TsConfPathsPlugin is not constructable" - is unjustified

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,6 +1,6 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -2,7 +2,7 @@ import { rmSync } from "node:fs";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import Cache from "../../src/cache/cache.mjs";
 
 use(chaiJSONSchema);

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,7 +1,7 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
 

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import normalizeOptions from "../../src/cli/normalize-cli-options.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -5,7 +5,7 @@ import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
 

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,7 +1,7 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
 

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -1,6 +1,6 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,6 +1,6 @@
 import { expect, use } from "chai";
 import chaiJSONSchema from "chai-json-schema";
-import { cruise } from "../../src/main/index.mjs";
+import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import { expect } from "chai";
-import { format } from "../../src/main/index.mjs";
+import format from "../../src/main/format.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);


### PR DESCRIPTION
## Description

- in 'main' splits off cruise and format in their own modules
- in the new 'cruise' module parallelizes dynamic imports of everything that can be optionally imported
- in the new 'cruise' module dynamically load _everything_ that can be optionally imported (in stead of just the perceived 'biggest wins')

## Motivation and Context

- the split improves legibility/ maintainability
- the rest improves performance (normal runs without cache it doesn't make much difference;  cached, and when it can served directly from cache ~60ms)

## How Has This Been Tested?

- [x] green ci

## Comparisons

### Before
#### serving from cache
```
$ hyperfine --warmup 3 --runs 30 "bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --cache node_modules/.cache/dependency-cruiser/load-cached --no-progress"
Benchmark 1: bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --cache node_modules/.cache/dependency-cruiser/load-cached --no-progress
  Time (mean ± σ):      1.262 s ±  0.012 s    [User: 1.320 s, System: 0.197 s]
  Range (min … max):    1.248 s …  1.299 s    30 runs
```
#### regular run

```
Benchmark 1: bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --no-cache --no-progress
  Time (mean ± σ):      3.068 s ±  0.019 s    [User: 4.715 s, System: 0.318 s]
  Range (min … max):    3.041 s …  3.118 s    30 runs
```
### After

#### serving from cache
```
$ hyperfine --warmup 3 --runs 30 "bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --cache node_modules/.cache/dependency-cruiser/load-cached --no-progress"
Benchmark 1: bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --cache node_modules/.cache/dependency-cruiser/load-cached --no-progress
  Time (mean ± σ):      1.200 s ±  0.013 s    [User: 1.229 s, System: 0.189 s]
  Range (min … max):    1.184 s …  1.236 s    30 runs
```
#### regular run
```
$ hyperfine --warmup 3 --runs 30 "bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --no-cache --no-progress"
Benchmark 1: bin/dependency-cruise.mjs src bin test configs types tools --ignore-known --no-cache --no-progress
  Time (mean ± σ):      3.066 s ±  0.019 s    [User: 4.761 s, System: 0.311 s]
  Range (min … max):    3.043 s …  3.130 s    30 runs
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [ ] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
