### PR TITLE
fix(types): add root and `extract-ts-config` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "main": "src/main/index.mjs",
   "exports": {
     ".": {
-      "import": "./src/main/index.mjs"
+      "import": "./src/main/index.mjs",
+      "types": "./types/dependency-cruiser.d.ts"
     },
     "./config-utl/extract-babel-config": {
       "import": "./src/config-utl/extract-babel-config.mjs"
@@ -55,7 +56,8 @@
       "import": "./src/config-utl/extract-depcruise-config/index.mjs"
     },
     "./config-utl/extract-ts-config": {
-      "import": "./src/config-utl/extract-ts-config.mjs"
+      "import": "./src/config-utl/extract-ts-config.mjs",
+      "types": "./types/extract-ts-config.d.ts"
     },
     "./config-utl/extract-webpack-resolve-config": {
       "import": "./src/config-utl/extract-webpack-resolve-config.mjs"

--- a/types/extract-ts-config.d.ts
+++ b/types/extract-ts-config.d.ts
@@ -1,0 +1,5 @@
+import { ParsedCommandLine } from "typescript";
+
+export default function extractTSConfig(
+  pTSConfigFileName: string
+): ParsedCommandLine;


### PR DESCRIPTION
## Description

This PR solves a small issue in 13.x, where types are missing when using the new `"exports"`.

The error from TypeScript was:
```
Could not find a declaration file for module 'dependency-cruiser'. '[...]/node_modules/dependency-cruiser/src/main/index.mjs' implicitly has an 'any' type.
There are types at '[...]/node_modules/dependency-cruiser/types/dependency-cruiser.d.ts', but this result could not be resolved when respecting package.json "exports". The 'dependency-cruiser' library may need to update its package.json or typings.ts (7016)
```

This PR also adds types for the `extract-ts-config` file, which we use and was previously untyped.

## Motivation and Context

This solves a bug, as outlined above.

## How Has This Been Tested?

I've tested this locally against a project using dependency cruiser.

- [x] green ci

## Screenshots

**Before (13.x)**
<img width="573" alt="image" src="https://github.com/sverweij/dependency-cruiser/assets/5043083/abd7f774-087f-4d82-b131-5b2bd328d706">

**After (13.x with changes)**
<img width="573" alt="image" src="https://github.com/sverweij/dependency-cruiser/assets/5043083/e34701df-5ddb-400e-90c5-71d3f22d21d4">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
