### PR TITLE
fix(main): still load tsconfig-paths-webpack-plugin when baseUrl misses from tsconfig

### DIFF
--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -31,7 +31,28 @@ describe("[I] main/resolve-options/normalize", () => {
     expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
   });
 
-  it("does not add the typescript paths plugin to the plugins if a tsConfig is specified without a baseUrl", async () => {
+  it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", async () => {
+    const lNormalizedOptions = await normalizeResolveOptions(
+      {},
+      normalizeCruiseOptions({
+        ruleSet: { options: {} },
+      }),
+      lTsconfigContents
+    );
+
+    expect(Object.keys(lNormalizedOptions).length).to.equal(
+      lDefaultNoOfResolveOptions
+    );
+    expect(lNormalizedOptions.symlinks).to.equal(false);
+    expect(lNormalizedOptions.tsConfig).to.equal(null);
+    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+    expect(lNormalizedOptions).to.ownProperty("extensions");
+    expect(lNormalizedOptions).to.ownProperty("fileSystem");
+    expect((lNormalizedOptions.plugins || []).length).to.equal(0);
+    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+  });
+
+  it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", async () => {
     const lNormalizedOptions = await normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
@@ -41,14 +62,14 @@ describe("[I] main/resolve-options/normalize", () => {
     );
 
     expect(Object.keys(lNormalizedOptions).length).to.equal(
-      lDefaultNoOfResolveOptions
+      lDefaultNoOfResolveOptions + 1
     );
     expect(lNormalizedOptions.symlinks).to.equal(false);
     expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
     expect(lNormalizedOptions.combinedDependencies).to.equal(false);
     expect(lNormalizedOptions).to.ownProperty("extensions");
     expect(lNormalizedOptions).to.ownProperty("fileSystem");
-    expect((lNormalizedOptions.plugins || []).length).to.equal(0);
+    expect((lNormalizedOptions.plugins || []).length).to.equal(1);
     expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
   });
 


### PR DESCRIPTION
## Description

1. still load the tsconfig-paths-webpack-plugin when the baseUrl isn't defined and pass it `./` for baseUrl as a default path in those cases
1. when the baseUrl _is_ defined pass `undefined` as baseUrl to tsconfig-paths-webpack-plugin, so the plugin will read the baseUrl from 

## Motivation and Context

Provides a workaround for https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/99; fixes #818

When https://github.com/dividab/tsconfig-paths-webpack-plugin/pull/105 lands the second part of this PR should be reverted to keep the code as simple as possible

## How Has This Been Tested?

- [x] green ci
- [x] additional & adapted automated tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
