### PR TITLE
feature(report): adds a 'null' reporter

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -24,7 +24,8 @@
           "\\.schema\\.json$",
           "^tools/istanbul-json-summary-to-markdown\\.mjs$",
           "^src/report/json\\.mjs",
-          "^src/report/identity\\.mjs"
+          "^src/report/identity\\.mjs",
+          "^src/report/null\\.mjs"
         ]
       }
     },

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -676,6 +676,13 @@ For more information about writing rules see the [tutorial](rules-tutorial.md) a
 
 For an easy set up of both use [--init](#--init)
 
+#### null - no output, just an exit code
+
+This dummy 'reporter' will print _nothing_, not even when there are errors. It
+will exit with the exit code _number of violations with severity `error` found_,
+though. This reporter primarily exists to help in the development of
+dependency-cruiser.
+
 ### `--no-config`
 
 Use this if you don't want to use a configuration file. Also overrides earlier

--- a/src/report/index.mjs
+++ b/src/report/index.mjs
@@ -20,6 +20,7 @@ const TYPE2MODULE = {
   baseline: "./baseline.mjs",
   metrics: "./metrics.mjs",
   mermaid: "./mermaid.mjs",
+  null: "./null.mjs",
 };
 
 /**

--- a/src/report/null.mjs
+++ b/src/report/null.mjs
@@ -1,0 +1,12 @@
+/**
+ * Returns the results of a cruise in JSON
+ *
+ * @param {import("../../types/cruise-result").ICruiseResult} pResults
+ * @returns {import("../../types/dependency-cruiser").IReporterOutput}
+ */
+export default function nullReporter(pResults) {
+  return {
+    output: "",
+    exitCode: pResults.summary.error,
+  };
+}

--- a/test/report/null/null.spec.mjs
+++ b/test/report/null/null.spec.mjs
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import nullReporter from "../../../src/report/null.mjs";
+
+const gSmallOKResult = {
+  modules: [
+    {
+      source: "lonely.js",
+      dependencies: [],
+      dependents: [],
+      orphan: true,
+      valid: true,
+    },
+  ],
+  summary: {
+    violations: [],
+    error: 0,
+    warn: 0,
+    info: 0,
+    ignore: 0,
+    totalCruised: 1,
+    totalDependenciesCruised: 0,
+    optionsUsed: {
+      baseDir: "/Users/sander/prg/js/dependency-cruiser",
+      combinedDependencies: false,
+      exoticRequireStrings: [],
+      externalModuleResolutionStrategy: "node_modules",
+      metrics: false,
+      moduleSystems: ["es6", "cjs", "tsd", "amd"],
+      outputTo: "-",
+      outputType: "null",
+      preserveSymlinks: false,
+      tsPreCompilationDeps: false,
+      args: "lonely.js",
+    },
+  },
+};
+
+const gSmallNOKResult = {
+  modules: [
+    {
+      source: "lonely.js",
+      dependencies: [],
+      dependents: [],
+      orphan: true,
+      valid: true,
+    },
+  ],
+  summary: {
+    violations: [],
+    error: 3,
+    warn: 0,
+    info: 0,
+    ignore: 0,
+    totalCruised: 1,
+    totalDependenciesCruised: 0,
+    optionsUsed: {
+      baseDir: "/Users/sander/prg/js/dependency-cruiser",
+      combinedDependencies: false,
+      exoticRequireStrings: [],
+      externalModuleResolutionStrategy: "node_modules",
+      metrics: false,
+      moduleSystems: ["es6", "cjs", "tsd", "amd"],
+      outputTo: "-",
+      outputType: "null",
+      preserveSymlinks: false,
+      tsPreCompilationDeps: false,
+      args: "lonely.js",
+    },
+  },
+};
+
+describe("[I] report/null", () => {
+  it("happy day no errors", () => {
+    const lResult = nullReporter(gSmallOKResult);
+    expect(lResult).to.deep.equal({
+      output: "",
+      exitCode: 0,
+    });
+  });
+  it("happy day some errors", () => {
+    const lResult = nullReporter(gSmallNOKResult);
+    expect(lResult).to.deep.equal({
+      output: "",
+      exitCode: 3,
+    });
+  });
+});


### PR DESCRIPTION
## Description

- adds a reporter that reports nothing, only returns an exit code

## Motivation and Context

Turns out to be useful during development 

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
