### PR TITLE
fix(enrich): adds used tsconfig to options used + adds it to IConfiguration type

### DIFF
--- a/src/enrich/summarize/summarize-options.mjs
+++ b/src/enrich/summarize/summarize-options.mjs
@@ -26,10 +26,10 @@ const SHAREABLE_OPTIONS = [
   "reaches",
   "reporterOptions",
   "rulesFile",
+  "tsConfig",
   "tsPreCompilationDeps",
   "webpackConfig",
   // "progress", TODO: could be enabled
-  // "tsConfig", TODO: should be enabled
 ];
 
 function makeOptionsPresentable(pOptions) {

--- a/test/cli/__fixtures__/dynamic-import-nok.json
+++ b/test/cli/__fixtures__/dynamic-import-nok.json
@@ -48,6 +48,9 @@
       "outputTo": "test/cli/__output__/dynamic-import-nok.json",
       "outputType": "json",
       "preserveSymlinks": false,
+      "tsConfig": {
+        "fileName": "test/cli/__fixtures__/typescriptconfig/cli-dynamic-imports/tsconfig.error_on_compile_dynamic_imports.json"
+      },
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],
       "args": "test/cli/__fixtures__/typescriptconfig/cli-dynamic-imports/import_dynamically2.ts"

--- a/test/cli/__fixtures__/dynamic-import-ok.json
+++ b/test/cli/__fixtures__/dynamic-import-ok.json
@@ -48,6 +48,9 @@
       "outputTo": "test/cli/__output__/dynamic-import-ok.json",
       "outputType": "json",
       "preserveSymlinks": false,
+      "tsConfig": {
+        "fileName": "test/cli/__fixtures__/typescriptconfig/cli-dynamic-imports/tsconfig.compile_dynamic_imports.json"
+      },
       "tsPreCompilationDeps": false,
       "exoticRequireStrings": [],
       "args": "test/cli/__fixtures__/typescriptconfig/cli-dynamic-imports/import_dynamically.ts"

--- a/test/cli/__fixtures__/typescript-path-resolution.json
+++ b/test/cli/__fixtures__/typescript-path-resolution.json
@@ -72,6 +72,9 @@
       "outputType": "json",
       "preserveSymlinks": false,
       "tsPreCompilationDeps": false,
+      "tsConfig": {
+        "fileName": "test/cli/__fixtures__/typescriptconfig/cli-config-with-path/tsconfig.json"
+      },
       "webpackConfig": {
         "fileName": "test/cli/__fixtures__/typescriptconfig/cli-config-with-path/webpack.config.js"
       },

--- a/test/main/__fixtures__/ts-no-precomp-cjs.json
+++ b/test/main/__fixtures__/ts-no-precomp-cjs.json
@@ -77,6 +77,9 @@
       "metrics": false,
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
+      "tsConfig": {
+        "fileName": "test/main/__mocks__/tsconfig.targetcjs.json"
+      },
       "tsPreCompilationDeps": false,
       "args": "test/main/__mocks__/ts-precompilation-deps-off-cjs",
       "baseDir": ""

--- a/test/main/__fixtures__/ts-no-precomp-es.json
+++ b/test/main/__fixtures__/ts-no-precomp-es.json
@@ -77,6 +77,9 @@
       "metrics": false,
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
+      "tsConfig": {
+        "fileName": "test/main/__mocks__/tsconfig.targetes.json"
+      },
       "tsPreCompilationDeps": false,
       "args": "test/main/__mocks__/ts-precompilation-deps-off-es",
       "baseDir": ""

--- a/test/main/__fixtures__/ts-precomp-cjs.json
+++ b/test/main/__fixtures__/ts-precomp-cjs.json
@@ -93,6 +93,9 @@
       "metrics": false,
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
+      "tsConfig": {
+        "fileName": "test/main/__mocks__/tsconfig.targetcjs.json"
+      },
       "tsPreCompilationDeps": true,
       "args": "test/main/__mocks__/ts-precompilation-deps-on-cjs"
     }

--- a/test/main/__fixtures__/ts-precomp-es.json
+++ b/test/main/__fixtures__/ts-precomp-es.json
@@ -93,6 +93,9 @@
       "metrics": false,
       "moduleSystems": ["es6", "cjs", "tsd", "amd"],
       "preserveSymlinks": false,
