### PR TITLE
feature(report): in dot reporters, by default makes dynamic dependencies dashed lines

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -440,10 +440,6 @@
               "attributes": { "fontcolor": "red", "color": "red" }
             },
             {
-              "criteria": { "dynamic": true },
-              "attributes": { "style": "dashed" }
-            },
-            {
               "criteria": { "resolved": "^src/cli" },
               "attributes": { "color": "#0000ff77" }
             },

--- a/configs/.dependency-cruiser-show-metrics-config.mjs
+++ b/configs/.dependency-cruiser-show-metrics-config.mjs
@@ -131,10 +131,6 @@ export default {
           ],
           dependencies: [
             {
-              criteria: { dynamic: true },
-              attributes: { style: "dashed" },
-            },
-            {
               criteria: { "rules[0].severity": "error" },
               attributes: { fontcolor: "red", color: "red" },
             },

--- a/src/main/format.mjs
+++ b/src/main/format.mjs
@@ -21,5 +21,6 @@ export default async function format(pResult, pFormatOptions = {}) {
 
   validateResultAgainstSchema(pResult);
 
+  // eslint-disable-next-line no-return-await
   return await reportWrap(pResult, lFormatOptions);
 }

--- a/src/report/dot/default-theme.mjs
+++ b/src/report/dot/default-theme.mjs
@@ -128,6 +128,10 @@ export default {
       attributes: { fontcolor: "blue", color: "blue" },
     },
     {
+      criteria: { dynamic: true },
+      attributes: { style: "dashed" },
+    },
+    {
       criteria: { valid: false },
       attributes: { fontcolor: "red", color: "red" },
     },


### PR DESCRIPTION
## Description

- By default, shows dynamic dependencies dashed lines in all dot reporters

## Motivation and Context

For many applications dynamic imports behave differently from regular imports i.e. splitting code (bundlers like web pack, rollup, esbuild), deferred loading (nodejs). Having this available in the dot reporters has proved to be very useful, so it only makes sense to have it in by default (together with the existing alternate notations for type only, npm and circular dependencies).

## How Has This Been Tested?

- [x] green ci

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
