### PR TITLE
Use transpilers installed locally first (regardless of install location)

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -10,7 +10,7 @@
 
 ### Q: TypeScript, CoffeeScript, LiveScript or Vue Single File Component (SFC) dependencies don't show up. How can I fix that?
 
-**A**: Install the compiler you use in the same spot dependency-cruiser is installed (or vv).
+**A**: Install the compiler you use in your node_modules, or the same spot dependency-cruiser is installed (or vv).
 
 For some types of TypeScript dependencies you need to flip a switch,
 which is what the next question is about.
@@ -26,16 +26,18 @@ running `depcruise --info`.
 
 When it turns out they aren't yet:
 
-- if you're running dependency-cruiser as a local (development-)
-  dependency (**recommended!**), install the necessary transpilers there.
-- if you're running dependency-cruiser as a global install, install
-  the necessary transpilers globally as well.
-- if you're running dependency-cruiser with npx you can pass the necessary
-  compiler(s) with the `-p` option. E.g. to get a list of all incoming and
-  outgoing dependencies of a TypeScript file you could use this:
-  ```
-  npx -p typescript@4.3.5 -p dependency-cruiser@latest depcruise src -T text --focus src/main/index.ts
-  ```
+- if transpilers are installed in your project (the node_modules directory reachable
+  from the current directory), dependency-cruiser will find them automatically.
+- if you don't want to install transpilers as dependencies of your project,
+  follow the instructions below:
+  - if you're running dependency-cruiser as a global install (npm i -g), install
+    the necessary transpilers globally.
+  - if you're running dependency-cruiser with npx, you can pass the necessary
+    compiler(s) with the `-p` option. E.g. to get a list of all incoming and
+    outgoing dependencies of a TypeScript file you could use this:
+    ```
+    npx -p typescript@4.3.5 -p dependency-cruiser@latest depcruise src -T text --focus src/main/index.ts
+    ```
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "ignore": "5.2.4",
     "indent-string": "5.0.0",
     "interpret": "^3.1.1",
-    "is-installed-globally": "0.4.0",
     "json5": "2.2.3",
     "lodash": "4.17.21",
     "prompts": "2.4.2",

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -2,7 +2,6 @@ import { join } from "node:path";
 import { glob } from "glob";
 import cloneDeep from "lodash/cloneDeep.js";
 import set from "lodash/set.js";
-import isInstalledGlobally from "is-installed-globally";
 import chalk from "chalk";
 
 import cruise from "../main/cruise.mjs";