+      "tsConfig": {
+        "fileName": "test/main/__mocks__/tsconfig.targetes.json"
+      },
       "tsPreCompilationDeps": true,
       "args": "test/main/__mocks__/ts-precompilation-deps-on-es"
     }

--- a/types/cruise-result.d.ts
+++ b/types/cruise-result.d.ts
@@ -358,50 +358,7 @@ export interface IOptions extends ICruiseOptions {
    * The rules file used to validate the dependencies (if any)
    */
   rulesFile?: string;
-  /**
-   * The TypeScript configuration file used (if any)
-   */
-  tsConfig?: ITsConfig;
-  /**
-   * The webpack configuration options used for the cruise
-   */
-  webpackConfig?: IWebpackConfig;
-  /**
-   * The Babel configuration file used (if any)
-   */
-  babelConfig?: IBabelConfig;
 }
-
-export interface ITsConfig {
-  fileName?: string;
-}
-
-export interface IBabelConfig {
-  fileName?: string;
-}
-
-/**
- * The webpack configuration options used for the cruise
- */
-export interface IWebpackConfig {
-  /**
-   * The arguments used
-   */
-  arguments?: { [key: string]: any };
-  /**
-   * The 'env' parameters passed
-   */
-  env?: WebpackEnvType;
-  /**
-   * The name of the webpack configuration file used
-   */
-  fileName?: string;
-}
-
-/**
- * The 'env' parameters passed
- */
-export type WebpackEnvType = { [key: string]: any } | string;
 
 export interface IFolderDependency {
   /**

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -19,6 +19,37 @@ export type ProgressType =
   | "ndjson"
   | "none";
 
+export interface ITsConfig {
+  fileName?: string;
+}
+
+export interface IBabelConfig {
+  fileName?: string;
+}
+
+/**
+ * The 'env' parameters passed to webpack, if any
+ */
+export type WebpackEnvType = { [key: string]: any } | string;
+
+/**
+ * The webpack configuration options used for the cruise
+ */
+export interface IWebpackConfig {
+  /**
+   * The arguments used
+   */
+  arguments?: { [key: string]: any };
+  /**
+   * The 'env' parameters passed
+   */
+  env?: WebpackEnvType;
+  /**
+   * The name of the webpack configuration file used
+   */
+  fileName?: string;
+}
+
 export interface ICruiseOptions {
   /**
    * if true, will attempt to validate with the rules in ruleSet.
@@ -175,7 +206,7 @@ export interface ICruiseOptions {
   /*
    * List of strings you have in use in addition to cjs/ es6 requires
    * & imports to declare module dependencies. Use this e.g. if you've
-   * redeclared require (`const want = require`), use a require-wrapper
+   * re-declared require (`const want = require`), use a require-wrapper
    * (like semver-try-require) or use window.require as a hack
    *
    * Defaults to `[]`
@@ -186,6 +217,30 @@ export interface ICruiseOptions {
    */
   reporterOptions?: IReporterOptions;
 
+  /**
+   * TypeScript project file ('tsconfig.json') to use for (1) compilation
+   * and (2) resolution (e.g. with the paths property)",
+   */
+  tsConfig?: ITsConfig;
+
+  /**
+   * Webpack configuration to use to get resolve options from
+   */
+  webpackConfig?: IWebpackConfig;
+
+  /**
+   * Babel configuration (e.g. '.babelrc.json') to use.
+   */
+  babelConfig?: IBabelConfig;
+
+  /**
+   * Overrides the parser dependency-cruiser will use - EXPERIMENTAL
+   *
+   * Note that you'll _very_ likely not need this - dependency-cruiser will
+   * typically sort out what the best parser for the job is out of the ones
+   * available
+   */
+  parser?: "acorn" | "tsc" | "swc";
   /**
    * Options used in module resolution that for dependency-cruiser's
    * use cannot go in a webpack config.


### PR DESCRIPTION
## Description, Motivation and Context

- adds tsconfig to the optionsUsed
  - it's more complete & truthful that way
  - we'll need it when we expand the cache feature to do incremental updates
- adds tsConfig, babelConfig, webpackConfig to the IConfiguration type
  so if you have type checking on your .dependency-cruiser.js (or use the API) these don't get flagged anymore

Fixes #653

## How Has This Been Tested?

- [x] green ci
- [x] adapted e2e tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
