### PR TITLE
fix(extract): also detects node:test as a core module

### DIFF
--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -71,6 +71,46 @@ describe("[I] extract/resolve/index - general", () => {
     });
   });
 
+  it("resolves the 'test'  core module as core module", () => {
+    expect(
+      resolve(
+        {
+          module: "test",
+          moduleSystem: "es6",
+        },
+        join(__dirname, "__mocks__"),
+        join(__dirname, "__mocks__", "resolve"),
+        {},
+      ),
+    ).to.deep.equal({
+      coreModule: true,
+      couldNotResolve: false,
+      dependencyTypes: ["core"],
+      followable: false,
+      resolved: "test",
+    });
+  });
+
+  it("resolves the 'node:test' core module as core module", () => {
+    expect(
+      resolve(
+        {
+          module: "node:test",
+          moduleSystem: "es6",
+        },
+        join(__dirname, "__mocks__"),
+        join(__dirname, "__mocks__", "resolve"),
+        {},
+      ),
+    ).to.deep.equal({
+      coreModule: true,
+      couldNotResolve: false,
+      dependencyTypes: ["core"],
+      followable: false,
+      resolved: "node:test",
+    });
+  });
+
   it("resolves to the moduleName input (and depType 'unknown') when not resolvable on disk", () => {
     expect(
       resolve(


### PR DESCRIPTION
## Description

- ensures `node:test` is detected as a core module

## Motivation and Context

Currently `node:test` dependencies are classified as unable to resolve. This is because `node:test` or `test` are not listed as `builtinModules` in node's `module` module. From the discussion on https://github.com/nodejs/node/issues/42785 I understand this is never going to happen either. Alternative is to use `module`'s `isBuiltin()` function, but that is not available in the lowest version of nodejs dependency-cruiser supports (16.14), so we have to work around that.

Additionally the `node:test` module can _only_ be required via the `node:` protocol (`const { test} = require('test')`/ `import { test } from 'test'` don't work). This means that with the current the way we split the protocol from the module name, using `isBuiltin` won't work either...

## How Has This Been Tested?

- [x] green ci
- [x] additional automated tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