@@ -147,21 +146,6 @@ export default async function executeCli(pFileDirectoryArray, pCruiseOptions) {
   let lExitCode = 0;
 
   try {
-    /* c8 ignore start */
-    if (isInstalledGlobally) {
-      process.stderr.write(
-        `\n  ${chalk.yellow(
-          "WARNING"
-        )}: You're running a globally installed dependency-cruiser.\n\n` +
-          `           We recommend to ${chalk.bold.italic.underline(
-            "install and run it as a local devDependency"
-          )} in\n` +
-          `           your project instead. There it has your project's environment and\n` +
-          `           transpilers at its disposal. That will ensure it can find e.g.\n` +
-          `           TypeScript, Vue or Svelte modules and dependencies.\n\n`
-      );
-    }
-    /* c8 ignore stop */
     if (lCruiseOptions.info === true) {
       const { default: formatMetaInfo } = await import(
         "./format-meta-info.mjs"

--- a/src/config-utl/extract-babel-config.mjs
+++ b/src/config-utl/extract-babel-config.mjs
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
 import json5 from "json5";
 import has from "lodash/has.js";
-import tryImport from "semver-try-require";
+import tryImport from "../extract/transpile/try-import.cjs";
 import meta from "../meta.js";
 import makeAbsolute from "./make-absolute.mjs";
 

--- a/src/config-utl/extract-ts-config.mjs
+++ b/src/config-utl/extract-ts-config.mjs
@@ -1,5 +1,5 @@
 import { dirname, resolve } from "node:path";
-import tryImport from "semver-try-require";
+import tryImport from "../extract/transpile/try-import.cjs";
 import meta from "../meta.js";
 
 const typescript = await tryImport(

--- a/src/extract/ast-extractors/extract-typescript-deps.mjs
+++ b/src/extract/ast-extractors/extract-typescript-deps.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-inline-comments */
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
+import tryImport from "../transpile/try-import.cjs";
 
 /** @type {import("typescript")} */
 const typescript = await tryImport(

--- a/src/extract/ast-extractors/swc-dependency-visitor.mjs
+++ b/src/extract/ast-extractors/swc-dependency-visitor.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-inline-comments */
 /* eslint-disable max-classes-per-file */
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
+import tryImport from "../transpile/try-import.cjs";
 
 /** @type {import('@swc/core/Visitor')} */
 const { Visitor } = await tryImport(
@@ -85,7 +85,7 @@ function extractExoticMemberCallExpression(pNode, pExoticRequireStrings) {
 }
 
 function isImportCallExpression(pNode) {
-  /* 
+  /*
     somewhere between swc 1.2.123 and 1.2.133 the swc AST started to
     represent import call expressions with .callee.type === "Import"
     instead of .callee.value === "import". Keeping both detection
@@ -99,7 +99,7 @@ function isNonExoticallyRequiredExpression(pNode) {
 }
 
 function isInterestingCallExpression(pExoticRequireStrings, pNode) {
-  /* 
+  /*
     somewhere between swc 1.2.123 and 1.2.133 the swc AST started to
     represent import call expressions with .callee.type === "Import"
     instead of .callee.value === "import". Keeping both detection

--- a/src/extract/parse/to-swc-ast.mjs
+++ b/src/extract/parse/to-swc-ast.mjs
@@ -1,6 +1,6 @@
-import tryImport from "semver-try-require";
 import memoize from "lodash/memoize.js";
 import meta from "../../meta.js";
+import tryImport from "../transpile/try-import.cjs";
 
 /** @type {import('@swc/core')} */
 const swc = await tryImport("@swc/core", meta.supportedTranspilers.swc);

--- a/src/extract/parse/to-typescript-ast.mjs
+++ b/src/extract/parse/to-typescript-ast.mjs
@@ -1,9 +1,9 @@
 import { readFileSync } from "node:fs";
-import tryImport from "semver-try-require";
 import memoize from "lodash/memoize.js";
 import meta from "../../meta.js";
 import transpile from "../transpile/index.mjs";
 import getExtension from "../../utl/get-extension.mjs";
+import tryImport from "../transpile/try-import.cjs";
 
 /** @type {import('typescript')} */
 const typescript = await tryImport(

--- a/src/extract/transpile/babel-wrap.mjs
+++ b/src/extract/transpile/babel-wrap.mjs
@@ -1,5 +1,5 @@
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
+import tryImport from "./try-import.cjs";
 
 const babel = await tryImport("@babel/core", meta.supportedTranspilers.babel);
 

--- a/src/extract/transpile/coffeescript-wrap.mjs
+++ b/src/extract/transpile/coffeescript-wrap.mjs
@@ -1,5 +1,5 @@
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
+import tryImport from "./try-import.cjs";
 
 /*
  * coffeescript's npm repo was renamed from coffee-script to coffeescript

--- a/src/extract/transpile/livescript-wrap.mjs
+++ b/src/extract/transpile/livescript-wrap.mjs
@@ -1,5 +1,5 @@
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
+import tryImport from "./try-import.cjs";
 
 const livescript = await tryImport(
   "livescript",

--- a/src/extract/transpile/svelte-wrap.mjs
+++ b/src/extract/transpile/svelte-wrap.mjs
@@ -1,6 +1,6 @@
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
 import preProcess from "./svelte-preprocess.mjs";
+import tryImport from "./try-import.cjs";
 
 const { compile } = await tryImport(
   "svelte/compiler",

--- a/src/extract/transpile/try-import.cjs
+++ b/src/extract/transpile/try-import.cjs
@@ -1,0 +1,26 @@
+const { join } = require("node:path");
+const tryRequire = require("semver-try-require");
+
+/**
+ * returns the (resolved) module identified by pModuleName:
+ * - if it is available, and
+ * - it satisfies the semantic version range specified by pSemVer
+ *
+ * returns false in all other cases
+ *
+ * resolves module in current working directory first, then fallback
+ * to node's default (for npm i -g)
+ *
+ * @param pModuleName the name of the module to resolve
+ * @param pSemanticVersion     (optional) a semantic version (range)
+ * @return            the (resolved) module identified by pModuleName
+ *                    or false
+ */
+function tryImport(pModuleName, pSupportedVersionRange) {
+  return (
+    tryRequire(pModuleName, pSupportedVersionRange, {
+      path: join(process.cwd(), "dummy.js"),
+    }) || tryRequire(pModuleName, pSupportedVersionRange)
+  );
+}
+module.exports = tryImport;

--- a/src/extract/transpile/typescript-wrap.mjs
+++ b/src/extract/transpile/typescript-wrap.mjs
@@ -1,5 +1,5 @@
-import tryImport from "semver-try-require";
 import meta from "../../meta.js";
+import tryImport from "./try-import.cjs";
 
 const typescript = await tryImport(
   "typescript",

--- a/src/extract/transpile/vue-template-wrap.cjs
+++ b/src/extract/transpile/vue-template-wrap.cjs
@@ -1,4 +1,5 @@
 const { EOL } = require("node:os");
+const { join } = require("node:path");
 const isEmpty = require("lodash/isEmpty");
 const tryRequire = require("semver-try-require");
 const meta = require("../../meta.js");
@@ -15,8 +16,26 @@ function getVueTemplateCompiler() {
 
   let lCompiler = tryRequire(
     "vue-template-compiler",
-    meta.supportedTranspilers["vue-template-compiler"]
+    meta.supportedTranspilers["vue-template-compiler"],
+    { path: join(process.cwd(), "dummy.js") }
   );
+
+  if (lCompiler === false) {
+    lCompiler = tryRequire(
+      "@vue/compiler-sfc",
+      meta.supportedTranspilers["@vue/compiler-sfc"],
+      { path: join(process.cwd(), "dummy.js") }
+    );
+    lIsVue3 = true;
+  }
+
+  if (lCompiler === false) {
+    lCompiler = tryRequire(
+      "vue-template-compiler",
+      meta.supportedTranspilers["vue-template-compiler"]
+    );
+    lIsVue3 = false;
+  }
 
   if (lCompiler === false) {
     lCompiler = tryRequire(


### PR DESCRIPTION
## Description

With this PR, dependency-cruiser will find locally installed transpilers first, then fallback to original behavior. So depcruise will work out-of-the-box with local transpilers regardless of `npx -p` or `npm i -g`.


Depends on this PR: https://github.com/sverweij/semver-try-require/pull/14

## Motivation and Context

Current depcruise will find transpilers in where depcruise itself is installed.
It means, transpilers installed in node_modules of local project are not used, unless depcruise is also installed locally.

https://github.com/sverweij/dependency-cruiser/issues/121#issuecomment-483259499
https://github.com/sverweij/dependency-cruiser/pull/661

Not only this PR solves setup issues, even we does not need to add depcruise to devDependencies. I wanted this to keep the number of dependencies fewer (e.g. for CI).

## How Has This Been Tested?

```
cd /path/to/semver-try-require # modified version
npm pack
cd /path/to/dependency-cruiser
npm i /path/to/semver-try-require/*.tgz
```

### Test for `npx`

```
cd /path/to/dependency-cruiser
rm -rf node_modules/typescript node_modules/@swc
cd /path/to/typescript-project

# ok
npx -p /path/to/dependency-cruiser depcruise -i 
npx -p ~/github/dependency-cruiser depcruise -p cli-feedback src --output-type dot --include-only "..." --ts-pre-compilation-deps
rm -rf node_modules/typescript

# ng
npx -p /path/to/dependency-cruiser depcruise -i # ng
npx -p ~/github/dependency-cruiser depcruise -p cli-feedback src --output-type dot --include-only "..." --ts-pre-compilation-deps
```

### Test for global install

```
cd /path/to/dependency-cruiser
npm pack
npm i -g dependency-cruiser-13.0.3.tgz
# we need to install locally referenced dependency manually. in my case:
npm i -g semver-try-require

cd /path/to/typescript-project

# ok
depcruise -i 
depcruise -p cli-feedback src --output-type dot --include-only "..." --ts-pre-compilation-deps


rm -rf node_modules/typescript
# ng
depcruise -i 
depcruise -p cli-feedback src --output-type dot --include-only "..." --ts-pre-compilation-deps

npm i -g typescript
# ok
depcruise -i 
depcruise -p cli-feedback src --output-type dot --include-only "..." --ts-pre-compilation-deps
```

### Of course also works when locally installed

```
cd /path/to/typescript-project
npm i -D /path/to/dependency-cruiser/dependency-cruiser-13.0.3.tgz

# ok
depcruise -i 
depcruise -p cli-feedback src --output-type dot --include-only "..." --ts-pre-compilation-deps
```

- [ ] green ci

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
