### PR TITLE
refactor(test): replaces chai with node:assert and chai-json-schema with ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,6 @@
     "@vue/compiler-sfc": "3.3.4",
     "c8": "8.0.0",
     "chai": "4.3.7",
-    "chai-json-schema": "1.5.1",
     "coffeescript": "2.7.0",
     "eslint": "8.45.0",
     "eslint-config-moving-meadow": "4.0.2",

--- a/test/api.spec.mjs
+++ b/test/api.spec.mjs
@@ -1,7 +1,7 @@
 // eslint disable because import/no-unresolved,node/no-missing-import don't
 // know about (local) module imports yet
 /* eslint-disable import/no-unresolved,node/no-missing-import */
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import satisfies from "semver/functions/satisfies.js";
 import dependencyCruiser from "dependency-cruiser";
 import extractBabelConfig from "dependency-cruiser/config-utl/extract-babel-config";
@@ -15,29 +15,27 @@ import extractWebpackResolveConfig from "dependency-cruiser/config-utl/extract-w
 if (satisfies(process.versions.node, "^12.19 || >=14.7")) {
   describe("[E] api from esm (on node ^12.19 || >= 14.7)", () => {
     it("exposes dependency-cruiser main with some functions", () => {
-      expect(typeof dependencyCruiser).to.equal("object");
-      expect(typeof dependencyCruiser.cruise).to.equal("function");
-      expect(typeof dependencyCruiser.format).to.equal("function");
-      expect(Array.isArray(dependencyCruiser.allExtensions)).to.equal(true);
-      expect(typeof dependencyCruiser.getAvailableTranspilers).to.equal(
-        "function",
-      );
+      strictEqual(typeof dependencyCruiser, "object");
+      strictEqual(typeof dependencyCruiser.cruise, "function");
+      strictEqual(typeof dependencyCruiser.format, "function");
+      strictEqual(Array.isArray(dependencyCruiser.allExtensions), true);
+      strictEqual(typeof dependencyCruiser.getAvailableTranspilers, "function");
     });
 
     it("exposes an extract-babel-config function", () => {
-      expect(typeof extractBabelConfig).to.equal("function");
+      strictEqual(typeof extractBabelConfig, "function");
     });
 
     it("exposes an extract-depcruise-config function", () => {
-      expect(typeof extractDepcruiseConfig).to.equal("function");
+      strictEqual(typeof extractDepcruiseConfig, "function");
     });
 
     it("exposes an extract-ts-config function", () => {
-      expect(typeof extractTsConfig).to.equal("function");
+      strictEqual(typeof extractTsConfig, "function");
     });
 
     it("exposes an extract-webpack-resolve-config function", () => {
-      expect(typeof extractWebpackResolveConfig).to.equal("function");
+      strictEqual(typeof extractWebpackResolveConfig, "function");
     });
   });
 }

--- a/test/cache/content-strategy.spec.mjs
+++ b/test/cache/content-strategy.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import ContentStrategy from "../../src/cache/content-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
@@ -37,7 +37,7 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
       ],
     };
 
-    expect(
+    deepStrictEqual(
       new ContentStrategy().getRevisionData(
         null,
         null,
@@ -49,11 +49,12 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
           diffListFn: () => lInputChanges,
         },
       ),
-    ).to.deep.equal(lExpected);
+      lExpected,
+    );
   });
 
   it("if there's no changes the change set contains the passed sha & an empty array", () => {
-    expect(
+    deepStrictEqual(
       new ContentStrategy().getRevisionData(
         null,
         null,
@@ -65,16 +66,17 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
           diffListFn: () => [],
         },
       ),
-    ).to.deep.equal({
-      SHA1: DUMMY_SHA,
-      changes: [],
-    });
+      {
+        SHA1: DUMMY_SHA,
+        changes: [],
+      },
+    );
   });
 
   it("returns only the extensions passed", () => {
     const lLimitedExtensions = new Set([".wim", ".noot"]);
 
-    expect(
+    deepStrictEqual(
       new ContentStrategy().getRevisionData(
         ".",
         { modules: [] },
@@ -85,16 +87,17 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
           baseDir: "test/cache/__mocks__/content-strategy/extensions-check",
         },
       ),
-    ).to.deep.equal({
-      SHA1: DUMMY_SHA,
-      changes: [
-        {
-          changeType: "added",
-          name: "noot-extension-hence-returned.noot",
-          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-        },
-      ],
-    });
+      {
+        SHA1: DUMMY_SHA,
+        changes: [
+          {
+            changeType: "added",
+            name: "noot-extension-hence-returned.noot",
+            checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+          },
+        ],
+      },
+    );
   });
 
   it("returns only the changeTypes passed", () => {
@@ -128,7 +131,7 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
       },
     ];
 
-    expect(
+    deepStrictEqual(
       new ContentStrategy().getRevisionData(
         null,
         null,
@@ -140,24 +143,25 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
           checksumFn: dummyCheckSumFunction,
         },
       ),
-    ).to.deep.equal({
-      SHA1: DUMMY_SHA,
-      changes: [
-        {
-          changeType: "added",
-          name: "added-hence-returned.aap",
-        },
-        {
-          changeType: "added",
-          name: "added-hence-returned.noot",
-        },
-        {
-          changeType: "renamed",
-          name: "renamed-hence-returned.mies",
-          oldName: "old-name.wim",
-        },
-      ],
-    });
+      {
+        SHA1: DUMMY_SHA,
+        changes: [
+          {
+            changeType: "added",
+            name: "added-hence-returned.aap",
+          },
+          {
+            changeType: "added",
+            name: "added-hence-returned.noot",
+          },
+          {
+            changeType: "renamed",
+            name: "renamed-hence-returned.mies",
+            oldName: "old-name.wim",
+          },
+        ],
+      },
+    );
   });
 });
 
@@ -182,52 +186,57 @@ describe("[U] cache/content-strategy - revisionDataEqual", () => {
   ];
 
   it("returns false when revision data objects don't exist", () => {
-    expect(new ContentStrategy().revisionDataEqual(null, null)).to.equal(false);
+    strictEqual(new ContentStrategy().revisionDataEqual(null, null), false);
   });
 
   it("returns false when old revision data object doesn't exist", () => {
-    expect(
+    strictEqual(
       new ContentStrategy().revisionDataEqual(null, {
         SHA1: "some-sha",
         changes: [],
       }),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns false when new revision data object doesn't exist", () => {
-    expect(
+    strictEqual(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         null,
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns false when changes are not equal", () => {
-    expect(
+    strictEqual(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: lChanges },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns true when changes are equal", () => {
-    expect(
+    strictEqual(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: lChanges },
         { SHA1: "some-sha", changes: lChanges },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("returns true when changes are equal  (even when neither contain changes)", () => {
-    expect(
+    strictEqual(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: [] },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 });
 
@@ -265,12 +274,13 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
       revisionData: lEmptyRevisionData,
     };
 
-    expect(
+    deepStrictEqual(
       new ContentStrategy().prepareRevisionDataForSaving(
         lEmptyCruiseResult,
         lEmptyRevisionData,
       ),
-    ).to.deep.equal(lExpectedCruiseResult);
+      lExpectedCruiseResult,
+    );
   });
 
   it("adds checksums to modules in the cruise result", () => {
@@ -323,12 +333,13 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
       revisionData: lEmptyRevisionData,
     };
 
-    expect(
+    deepStrictEqual(
       new ContentStrategy().prepareRevisionDataForSaving(
         lEmptyCruiseResult,
         lEmptyRevisionData,
       ),
-    ).to.deep.equal(lExpectedCruiseResult);
+      lExpectedCruiseResult,
+    );
   });
 
   it("removes changes from the revision data that aren't different anymore from the cruise result", () => {
@@ -411,11 +422,12 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
       },
     };
 
-    expect(
+    deepStrictEqual(
       new ContentStrategy().prepareRevisionDataForSaving(
         lCruiseResult,
         lRevisionData,
       ),
-    ).to.deep.equal(lExpectedCruiseResult);
+      lExpectedCruiseResult,
+    );
   });
 });

--- a/test/cache/find-content-changes.spec.mjs
+++ b/test/cache/find-content-changes.spec.mjs
@@ -1,9 +1,9 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import findContentChanges from "../../src/cache/find-content-changes.mjs";
 
 describe("[U] cache/find-content-changes - cached vs new", () => {
   it("returns files not in directory but in cache as 'ignored' when they're not interesting for diffing", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         {
@@ -33,28 +33,29 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "consolidated",
-        changeType: "ignored",
-      },
-      {
-        name: "path",
-        changeType: "ignored",
-      },
-      {
-        name: "could-not-resolve.js",
-        changeType: "ignored",
-      },
-      {
-        name: "node_modules/matches-do-not/follow.js",
-        changeType: "ignored",
-      },
-    ]);
+      [
+        {
+          name: "consolidated",
+          changeType: "ignored",
+        },
+        {
+          name: "path",
+          changeType: "ignored",
+        },
+        {
+          name: "could-not-resolve.js",
+          changeType: "ignored",
+        },
+        {
+          name: "node_modules/matches-do-not/follow.js",
+          changeType: "ignored",
+        },
+      ],
+    );
   });
 
   it("returns files not in directory but in cache as 'deleted'", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         { modules: [{ source: "only-in-cache-ends-up-as-deleted.js" }] },
@@ -65,16 +66,17 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "only-in-cache-ends-up-as-deleted.js",
-        changeType: "deleted",
-      },
-    ]);
+      [
+        {
+          name: "only-in-cache-ends-up-as-deleted.js",
+          changeType: "deleted",
+        },
+      ],
+    );
   });
 
   it("returns files that have been earmarked as not followable as 'ignored'", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         {
@@ -93,16 +95,17 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "not-in-content-changes-as-extension.weird",
-        changeType: "ignored",
-      },
-    ]);
+      [
+        {
+          name: "not-in-content-changes-as-extension.weird",
+          changeType: "ignored",
+        },
+      ],
+    );
   });
 
   it("returns files both in directory and in cache that are different as 'modified'", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         {
@@ -123,22 +126,23 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "in-folder-as-well-different-checksum.js",
-        changeType: "modified",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-      {
-        name: "in-folder-as-well-no-checksum.js",
-        changeType: "modified",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-    ]);
+      [
+        {
+          name: "in-folder-as-well-different-checksum.js",
+          changeType: "modified",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+        {
+          name: "in-folder-as-well-no-checksum.js",
+          changeType: "modified",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+      ],
+    );
   });
 
   it("returns files both in directory and in cache that are the same as 'unmodified'", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         {
@@ -156,19 +160,20 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "in-folder-as-well-unmodified.js",
-        changeType: "unmodified",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-    ]);
+      [
+        {
+          name: "in-folder-as-well-unmodified.js",
+          changeType: "unmodified",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+      ],
+    );
   });
 });
 
 describe("[U] cache/find-content-changes - new vs cached", () => {
   it("returns an empty set when the directory and modules are empty", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -179,11 +184,12 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([]);
+      [],
+    );
   });
 
   it("returns changes when there's file in the directory and modules is empty (extensions only)", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -194,17 +200,18 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "interesting-extension.js",
-        changeType: "added",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-    ]);
+      [
+        {
+          name: "interesting-extension.js",
+          changeType: "added",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+      ],
+    );
   });
 
   it("returns changes when there's file in the directory and modules is empty (missing includeOnly filter)", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -214,17 +221,18 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "interesting-extension.js",
-        changeType: "added",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-    ]);
+      [
+        {
+          name: "interesting-extension.js",
+          changeType: "added",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+      ],
+    );
   });
 
   it("returns changes when there's file in the directory and modules is empty (exclude filter)", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -235,17 +243,18 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "interesting-extension.js",
-        changeType: "added",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-    ]);
+      [
+        {
+          name: "interesting-extension.js",
+          changeType: "added",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+      ],
+    );
   });
 
   it("returns changes when there's file in the directory and modules is empty (includeOnly filter)", () => {
-    expect(
+    deepStrictEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -257,17 +266,18 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
           extensions: new Set([".js"]),
         },
       ),
-    ).to.deep.equal([
-      {
-        name: "interesting-as-well.js",
-        changeType: "added",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-      {
-        name: "interesting-extension.js",
-        changeType: "added",
-        checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
-      },
-    ]);
+      [
+        {
+          name: "interesting-as-well.js",
+          changeType: "added",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+        {
+          name: "interesting-extension.js",
+          changeType: "added",
+          checksum: "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        },
+      ],
+    );
   });
 });

--- a/test/cache/metadata-strategy.spec.mjs
+++ b/test/cache/metadata-strategy.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual, match } from "node:assert";
 import MetaDataStrategy from "../../src/cache/metadata-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
@@ -40,7 +40,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
     } catch (pError) {
       lError = pError.message;
     }
-    expect(lError).to.match(/The --cache option works in concert with git/);
+    match(lError, /The --cache option works in concert with git/);
   });
 
   it("if one of the listed changes doesn't exist on disk it gets shasum 'file not found'", async () => {
@@ -51,7 +51,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "file-does-not-exist.aap",
       },
     ];
-    const lExpected = {
+    const lLstrictEqualed = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -62,19 +62,18 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
       ],
     };
 
-    expect(
-      await new MetaDataStrategy().getRevisionData(
-        null,
-        null,
-        { exclude: {}, includeOnly: {} },
-        {
-          extensions: INTERESTING_EXTENSIONS,
-          interestingChangeTypes: INTERESTING_CHANGE_TYPES,
-          shaRetrievalFn: () => DUMMY_SHA,
-          diffListFn: () => lInputChanges,
-        },
-      ),
-    ).to.deep.equal(lExpected);
+    const lFound = await new MetaDataStrategy().getRevisionData(
+      null,
+      null,
+      { exclude: {}, includeOnly: {} },
+      {
+        extensions: INTERESTING_EXTENSIONS,
+        interestingChangeTypes: INTERESTING_CHANGE_TYPES,
+        shaRetrievalFn: () => DUMMY_SHA,
+        diffListFn: () => lInputChanges,
+      },
+    );
+    deepStrictEqual(lFound, lLstrictEqualed);
   });
 
   it("if a listed change does exist on disk shasum is calculated", async () => {
@@ -85,7 +84,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "test/cache/__mocks__/calculate-shasum-of-this.aap",
       },
     ];
-    const lExpected = {
+    const lLstrictEqualed = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -95,39 +94,37 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         },
       ],
     };
-
-    expect(
-      await new MetaDataStrategy().getRevisionData(
-        null,
-        null,
-        { exclude: {}, includeOnly: {} },
-        {
-          extensions: INTERESTING_EXTENSIONS,
-          interestingChangeTypes: INTERESTING_CHANGE_TYPES,
-          shaRetrievalFn: () => DUMMY_SHA,
-          diffListFn: () => lInputChanges,
-        },
-      ),
-    ).to.deep.equal(lExpected);
+    const lFound = await new MetaDataStrategy().getRevisionData(
+      null,
+      null,
+      { exclude: {}, includeOnly: {} },
+      {
+        extensions: INTERESTING_EXTENSIONS,
+        interestingChangeTypes: INTERESTING_CHANGE_TYPES,
+        shaRetrievalFn: () => DUMMY_SHA,
+        diffListFn: () => lInputChanges,
+      },
+    );
+    deepStrictEqual(lFound, lLstrictEqualed);
   });
 
   it("if there's no changes the change set contains the passed sha & an empty array", async () => {
-    expect(
-      await new MetaDataStrategy().getRevisionData(
-        null,
-        null,
-        { exclude: {}, includeOnly: {} },
-        {
-          extensions: INTERESTING_EXTENSIONS,
-          interestingChangeTypes: INTERESTING_CHANGE_TYPES,
-          shaRetrievalFn: () => DUMMY_SHA,
-          diffListFn: () => [],
-        },
-      ),
-    ).to.deep.equal({
+    const lLstrictEqualed = {
       SHA1: DUMMY_SHA,
       changes: [],
-    });
+    };
+    const lFound = await new MetaDataStrategy().getRevisionData(
+      null,
+      null,
+      { exclude: {}, includeOnly: {} },
+      {
+        extensions: INTERESTING_EXTENSIONS,
+        interestingChangeTypes: INTERESTING_CHANGE_TYPES,
+        shaRetrievalFn: () => DUMMY_SHA,
+        diffListFn: () => [],
+      },
+    );
+    deepStrictEqual(lFound, lLstrictEqualed);
   });
 
   it("returns only the extensions passed", async () => {
@@ -156,21 +153,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "no-extension-hence-ignored",
       },
     ];
-
-    expect(
-      await new MetaDataStrategy().getRevisionData(
-        null,
-        null,
-        { exclude: {}, includeOnly: {} },
-        {
-          extensions: lLimitedExtensions,
-          interestingChangeTypes: INTERESTING_CHANGE_TYPES,
-          shaRetrievalFn: () => DUMMY_SHA,
-          diffListFn: () => lInputChanges,
-          checksumFn: dummyCheckSumFunction,
-        },
-      ),
-    ).to.deep.equal({
+    const lFound = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -185,7 +168,20 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
           checksum: "dummy-checksum",
         },
       ],
-    });
+    };
+    const lstrictEqualed = await new MetaDataStrategy().getRevisionData(
+      null,
+      null,
+      { exclude: {}, includeOnly: {} },
+      {
+        extensions: lLimitedExtensions,
+        interestingChangeTypes: INTERESTING_CHANGE_TYPES,
+        shaRetrievalFn: () => DUMMY_SHA,
+        diffListFn: () => lInputChanges,
+        checksumFn: dummyCheckSumFunction,
+      },
+    );
+    deepStrictEqual(lstrictEqualed, lFound);
   });
 
   it("returns only the changeTypes passed", async () => {
@@ -218,21 +214,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "untracked-hence-ignored.aap",
       },
     ];
-
-    expect(
-      await new MetaDataStrategy().getRevisionData(
-        null,
-        null,
-        { exclude: {}, includeOnly: {} },
-        {
-          extensions: INTERESTING_EXTENSIONS,
-          interestingChangeTypes: lLimitedChangeTypes,
-          shaRetrievalFn: () => DUMMY_SHA,
-          diffListFn: () => lInputChanges,
-          checksumFn: dummyCheckSumFunction,
-        },
-      ),
-    ).to.deep.equal({
+    const lLstrictEqualed = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -252,7 +234,21 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
           checksum: "dummy-checksum",
         },
       ],
-    });
+    };
+    const lFound = await new MetaDataStrategy().getRevisionData(
+      null,
+      null,
+      { exclude: {}, includeOnly: {} },
+      {
+        extensions: INTERESTING_EXTENSIONS,
+        interestingChangeTypes: lLimitedChangeTypes,
+        shaRetrievalFn: () => DUMMY_SHA,
+        diffListFn: () => lInputChanges,
+        checksumFn: dummyCheckSumFunction,
+      },
+    );
+
+    deepStrictEqual(lLstrictEqualed, lFound);
   });
 
   it("by default only returns a subset of change types", async () => {
@@ -304,21 +300,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "ignored-hence-ignored.aap",
       },
     ];
-
-    expect(
-      await new MetaDataStrategy().getRevisionData(
-        null,
-        null,
-        { exclude: {}, includeOnly: {} },
-        {
-          extensions: INTERESTING_EXTENSIONS,
-          // interestingChangeTypes NOT specified here
-          shaRetrievalFn: () => DUMMY_SHA,
-          diffListFn: () => lInputChanges,
-          checksumFn: dummyCheckSumFunction,
-        },
-      ),
-    ).to.deep.equal({
+    const lLstrictEqualed = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -358,7 +340,21 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
           checksum: "dummy-checksum",
         },
       ],
-    });
+    };
+    const lFound = await new MetaDataStrategy().getRevisionData(
+      null,
+      null,
+      { exclude: {}, includeOnly: {} },
+      {
+        extensions: INTERESTING_EXTENSIONS,
+        // interestingChangeTypes NOT specified here
+        shaRetrievalFn: () => DUMMY_SHA,
+        diffListFn: () => lInputChanges,
+        checksumFn: dummyCheckSumFunction,
+      },
+    );
+
+    deepStrictEqual(lLstrictEqualed, lFound);
   });
 });
 
@@ -383,62 +379,66 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   ];
 
   it("returns false when revision data objects are don't exist", () => {
-    expect(new MetaDataStrategy().revisionDataEqual(null, null)).to.equal(
-      false,
-    );
+    strictEqual(new MetaDataStrategy().revisionDataEqual(null, null), false);
   });
 
   it("returns false when old revision data object doesn't exist", () => {
-    expect(
+    strictEqual(
       new MetaDataStrategy().revisionDataEqual(null, {
         SHA1: "some-sha",
         changes: [],
       }),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns false when new revision data object doesn't exist", () => {
-    expect(
+    strictEqual(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         null,
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns false when sha-sums aren't equal", () => {
-    expect(
+    strictEqual(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-other-sha", changes: [] },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns false when sha-sums are equal, but changes are not", () => {
-    expect(
+    strictEqual(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: lChanges },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("returns true when sha-sums are equal, and changes are as well", () => {
-    expect(
+    strictEqual(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: lChanges },
         { SHA1: "some-sha", changes: lChanges },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("returns true when sha-sums are equal, and changes are as well (even when neither contain changes)", () => {
-    expect(
+    strictEqual(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: [] },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 });

--- a/test/cache/options-compatible.spec.mjs
+++ b/test/cache/options-compatible.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import {
   optionIsCompatible,
   filterOptionIsCompatible,
@@ -12,246 +12,261 @@ import {
 
 describe("[U] cache/options-compatible - optionIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {
-    expect(optionIsCompatible()).to.equal(true);
+    strictEqual(optionIsCompatible(), true);
   });
 
   it("if the old option doesn't exist, the new one is not compatible, whatever it is", () => {
-    expect(
+    strictEqual(
       // eslint-disable-next-line no-undefined
       optionIsCompatible(undefined, { path: ["aap", "noot", "mies"] }),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("if the old option exists, the new one is compatible when it's _exactly_ the same", () => {
-    expect(
+    strictEqual(
       optionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "noot", "mies"] },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("if the old option exists, the new one is _not_ compatible when it doesn't exist", () => {
-    expect(
+    strictEqual(
       optionIsCompatible({ path: ["aap", "noot", "mies"] }, null),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("if the old option exists, the new one is _not_ compatible when it isn't exactly the same", () => {
-    expect(
+    strictEqual(
       optionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "mies"] },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("if the old option equals false and the new one is as well, they're compatible", () => {
-    expect(optionIsCompatible(false, false)).to.equal(true);
+    strictEqual(optionIsCompatible(false, false), true);
   });
 
   it("if the old option equals false and the new one is true, they're _not_ compatible", () => {
-    expect(optionIsCompatible(false, true)).to.equal(false);
+    strictEqual(optionIsCompatible(false, true), false);
   });
 });
 
 describe("[U] cache/options-compatible - filterOptionIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {
-    expect(filterOptionIsCompatible()).to.equal(true);
+    strictEqual(filterOptionIsCompatible(), true);
   });
 
   it("if the old (filter) option doesn't exist, the new one is compatible, whatever it is", () => {
-    expect(
+    strictEqual(
       // eslint-disable-next-line no-undefined
       filterOptionIsCompatible(undefined, { path: ["aap", "noot", "mies"] }),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("if the old (filter) option is null, the new one is compatible, whatever it is", () => {
-    expect(
+    strictEqual(
       filterOptionIsCompatible(null, { path: ["aap", "noot", "mies"] }),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("if the old (filter) option exists, the new one is compatible when it's _exactly_ the same", () => {
-    expect(
+    strictEqual(
       filterOptionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "noot", "mies"] },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("if the old (filter) option exists, the new one is _not_ compatible when it doesn't exist", () => {
-    expect(
+    strictEqual(
       filterOptionIsCompatible({ path: ["aap", "noot", "mies"] }, null),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("if the old (filter) option exists, the new one is _not_ compatible when it isn't exactly the same", () => {
-    expect(
+    strictEqual(
       filterOptionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "mies"] },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("if the old (filter) option equals false and the new one is as well, they're compatible", () => {
-    expect(filterOptionIsCompatible(false, false)).to.equal(true);
+    strictEqual(filterOptionIsCompatible(false, false), true);
   });
 
   it("if the old (filter) option equals false and the new one is true, they're compatible", () => {
-    expect(filterOptionIsCompatible(false, true)).to.equal(true);
+    strictEqual(filterOptionIsCompatible(false, true), true);
   });
 });
 
 describe("[U] cache/options-compatible - includeOnlyIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {
-    expect(includeOnlyIsCompatible()).to.equal(true);
+    strictEqual(includeOnlyIsCompatible(), true);
   });
 
   it("if the old filter doesn't exist, the new one is compatible, whatever it is", () => {
-    expect(
+    strictEqual(
       includeOnlyIsCompatible(null, { path: ["aap", "noot", "mies"] }),
-    ).to.equal(true);
-  });
-
-  it("if the old filter exists, the new one is compatible when it's _exactly_ the same", () => {
-    expect(
-      includeOnlyIsCompatible(["aap", "noot", "mies"], {
-        path: ["aap", "noot", "mies"],
-      }),
-    ).to.equal(true);
-  });
-
-  it("if the old filter exists, the new one is _not_ compatible when it doesn't exist", () => {
-    expect(includeOnlyIsCompatible(["aap", "noot", "mies"], null)).to.equal(
-      false,
+      true,
     );
   });
 
+  it("if the old filter exists, the new one is compatible when it's _exactly_ the same", () => {
+    strictEqual(
+      includeOnlyIsCompatible(["aap", "noot", "mies"], {
+        path: ["aap", "noot", "mies"],
+      }),
+      true,
+    );
+  });
+
+  it("if the old filter exists, the new one is _not_ compatible when it doesn't exist", () => {
+    strictEqual(includeOnlyIsCompatible(["aap", "noot", "mies"], null), false);
+  });
+
   it("if the old filter exists, the new one is _not_ compatible when it isn't exactly the same", () => {
-    expect(
+    strictEqual(
       includeOnlyIsCompatible(["aap", "noot", "mies"], {
         path: ["aap", "mies"],
       }),
-    ).to.equal(false);
+      false,
+    );
   });
 });
 
 describe("[U] cache/options-compatible - limitIsCompatible", () => {
   it("if neither limit exists they're compatible", () => {
-    expect(limitIsCompatible()).to.equal(true);
+    strictEqual(limitIsCompatible(), true);
   });
 
   it("if the old limit doesn't exist compatible", () => {
-    expect(limitIsCompatible(null, 1)).to.equal(true);
+    strictEqual(limitIsCompatible(null, 1), true);
   });
 
   it("if the old limit exists and it's not infinite ('0') it's compatible when it's >= the new value", () => {
-    expect(limitIsCompatible(3, 3)).to.equal(true);
-    expect(limitIsCompatible(3, 2)).to.equal(true);
+    strictEqual(limitIsCompatible(3, 3), true);
+    strictEqual(limitIsCompatible(3, 2), true);
   });
 
   it("if the old limit exists and it's not infinite ('0') it's not compatible when it's < the new value", () => {
-    expect(limitIsCompatible(3, 4)).to.equal(false);
-    expect(limitIsCompatible(3, 0)).to.equal(false);
+    strictEqual(limitIsCompatible(3, 4), false);
+    strictEqual(limitIsCompatible(3, 0), false);
   });
 
   it("if the old limit exists and it's infinite ('0') it's compatible whatever the new value is", () => {
-    expect(limitIsCompatible(0, null)).to.equal(true);
-    expect(limitIsCompatible(0, 0)).to.equal(true);
-    expect(limitIsCompatible(0, 1)).to.equal(true);
-    expect(limitIsCompatible(0, 99)).to.equal(true);
+    strictEqual(limitIsCompatible(0, null), true);
+    strictEqual(limitIsCompatible(0, 0), true);
+    strictEqual(limitIsCompatible(0, 1), true);
+    strictEqual(limitIsCompatible(0, 99), true);
   });
 });
 
 describe("[U] cache/options-compatible - metricsIsCompatible", () => {
   it("if neither metrics exist they're compatible", () => {
-    expect(metricsIsCompatible()).to.equal(true);
+    strictEqual(metricsIsCompatible(), true);
   });
 
   it("is compatible when the old results have metrics and the new options don't", () => {
-    expect(metricsIsCompatible(true, false)).to.equal(true);
+    strictEqual(metricsIsCompatible(true, false), true);
   });
 
   it("is compatible when the old results have metrics and the new options also do", () => {
-    expect(metricsIsCompatible(true, true)).to.equal(true);
+    strictEqual(metricsIsCompatible(true, true), true);
   });
   it("is not compatible when the old results don't have metrics and the new options  do", () => {
-    expect(metricsIsCompatible(false, true)).to.equal(false);
+    strictEqual(metricsIsCompatible(false, true), false);
   });
   it("is compatible when the old results don't have metrics and the new options don't either", () => {
-    expect(metricsIsCompatible(false, false)).to.equal(true);
+    strictEqual(metricsIsCompatible(false, false), true);
   });
 });
 
 describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
   it("returns true when both equal 'true'", () => {
-    expect(cacheOptionIsCompatible(true, true)).to.equal(true);
+    strictEqual(cacheOptionIsCompatible(true, true), true);
   });
   it("returns true when are objects & they're 100% equal", () => {
-    expect(
+    strictEqual(
       cacheOptionIsCompatible(
         { folder: "x", strategy: "metadata" },
         { folder: "x", strategy: "metadata" },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
   it("returns false when are objects & the folders differ", () => {
-    expect(
+    strictEqual(
       cacheOptionIsCompatible(
         { folder: "x", strategy: "metadata" },
         { folder: "not-x", strategy: "metadata" },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
   it("returns false when both cache options are objects & the strategies differ", () => {
-    expect(
+    strictEqual(
       cacheOptionIsCompatible(
         { folder: "x", strategy: "metadata" },
         { folder: "x", strategy: "content" },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
   it("returns false when one cache option is an object and the other one isn't", () => {
-    expect(
+    strictEqual(
       cacheOptionIsCompatible(true, { folder: "x", strategy: "metadata" }),
-    ).to.equal(false);
-    expect(
+      false,
+    );
+    strictEqual(
       cacheOptionIsCompatible("x", { folder: "x", strategy: "metadata" }),
-    ).to.equal(false);
+      false,
+    );
   });
 });
 
 describe("[U] cache/options-compatible - optionsAreCompatible", () => {
   it("options are not compatible when there's none in either", () => {
-    expect(optionsAreCompatible({}, {})).to.equal(false);
+    strictEqual(optionsAreCompatible({}, {}), false);
   });
   it("options are compatible when there's none in either (except a cache option)", () => {
-    expect(optionsAreCompatible({ cache: true }, { cache: true })).to.equal(
-      true,
-    );
+    strictEqual(optionsAreCompatible({ cache: true }, { cache: true }), true);
   });
   it("options are compatible when args are exactly equal", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         { args: "aap noot mies", cache: true },
         { args: "aap noot mies", cache: true },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
   it("options are not compatible when args are not exactly equal", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         { args: "aap noot mies", cache: true },
         { args: "aap noot", cache: true },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
   it("options are compatible when also rulesFiles are exactly equal", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         {
           args: "aap",
@@ -266,10 +281,11 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
           cache: true,
         },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
   it("options are not compatible when also tsPreCompilationDeps are not exactly equal", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         {
           args: "aap",
@@ -284,11 +300,12 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
           cache: true,
         },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("options are compatible when also includeOnly filters are exactly equal", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         {
           args: "aap",
@@ -305,20 +322,22 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
           cache: true,
         },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 
   it("options are not compatible when also collapse filters are not compatible equal", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         { args: "aap", rulesFile: "thing.js", collapse: "zus", cache: true },
         { args: "aap", rulesFile: "thing.js", collapse: "jet", cache: true },
       ),
-    ).to.equal(false);
+      false,
+    );
   });
 
   it("options are compatible when also collapse filters are compatible", () => {
-    expect(
+    strictEqual(
       optionsAreCompatible(
         {
           args: "aap",
@@ -334,6 +353,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
           cache: true,
         },
       ),
-    ).to.equal(true);
+      true,
+    );
   });
 });

--- a/test/cli/asserthelpers.utl.mjs
+++ b/test/cli/asserthelpers.utl.mjs
@@ -1,19 +1,17 @@
 import { readFileSync } from "node:fs";
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import normalizeNewline from "normalize-newline";
 import normBaseDirectory from "../main/norm-base-directory.utl.mjs";
 
 export function assertFileEqual(pActualFileName, pExpectedFileName) {
-  expect(
+  deepStrictEqual(
     normalizeNewline(readFileSync(pActualFileName, { encoding: "utf8" })),
-  ).to.equal(
     normalizeNewline(readFileSync(pExpectedFileName, { encoding: "utf8" })),
   );
 }
 export function assertJSONFileEqual(pActualFileName, pExpectedFileName) {
-  expect(
+  deepStrictEqual(
     JSON.parse(readFileSync(pActualFileName, { encoding: "utf8" })),
-  ).to.deep.equal(
     normBaseDirectory(
       JSON.parse(readFileSync(pExpectedFileName, { encoding: "utf8" })),
     ),

--- a/test/cli/format-meta-info.spec.mjs
+++ b/test/cli/format-meta-info.spec.mjs
@@ -1,10 +1,11 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import meta from "../../src/cli/format-meta-info.mjs";
 
 describe("[U] cli/formatMetaInfo - transpiler formatted meta information", () => {
   it("tells which extensions can be scanned", () => {
-    expect(meta()).to.contain(
-      "If you need a supported, but not enabled transpiler",
+    strictEqual(
+      meta().includes("If you need a supported, but not enabled transpiler"),
+      true,
     );
   });
 });

--- a/test/cli/format.spec.mjs
+++ b/test/cli/format.spec.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import { readFileSync } from "node:fs";
+import { strictEqual } from "node:assert";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import format from "../../src/cli/format.mjs";
 import deleteDammit from "./delete-dammit.utl.cjs";
 
@@ -18,8 +18,11 @@ describe("[E] cli/format", () => {
       outputTo: lOutFile,
     });
 
-    expect(readFileSync(lOutFile, "utf8")).to.contain("dependencies cruised");
-    expect(lExitCode).to.equal(0);
+    strictEqual(
+      readFileSync(lOutFile, "utf8").includes("dependencies cruised"),
+      true,
+    );
+    strictEqual(lExitCode, 0);
     deleteDammit(lOutFile);
   });
 
@@ -37,23 +40,35 @@ describe("[E] cli/format", () => {
       },
     );
     const lResult = JSON.parse(readFileSync(lOutFile, "utf8"));
-    expect(lResult.summary.error).to.equal(0);
-    expect(lResult.summary.totalCruised).to.be.lessThan(175);
-    expect(lResult.summary.totalDependenciesCruised).to.be.lessThan(298);
-    expect(lResult.summary.violations.length).to.equal(1);
-    expect(lResult.modules.map((pModule) => pModule.source)).to.not.include(
-      "bin/depcruise-fmt.mjs",
+    strictEqual(lResult.summary.error, 0);
+    strictEqual(lResult.summary.totalCruised < 175, true);
+    strictEqual(lResult.summary.totalDependenciesCruised < 298, true);
+    strictEqual(lResult.summary.violations.length, 1);
+    strictEqual(
+      lResult.modules
+        .map((pModule) => pModule.source)
+        .includes("bin/depcruise-fmt.mjs"),
+      false,
     );
-    expect(lResult.modules.map((pModule) => pModule.source)).to.include(
-      "src/main/index.js",
+    strictEqual(
+      lResult.modules
+        .map((pModule) => pModule.source)
+        .includes("src/main/index.js"),
+      true,
     );
-    expect(lResult.modules.map((pModule) => pModule.source)).to.include(
-      "src/cli/index.js",
+    strictEqual(
+      lResult.modules
+        .map((pModule) => pModule.source)
+        .includes("src/cli/index.js"),
+      true,
     );
-    expect(lResult.modules.map((pModule) => pModule.source)).to.not.include(
-      "src/cli/init-config/index.js",
+    strictEqual(
+      lResult.modules
+        .map((pModule) => pModule.source)
+        .includes("src/cli/init-config/index.js"),
+      false,
     );
-    expect(lExitCode).to.equal(0);
+    strictEqual(lExitCode, 0);
     deleteDammit(lOutFile);
   });
 
@@ -73,7 +88,7 @@ describe("[E] cli/format", () => {
     );
     const lResult = JSON.parse(readFileSync(lOutFile, "utf8"));
 
-    expect(lResult.summary.optionsUsed.prefix).to.equal(lAlternatePrefix);
+    strictEqual(lResult.summary.optionsUsed.prefix, lAlternatePrefix);
 
     deleteDammit(lOutFile);
   });
@@ -90,7 +105,7 @@ describe("[E] cli/format", () => {
       },
     );
 
-    expect(lExitCode).to.equal(2);
+    strictEqual(lExitCode, 2);
     deleteDammit(lOutFile);
   });
 });

--- a/test/cli/index.spec.mjs
+++ b/test/cli/index.spec.mjs
@@ -1,10 +1,10 @@
-import { unlinkSync, readFileSync } from "node:fs";
+import { readFileSync, unlinkSync } from "node:fs";
 // path.posix instead of path because otherwise on win32 the resulting
 // outputTo would contain \\ instead of / which for this unit test doesn't matter
+import { doesNotThrow, strictEqual, throws } from "node:assert";
 import { join, posix as path } from "node:path";
-import { expect } from "chai";
-import intercept from "intercept-stdout";
 import chalk from "chalk";
+import intercept from "intercept-stdout";
 import cli from "../../src/cli/index.mjs";
 import { assertFileEqual, assertJSONFileEqual } from "./asserthelpers.utl.mjs";
 import deleteDammit from "./delete-dammit.utl.cjs";
@@ -183,7 +183,7 @@ function runFileBasedTests(pModuleType) {
     it(pPair.description, async () => {
       const lExitCode = await cli([pPair.dirOrFile], pPair.options);
 
-      expect(lExitCode).to.equal(pPair.expectExitCode);
+      strictEqual(lExitCode, pPair.expectExitCode);
       if (pPair.options.outputType === "json") {
         assertJSONFileEqual(
           pPair.options.outputTo,
@@ -232,7 +232,7 @@ describe("[E] cli/index", () => {
         },
       );
 
-      expect(lExitCode).to.equal(0);
+      strictEqual(lExitCode, 0);
       assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
     });
 
@@ -246,7 +246,7 @@ describe("[E] cli/index", () => {
       });
       const lExpectedTransgressions = 0;
 
-      expect(lExitCode).to.equal(lExpectedTransgressions);
+      strictEqual(lExitCode, lExpectedTransgressions);
     });
 
     it("returns the number of transgressions if outputType === 'error' ", async () => {
@@ -259,7 +259,7 @@ describe("[E] cli/index", () => {
       });
       const lExpectedTransgressions = 3;
 
-      expect(lExitCode).to.equal(lExpectedTransgressions);
+      strictEqual(lExitCode, lExpectedTransgressions);
     });
 
     it("dependency-cruise -i shows meta info about the current environment", async () => {
@@ -271,9 +271,12 @@ describe("[E] cli/index", () => {
 
       unhookIntercept();
 
-      expect(lExitCode).to.equal(0);
-      expect(lCapturedStdout).to.contain(
-        "If you need a supported, but not enabled transpiler",
+      strictEqual(lExitCode, 0);
+      strictEqual(
+        lCapturedStdout.includes(
+          "If you need a supported, but not enabled transpiler",
+        ),
+        true,
       );
     });
 
@@ -292,9 +295,12 @@ describe("[E] cli/index", () => {
       unhookInterceptStdOut();
       unhookInterceptStdError();
 
-      expect(lExitCode).to.equal(1);
-      expect(lCapturedStderr).to.contain(
-        "ERROR: Can't open 'this-doesnot-exist' for reading. Does it exist?\n",
+      strictEqual(lExitCode, 1);
+      strictEqual(
+        lCapturedStderr.includes(
+          "ERROR: Can't open 'this-doesnot-exist' for reading. Does it exist?\n",
+        ),
+        true,
       );
     });
 
@@ -316,9 +322,12 @@ describe("[E] cli/index", () => {
         lCapturedStderr += pText;
       })();
 
-      expect(lExitCode).to.equal(1);
-      expect(lCapturedStderr).to.contain(
-        "didn't work. Error: ENOENT: no such file or directory, open",
+      strictEqual(lExitCode, 1);
+      strictEqual(
+        lCapturedStderr.includes(
+          "didn't work. Error: ENOENT: no such file or directory, open",
+        ),
+        true,
       );
     });
 
@@ -338,8 +347,11 @@ describe("[E] cli/index", () => {
         lCapturedStderr += pText;
       })();
 
-      expect(lExitCode).to.equal(0);
-      expect(lCapturedStderr).to.contain("no dependency violations found");
+      strictEqual(lExitCode, 0);
+      strictEqual(
+        lCapturedStderr.includes("no dependency violations found"),
+        true,
+      );
     });
 
     it("dependency-cruise --init will generate a rules file and tells that back on stdout", async () => {
@@ -363,9 +375,12 @@ describe("[E] cli/index", () => {
         lCapturedStdout += pText;
       })();
 
-      expect(lExitCode).to.equal(0);
-      expect(lCapturedStdout).to.contain(
-        `Successfully created '${lValidationFileName}'`,
+      strictEqual(lExitCode, 0);
+      strictEqual(
+        lCapturedStdout.includes(
+          `Successfully created '${lValidationFileName}'`,
+        ),
+        true,
       );
       deleteDammit(lValidationFileName);
     });
@@ -383,7 +398,7 @@ describe("[E] cli/index", () => {
         },
       );
 
-      expect(lExitCode).to.equal(0);
+      strictEqual(lExitCode, 0);
       assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
     });
 
@@ -400,7 +415,7 @@ describe("[E] cli/index", () => {
         },
       );
 
-      expect(lExitCode).to.equal(0);
+      strictEqual(lExitCode, 0);
       assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
     });
   });
@@ -420,7 +435,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    expect(lExitCode).to.equal(0);
+    strictEqual(lExitCode, 0);
     assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
   });
 
@@ -439,7 +454,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    expect(lExitCode).to.equal(0);
+    strictEqual(lExitCode, 0);
     assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
   });
 
@@ -459,7 +474,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    expect(lExitCode).to.equal(0);
+    strictEqual(lExitCode, 0);
     assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
   });
 
@@ -475,7 +490,7 @@ describe("[E] cli/index", () => {
         "test/cli/__fixtures__/babel/es6/webpack-cache-bust.config.js",
     });
 
-    expect(lExitCode).to.equal(0);
+    strictEqual(lExitCode, 0);
     assertJSONFileEqual(
       lOutputTo,
       path.join(FIX_DIR, "babel", lOutputFileName),
@@ -494,7 +509,7 @@ describe("[E] cli/index", () => {
         "test/cli/__fixtures__/babel/ts/webpack-cache-bust.config.js",
     });
 
-    expect(lExitCode).to.equal(0);
+    strictEqual(lExitCode, 0);
     assertJSONFileEqual(
       lOutputTo,
       path.join(FIX_DIR, "babel", lOutputFileName),
@@ -515,7 +530,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    expect(lExitCode).to.equal(lExpectedAmountOfErrors);
+    strictEqual(lExitCode, lExpectedAmountOfErrors);
 
     // assertJSONFileEqual(
     //   lOutputTo,
@@ -539,14 +554,17 @@ describe("[E] cli/index", () => {
       },
     );
 
-    expect(lExitCode).to.equal(lExpectedAmountOfErrors);
-    expect(() => {
+    strictEqual(lExitCode, lExpectedAmountOfErrors);
+    doesNotThrow(() => {
       lResult = readFileSync(lOutputTo, { encoding: "utf8" });
-    }).to.not.throw();
-    expect(lResult).to.contain(
-      "1 dependency violations (1 errors, 0 warnings). 6 modules, 3 dependencies cruised",
+    });
+    strictEqual(
+      lResult.includes(
+        "1 dependency violations (1 errors, 0 warnings). 6 modules, 3 dependencies cruised",
+      ),
+      true,
     );
-    expect(lResult).to.contain("1 known violations ignored");
+    strictEqual(lResult.includes("1 known violations ignored"), true);
   });
 
   it("will barf when the known violations file is invalid", async () => {
@@ -565,10 +583,10 @@ describe("[E] cli/index", () => {
       },
     );
 
-    expect(lExitCode).to.equal(lExpectedAmountOfErrors);
-    expect(() => {
+    strictEqual(lExitCode, lExpectedAmountOfErrors);
+    throws(() => {
       readFileSync(lOutputTo, { encoding: "utf8" });
-    }).to.throw();
+    });
   });
 
   describe("[I] file based tests - commonJS", () => {

--- a/test/cli/init-config/create-config.spec.mjs
+++ b/test/cli/init-config/create-config.spec.mjs
@@ -2,13 +2,13 @@ import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path/posix";
 import { expect, use } from "chai";
-import chaiJsonSchema from "chai-json-schema";
+import Ajv from "ajv";
 import buildConfig from "../../../src/cli/init-config/build-config.mjs";
 import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";
 import configurationSchema from "../../../src/schema/configuration.schema.mjs";
 import deleteDammit from "../delete-dammit.utl.cjs";
 
-use(chaiJsonSchema);
+const ajv = new Ajv();
 
 const createConfigNormalized = async (pInitOptions) => {
   const lConfigAsString = buildConfig(normalizeInitOptions(pInitOptions));
@@ -37,7 +37,7 @@ describe("[I] cli/init-config/build-config", () => {
       configType: "preset",
     });
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.haveOwnProperty("extends");
     expect(lResult.extends).to.equal(
       "dependency-cruiser/configs/recommended-warn-only",
@@ -49,7 +49,7 @@ describe("[I] cli/init-config/build-config", () => {
 
     const lResult = await createConfigNormalized({});
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.not.haveOwnProperty("extends");
   });
 
@@ -61,7 +61,7 @@ describe("[I] cli/init-config/build-config", () => {
       preset: "@my/cool/company/configs/depcruise-preset",
     });
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.haveOwnProperty("forbidden");
     expect(lResult.extends).to.equal(
       "@my/cool/company/configs/depcruise-preset",
@@ -76,7 +76,7 @@ describe("[I] cli/init-config/build-config", () => {
       hasTestsOutsideSource: false,
     });
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.haveOwnProperty("forbidden");
     expect(
       lResult.forbidden.some((pRule) => pRule.name === "not-to-test"),
@@ -91,7 +91,7 @@ describe("[I] cli/init-config/build-config", () => {
       hasTestsOutsideSource: true,
     });
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.haveOwnProperty("forbidden");
     expect(
       lResult.forbidden.some((pRule) => pRule.name === "not-to-test"),
@@ -106,7 +106,7 @@ describe("[I] cli/init-config/build-config", () => {
       webpackConfig: "./webpack.prod.js",
     });
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.haveOwnProperty("options");
     expect(lResult.options.webpackConfig).to.deep.equal({
       fileName: "./webpack.prod.js",
@@ -121,7 +121,7 @@ describe("[I] cli/init-config/build-config", () => {
       tsConfig: "./tsconfig.json",
     });
 
-    expect(lResult).to.be.jsonSchema(configurationSchema);
+    ajv.validate(configurationSchema, lResult);
     expect(lResult).to.haveOwnProperty("options");
     expect(lResult.options.tsConfig).to.deep.equal({
       fileName: "./tsconfig.json",

--- a/test/cli/init-config/create-config.spec.mjs
+++ b/test/cli/init-config/create-config.spec.mjs
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path/posix";
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import buildConfig from "../../../src/cli/init-config/build-config.mjs";
 import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";

--- a/test/cli/init-config/find-extensions.spec.mjs
+++ b/test/cli/init-config/find-extensions.spec.mjs
@@ -1,15 +1,15 @@
-import { expect } from "chai";
+import { deepStrictEqual, throws } from "node:assert";
 import findExtensions from "../../../src/cli/init-config/find-extensions.mjs";
 
 describe("[U] cli/init-config/find-extensions", () => {
   it("returns an empty array of extensions when passed no directories", () => {
-    expect(findExtensions([])).to.deep.equal([]);
+    deepStrictEqual(findExtensions([]), []);
   });
 
   it("throws when passed non-existent folders", () => {
-    expect(() => {
+    throws(() => {
       findExtensions(["yo-this-folder-does-not-exist", "and neither this one"]);
-    }).to.throw(/ENOENT/);
+    }, /ENOENT/);
   });
 
   it("returns an empty array of extension when passed a directory with files that have no extensions", () => {
@@ -18,7 +18,7 @@ describe("[U] cli/init-config/find-extensions", () => {
       scannableExtensions: [".js", ".mjs", ".cjs", ".jsx"],
     });
 
-    expect(lFound).to.deep.equal([]);
+    deepStrictEqual(lFound, []);
   });
 
   it("filters scannable extensions from all extensions", () => {
@@ -27,7 +27,7 @@ describe("[U] cli/init-config/find-extensions", () => {
       scannableExtensions: [".js", ".mjs", ".cjs", ".jsx"],
     });
 
-    expect(lFound).to.deep.equal([".js", ".cjs"]);
+    deepStrictEqual(lFound, [".js", ".cjs"]);
   });
 
   it("sorts by the number of times the extension occurs", () => {
@@ -48,7 +48,7 @@ describe("[U] cli/init-config/find-extensions", () => {
       ],
     });
 
-    expect(lFound).to.deep.equal([".js", ".ts", ".cjs", ".d.mts"]);
+    deepStrictEqual(lFound, [".js", ".ts", ".cjs", ".d.mts"]);
   });
 
   it("ignores path elements that aren't worth scanning", () => {
@@ -71,6 +71,6 @@ describe("[U] cli/init-config/find-extensions", () => {
       ],
     });
 
-    expect(lFound).to.deep.equal([".ts", ".d.mts"]);
+    deepStrictEqual(lFound, [".ts", ".d.mts"]);
   });
 });

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -1,12 +1,12 @@
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { use, expect } from "chai";
-import chaiJsonSchema from "chai-json-schema";
+import Ajv from "ajv";
 import deleteDammit from "../delete-dammit.utl.cjs";
 import initConfig from "../../../src/cli/init-config/index.mjs";
 import configurationSchema from "../../../src/schema/configuration.schema.mjs";
 
-use(chaiJsonSchema);
+const ajv = new Ajv();
 
 const RULES_FILE_JS = ".dependency-cruiser.js";
 
@@ -28,7 +28,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("notyes");
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(lResult.default).to.not.haveOwnProperty("extends");
     } finally {
       deleteDammit(RULES_FILE_JS);
@@ -47,7 +47,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("preset", lConfig);
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(lResult.default).to.haveOwnProperty("extends");
       expect(lResult.default.extends).to.equal(
         "dependency-cruiser/configs/recommended-strict",
@@ -69,7 +69,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("yes", lConfig);
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(lResult.default).to.not.haveOwnProperty("extends");
       expect(lResult.default.options).to.not.haveOwnProperty("tsConfig");
     } finally {
@@ -88,7 +88,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("yes");
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(lResult.default).to.not.haveOwnProperty("extends");
       expect(lResult.default.options).to.haveOwnProperty("tsConfig");
       expect(lResult.default.options.tsConfig).to.deep.equal({
@@ -110,7 +110,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("yes");
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(lResult.default).to.not.haveOwnProperty("extends");
       expect(lResult.default.options).to.haveOwnProperty("webpackConfig");
       expect(lResult.default.options.webpackConfig).to.deep.equal({
@@ -136,7 +136,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("experimental-scripts");
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(
         JSON.parse(readFileSync(lManifestFilename, "utf8")),
       ).to.haveOwnProperty("scripts");
@@ -162,7 +162,7 @@ describe("[I] cli/init-config/index", () => {
       initConfig("experimental-scripts");
       const lResult = await import(lConfigResultFileName);
 
-      expect(lResult.default).to.be.jsonSchema(configurationSchema);
+      ajv.validate(configurationSchema, lResult.default);
       expect(lResult.default).to.deep.equal({});
       expect(
         JSON.parse(readFileSync(lManifestFilename, "utf8")),

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -1,5 +1,6 @@
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { deepStrictEqual } from "node:assert";
 import { expect } from "chai";
 import Ajv from "ajv";
 import deleteDammit from "../delete-dammit.utl.cjs";
@@ -163,7 +164,7 @@ describe("[I] cli/init-config/index", () => {
       const lResult = await import(lConfigResultFileName);
 
       ajv.validate(configurationSchema, lResult.default);
-      expect(lResult.default).to.deep.equal({});
+      deepStrictEqual(lResult.default, {});
       expect(
         JSON.parse(readFileSync(lManifestFilename, "utf8")),
       ).to.haveOwnProperty("scripts");

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { use, expect } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import deleteDammit from "../delete-dammit.utl.cjs";
 import initConfig from "../../../src/cli/init-config/index.mjs";

--- a/test/cli/init-config/write-config.spec.mjs
+++ b/test/cli/init-config/write-config.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect } from "chai";
@@ -59,7 +60,7 @@ describe("[U] cli/init-config/write-config", () => {
       expect(pError.message).to.contain("already exists here - leaving it be");
     }
 
-    expect(lStillHere).to.equal(false);
+    strictEqual(lStillHere, false);
 
     expect(readFileSync(RULES_FILE_JS, "utf8")).to.equal("module.exports = {}");
   });

--- a/test/cli/listeners/performance-log-listener/handlers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/handlers.spec.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable no-magic-numbers */
+import { match } from "node:assert";
 import { expect } from "chai";
 import {
   getHeader,
@@ -68,7 +69,8 @@ describe("[U] cli/listeners/performance-log/handlers - getEndText", () => {
   });
 
   it("message contains a line with totals", () => {
-    expect(getEndText(lStateMock, 10, MAX_LEVEL)).to.match(
+    match(
+      getEndText(lStateMock, 10, MAX_LEVEL),
       /really done\n------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------\n[ ]*[+-]?[0-9,]+kB[ ]*[+-]?[0-9,]+kB[ ]*[+-]?[0-9,]+kB[ ]*[+-]?[0-9,]+kB[ ]*[0-9,]+ms[ ]*[0-9,]+ms[ ]*[0-9,]+ms/g,
     );
   });

--- a/test/cli/listeners/performance-log-listener/handlers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/handlers.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable no-magic-numbers */
-import { match } from "node:assert";
+import { match, strictEqual } from "node:assert";
 import { expect } from "chai";
 import {
   getHeader,
@@ -48,7 +48,7 @@ describe("[U] cli/listeners/performance-log/handlers - getProgressLine", () => {
     expect(
       getProgressLine("next message", lUpdatableStateMock, 10, MAX_LEVEL),
     ).to.match(/previous message/);
-    expect(lUpdatableStateMock.previousMessage).to.equal("next message");
+    strictEqual(lUpdatableStateMock.previousMessage, "next message");
     expect(lUpdatableStateMock.previousTime).to.not.equal(lPreviousTime);
   });
 });

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -1,5 +1,6 @@
+/* eslint-disable no-prototype-builtins */
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import normalizeCliOptions, {
   determineRulesFileName,
 } from "../../src/cli/normalize-cli-options.mjs";
@@ -13,7 +14,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("normalizes empty options to no exclude, stdout, json and 'cjs, amd, es6'", async () => {
-    expect(await normalizeCliOptions({})).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({}), {
       outputTo: "-",
       outputType: "err",
       validate: false,
@@ -21,9 +22,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("normalizes --module-systems cjs,es6 to [cjs, es6]", async () => {
-    expect(
-      await normalizeCliOptions({ moduleSystems: "cjs,es6" }),
-    ).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ moduleSystems: "cjs,es6" }), {
       outputTo: "-",
       outputType: "err",
       moduleSystems: ["cjs", "es6"],
@@ -35,16 +34,12 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
     const lNormalizedCliOptions = await normalizeCliOptions({
       moduleSystems: " amd,cjs ,  es6 ",
     });
-    expect(lNormalizedCliOptions.moduleSystems).to.deep.equal([
-      "amd",
-      "cjs",
-      "es6",
-    ]);
+    deepStrictEqual(lNormalizedCliOptions.moduleSystems, ["amd", "cjs", "es6"]);
   });
 
   it("-c / --config without params gets translated to -v/ --validate.", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/json-only");
-    expect(await normalizeCliOptions({ config: true })).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ config: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.json",
@@ -56,16 +51,17 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("-c / --config with something gets translated to -v/ --validate.", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/json-only");
-    expect(
+    deepStrictEqual(
       await normalizeCliOptions({ config: ".dependency-cruiser.json" }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      rulesFile: ".dependency-cruiser.json",
-      ruleSet: {},
-      config: ".dependency-cruiser.json",
-      validate: true,
-    });
+      {
+        outputTo: "-",
+        outputType: "err",
+        rulesFile: ".dependency-cruiser.json",
+        ruleSet: {},
+        config: ".dependency-cruiser.json",
+        validate: true,
+      },
+    );
   });
 
   it("-v argument assumes .dependency-cruiser.json for rules (and borks if it doesn't exist)", async () => {
@@ -73,13 +69,13 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
     try {
       await normalizeCliOptions({ validate: true });
     } catch (pError) {
-      expect(pError.message).to.include(".dependency-cruiser.(c)js");
+      strictEqual(pError.message.includes(".dependency-cruiser.(c)js"), true);
     }
   });
 
   it("-v finds .dependency-cruiser.js when no parameters to it are passed and it exists", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/js-only");
-    expect(await normalizeCliOptions({ validate: true })).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ validate: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.js",
@@ -90,7 +86,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("-v finds .dependency-cruiser.json when no parameters to it are passed and it exists", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/json-only");
-    expect(await normalizeCliOptions({ validate: true })).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ validate: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.json",
@@ -101,7 +97,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("-v finds .dependency-cruiser.json when no parameters to it are passed and also the .js variant exists", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/both-js-and-json");
-    expect(await normalizeCliOptions({ validate: true })).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ validate: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.json",
@@ -116,72 +112,78 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
         validate: "./non-existing-config-file-name",
       });
     } catch (pError) {
-      expect(pError.message).to.include("./non-existing-config-file-name");
+      strictEqual(
+        pError.message.includes("non-existing-config-file-name"),
+        true,
+      );
     }
   });
 
   it("-v with parameter uses that parameter as rules file", async () => {
-    expect(
+    deepStrictEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.empty.json",
       }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      rulesFile: "./test/cli/__fixtures__/rules.empty.json",
-      ruleSet: {},
-      validate: true,
-    });
+      {
+        outputTo: "-",
+        outputType: "err",
+        rulesFile: "./test/cli/__fixtures__/rules.empty.json",
+        ruleSet: {},
+        validate: true,
+      },
+    );
   });
 
   it("a rules file with comments gets the comments stripped out & parsed", async () => {
-    expect(
+    deepStrictEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.withcomments.json",
       }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      rulesFile: "./test/cli/__fixtures__/rules.withcomments.json",
-      ruleSet: {
-        forbidden: [
-          {
-            name: "sub-not-allowed",
-            severity: "warn",
-            from: {},
-            to: {
-              path: "sub",
+      {
+        outputTo: "-",
+        outputType: "err",
+        rulesFile: "./test/cli/__fixtures__/rules.withcomments.json",
+        ruleSet: {
+          forbidden: [
+            {
+              name: "sub-not-allowed",
+              severity: "warn",
+              from: {},
+              to: {
+                path: "sub",
+              },
             },
-          },
-        ],
+          ],
+        },
+        validate: true,
       },
-      validate: true,
-    });
+    );
   });
 
   it("accepts and interprets a javascript rule file (relative path)", async () => {
-    expect(
+    deepStrictEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.withcomments.js",
       }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      rulesFile: "./test/cli/__fixtures__/rules.withcomments.js",
-      ruleSet: {
-        forbidden: [
-          {
-            name: "sub-not-allowed",
-            severity: "warn",
-            from: {},
-            to: {
-              path: "sub",
+      {
+        outputTo: "-",
+        outputType: "err",
+        rulesFile: "./test/cli/__fixtures__/rules.withcomments.js",
+        ruleSet: {
+          forbidden: [
+            {
+              name: "sub-not-allowed",
+              severity: "warn",
+              from: {},
+              to: {
+                path: "sub",
+              },
             },
-          },
-        ],
+          ],
+        },
+        validate: true,
       },
-      validate: true,
-    });
+    );
   });
 
   it("accepts and interprets a javascript rule file (absolute path)", async () => {
@@ -189,9 +191,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       new URL("__fixtures__/rules.withcomments.js", import.meta.url),
     );
 
-    expect(
-      await normalizeCliOptions({ validate: lRulesFileName }),
-    ).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ validate: lRulesFileName }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: lRulesFileName,
@@ -212,140 +212,125 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("defaults tsConfig.fileName to 'tsconfig.json' if it wasn't specified", async () => {
-    expect(
+    deepStrictEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.tsConfigNoFileName.json",
       }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      rulesFile: "./test/cli/__fixtures__/rules.tsConfigNoFileName.json",
-      ruleSet: {
-        options: {
-          tsConfig: {
-            fileName: "tsconfig.json",
-          },
-        },
-      },
-      validate: true,
-    });
-  });
-
-  it("defaults webpackConfig.fileName to 'tsconfig.json' if it wasn't specified", async () => {
-    expect(
-      await normalizeCliOptions({
-        validate: "./test/cli/__fixtures__/rules.webpackConfigNoFileName.json",
-      }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      rulesFile: "./test/cli/__fixtures__/rules.webpackConfigNoFileName.json",
-      ruleSet: {
-        options: {
-          webpackConfig: {
-            fileName: "webpack.config.js",
-          },
-        },
-      },
-      validate: true,
-    });
-  });
-
-  it("progress without parameter defaults to cli-feedback", async () => {
-    expect(await normalizeCliOptions({ progress: true })).to.contain({
-      progress: "cli-feedback",
-    });
-  });
-
-  it("progress with parameter none ends up as progress: none", async () => {
-    expect(
-      await normalizeCliOptions({ progress: "performance-log" }),
-    ).to.contain({
-      progress: "performance-log",
-    });
-  });
-
-  it("cache with value true translates to {}", async () => {
-    expect(await normalizeCliOptions({ cache: true })).to.deep.contain({
-      cache: {},
-    });
-  });
-
-  it("cache with a string value translates to the folder name in the cache option", async () => {
-    expect(await normalizeCliOptions({ cache: "some-string" })).to.deep.contain(
       {
-        cache: { folder: "some-string" },
+        outputTo: "-",
+        outputType: "err",
+        rulesFile: "./test/cli/__fixtures__/rules.tsConfigNoFileName.json",
+        ruleSet: {
+          options: {
+            tsConfig: {
+              fileName: "tsconfig.json",
+            },
+          },
+        },
+        validate: true,
       },
     );
   });
 
-  it("cache with an numerical value (which is invalid) translates to explicitly false cache option", async () => {
-    expect(await normalizeCliOptions({ cache: 481 })).to.deep.contain({
-      cache: false,
-    });
+  it("defaults webpackConfig.fileName to 'tsconfig.json' if it wasn't specified", async () => {
+    deepStrictEqual(
+      await normalizeCliOptions({
+        validate: "./test/cli/__fixtures__/rules.webpackConfigNoFileName.json",
+      }),
+      {
+        outputTo: "-",
+        outputType: "err",
+        rulesFile: "./test/cli/__fixtures__/rules.webpackConfigNoFileName.json",
+        ruleSet: {
+          options: {
+            webpackConfig: {
+              fileName: "webpack.config.js",
+            },
+          },
+        },
+        validate: true,
+      },
+    );
   });
 
-  it("cache with value true translates explicitly false cache option", async () => {
-    expect(await normalizeCliOptions({ cache: false })).to.deep.contain({
-      cache: false,
-    });
+  it("progress without parameter defaults to cli-feedback", async () => {
+    const lResult = await normalizeCliOptions({ progress: true });
+    strictEqual(lResult.progress, "cli-feedback");
+  });
+
+  it("progress with parameter none ends up as progress: none", async () => {
+    const lResult = await normalizeCliOptions({ progress: "none" });
+    strictEqual(lResult.progress, "none");
+  });
+
+  it("cache with value true translates to {}", async () => {
+    const lResult = await normalizeCliOptions({ cache: true });
+    deepStrictEqual(lResult.cache, {});
+  });
+
+  it("cache with a string value translates to the folder name in the cache option", async () => {
+    const lResult = await normalizeCliOptions({ cache: "some-string" });
+    deepStrictEqual(lResult.cache, { folder: "some-string" });
+  });
+
+  it("cache with an numerical value (which is invalid) translates to explicitly false cache option", async () => {
+    const lResult = await normalizeCliOptions({ cache: 481 });
+    strictEqual(lResult.cache, false);
+  });
+
+  it("cache with value false translates explicitly false cache option", async () => {
+    const lResult = await normalizeCliOptions({ cache: false });
+    strictEqual(lResult.cache, false);
   });
 
   it("no cache option translates to still not having a cache option", async () => {
-    expect(
-      await normalizeCliOptions({ "not-a-cache-option": true }),
-    ).to.not.haveOwnProperty("cache");
+    const lResult = await normalizeCliOptions({ "not-a-cache-option": true });
+    strictEqual(lResult.hasOwnProperty("cache"), false);
   });
 
   it("cache-strategy with a string value == 'content' translates to the strategy 'content' in the cache option", async () => {
-    expect(
-      await normalizeCliOptions({ cacheStrategy: "content" }),
-    ).to.deep.contain({
-      cache: { strategy: "content" },
-    });
+    const lResult = await normalizeCliOptions({ cacheStrategy: "content" });
+    deepStrictEqual(lResult.cache, { strategy: "content" });
   });
 
   it("cache-strategy with a string value !== 'content' translates to the strategy 'metadata' in the cache option", async () => {
-    expect(
-      await normalizeCliOptions({ cacheStrategy: "some-string" }),
-    ).to.deep.contain({
-      cache: { strategy: "metadata" },
-    });
+    const lResult = await normalizeCliOptions({ cacheStrategy: "some-string" });
+    deepStrictEqual(lResult.cache, { strategy: "metadata" });
   });
 
   it("cache with a string value & cache-strategy with a string value translates both present in the cache option", async () => {
-    expect(
-      await normalizeCliOptions({
-        cache: "somewhere",
-        cacheStrategy: "some-string",
-      }),
-    ).to.deep.contain({
-      cache: { folder: "somewhere", strategy: "metadata" },
+    const lResult = await normalizeCliOptions({
+      cache: "somewhere",
+      cacheStrategy: "some-string",
+    });
+    deepStrictEqual(lResult.cache, {
+      folder: "somewhere",
+      strategy: "metadata",
     });
   });
 
   it("cache with a value of true & cache-strategy with a string value translates to a cache option with that strategy", async () => {
-    expect(
-      await normalizeCliOptions({ cache: true, cacheStrategy: "metadata" }),
-    ).to.deep.contain({
-      cache: { strategy: "metadata" },
+    const lResult = await normalizeCliOptions({
+      cache: true,
+      cacheStrategy: "metadata",
     });
+    deepStrictEqual(lResult.cache, { strategy: "metadata" });
   });
 
   it("cache with a value of false & cache-strategy with a string value translates to a cache option with that strategy", async () => {
-    expect(
-      await normalizeCliOptions({ cache: false, cacheStrategy: "metadata" }),
-    ).to.deep.contain({
-      cache: { strategy: "metadata" },
+    const lResult = await normalizeCliOptions({
+      cache: false,
+      cacheStrategy: "metadata",
     });
+    deepStrictEqual(lResult.cache, { strategy: "metadata" });
   });
 
   it("cache with a value of true & cache-strategy with a string value translates to a cache option with that strategy x", async () => {
-    expect(
-      await normalizeCliOptions({ cache: true, cacheStrategy: "content" }),
-    ).to.deep.contain({
-      cache: { strategy: "content" },
+    const lResult = await normalizeCliOptions({
+      cache: true,
+      cacheStrategy: "content",
     });
+    deepStrictEqual(lResult.cache, { strategy: "content" });
   });
 });
 
@@ -358,7 +343,7 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
 
   it("--ignore-known without params gets the default known-violations json", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
-    expect(await normalizeCliOptions({ ignoreKnown: true })).to.deep.equal({
+    deepStrictEqual(await normalizeCliOptions({ ignoreKnown: true }), {
       outputTo: "-",
       outputType: "err",
       knownViolationsFile: ".dependency-cruiser-known-violations.json",
@@ -369,17 +354,18 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
 
   it("--ignore-known with params gets the mentioned known-violations", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
-    expect(
+    deepStrictEqual(
       await normalizeCliOptions({
         ignoreKnown: "custom-known-violations.json",
       }),
-    ).to.deep.equal({
-      outputTo: "-",
-      outputType: "err",
-      knownViolationsFile: "custom-known-violations.json",
-      ignoreKnown: "custom-known-violations.json",
-      validate: false,
-    });
+      {
+        outputTo: "-",
+        outputType: "err",
+        knownViolationsFile: "custom-known-violations.json",
+        ignoreKnown: "custom-known-violations.json",
+        validate: false,
+      },
+    );
   });
 
   it("--ignore-known with non-existing file as param throws", async () => {
@@ -393,22 +379,25 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
     } catch (pError) {
       lError = pError.toString();
     }
-    expect(lError).to.contain(
-      `Can't open 'this-file-does-not-exist' for reading. Does it exist?`,
+    strictEqual(
+      lError.includes(
+        `Can't open 'this-file-does-not-exist' for reading. Does it exist?`,
+      ),
+      true,
     );
   });
 });
 
 describe("[U] cli/determineRulesFileName", () => {
   it("returns '.dependency-cruiser.json' when no file name is passed", () => {
-    expect(determineRulesFileName()).to.equal(".dependency-cruiser.json");
+    strictEqual(determineRulesFileName(), ".dependency-cruiser.json");
   });
 
   it("returns '.dependency-cruiser.json' when a non-string is passed", () => {
-    expect(determineRulesFileName(true)).to.equal(".dependency-cruiser.json");
+    strictEqual(determineRulesFileName(true), ".dependency-cruiser.json");
   });
 
   it("returns string passed when a string is passed", () => {
-    expect(determineRulesFileName("a string")).to.equal("a string");
+    strictEqual(determineRulesFileName("a string"), "a string");
   });
 });

--- a/test/cli/tools/wrap-stream-in-html.spec.mjs
+++ b/test/cli/tools/wrap-stream-in-html.spec.mjs
@@ -1,6 +1,6 @@
 import { createReadStream } from "node:fs";
 import { Writable } from "node:stream";
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import wrapStreamInHTML from "../../../src/cli/tools/wrap-stream-in-html.mjs";
 
 class WriteableExpectStream extends Writable {
@@ -13,10 +13,10 @@ class WriteableExpectStream extends Writable {
   }
 
   end() {
-    expect(this.buffer).to.contain("<html");
-    expect(this.buffer).to.contain("<style>");
-    expect(this.buffer).to.contain('"name": "dependency-cruiser"');
-    expect(this.buffer).to.contain("</html");
+    strictEqual(this.buffer.includes("<html"), true);
+    strictEqual(this.buffer.includes("</style>"), true);
+    strictEqual(this.buffer.includes('"name": "dependency-cruiser"'), true);
+    strictEqual(this.buffer.includes("</html"), true);
   }
 }
 

--- a/test/cli/utl/io.spec.mjs
+++ b/test/cli/utl/io.spec.mjs
@@ -1,8 +1,7 @@
-/* eslint-disable no-unused-expressions */
 import { ReadStream } from "node:fs";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual, notDeepStrictEqual, strictEqual } from "node:assert";
 import { getInStream } from "../../../src/cli/utl/io.mjs";
 
 describe("[U] cli/utl/io", () => {
@@ -11,21 +10,21 @@ describe("[U] cli/utl/io", () => {
   );
 
   it("getInStream(OUTFILE) yields a readable stream", () => {
-    expect(getInStream(OUTFILE) instanceof Readable).to.be.true;
+    strictEqual(getInStream(OUTFILE) instanceof Readable, true);
   });
   it("getInStream(OUTFILE) yields a readable file stream", () => {
-    expect(getInStream(OUTFILE) instanceof ReadStream).to.be.true;
+    strictEqual(getInStream(OUTFILE) instanceof ReadStream, true);
   });
-  it("getInStream(OUTFILE) does not yields stdin", () => {
-    expect(getInStream(OUTFILE)).to.not.equal(process.stdin);
+  it("getInStream(OUTFILE) does not yield stdin", () => {
+    notDeepStrictEqual(getInStream(OUTFILE), process.stdin);
   });
   it("getInStream('-') is a readable stream", () => {
-    expect(getInStream("-") instanceof Readable).to.be.true;
+    strictEqual(getInStream("-") instanceof Readable, true);
   });
   it("getInStream('-') yields stdin", () => {
-    expect(getInStream("-")).to.equal(process.stdin);
+    deepStrictEqual(getInStream("-"), process.stdin);
   });
   it("getInStream('-') does not yield a file stream", () => {
-    expect(getInStream("-") instanceof ReadStream).to.be.false;
+    strictEqual(getInStream("-") instanceof ReadStream, false);
   });
 });

--- a/test/cli/utl/validate-file-existence.spec.mjs
+++ b/test/cli/utl/validate-file-existence.spec.mjs
@@ -1,5 +1,4 @@
 import { doesNotThrow, throws } from "node:assert";
-import { EOL } from "node:os";
 import validateFileExistence from "../../../src/cli/utl/validate-file-existence.mjs";
 
 describe("[U] cli/utl/validateFileExistence", () => {
@@ -9,7 +8,8 @@ describe("[U] cli/utl/validateFileExistence", () => {
         validateFileExistence("file-or-dir-does-not-exist");
       },
       {
-        message: `Can't open 'file-or-dir-does-not-exist' for reading. Does it exist?${EOL}`,
+        // even on windows it apparently uses \n only, so no need to use EOL
+        message: `Can't open 'file-or-dir-does-not-exist' for reading. Does it exist?\n`,
       },
     );
   });

--- a/test/cli/utl/validate-file-existence.spec.mjs
+++ b/test/cli/utl/validate-file-existence.spec.mjs
@@ -1,18 +1,22 @@
-import { expect } from "chai";
+import { doesNotThrow, throws } from "node:assert";
+import { EOL } from "node:os";
 import validateFileExistence from "../../../src/cli/utl/validate-file-existence.mjs";
 
 describe("[U] cli/utl/validateFileExistence", () => {
   it("throws when the file or dir passed does not exists", () => {
-    expect(() => {
-      validateFileExistence("file-or-dir-does-not-exist");
-    }).to.throw(
-      "Can't open 'file-or-dir-does-not-exist' for reading. Does it exist?",
+    throws(
+      () => {
+        validateFileExistence("file-or-dir-does-not-exist");
+      },
+      {
+        message: `Can't open 'file-or-dir-does-not-exist' for reading. Does it exist?${EOL}`,
+      },
     );
   });
 
   it("passes when the file or dir passed exists", () => {
-    expect(() => {
+    doesNotThrow(() => {
       validateFileExistence("package.json");
-    }).to.not.throw();
+    });
   });
 });

--- a/test/cli/validate-node-environment.spec.mjs
+++ b/test/cli/validate-node-environment.spec.mjs
@@ -1,46 +1,46 @@
-import { expect } from "chai";
+import { doesNotThrow, throws } from "node:assert";
 import validateNodeEnvironment from "../../src/cli/validate-node-environment.mjs";
 
 describe("[U] cli/validateNodeEnv", () => {
   it("throws when an older and unsupported node version is passed", () => {
-    expect(() => {
+    throws(() => {
       validateNodeEnvironment("6.0.0");
-    }).to.throw();
+    });
   });
 
   it("throws when a newer but unsupported node version is passed", () => {
-    expect(() => {
+    throws(() => {
       validateNodeEnvironment("9.0.0");
-    }).to.throw();
+    });
   });
 
   it("doesn't throw when an empty node version is passed (assuming test is run on a supported platform)", () => {
-    expect(() => {
+    doesNotThrow(() => {
       validateNodeEnvironment("");
-    }).to.not.throw();
+    });
   });
 
   it("doesn't throw when a null node version is passed (assuming test is run on a supported platform)", () => {
-    expect(() => {
+    doesNotThrow(() => {
       validateNodeEnvironment(null);
-    }).to.not.throw();
+    });
   });
 
   it("doesn't throw when an undefined node version is passed (assuming test is run on a supported platform)", () => {
-    expect(() => {
+    doesNotThrow(() => {
       validateNodeEnvironment();
-    }).to.not.throw();
+    });
   });
 
   it("doesn't throw when no node version is passed (assuming this test is run on a supported platform ...)", () => {
-    expect(() => {
+    doesNotThrow(() => {
       validateNodeEnvironment();
-    }).to.not.throw();
+    });
   });
 
   it("doesn't throw when a supported node version is passed", () => {
-    expect(() => {
+    doesNotThrow(() => {
       validateNodeEnvironment("18.0.0");
-    }).to.not.throw();
+    });
   });
 });

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -1,9 +1,9 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { fileURLToPath } from "node:url";
-import { strictEqual } from "node:assert";
-import omit from "lodash/omit.js";
 import { expect } from "chai";
-import pathToPosix from "../../src/utl/path-to-posix.mjs";
+import omit from "lodash/omit.js";
 import extractBabelConfig from "../../src/config-utl/extract-babel-config.mjs";
+import pathToPosix from "../../src/utl/path-to-posix.mjs";
 
 function getFullPath(pRelativePath) {
   return fileURLToPath(new URL(pRelativePath, import.meta.url));
@@ -117,7 +117,7 @@ describe("[I] config-utl/extract-babel-config", () => {
       getFullPath("./__mocks__/babelconfig/babelrc.with-a-preset.json"),
     );
     strictEqual(lFoundConfig.presets.length, 1);
-    expect(lFoundConfig.presets).to.deep.equal(["@babel/preset-typescript"]);
+    deepStrictEqual(lFoundConfig.presets, ["@babel/preset-typescript"]);
   });
 
   it("throws when a javascript file with a function export is passed", async () => {

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { strictEqual } from "node:assert";
 import omit from "lodash/omit.js";
 import { expect } from "chai";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
@@ -32,7 +33,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws when a non-existing config file is passed", async () => {
@@ -42,7 +43,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws when a config file is passed that does not contain valid json5", async () => {
@@ -54,7 +55,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws when a config file is passed contains a non-babel option", async () => {
@@ -66,7 +67,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("returns a default options object when an empty config file is passed", async () => {
@@ -86,7 +87,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     const lBabelKey = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig/package.json"),
     );
-    expect(lBabelKey.plugins.length).to.equal(1);
+    strictEqual(lBabelKey.plugins.length, 1);
   });
 
   it("returns an empty (/ default) options object when package.json without a babel key is passed", async () => {
@@ -108,14 +109,14 @@ describe("[I] config-utl/extract-babel-config", () => {
     const lModule = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig-js/babel.object-export.config.js"),
     );
-    expect(lModule.plugins.length).to.equal(1);
+    strictEqual(lModule.plugins.length, 1);
   });
 
   it("returns a babel config _including_ the array of plugins when a config with presets is passed", async () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig/babelrc.with-a-preset.json"),
     );
-    expect(lFoundConfig.presets.length).to.equal(1);
+    strictEqual(lFoundConfig.presets.length, 1);
     expect(lFoundConfig.presets).to.deep.equal(["@babel/preset-typescript"]);
   });
 
@@ -130,7 +131,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws when a config with an unsupported extension is passed", async () => {
@@ -144,14 +145,14 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("returns a babel config even when an es module is passed (.js extension)", async () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig-js/babel.es-module.config.mjs"),
     );
-    expect(lFoundConfig.plugins.length).to.equal(1);
+    strictEqual(lFoundConfig.plugins.length, 1);
     expect(lFoundConfig.plugins[0].key).to.deep.equal(
       "transform-modules-commonjs",
     );
@@ -160,7 +161,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig-js/babel.es-module.config.mjs"),
     );
-    expect(lFoundConfig.plugins.length).to.equal(1);
+    strictEqual(lFoundConfig.plugins.length, 1);
     expect(lFoundConfig.plugins[0].key).to.deep.equal(
       "transform-modules-commonjs",
     );

--- a/test/config-utl/extract-depcruise-config/read-config.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/read-config.spec.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import readConfig from "../../../src/config-utl/extract-depcruise-config/read-config.mjs";
 
 function getFullPath(pRelativePath) {
@@ -11,30 +11,30 @@ describe("[U] config-utl/extract-depcruise-config/read-config", () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.js"),
     );
-    expect(lConfig).to.deep.equal({});
+    deepStrictEqual(lConfig, {});
   });
   it("imports when it encounters .cjs", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.cjs"),
     );
-    expect(lConfig).to.deep.equal({});
+    deepStrictEqual(lConfig, {});
   });
   it("imports when it encounters .mjs", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.mjs"),
     );
-    expect(lConfig).to.deep.equal({});
+    deepStrictEqual(lConfig, {});
   });
   it("json5 parse when it encounters .json", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.json"),
     );
-    expect(lConfig).to.deep.equal({});
+    deepStrictEqual(lConfig, {});
   });
   it("json5 parse when it encounters something alien", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.alien"),
     );
-    expect(lConfig).to.deep.equal({});
+    deepStrictEqual(lConfig, {});
   });
 });

--- a/test/config-utl/extract-ts-config.spec.mjs
+++ b/test/config-utl/extract-ts-config.spec.mjs
@@ -156,7 +156,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - 'extend
     // reason or other typescript's TSConfig parser overrides this again with false
     // even though it isn't specified in the file that extends it =>
     // I suspect a bug in typescripts' TSConfig parser ...
-    // expect(lParseResult.compileOnSave).to.equal(true);
+    // strictEqual(lParseResult.compileOnSave, true);
   });
 
   it("returns an object with properties from base, extends & overrides from extends - compilerOptions", () => {

--- a/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { strictEqual } from "node:assert";
 import { expect } from "chai";
 import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
 
@@ -13,7 +14,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     } catch (_pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws when a non-existing config file is passed", async () => {
@@ -23,7 +24,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     } catch (_pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws when a config file is passed that does not contain valid javascript", async () => {
@@ -35,7 +36,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     } catch (_pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("returns an empty object when a config file is passed without a 'resolve' section", async () => {

--- a/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "chai";
@@ -23,7 +24,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - non-native formats", (
     } catch (_pError) {
       lThrown = true;
     }
-    expect(lThrown).to.equal(true);
+    strictEqual(lThrown, true);
   });
 
   it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (livescript)", async () => {

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,12 +1,12 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import summarize from "../../src/enrich/summarize/index.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cycleStartsOnOne from "./__mocks__/cycle-starts-on-one.mjs";
 import cycleStartsOnTwo from "./__mocks__/cycle-starts-on-two.mjs";
 import cycleFest from "./__mocks__/cycle-fest.mjs";
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 describe("[I] enrich/summarize", () => {
   it("doesn't add a rule set when there isn't one", () => {
@@ -44,9 +44,7 @@ describe("[I] enrich/summarize", () => {
       violations: [],
       warn: 0,
     });
-    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
-      cruiseResultSchema,
-    );
+    ajv.validate(cruiseResultSchema, { modules: [], summary: lSummary });
   });
 
   it("consistently summarizes the same circular dependency, regardless the order", () => {
@@ -68,9 +66,7 @@ describe("[I] enrich/summarize", () => {
     const lResult2 = summarize(cycleStartsOnTwo, lOptions, ["src"]);
 
     expect(lResult1).to.deep.equal(lResult2);
-    expect({ modules: [], summary: lResult1 }).to.be.jsonSchema(
-      cruiseResultSchema,
-    );
+    ajv.validate(cruiseResultSchema, { modules: [], summary: lResult1 });
   });
 
   it("summarizes all circular dependencies, even when there's more per thingus", () => {
@@ -145,9 +141,7 @@ describe("[I] enrich/summarize", () => {
     };
     const lSummary = summarize(cycleFest, lOptions, ["src"]);
     expect(lSummary).to.deep.equal(lExpected);
-    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
-      cruiseResultSchema,
-    );
+    ajv.validate(cruiseResultSchema, { modules: [], summary: lSummary });
   });
 
   it("includes known violations in the summary", () => {
@@ -271,8 +265,6 @@ describe("[I] enrich/summarize", () => {
         ],
       },
     });
-    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
-      cruiseResultSchema,
-    );
+    ajv.validate(cruiseResultSchema, { modules: [], summary: lSummary });
   });
 });

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import summarize from "../../src/enrich/summarize/index.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -23,9 +23,7 @@ describe("[I] enrich/summarize", () => {
       violations: [],
       warn: 0,
     });
-    expect({ modules: [], summary: lSummary }).to.be.jsonSchema(
-      cruiseResultSchema,
-    );
+    ajv.validate(cruiseResultSchema, { modules: [], summary: lSummary });
   });
   it("adds a rule set when there is one", () => {
     const lSummary = summarize([], { ruleSet: { required: [] } }, []);

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from "node:assert";
 import { expect } from "chai";
 import Ajv from "ajv";
 import summarize from "../../src/enrich/summarize/index.mjs";
@@ -63,7 +64,7 @@ describe("[I] enrich/summarize", () => {
     const lResult1 = summarize(cycleStartsOnOne, lOptions, ["src"]);
     const lResult2 = summarize(cycleStartsOnTwo, lOptions, ["src"]);
 
-    expect(lResult1).to.deep.equal(lResult2);
+    deepStrictEqual(lResult1, lResult2);
     ajv.validate(cruiseResultSchema, { modules: [], summary: lResult1 });
   });
 
@@ -138,7 +139,7 @@ describe("[I] enrich/summarize", () => {
       },
     };
     const lSummary = summarize(cycleFest, lOptions, ["src"]);
-    expect(lSummary).to.deep.equal(lExpected);
+    deepStrictEqual(lSummary, lExpected);
     ajv.validate(cruiseResultSchema, { modules: [], summary: lSummary });
   });
 

--- a/test/extract/ast-extractors/extract-cjs-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-cjs-deps.spec.mjs
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from "node:assert";
 import { expect } from "chai";
 import extractcommonJSDeps from "../../../src/extract/ast-extractors/extract-cjs-deps.mjs";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
@@ -74,7 +75,7 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
       "const need = require; const x = need('./static-required-with-need')",
       lDeps,
     );
-    expect(lDeps).to.deep.equal([]);
+    deepStrictEqual(lDeps, []);
   });
 
   it("require with in an assignment - template literal argument", () => {
@@ -95,7 +96,7 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
     let lDeps = [];
 
     extractcommonJS("require(42);", lDeps);
-    expect(lDeps).to.deep.equal([]);
+    deepStrictEqual(lDeps, []);
   });
 
   it("non-string argument doesn't yield a dependency (function call)", () => {
@@ -108,6 +109,6 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
         `,
       lDeps,
     );
-    expect(lDeps).to.deep.equal([]);
+    deepStrictEqual(lDeps, []);
   });
 });

--- a/test/extract/ast-extractors/extract-es6-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-es6-deps.spec.mjs
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from "node:assert";
 import { expect } from "chai";
 import extractES6Deps from "../../../src/extract/ast-extractors/extract-es6-deps.mjs";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
@@ -45,7 +46,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
       "import(`./dynamic/${enhop}`).then(pModule => pModule.x);",
       lDeps,
     );
-    expect(lDeps).to.deep.equal([]);
+    deepStrictEqual(lDeps, []);
   });
 
   it("yield a dynamic import yields an import", () => {
@@ -69,7 +70,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
     let lDeps = [];
 
     extractES6("import(42).then(pModule => pModule.x);", lDeps);
-    expect(lDeps).to.deep.equal([]);
+    deepStrictEqual(lDeps, []);
   });
 
   it("dynamic imports of a function call doesn't yield an import", () => {
@@ -82,7 +83,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
         `,
       lDeps,
     );
-    expect(lDeps).to.deep.equal([]);
+    deepStrictEqual(lDeps, []);
   });
 
   it("doesn't get confused about import keywords in jsx components", () => {

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -1,4 +1,5 @@
 import { renameSync } from "node:fs";
+import { deepStrictEqual } from "node:assert";
 import { expect } from "chai";
 import extract from "../../src/extract/index.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -75,8 +76,8 @@ describe("[I] extract/index - cache busting", () => {
       "./test/extract/__mocks__/cache-busting-second-tree",
     );
 
-    expect(lFirstResult).to.deep.equal(lFirstResultFixture);
-    expect(lSecondResult).to.deep.equal(lSecondResultFixture);
+    deepStrictEqual(lFirstResult, lFirstResultFixture);
+    deepStrictEqual(lSecondResult, lSecondResultFixture);
     expect(lSecondResult).to.not.deep.equal(lFirstResult);
   });
 });

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -1,11 +1,8 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
-
-use(chaiJSONSchema);
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -1,11 +1,8 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
-
-use(chaiJSONSchema);
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -1,13 +1,10 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
-
-use(chaiJSONSchema);
 
 describe("[I] extract/index - max depth", () => {
   /* eslint no-magic-numbers:0 */
@@ -32,7 +29,7 @@ describe("[I] extract/index - max depth", () => {
       expect(lResult).to.deep.equal(
         requireJSON(`./__fixtures__/max-depth-${pDepth}.json`),
       );
-      // expect(lResult).to.be.jsonSchema(resultSchema);
+      // ajv.validate(resultSchema, lResult);
     }),
   );
 });

--- a/test/extract/parse/to-javascript-ast.spec.mjs
+++ b/test/extract/parse/to-javascript-ast.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { expect } from "chai";
 import get from "lodash/get.js";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
@@ -73,7 +74,7 @@ describe("[U] extract/parse/to-javascript-ast", () => {
       "body[0].declarations.[0].init",
       {},
     );
-    expect(likelyTheArrowExpression.type).to.equal("ArrowFunctionExpression");
+    strictEqual(likelyTheArrowExpression.type, "ArrowFunctionExpression");
     expect(
       get(
         likelyTheArrowExpression,

--- a/test/extract/resolve/external-module-helpers.spec.mjs
+++ b/test/extract/resolve/external-module-helpers.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { expect } from "chai";
 import has from "lodash/has.js";
 import clearCaches from "../../../src/extract/clear-caches.mjs";
@@ -61,7 +62,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
 
     expect(lPackageJson).to.be.not.null;
     expect(has(lPackageJson, "name")).to.be.true;
-    expect(lPackageJson.name).to.equal("chai");
+    strictEqual(lPackageJson.name, "chai");
   });
 
   it("returns a package.json when there is one (root) - base dir defaults to current working dir", () => {
@@ -69,7 +70,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
 
     expect(lPackageJson).to.be.not.null;
     expect(has(lPackageJson, "name")).to.be.true;
-    expect(lPackageJson.name).to.equal("chai");
+    strictEqual(lPackageJson.name, "chai");
   });
 
   it("returns a package.json when there is one ('local' node_modules)", () => {
@@ -95,7 +96,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
 
     expect(lPackageJson).to.be.not.null;
     expect(has(lPackageJson, "name")).to.be.true;
-    expect(lPackageJson.description).to.equal("testinga 2");
+    strictEqual(lPackageJson.description, "testinga 2");
   });
 });
 

--- a/test/extract/transpile/babel-wrap.spec.mjs
+++ b/test/extract/transpile/babel-wrap.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
@@ -45,6 +46,6 @@ describe("[I] extract/transpile/babel-wrap", () => {
       "utf8",
     );
 
-    expect(lOutput).to.equal(lExpected);
+    strictEqual(lOutput, lExpected);
   });
 });

--- a/test/extract/transpile/index.spec.mjs
+++ b/test/extract/transpile/index.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,7 +43,7 @@ describe("[I] transpile", () => {
       readFileSync(join(__dirname, "__fixtures__", "svelte.js"), "utf8"),
     );
 
-    expect(lObservedOutput).to.equal(lExpectedOutput);
+    strictEqual(lObservedOutput, lExpectedOutput);
   });
 
   it("Does not confuse .ts for .tsx", async () => {
@@ -61,7 +62,7 @@ describe("[I] transpile", () => {
     const lFound = await normalizeSource(
       transpile({ extension: ".ts", source: lInputFixture }),
     );
-    expect(lExpected).to.equal(lFound);
+    strictEqual(lExpected, lFound);
   });
 
   it("Takes a tsconfig and takes that into account on transpilation", async () => {
@@ -92,7 +93,7 @@ describe("[I] transpile", () => {
         lTranspilerOptions,
       ),
     );
-    expect(lExpected).to.equal(lTranspiledFixture);
+    strictEqual(lExpected, lTranspiledFixture);
   });
 });
 

--- a/test/extract/transpile/svelte-preprocess.spec.mjs
+++ b/test/extract/transpile/svelte-preprocess.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { expect } from "chai";
 // eslint-disable-next-line node/file-extension-in-import
 import * as svelteCompiler from "svelte/compiler";
@@ -43,7 +44,7 @@ describe("[U] sync svelte pre-processor", () => {
         },
       });
 
-      expect(lSyncResult).to.equal(lAsyncResult.code);
+      strictEqual(lSyncResult, lAsyncResult.code);
     });
   });
   it("pre-processes svelte like svelte, but sync (with an unavailable wrapper)", async () => {
@@ -51,7 +52,7 @@ describe("[U] sync svelte pre-processor", () => {
     const lSyncResult = sveltePreProcess(lInput, {}, {});
     const lAsyncResult = await svelteCompiler.preprocess(lInput, {});
 
-    expect(lSyncResult).to.equal(lAsyncResult.code);
+    strictEqual(lSyncResult, lAsyncResult.code);
   });
   it("ignores style tags that require a pre-processor", () => {
     const lInput = `<script lang="ts">console.log(713)</script>

--- a/test/extract/transpile/svelte-wrap.spec.mjs
+++ b/test/extract/transpile/svelte-wrap.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import svelteWrap from "../../../src/extract/transpile/svelte-wrap.mjs";
@@ -36,7 +37,7 @@ describe("[I] svelte transpiler", () => {
         ),
       );
 
-      expect(lObserved).to.equal(lExpected);
+      strictEqual(lObserved, lExpected);
     });
   });
 });

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { expect } from "chai";
 import normalizeSource from "../normalize-source.utl.mjs";
@@ -27,7 +28,7 @@ describe("[I] typescript transpiler", () => {
         "utf8",
       ),
     );
-    expect(lExpected).to.equal(lFound);
+    strictEqual(lExpected, lFound);
   });
 });
 
@@ -45,7 +46,7 @@ describe("[I] typescript transpiler (tsx)", () => {
     const lFound = await normalizeSource(
       readFileSync("./test/extract/transpile/__fixtures__/tsx.js", "utf8"),
     );
-    expect(lExpected).to.equal(lFound);
+    strictEqual(lExpected, lFound);
   });
 });
 
@@ -63,6 +64,6 @@ describe("[I] typescript transpiler (esm)", () => {
     const lFound = await normalizeSource(
       readFileSync("./test/extract/transpile/__fixtures__/mts.mjs", "utf8"),
     );
-    expect(lExpected).to.equal(lFound);
+    strictEqual(lExpected, lFound);
   });
 });

--- a/test/main/helpers.spec.mjs
+++ b/test/main/helpers.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import { normalizeREProperties } from "../../src/main/helpers.mjs";
 
 const POTENTIAL_ARRAY_PROPERTIES = ["aap", "noot", "mies", "wim"];

--- a/test/main/helpers.spec.mjs
+++ b/test/main/helpers.spec.mjs
@@ -1,8 +1,5 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
 import { normalizeREProperties } from "../../src/main/helpers.mjs";
-
-use(chaiJSONSchema);
 
 const POTENTIAL_ARRAY_PROPERTIES = ["aap", "noot", "mies", "wim"];
 const ARRAYED_OBJECT = {

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -46,9 +46,9 @@ function runFixture(pFixture) {
       );
 
       ajv.validate(cruiseResultSchema, lResult.output);
-      expect(lResult.output.modules).to.deep.equal(pFixture.expected);
+      deepStrictEqual(lResult.output.modules, pFixture.expected);
       if (lResult.output.folders) {
-        expect(lResult.output.folders).to.deep.equal(pFixture.expectedFolders);
+        deepStrictEqual(lResult.output.folders, pFixture.expectedFolders);
       }
     });
   }

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,5 +1,5 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -30,7 +30,7 @@ const folderFixtures = requireJSON(
   "./__fixtures__/cruise-reporterless/folder.json",
 );
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 function runFixture(pFixture) {
   if (!Boolean(pFixture.ignore)) {
@@ -45,7 +45,7 @@ function runFixture(pFixture) {
         },
       );
 
-      expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+      ajv.validate(cruiseResultSchema, lResult.output);
       expect(lResult.output.modules).to.deep.equal(pFixture.expected);
       if (lResult.output.folders) {
         expect(lResult.output.folders).to.deep.equal(pFixture.expectedFolders);

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -1,11 +1,11 @@
 import { rmSync } from "node:fs";
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
 import Cache from "../../src/cache/cache.mjs";
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const CACHE_FOLDER =
   "test/main/__mocks__/cache/node_modules/.cache/dependency-cruiser";
@@ -32,7 +32,7 @@ describe("[E] main.cruise - cache", () => {
     Reflect.deleteProperty(lCache, "revisionData");
 
     expect(lResult.output).to.deep.equal(lCache);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("cruising twice yields the same result (minus 'revisionData')", async () => {
@@ -60,7 +60,7 @@ describe("[E] main.cruise - cache", () => {
     );
     Reflect.deleteProperty(lResultTwo.output, "revisionData");
     expect(lResultTwo.output).to.deep.equal(lResult.output);
-    expect(lResultTwo.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResultTwo.output);
   });
 
   it("cruising twice with non-compatible arguments yields different results", async () => {
@@ -91,6 +91,6 @@ describe("[E] main.cruise - cache", () => {
     Reflect.deleteProperty(lNewCache, "revisionData");
     expect(lNewCache).to.not.deep.equal(lOldCache);
     expect(lNewCache).to.deep.equal(lResultTwo.output);
-    expect(lNewCache).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lNewCache);
   });
 });

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -1,5 +1,5 @@
 import { rmSync } from "node:fs";
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from "node:assert";
 import { rmSync } from "node:fs";
 import { expect } from "chai";
 import Ajv from "ajv";
@@ -31,7 +32,7 @@ describe("[E] main.cruise - cache", () => {
     const lCache = await lCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lCache, "revisionData");
 
-    expect(lResult.output).to.deep.equal(lCache);
+    deepStrictEqual(lResult.output, lCache);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -48,7 +49,7 @@ describe("[E] main.cruise - cache", () => {
     const lCache = await lCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lCache, "revisionData");
 
-    expect(lResult.output).to.deep.equal(lCache);
+    deepStrictEqual(lResult.output, lCache);
 
     const lResultTwo = await cruise(
       ["test/main/__mocks__/cache"],
@@ -59,7 +60,7 @@ describe("[E] main.cruise - cache", () => {
       {},
     );
     Reflect.deleteProperty(lResultTwo.output, "revisionData");
-    expect(lResultTwo.output).to.deep.equal(lResult.output);
+    deepStrictEqual(lResultTwo.output, lResult.output);
     ajv.validate(cruiseResultSchema, lResultTwo.output);
   });
 
@@ -76,7 +77,7 @@ describe("[E] main.cruise - cache", () => {
     const lOldCache = await lCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lOldCache, "revisionData");
 
-    expect(lResult.output).to.deep.equal(lOldCache);
+    deepStrictEqual(lResult.output, lOldCache);
 
     const lResultTwo = await cruise(
       ["test/main/__mocks__/cache test/main/__mocks__/cache-too "],
@@ -90,7 +91,7 @@ describe("[E] main.cruise - cache", () => {
     const lNewCache = await lNewCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lNewCache, "revisionData");
     expect(lNewCache).to.not.deep.equal(lOldCache);
-    expect(lNewCache).to.deep.equal(lResultTwo.output);
+    deepStrictEqual(lNewCache, lResultTwo.output);
     ajv.validate(cruiseResultSchema, lNewCache);
   });
 });

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,5 +1,5 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -19,7 +19,7 @@ const tsOutpre = normBaseDirectory(
   ),
 );
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const WORKING_DIRECTORY = process.cwd();
 
@@ -64,7 +64,7 @@ describe("[E] main.cruise - dynamic imports", () => {
     );
 
     expect(lResult.output).to.deep.equal(esOut);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("detects dynamic dependencies in typescript", async () => {
@@ -99,7 +99,7 @@ describe("[E] main.cruise - dynamic imports", () => {
     );
 
     expect(lResult.output).to.deep.equal(tsOut);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("detects dynamic dependencies in typescript when using tsPreCompilationDeps", async () => {
@@ -135,6 +135,6 @@ describe("[E] main.cruise - dynamic imports", () => {
     );
 
     expect(lResult.output).to.deep.equal(tsOutpre);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
@@ -63,7 +63,7 @@ describe("[E] main.cruise - dynamic imports", () => {
       { bustTheCache: true },
     );
 
-    expect(lResult.output).to.deep.equal(esOut);
+    deepStrictEqual(lResult.output, esOut);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -98,7 +98,7 @@ describe("[E] main.cruise - dynamic imports", () => {
       { bustTheCache: true },
     );
 
-    expect(lResult.output).to.deep.equal(tsOut);
+    deepStrictEqual(lResult.output, tsOut);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -134,7 +134,7 @@ describe("[E] main.cruise - dynamic imports", () => {
       { bustTheCache: true },
     );
 
-    expect(lResult.output).to.deep.equal(tsOutpre);
+    deepStrictEqual(lResult.output, tsOutpre);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,11 +1,11 @@
 import { join } from "node:path";
-import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import { expect } from "chai";
+import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import normalizeOptions from "../../src/cli/normalize-cli-options.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const WORKING_DIRECTORY = process.cwd();
 
@@ -62,7 +62,7 @@ describe("[E] main.cruise - reachable integration", () => {
         },
       },
     ]);
-    expect(lResult).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult);
   });
 
   it("finds the dead wood from an 'allowed' rule set", async () => {
@@ -96,7 +96,7 @@ describe("[E] main.cruise - reachable integration", () => {
         },
       },
     ]);
-    expect(lResult).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult);
   });
 
   it("finds the stuff that needs to be isolated from an 'allowed' rule set", async () => {
@@ -122,6 +122,6 @@ describe("[E] main.cruise - reachable integration", () => {
         },
       },
     ]);
-    expect(lResult).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult);
   });
 });

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -1,7 +1,7 @@
 import { posix as path } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -2,7 +2,7 @@ import { posix as path } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
@@ -19,7 +19,7 @@ const jsxAsObjectFixture = normBaseDirectory(
   requireJSON("./__fixtures__/jsx-as-object.json"),
 );
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 function pathPosixify(pOutput) {
   const lReturnValue = { ...pOutput };
@@ -34,7 +34,7 @@ describe("[E] main.cruise - main", () => {
     const lResult = await cruise(["test/main/__mocks__/ts"]);
 
     expect(pathPosixify(lResult.output)).to.deep.equal(tsFixture);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("Returns an object when no options are passed (absolute path)", async () => {
@@ -45,7 +45,7 @@ describe("[E] main.cruise - main", () => {
     );
 
     expect(pathPosixify(lResult.output)).to.deep.equal(tsFixture);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("processes tsx correctly", async () => {
@@ -56,7 +56,7 @@ describe("[E] main.cruise - main", () => {
     );
 
     expect(pathPosixify(lResult.output)).to.deep.equal(tsxFixture);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("processes jsx correctly", async () => {
@@ -67,7 +67,7 @@ describe("[E] main.cruise - main", () => {
     );
 
     expect(pathPosixify(lResult.output)).to.deep.equal(jsxFixture);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("process rulesets in the form a an object instead of json", async () => {
     const lResult = await cruise(
@@ -79,7 +79,7 @@ describe("[E] main.cruise - main", () => {
     );
 
     expect(pathPosixify(lResult.output)).to.deep.equal(jsxAsObjectFixture);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("Collapses to a pattern when a collapse pattern is passed", async () => {
     const lResult = await cruise(
@@ -101,6 +101,6 @@ describe("[E] main.cruise - main", () => {
         ),
       ),
     );
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,5 +1,5 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -20,7 +20,7 @@ const tsNoPrecompFixtureES = normBaseDirectory(
   requireJSON("./__fixtures__/ts-no-precomp-es.json"),
 );
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 describe("[E] main.cruise - tsPreCompilationDeps", () => {
   it("ts-pre-compilation-deps: on, target CJS", async () => {
@@ -44,7 +44,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
     );
 
     expect(lResult.output).to.deep.equal(tsPreCompFixtureCJS);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: on, target ES", async () => {
     const lResult = await cruise(
@@ -67,7 +67,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
     );
 
     expect(lResult.output).to.deep.equal(tsPreCompFixtureES);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: off, target CJS", async () => {
     const lResult = await cruise(
@@ -90,7 +90,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
     );
 
     expect(lResult.output).to.deep.equal(tsNoPrecompFixtureCJS);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: off, target ES", async () => {
     const lResult = await cruise(
@@ -113,6 +113,6 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
     );
 
     expect(lResult.output).to.deep.equal(tsNoPrecompFixtureES);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
@@ -43,7 +43,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    expect(lResult.output).to.deep.equal(tsPreCompFixtureCJS);
+    deepStrictEqual(lResult.output, tsPreCompFixtureCJS);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: on, target ES", async () => {
@@ -66,7 +66,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    expect(lResult.output).to.deep.equal(tsPreCompFixtureES);
+    deepStrictEqual(lResult.output, tsPreCompFixtureES);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: off, target CJS", async () => {
@@ -89,7 +89,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    expect(lResult.output).to.deep.equal(tsNoPrecompFixtureCJS);
+    deepStrictEqual(lResult.output, tsNoPrecompFixtureCJS);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: off, target ES", async () => {
@@ -112,7 +112,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    expect(lResult.output).to.deep.equal(tsNoPrecompFixtureES);
+    deepStrictEqual(lResult.output, tsNoPrecompFixtureES);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -1,5 +1,5 @@
-import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import { expect } from "chai";
+import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -14,7 +14,7 @@ const outputWithRules = normBaseDirectory(
   requireJSON("./__mocks__/type-only-imports/output-with-rules.json"),
 );
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const WORKING_DIRECTORY = process.cwd();
 
@@ -39,7 +39,7 @@ describe("[E] main.cruise - explicitly type only imports", () => {
     );
 
     expect(lResult.output).to.deep.equal(output);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("flags type only imports when forbidden", async () => {
@@ -66,6 +66,6 @@ describe("[E] main.cruise - explicitly type only imports", () => {
     );
 
     expect(lResult.output).to.deep.equal(outputWithRules);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -38,7 +38,7 @@ describe("[E] main.cruise - explicitly type only imports", () => {
       { bustTheCache: true, resolveLicenses: false },
     );
 
-    expect(lResult.output).to.deep.equal(output);
+    deepStrictEqual(lResult.output, output);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -65,7 +65,7 @@ describe("[E] main.cruise - explicitly type only imports", () => {
       { bustTheCache: true, resolveLicenses: false },
     );
 
-    expect(lResult.output).to.deep.equal(outputWithRules);
+    deepStrictEqual(lResult.output, outputWithRules);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,5 +1,5 @@
 import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -14,7 +14,7 @@ const outputNoTS = normBaseDirectory(
   requireJSON("./__mocks__/type-only-module-references/output-no-ts.json"),
 );
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const WORKING_DIRECTORY = process.cwd();
 
@@ -39,7 +39,7 @@ describe("[E] main.cruise - type only module references", () => {
     );
 
     expect(lResult.output).to.deep.equal(output);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 
   it("don't find it when not looking for pre-compilation deps", async () => {
@@ -54,6 +54,6 @@ describe("[E] main.cruise - type only module references", () => {
     );
 
     expect(lResult.output).to.deep.equal(outputNoTS);
-    expect(lResult.output).to.be.jsonSchema(cruiseResultSchema);
+    ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -38,7 +38,7 @@ describe("[E] main.cruise - type only module references", () => {
       { bustTheCache: true, resolveLicenses: true },
     );
 
-    expect(lResult.output).to.deep.equal(output);
+    deepStrictEqual(lResult.output, output);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -53,7 +53,7 @@ describe("[E] main.cruise - type only module references", () => {
       { bustTheCache: true },
     );
 
-    expect(lResult.output).to.deep.equal(outputNoTS);
+    deepStrictEqual(lResult.output, outputNoTS);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,4 +1,4 @@
-import { expect, use } from "chai";
+import { expect } from "chai";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-magic-numbers */
+import { strictEqual } from "node:assert";
 import { expect } from "chai";
 import format from "../../src/main/format.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -91,8 +92,8 @@ describe("[E] main.format - format", () => {
         },
       },
     ]);
-    expect(lCollapsedResult.summary.totalCruised).to.equal(19);
-    expect(lCollapsedResult.summary.totalDependenciesCruised).to.equal(18);
+    strictEqual(lCollapsedResult.summary.totalCruised, 19);
+    strictEqual(lCollapsedResult.summary.totalDependenciesCruised, 18);
   });
 
   it("returns string with error explanations when asked for the err-long report", async () => {
@@ -122,9 +123,9 @@ describe("[E] main.format - format", () => {
     });
     const lJSONResult = JSON.parse(lResult.output);
     expect(Object.keys(lJSONResult.summary.optionsUsed).length).to.equal(16);
-    expect(lJSONResult.summary.optionsUsed.outputType).to.equal("anon");
-    expect(lJSONResult.summary.optionsUsed.includeOnly).to.equal("^src/");
+    strictEqual(lJSONResult.summary.optionsUsed.outputType, "anon");
+    strictEqual(lJSONResult.summary.optionsUsed.includeOnly, "^src/");
     // without includeOnly it'd be 53
-    expect(lJSONResult.modules.length).to.equal(33);
+    strictEqual(lJSONResult.modules.length, 33);
   });
 });

--- a/test/main/options/validate.spec.mjs
+++ b/test/main/options/validate.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { expect } from "chai";
 import {
   validateCruiseOptions,
@@ -197,7 +198,7 @@ describe("[U] main/options/validate - exclude", () => {
       ruleSet: { options: { exclude: "from the ruleset" } },
     });
 
-    expect(lOptions.exclude).to.equal("from the commandline");
+    strictEqual(lOptions.exclude, "from the commandline");
   });
 
   it("options passed in --validate rule-set drip down to the proper options", () => {
@@ -206,7 +207,7 @@ describe("[U] main/options/validate - exclude", () => {
       ruleSet: { options: { exclude: "from the ruleset" } },
     });
 
-    expect(lOptions.exclude).to.equal("from the ruleset");
-    expect(lOptions.doNotFollow).to.equal("from the commandline");
+    strictEqual(lOptions.exclude, "from the ruleset");
+    strictEqual(lOptions.doNotFollow, "from the commandline");
   });
 });

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -1,3 +1,4 @@
+import { strictEqual } from "node:assert";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "chai";
@@ -23,12 +24,12 @@ describe("[I] main/resolve-options/normalize", () => {
     expect(Object.keys(lNormalizedOptions).length).to.equal(
       lDefaultNoOfResolveOptions,
     );
-    expect(lNormalizedOptions.symlinks).to.equal(false);
-    expect(lNormalizedOptions.tsConfig).to.equal(null);
-    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+    strictEqual(lNormalizedOptions.symlinks, false);
+    strictEqual(lNormalizedOptions.tsConfig, null);
+    strictEqual(lNormalizedOptions.combinedDependencies, false);
     expect(lNormalizedOptions).to.ownProperty("extensions");
     expect(lNormalizedOptions).to.ownProperty("fileSystem");
-    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
   it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", async () => {
@@ -43,13 +44,13 @@ describe("[I] main/resolve-options/normalize", () => {
     expect(Object.keys(lNormalizedOptions).length).to.equal(
       lDefaultNoOfResolveOptions,
     );
-    expect(lNormalizedOptions.symlinks).to.equal(false);
-    expect(lNormalizedOptions.tsConfig).to.equal(null);
-    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+    strictEqual(lNormalizedOptions.symlinks, false);
+    strictEqual(lNormalizedOptions.tsConfig, null);
+    strictEqual(lNormalizedOptions.combinedDependencies, false);
     expect(lNormalizedOptions).to.ownProperty("extensions");
     expect(lNormalizedOptions).to.ownProperty("fileSystem");
     expect((lNormalizedOptions.plugins || []).length).to.equal(0);
-    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
   it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", async () => {
@@ -64,13 +65,13 @@ describe("[I] main/resolve-options/normalize", () => {
     expect(Object.keys(lNormalizedOptions).length).to.equal(
       lDefaultNoOfResolveOptions + 1,
     );
-    expect(lNormalizedOptions.symlinks).to.equal(false);
-    expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
-    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+    strictEqual(lNormalizedOptions.symlinks, false);
+    strictEqual(lNormalizedOptions.tsConfig, TEST_TSCONFIG);
+    strictEqual(lNormalizedOptions.combinedDependencies, false);
     expect(lNormalizedOptions).to.ownProperty("extensions");
     expect(lNormalizedOptions).to.ownProperty("fileSystem");
     expect((lNormalizedOptions.plugins || []).length).to.equal(1);
-    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
   it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", async () => {
@@ -85,12 +86,12 @@ describe("[I] main/resolve-options/normalize", () => {
     expect(Object.keys(lNormalizedOptions).length).to.equal(
       lDefaultNoOfResolveOptions + 1,
     );
-    expect(lNormalizedOptions.symlinks).to.equal(false);
-    expect(lNormalizedOptions.tsConfig).to.equal(TEST_TSCONFIG);
-    expect(lNormalizedOptions.combinedDependencies).to.equal(false);
+    strictEqual(lNormalizedOptions.symlinks, false);
+    strictEqual(lNormalizedOptions.tsConfig, TEST_TSCONFIG);
+    strictEqual(lNormalizedOptions.combinedDependencies, false);
     expect(lNormalizedOptions).to.ownProperty("extensions");
     expect(lNormalizedOptions).to.ownProperty("fileSystem");
-    expect(lNormalizedOptions.plugins.length).to.equal(1);
-    expect(lNormalizedOptions.useSyncFileSystemCalls).to.equal(true);
+    strictEqual(lNormalizedOptions.plugins.length, 1);
+    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 });

--- a/test/report/anon/anonymize-path-element.spec.mjs
+++ b/test/report/anon/anonymize-path-element.spec.mjs
@@ -1,50 +1,47 @@
-import { expect } from "chai";
+import { match, notDeepStrictEqual, strictEqual } from "node:assert";
 import { anonymizePathElement } from "../../../src/report/anon/anonymize-path-element.mjs";
 
 describe("[U] report/anon/anonymizePathElement - uncached", () => {
   it("'' => ''", () => {
-    expect(anonymizePathElement("", [], /^$/, false)).to.equal("");
+    strictEqual(anonymizePathElement("", [], /^$/, false), "");
   });
 
   it("'string' => random string", () => {
-    expect(anonymizePathElement("string", [], /^$/, false)).to.match(
-      /[a-z]{6}/,
-    );
+    match(anonymizePathElement("string", [], /^$/, false), /[a-z]{6}/);
   });
 
   it("consecutive calls with a word list yield words from that list, until empty", () => {
     const lWordlist = ["aap", "noot"];
 
-    expect(anonymizePathElement("one", lWordlist, /^$/, false)).to.equal("aap");
-    expect(anonymizePathElement("two", lWordlist, /^$/, false)).to.equal(
-      "noot",
-    );
-    expect(anonymizePathElement("three", lWordlist, /^$/, false)).to.match(
-      /[a-z]{5}/,
-    );
+    strictEqual(anonymizePathElement("one", lWordlist, /^$/, false), "aap");
+    strictEqual(anonymizePathElement("two", lWordlist, /^$/, false), "noot");
+    match(anonymizePathElement("three", lWordlist, /^$/, false), /[a-z]{5}/);
   });
 
   it("returns the passed string when it matches the whitelist", () => {
-    expect(anonymizePathElement("package", [], /^packages?$/, false)).to.equal(
+    strictEqual(
+      anonymizePathElement("package", [], /^packages?$/, false),
       "package",
     );
   });
 
   it("returns the passed string when it does not match the whitelist", () => {
-    expect(
+    strictEqual(
       anonymizePathElement("thing", ["aap", "noot"], /^packages?$/, false),
-    ).to.equal("aap");
+      "aap",
+    );
   });
 
   it("only replaces the string up till the fist dot", () => {
-    expect(
+    strictEqual(
       anonymizePathElement(
         "thing.spec.js",
         ["aap", "noot"],
         /^packages?$/,
         false,
       ),
-    ).to.equal("aap.spec.js");
+      "aap.spec.js",
+    );
   });
 });
 
@@ -52,12 +49,12 @@ describe("[U] report/anon/anonymizePathElement - cached", () => {
   it("subsequent calls with the same string yield the same result", () => {
     const lFirstResult = anonymizePathElement("yudelyo");
 
-    expect(anonymizePathElement("yudelyo")).to.equal(lFirstResult);
+    strictEqual(anonymizePathElement("yudelyo"), lFirstResult);
   });
 
   it("subsequent calls with different strings yield different results", () => {
     const lFirstResult = anonymizePathElement("yudelyo");
 
-    expect(anonymizePathElement("yoyudel")).to.not.equal(lFirstResult);
+    notDeepStrictEqual(anonymizePathElement("yoyudel"), lFirstResult);
   });
 });

--- a/test/report/anon/anonymize-path.spec.mjs
+++ b/test/report/anon/anonymize-path.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import { anonymizePath } from "../../../src/report/anon/anonymize-path.mjs";
 import { clearCache } from "../../../src/report/anon/anonymize-path-element.mjs";
 
@@ -8,36 +8,41 @@ describe("[U] report/anon/anonymizePath", () => {
   });
 
   it("'' => ''", () => {
-    expect(anonymizePath("")).to.equal("");
+    strictEqual(anonymizePath(""), "");
   });
 
   it("'////' => '////'", () => {
-    expect(anonymizePath("////")).to.equal("////");
+    strictEqual(anonymizePath("////"), "////");
   });
 
   it("replaces with words from the word list", () => {
-    expect(
+    strictEqual(
       anonymizePath("src/tien/kleine/geitjes/index.ts", ["foo", "bar", "baz"]),
-    ).to.equal("src/foo/bar/baz/index.ts");
+      "src/foo/bar/baz/index.ts",
+    );
   });
 
   it("repeat calls with similar paths yield similar anon paths", () => {
     const lWords = ["aap", "noot", "mies", "wim", "zus", "jet", "heide"];
 
-    expect(anonymizePath("src/tien/kleine/geitjes/index.ts", lWords)).to.equal(
+    strictEqual(
+      anonymizePath("src/tien/kleine/geitjes/index.ts", lWords),
       "src/aap/noot/mies/index.ts",
     );
 
-    expect(anonymizePath("src/tien/kleine/geitjes/tien.ts", lWords)).to.equal(
+    strictEqual(
+      anonymizePath("src/tien/kleine/geitjes/tien.ts", lWords),
       "src/aap/noot/mies/aap.ts",
     );
 
-    expect(anonymizePath("shwoop/tien/grote/geiten/index.ts", lWords)).to.equal(
+    strictEqual(
+      anonymizePath("shwoop/tien/grote/geiten/index.ts", lWords),
       "wim/aap/zus/jet/index.ts",
     );
 
-    expect(
+    strictEqual(
       anonymizePath("test/tien/kleine/geitjes/tien.spec.ts", lWords),
-    ).to.equal("test/aap/noot/mies/aap.spec.ts");
+      "test/aap/noot/mies/aap.spec.ts",
+    );
   });
 });

--- a/test/report/anon/anonymize.spec.mjs
+++ b/test/report/anon/anonymize.spec.mjs
@@ -1,6 +1,6 @@
-import { expect, use } from "chai";
+import { strictEqual, deepStrictEqual } from "node:assert";
 import _clone from "lodash/clone.js";
-import chaiJSONSchema from "chai-json-schema";
+import Ajv from "ajv";
 import cruiseResultSchema from "../../../src/schema/cruise-result.schema.mjs";
 import { clearCache } from "../../../src/report/anon/anonymize-path-element.mjs";
 import anonymize from "../../../src/report/anon/index.mjs";
@@ -19,7 +19,7 @@ import fixtureFolders from "./__fixtures__/folders.mjs";
 import sourceFolderCycles from "./__mocks__/folder-cycles.mjs";
 import fixtureFolderCycles from "./__fixtures__/folder-cycles.mjs";
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const META_SYNTACTIC_VARIABLES = [
   "foo",
@@ -53,18 +53,18 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureReport);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureReport);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("anonymizes a result tree with the word list passed in the result tree", () => {
     const lResult = anonymize(sourceReportWithWordlist);
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureReportWithWordlist);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureReportWithWordlist);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("anonymizes a result tree with (violated) rules", () => {
@@ -73,9 +73,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureCycle);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureCycle);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
   it("anonymizes a result tree with (violated) reaches rules", () => {
     const lResult = anonymize(reachesReport, {
@@ -83,9 +83,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureReachesReport);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureReachesReport);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
   it("anonymizes a result tree with dependents", () => {
     const lResult = anonymize(sourceDependents, {
@@ -93,9 +93,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureDependents);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureDependents);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
   it("anonymizes a result tree with folders", () => {
     const lResult = anonymize(sourceFolders, {
@@ -103,9 +103,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureFolders);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureFolders);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("anonymizes a result tree with folders that contain folder cycles", () => {
@@ -114,8 +114,8 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    expect(lOutput).to.deep.equal(fixtureFolderCycles);
-    expect(lOutput).to.be.jsonSchema(cruiseResultSchema);
-    expect(lResult.exitCode).to.equal(0);
+    deepStrictEqual(lOutput, fixtureFolderCycles);
+    ajv.validate(cruiseResultSchema, lOutput);
+    strictEqual(lResult.exitCode, 0);
   });
 });

--- a/test/report/anon/random-string.spec.mjs
+++ b/test/report/anon/random-string.spec.mjs
@@ -1,37 +1,38 @@
-import { expect } from "chai";
+import { match, strictEqual } from "node:assert";
 import randomString from "../../../src/report/anon/random-string.mjs";
 
 describe("[U] report/anon/random-string", () => {
   it("returns the empty string when passed the empty string", () => {
-    expect(randomString("")).to.equal("");
+    strictEqual(randomString(""), "");
   });
 
   it("returns a lower case ascii character when passed such", () => {
-    expect(randomString("a")).to.match(/[a-z]/);
+    match(randomString("a"), /[a-z]/);
   });
 
   it("returns a lower case ascii character when passed a diacritical", () => {
-    expect(randomString("ü")).to.match(/[a-z]/);
+    match(randomString("ü"), /[a-z]/);
   });
 
   it("returns an upper case ascii character when passed such", () => {
-    expect(randomString("U")).to.match(/[A-Z]/);
+    match(randomString("U"), /[A-Z]/);
   });
 
   it("returns an upper case ascii character when passed an upper case diacritical", () => {
-    expect(randomString("Ü")).to.match(/[A-Z]/);
+    match(randomString("Ü"), /[A-Z]/);
   });
 
   it("echoes separators", () => {
-    expect(randomString("-")).to.equal("-");
+    strictEqual(randomString("-"), "-");
   });
 
   it("returns a number when passed a number", () => {
-    expect(randomString("1")).to.match(/\d/);
+    match(randomString("1"), /\d/);
   });
 
   it("returns a lower case ascii character when passed a single character", () => {
-    expect(randomString("better-someStuff_operator")).to.match(
+    match(
+      randomString("better-someStuff_operator"),
       /[a-z]{6}-[a-z]{4}[A-Z][a-z]{4}_[a-z]{8}/,
     );
   });

--- a/test/report/azure-devops/azure-devops.spec.mjs
+++ b/test/report/azure-devops/azure-devops.spec.mjs
@@ -1,6 +1,6 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import normalizeNewline from "normalize-newline";
 import render from "../../../src/report/azure-devops.mjs";
 import okdeps from "./__mocks__/everything-fine.mjs";
@@ -28,10 +28,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(okdeps);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("says there's warnings when there's warnings", () => {
@@ -40,10 +38,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(warndeps);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("says there's errors when there's errors", () => {
@@ -52,10 +48,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(errdeps);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
-    expect(lResult.exitCode).to.equal(1);
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    strictEqual(lResult.exitCode, 1);
   });
 
   it("renders module only transgressions", () => {
@@ -64,11 +58,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(moduleErrs);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(5);
+    strictEqual(lResult.exitCode, 5);
   });
 
   it("renders 'required' violations", () => {
@@ -77,11 +69,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(requiredErrs);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(5);
+    strictEqual(lResult.exitCode, 5);
   });
 
   it("renders circular transgressions", () => {
@@ -90,22 +80,18 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(circulars);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(3);
+    strictEqual(lResult.exitCode, 3);
   });
 
   it("renders via transgressions", () => {
     const lFixture = readFixture("__mocks__/via-deps-azure-devops-format.txt");
     const lResult = render(vias);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(4);
+    strictEqual(lResult.exitCode, 4);
   });
 
   it("renders instability transgressions", () => {
@@ -114,11 +100,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(instabilities);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
 
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("renders unsupported error levels (like 'ignore') as 'info'", () => {
@@ -127,11 +111,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(unsupportedErrorLevels);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(5);
+    strictEqual(lResult.exitCode, 5);
   });
 
   it("renders known errors in a single warning", () => {
@@ -140,10 +122,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(knownViolations);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("renders known errors along with other errors", () => {
@@ -152,9 +132,7 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(errorsAndKnownViolations);
 
-    expect(normalizeNewline(lResult.output)).to.equal(
-      normalizeNewline(lFixture),
-    );
-    expect(lResult.exitCode).to.equal(1);
+    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    strictEqual(lResult.exitCode, 1);
   });
 });

--- a/test/report/baseline/baseline.spec.mjs
+++ b/test/report/baseline/baseline.spec.mjs
@@ -1,11 +1,11 @@
-import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import { deepStrictEqual, strictEqual } from "node:assert";
+import Ajv from "ajv";
 import baseline from "../../../src/report/baseline.mjs";
 import { createRequireJSON } from "../../backwards.utl.mjs";
 import baselineSchema from "../../../src/schema/baseline-violations.schema.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 describe("[I] report/baseline", () => {
   it("returns an empty array when there's no violations", () => {
@@ -13,9 +13,9 @@ describe("[I] report/baseline", () => {
     const lExpected = [];
     const lResult = baseline(lInput);
 
-    expect(JSON.parse(lResult.output)).to.deep.equal(lExpected);
-    expect(lResult.exitCode).to.equal(0);
-    expect(JSON.parse(lResult.output)).to.be.jsonSchema(baselineSchema);
+    deepStrictEqual(JSON.parse(lResult.output), lExpected);
+    strictEqual(lResult.exitCode, 0);
+    ajv.validate(baselineSchema, JSON.parse(lResult.output));
   });
 
   it("returns the violations in a json object", () => {
@@ -23,8 +23,8 @@ describe("[I] report/baseline", () => {
     const lExpected = requireJSON("./__fixtures__/baseline-result.json");
     const lResult = baseline(lInput);
 
-    expect(JSON.parse(lResult.output)).to.deep.equal(lExpected);
-    expect(lResult.exitCode).to.equal(0);
-    expect(JSON.parse(lResult.output)).to.be.jsonSchema(baselineSchema);
+    deepStrictEqual(JSON.parse(lResult.output), lExpected);
+    strictEqual(lResult.exitCode, 0);
+    ajv.validate(baselineSchema, JSON.parse(lResult.output));
   });
 });

--- a/test/report/csv/csv.spec.mjs
+++ b/test/report/csv/csv.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import normalizeNewline from "normalize-newline";
 import render from "../../../src/report/csv.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
@@ -18,7 +18,7 @@ describe("[I] report/csv reporter", () => {
   it("renders csv", () => {
     const lReturnValue = render(deps);
 
-    expect(normalizeNewline(lReturnValue.output)).to.deep.equal(elementFixture);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(normalizeNewline(lReturnValue.output), elementFixture);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 });

--- a/test/report/dot/custom-level/index.spec.mjs
+++ b/test/report/dot/custom-level/index.spec.mjs
@@ -1,7 +1,7 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.mjs";
 
@@ -29,23 +29,21 @@ describe("[I] report/dot/custom-level reporter", () => {
   it("consolidates to custome levels", () => {
     const lReturnValue = render(deps);
 
-    expect(lReturnValue.output).to.deep.equal(consolidatedDot);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, consolidatedDot);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 
   it("consolidates module only transgressions correctly", () => {
     const lReturnValue = render(orphans);
 
-    expect(lReturnValue.output).to.deep.equal(consolidatedOrphansDot);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, consolidatedOrphansDot);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 
   it("consolidates a slightly larger code base in a timely fashion", () => {
     const lReturnValue = render(rxjs);
 
-    expect(lReturnValue.output).to.deep.equal(consolidatedRxJs);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, consolidatedRxJs);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 });
-
-/* eslint max-len: 0 */

--- a/test/report/dot/flat-level/index.spec.mjs
+++ b/test/report/dot/flat-level/index.spec.mjs
@@ -1,9 +1,9 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
-import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.mjs";
+import { createRequireJSON } from "../../../backwards.utl.mjs";
 
 const render = dot("flat");
 const requireJSON = createRequireJSON(import.meta.url);
@@ -29,22 +29,22 @@ describe("[I] report/dot/flat-level reporter", () => {
   it("consolidates to flat levels", () => {
     const lReturnValue = render(deps);
 
-    expect(lReturnValue.output).to.deep.equal(flatDot);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, flatDot);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 
   it("consolidates module only transgressions correctly", () => {
     const lReturnValue = render(orphans);
 
-    expect(lReturnValue.output).to.deep.equal(flatOrphansDot);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, flatOrphansDot);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 
   it("consolidates a slightly larger code base in a timely fashion", () => {
     const lReturnValue = render(rxjs);
 
-    expect(lReturnValue.output).to.deep.equal(flatRxJs);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, flatRxJs);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 });
 

--- a/test/report/dot/folder-level/folder-level.spec.mjs
+++ b/test/report/dot/folder-level/folder-level.spec.mjs
@@ -1,7 +1,7 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
 import dot from "../../../../src/report/dot/index.mjs";
 
@@ -29,22 +29,22 @@ describe("[I] report/dot/folder-level reporter", () => {
   it("consolidates to folder level", () => {
     const lReturnValue = render(deps);
 
-    expect(lReturnValue.output).to.deep.equal(consolidatedDot);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, consolidatedDot);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 
   it("consolidates module only transgressions correctly", () => {
     const lReturnValue = render(orphans);
 
-    expect(lReturnValue.output).to.deep.equal(consolidatedOrphansDot);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, consolidatedOrphansDot);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 
   it("consolidates a slightly larger code base in a timely fashion", () => {
     const lReturnValue = render(rxjs);
 
-    expect(lReturnValue.output).to.deep.equal(consolidatedRxJs);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, consolidatedRxJs);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 });
 

--- a/test/report/dot/module-level/index.spec.mjs
+++ b/test/report/dot/module-level/index.spec.mjs
@@ -1,7 +1,7 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import defaultTheme from "../../../../src/report/dot/default-theme.mjs";
 import dot from "../../../../src/report/dot/index.mjs";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
@@ -72,75 +72,83 @@ const focusMeModulesFixture = readFileSync(
 
 describe("[I] report/dot/module-level reporter", () => {
   it("renders a dot - modules in the root don't come in a cluster", () => {
-    expect(render(clusterLess, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(clusterLess, { theme: bareTheme }).output,
       clusterLessFixture,
     );
   });
 
   it("renders a dot - unresolvable in a sub folder (either existing or not) get labeled as unresolvable", () => {
-    expect(render(unresolvableDeps, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(unresolvableDeps, { theme: bareTheme }).output,
       unresolvableFixture,
     );
   });
 
   it("renders a dot - bare theme matchesDoNotFollow NOT rendered as folders", () => {
-    expect(render(doNotFollowDeps, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(doNotFollowDeps, { theme: bareTheme }).output,
       doNotFollowFixture,
     );
   });
 
   it("renders a dot - default color theme matchesDoNotFollow rendered as folders", () => {
-    expect(render(doNotFollowDeps).output).to.deep.equal(
-      doNotFollowFixtureDefaultTheme,
-    );
+    strictEqual(render(doNotFollowDeps).output, doNotFollowFixtureDefaultTheme);
   });
 
   it("renders a dot - bare theme renders modules with module level transgression with NO severity deduced colors", () => {
-    expect(render(orphanDeps, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(orphanDeps, { theme: bareTheme }).output,
       orphanFixtureBoring,
     );
   });
 
   it("renders a dot - default theme renders modules with module level transgression with severity deduced colors", () => {
-    expect(render(orphanDeps).output).to.deep.equal(orphanFixture);
+    strictEqual(render(orphanDeps).output, orphanFixture);
   });
 
   it("renders a dot - uri prefix get concatenated", () => {
-    expect(render(prefixUri, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(prefixUri, { theme: bareTheme }).output,
       prefixUriFixture,
     );
   });
 
   it("renders a dot - non-uri prefixes get path.posix.joined", () => {
-    expect(render(prefixNonUri, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(prefixNonUri, { theme: bareTheme }).output,
       prefixNonUriFixture,
     );
   });
 
   it("richly colors modules when passed the default theme", () => {
-    expect(
+    strictEqual(
       render(bunchOfModules, { theme: defaultTheme }).output,
-    ).to.deep.equal(defaultColorFixture);
+      defaultColorFixture,
+    );
   });
 
   it("richly colors modules when passed no theme", () => {
-    expect(render(bunchOfModules).output).to.deep.equal(defaultColorFixture);
+    strictEqual(render(bunchOfModules).output, defaultColorFixture);
   });
 
   it("colors boringly when passed a bare theme", () => {
-    expect(render(bunchOfModules, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(bunchOfModules, { theme: bareTheme }).output,
       bareColorFixture,
     );
   });
 
   it("Also renders on module level when the reporter granularity isn't specified", () => {
-    expect(
+    strictEqual(
       defaultRender(bunchOfModules, { theme: bareTheme }).output,
-    ).to.deep.equal(bareColorFixture);
+      bareColorFixture,
+    );
   });
 
   it("applies filter when passed", () => {
-    expect(render(focusMeModules, { theme: bareTheme }).output).to.deep.equal(
+    strictEqual(
+      render(focusMeModules, { theme: bareTheme }).output,
       focusMeModulesFixture,
     );
   });

--- a/test/report/dot/module-utl.spec.mjs
+++ b/test/report/dot/module-utl.spec.mjs
@@ -1,17 +1,15 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import moduleUtl from "../../../src/report/dot/module-utl.mjs";
 
 describe("[U] report/dot/module-utl", () => {
   it("extractFirstTransgression - keeps as is when there's no transgressions", () => {
-    expect(
-      moduleUtl.extractFirstTransgression({ dependencies: [] }),
-    ).to.deep.equal({
+    deepStrictEqual(moduleUtl.extractFirstTransgression({ dependencies: [] }), {
       dependencies: [],
     });
   });
 
   it("extractFirstTransgression - adds the first module rule if there's at least one", () => {
-    expect(
+    deepStrictEqual(
       moduleUtl.extractFirstTransgression({
         dependencies: [],
         rules: [
@@ -19,18 +17,19 @@ describe("[U] report/dot/module-utl", () => {
           { name: "warn-thing", severity: "warn" },
         ],
       }),
-    ).to.deep.equal({
-      dependencies: [],
-      tooltip: "error-thing",
-      rules: [
-        { name: "error-thing", severity: "error" },
-        { name: "warn-thing", severity: "warn" },
-      ],
-    });
+      {
+        dependencies: [],
+        tooltip: "error-thing",
+        rules: [
+          { name: "error-thing", severity: "error" },
+          { name: "warn-thing", severity: "warn" },
+        ],
+      },
+    );
   });
 
   it("extractFirstTransgression - adds the first dependency rule if there's at least one", () => {
-    expect(
+    deepStrictEqual(
       moduleUtl.extractFirstTransgression({
         dependencies: [
           {
@@ -41,54 +40,58 @@ describe("[U] report/dot/module-utl", () => {
           },
         ],
       }),
-    ).to.deep.equal({
-      dependencies: [
-        {
-          rule: { name: "error-thing", severity: "error" },
-          rules: [
-            { name: "error-thing", severity: "error" },
-            { name: "warn-thing", severity: "warn" },
-          ],
-        },
-      ],
-    });
+      {
+        dependencies: [
+          {
+            rule: { name: "error-thing", severity: "error" },
+            rules: [
+              { name: "error-thing", severity: "error" },
+              { name: "warn-thing", severity: "warn" },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   it("flatLabel - returns the value of source as label", () => {
-    expect(
+    deepStrictEqual(
       moduleUtl.flatLabel(true)({ source: "aap/noot/mies/wim/zus.jet" }),
-    ).to.deep.equal({
-      source: "aap/noot/mies/wim/zus.jet",
-      label: "<aap/noot/mies/wim/<BR/><B>zus.jet</B>>",
-      tooltip: "zus.jet",
-    });
+      {
+        source: "aap/noot/mies/wim/zus.jet",
+        label: "<aap/noot/mies/wim/<BR/><B>zus.jet</B>>",
+        tooltip: "zus.jet",
+      },
+    );
   });
 
   it("flatLabel - returns the value of source & instability metric as label when instability is known", () => {
-    expect(
+    deepStrictEqual(
       moduleUtl.flatLabel(true)({
         source: "aap/noot/mies/wim/zus.jet",
         instability: "0.481",
       }),
-    ).to.deep.equal({
-      source: "aap/noot/mies/wim/zus.jet",
-      label: `<aap/noot/mies/wim/<BR/><B>zus.jet</B> <FONT color="#808080" point-size="8">48%</FONT>>`,
-      tooltip: "zus.jet",
-      instability: "0.481",
-    });
+      {
+        source: "aap/noot/mies/wim/zus.jet",
+        label: `<aap/noot/mies/wim/<BR/><B>zus.jet</B> <FONT color="#808080" point-size="8">48%</FONT>>`,
+        tooltip: "zus.jet",
+        instability: "0.481",
+      },
+    );
   });
 
   it("flatLabel - returns the value of source when instability is known, but showMetrics is false", () => {
-    expect(
+    deepStrictEqual(
       moduleUtl.flatLabel(false)({
         source: "aap/noot/mies/wim/zus.jet",
         instability: "0.481",
       }),
-    ).to.deep.equal({
-      source: "aap/noot/mies/wim/zus.jet",
-      label: `<aap/noot/mies/wim/<BR/><B>zus.jet</B>>`,
-      tooltip: "zus.jet",
-      instability: "0.481",
-    });
+      {
+        source: "aap/noot/mies/wim/zus.jet",
+        label: `<aap/noot/mies/wim/<BR/><B>zus.jet</B>>`,
+        tooltip: "zus.jet",
+        instability: "0.481",
+      },
+    );
   });
 });

--- a/test/report/dot/theming.spec.mjs
+++ b/test/report/dot/theming.spec.mjs
@@ -1,45 +1,49 @@
+import { deepStrictEqual } from "node:assert";
 import _cloneDeep from "lodash/cloneDeep.js";
-import { expect } from "chai";
 import theming from "../../../src/report/dot/theming.mjs";
 
 describe("[U] report/dot/theming - determineModuleColors - default theme", () => {
   it("empty module => no colors", () => {
-    expect(
+    deepStrictEqual(
       theming.determineAttributes({}, theming.normalizeTheme({}).module),
-    ).to.deep.equal({});
+      {},
+    );
   });
 
   it("core module => grey", () => {
-    expect(
+    deepStrictEqual(
       theming.determineAttributes(
         { coreModule: true },
         theming.normalizeTheme({}).modules,
       ),
-    ).to.deep.equal({ color: "grey", fontcolor: "grey" });
+      { color: "grey", fontcolor: "grey" },
+    );
   });
 
   it("couldNotResolve => red", () => {
-    expect(
+    deepStrictEqual(
       theming.determineAttributes(
         { couldNotResolve: true },
         theming.normalizeTheme({}).modules,
       ),
-    ).to.deep.equal({ color: "red", fontcolor: "red" });
+      { color: "red", fontcolor: "red" },
+    );
   });
 
   it("json => darker yellowish fillcolor", () => {
-    expect(
+    deepStrictEqual(
       theming.determineAttributes(
         { source: "package.json" },
         theming.normalizeTheme({}).modules,
       ),
-    ).to.deep.equal({ fillcolor: "#ffee44" });
+      { fillcolor: "#ffee44" },
+    );
   });
 
   it("normalizeTheme doesn't mutate the default theme", () => {
     const lOriginalDefaultTheme = _cloneDeep(theming.normalizeTheme());
 
     theming.normalizeTheme({ graph: { someAttribute: 1234 } });
-    expect(theming.normalizeTheme()).to.deep.equal(lOriginalDefaultTheme);
+    deepStrictEqual(theming.normalizeTheme(), lOriginalDefaultTheme);
   });
 });

--- a/test/report/error-html/error-html.spec.mjs
+++ b/test/report/error-html/error-html.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { match, strictEqual, doesNotMatch } from "node:assert";
 import errorHTML from "../../../src/report/error-html/index.mjs";
 import everythingFineResult from "./__mocks__/everything-fine.mjs";
 import validationMoreThanOnce from "./__mocks__/violation-more-than-once.mjs";
@@ -11,48 +11,50 @@ describe("[I] report/error-html", () => {
   it("happy day no errors", () => {
     const lResult = errorHTML(everythingFineResult);
 
-    expect(lResult.output).to.contain(lOkeliDokelyKey);
-    expect(lResult.output).to.contain(lOkeliDokelyHeader);
-    expect(lResult.exitCode).to.equal(0);
+    match(lResult.output, new RegExp(lOkeliDokelyKey));
+    match(lResult.output, new RegExp(lOkeliDokelyHeader));
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report with errors", () => {
-    const lReport = errorHTML(validationMoreThanOnce);
+    const lResult = errorHTML(validationMoreThanOnce);
 
-    expect(lReport.output).to.not.contain(lOkeliDokelyKey);
-    expect(lReport.output).to.not.contain(lOkeliDokelyHeader);
-    expect(lReport.output).to.contain("All violations");
-    expect(lReport.output).to.contain("<strong>127</strong> modules");
-    expect(lReport.output).to.contain("<strong>259</strong> dependencies");
-    expect(lReport.output).to.contain("<strong>0</strong> errors");
-    expect(lReport.output).to.contain("<strong>1</strong> warnings");
-    expect(lReport.output).to.contain("<strong>2</strong> informational");
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
+    match(lResult.output, /All violations/);
+    match(lResult.output, /<strong>127<\/strong> modules/);
+    match(lResult.output, /<strong>259<\/strong> dependencies/);
+    match(lResult.output, /<strong>0<\/strong> errors/);
+    match(lResult.output, /<strong>1<\/strong> warnings/);
+    match(lResult.output, /<strong>2<\/strong> informational/);
 
-    expect(lReport.output).to.contain("<td><strong>2</strong></td>");
-    expect(lReport.output).to.contain(
-      '<a href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/index.js">',
+    match(lResult.output, /<td><strong>2<\/strong><\/td>/);
+    match(
+      lResult.output,
+      /<a href="https:\/\/github.com\/sverweij\/dependency-cruiser\/blob\/develop\/src\/cli\/compileConfig\/index.js">/,
     );
-    expect(lReport.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report with violations and ignored violations", () => {
-    const lReport = errorHTML(validationMoreThanOnceWithAnIgnore);
+    const lResult = errorHTML(validationMoreThanOnceWithAnIgnore);
 
-    expect(lReport.output).to.not.contain(lOkeliDokelyKey);
-    expect(lReport.output).to.not.contain(lOkeliDokelyHeader);
-    expect(lReport.output).to.contain("All violations");
-    expect(lReport.output).to.contain("<strong>127</strong> modules");
-    expect(lReport.output).to.contain("<strong>259</strong> dependencies");
-    expect(lReport.output).to.contain("<strong>0</strong> errors");
-    expect(lReport.output).to.contain("<strong>0</strong> warnings");
-    expect(lReport.output).to.contain("<strong>1</strong> informational");
-    expect(lReport.output).to.contain("<strong>2</strong> ignored");
-    expect(lReport.output).to.contain("also show ignored violations");
-    expect(lReport.output).to.contain("<th>ignored</th>");
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
+    match(lResult.output, /All violations/);
+    match(lResult.output, /<strong>127<\/strong> modules/);
+    match(lResult.output, /<strong>259<\/strong> dependencies/);
+    match(lResult.output, /<strong>0<\/strong> errors/);
+    match(lResult.output, /<strong>0<\/strong> warnings/);
+    match(lResult.output, /<strong>1<\/strong> informational/);
+    match(lResult.output, /<strong>2<\/strong> ignored/);
+    match(lResult.output, /also show ignored violations/);
+    match(lResult.output, /<th>ignored<\/th>/);
 
-    expect(lReport.output).to.contain(
-      '<a href="https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/compileConfig/index.js">',
+    match(
+      lResult.output,
+      /<a href="https:\/\/github.com\/sverweij\/dependency-cruiser\/blob\/develop\/src\/cli\/compileConfig\/index.js">/,
     );
-    expect(lReport.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 });

--- a/test/report/error-html/utl.spec.mjs
+++ b/test/report/error-html/utl.spec.mjs
@@ -1,35 +1,37 @@
-import { expect } from "chai";
+/* eslint-disable no-prototype-builtins */
+import { deepStrictEqual, strictEqual } from "node:assert";
 import utl from "../../../src/report/error-html/utl.mjs";
 
 function summaryHasMinimalAttributes(pResult) {
-  expect(pResult).to.haveOwnProperty("depcruiseVersion");
-  expect(pResult).to.haveOwnProperty("runDate");
-  expect(pResult).to.haveOwnProperty("violations");
+  strictEqual(pResult.hasOwnProperty("depcruiseVersion"), true);
+  strictEqual(pResult.hasOwnProperty("runDate"), true);
+  strictEqual(pResult.hasOwnProperty("violations"), true);
 }
 
 describe("[U] report/error-html/utl", () => {
   it("getFormattedAllowedRule - no allowed rule available returns empty array", () => {
-    expect(utl.getFormattedAllowedRule({})).to.deep.equal([]);
+    deepStrictEqual(utl.getFormattedAllowedRule({}), []);
   });
 
   it("getFormattedAllowedRule - empty allowed array returns empty array", () => {
-    expect(utl.getFormattedAllowedRule({ allowed: [] })).to.deep.equal([]);
+    deepStrictEqual(utl.getFormattedAllowedRule({ allowed: [] }), []);
   });
 
   it("getFormattedAllowedRule - one rule with no comment, no severity returns default comment & severity", () => {
-    expect(
+    deepStrictEqual(
       utl.getFormattedAllowedRule({
         allowed: [{ from: {}, to: {} }],
       }),
-    ).to.deep.equal({
-      name: "not-in-allowed",
-      severity: "warn",
-      comment: "-",
-    });
+      {
+        name: "not-in-allowed",
+        severity: "warn",
+        comment: "-",
+      },
+    );
   });
 
   it("getFormattedAllowedRule - a rule with a comment, no severity returns that comment & default severity", () => {
-    expect(
+    deepStrictEqual(
       utl.getFormattedAllowedRule({
         allowed: [
           {
@@ -51,15 +53,16 @@ describe("[U] report/error-html/utl", () => {
           },
         ],
       }),
-    ).to.deep.equal({
-      name: "not-in-allowed",
-      severity: "warn",
-      comment: "this is a comment",
-    });
+      {
+        name: "not-in-allowed",
+        severity: "warn",
+        comment: "this is a comment",
+      },
+    );
   });
 
   it("getFormattedAllowedRule - a rule with a severity, no comment returns a default comment & that severity", () => {
-    expect(
+    deepStrictEqual(
       utl.getFormattedAllowedRule({
         allowed: [
           {
@@ -73,15 +76,16 @@ describe("[U] report/error-html/utl", () => {
         ],
         allowedSeverity: "info",
       }),
-    ).to.deep.equal({
-      name: "not-in-allowed",
-      severity: "info",
-      comment: "-",
-    });
+      {
+        name: "not-in-allowed",
+        severity: "info",
+        comment: "-",
+      },
+    );
   });
 
   it("mergeCountIntoRule - no violation", () => {
-    expect(utl.mergeCountsIntoRule({ name: "blah" }, {})).to.deep.equal({
+    deepStrictEqual(utl.mergeCountsIntoRule({ name: "blah" }, {}), {
       name: "blah",
       count: 0,
       ignoredCount: 0,
@@ -90,24 +94,25 @@ describe("[U] report/error-html/utl", () => {
   });
 
   it("mergeCountIntoRule - some violations", () => {
-    expect(
+    deepStrictEqual(
       utl.mergeCountsIntoRule(
         { name: "blah" },
         { blah: { count: 69, ignoredCount: 0 } },
       ),
-    ).to.deep.equal({
-      name: "blah",
-      count: 69,
-      ignoredCount: 0,
-      unviolated: false,
-    });
+      {
+        name: "blah",
+        count: 69,
+        ignoredCount: 0,
+        unviolated: false,
+      },
+    );
   });
 
   it("formatSummaryForReport - empty", () => {
     const lResult = utl.formatSummaryForReport({});
 
     summaryHasMinimalAttributes(lResult);
-    expect(lResult.violations).to.deep.equal([]);
+    deepStrictEqual(lResult.violations, []);
   });
 
   it("formatSummaryForReport - one module violation", () => {
@@ -122,7 +127,7 @@ describe("[U] report/error-html/utl", () => {
     });
 
     summaryHasMinimalAttributes(lResult);
-    expect(lResult.violations).to.deep.equal([
+    deepStrictEqual(lResult.violations, [
       {
         type: "dependency",
         from: "aap",
@@ -144,7 +149,7 @@ describe("[U] report/error-html/utl", () => {
     });
 
     summaryHasMinimalAttributes(lResult);
-    expect(lResult.violations).to.deep.equal([
+    deepStrictEqual(lResult.violations, [
       {
         type: "module",
         from: "aap",
@@ -165,7 +170,7 @@ describe("[U] report/error-html/utl", () => {
     const lExpectation =
       "thing/a &rightarrow;<br/>b &rightarrow;<br/>thingy/bingy/c &rightarrow;<br/>a";
 
-    expect(utl.determineTo(lInputViolation)).to.deep.equal(lExpectation);
+    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - via violation", () => {
@@ -179,7 +184,7 @@ describe("[U] report/error-html/utl", () => {
     const lExpectation =
       "thing/a<br/>thing/a &rightarrow;<br/>b &rightarrow;<br/>thingy/bingy/c &rightarrow;<br/>a";
 
-    expect(utl.determineTo(lInputViolation)).to.deep.equal(lExpectation);
+    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - dependency violation", () => {
@@ -191,7 +196,7 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = "thing/a";
 
-    expect(utl.determineTo(lInputViolation)).to.deep.equal(lExpectation);
+    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - module violation", () => {
@@ -203,7 +208,7 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = "";
 
-    expect(utl.determineTo(lInputViolation)).to.deep.equal(lExpectation);
+    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - instability violation", () => {
@@ -216,7 +221,7 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = 'b&nbsp;<span class="extra">(I: 100%)</span>';
 
-    expect(utl.determineTo(lInputViolation)).to.deep.equal(lExpectation);
+    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineFromExtras - instability violation", () => {
@@ -229,8 +234,6 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = '&nbsp;<span class="extra">(I: 10%)</span>';
 
-    expect(utl.determineFromExtras(lInputViolation)).to.deep.equal(
-      lExpectation,
-    );
+    deepStrictEqual(utl.determineFromExtras(lInputViolation), lExpectation);
   });
 });

--- a/test/report/error/error-long.spec.mjs
+++ b/test/report/error/error-long.spec.mjs
@@ -1,6 +1,7 @@
+/* eslint-disable security/detect-non-literal-regexp */
 /* eslint-disable no-magic-numbers */
+import { strictEqual, match } from "node:assert";
 import { EOL } from "node:os";
-import { expect } from "chai";
 import chalk from "chalk";
 import render from "../../../src/report/error-long.mjs";
 import okDeps from "./__mocks__/everything-fine.mjs";
@@ -21,39 +22,39 @@ describe("[I] report/error-long", () => {
   it("says everything fine", () => {
     const lResult = render(okDeps);
 
-    expect(lResult.output).to.contain("no dependency violations found");
-    expect(lResult.exitCode).to.equal(0);
+    match(lResult.output, /no dependency violations found/);
+    strictEqual(lResult.exitCode, 0);
   });
   it("renders a bunch of errors", () => {
     const lResult = render(deps);
 
-    expect(lResult.output).to.contain(`error no-leesplank: aap → noot${EOL}`);
-    expect(lResult.output).to.contain(
-      "2 dependency violations (2 errors, 0 warnings). 33 modules, 333 dependencies cruised.",
+    match(lResult.output, new RegExp(`error no-leesplank: aap → noot${EOL}`));
+    match(
+      lResult.output,
+      /2 dependency violations \(2 errors, 0 warnings\)\. 33 modules, 333 dependencies cruised\./,
     );
-    expect(lResult.output).to.contain("    comment to no-leesplank");
-    expect(lResult.exitCode).to.equal(2);
+    match(lResult.output, / {4}comment to no-leesplank/);
+    strictEqual(lResult.exitCode, 2);
   });
   it("renders a bunch of warnings", () => {
     const lResult = render(warnDeps);
 
-    expect(lResult.output).to.contain(
-      "1 dependency violations (0 errors, 1 warnings)",
-    );
-    expect(lResult.exitCode).to.equal(0);
+    match(lResult.output, /1 dependency violations \(0 errors, 1 warnings\)/);
+    strictEqual(lResult.exitCode, 0);
   });
   it("renders module only violations as module only", () => {
     const lResult = render(orphanErrs);
 
-    expect(lResult.output).to.contain(`error no-orphans: remi.js${EOL}`);
-    expect(lResult.output).to.contain(
-      "1 dependency violations (1 errors, 0 warnings). 1 modules, 0 dependencies cruised.",
+    match(lResult.output, new RegExp(`error no-orphans: remi.js${EOL}`));
+    match(
+      lResult.output,
+      /1 dependency violations \(1 errors, 0 warnings\)\. 1 modules, 0 dependencies cruised\./,
     );
-    expect(lResult.exitCode).to.equal(1);
+    strictEqual(lResult.exitCode, 1);
   });
   it("renders a '-' for comment if it couldn't find the rule", () => {
     const lResult = render(errorsAdditionalInfo);
 
-    expect(lResult.output).to.contain("    -");
+    match(lResult.output, / {4}-/);
   });
 });

--- a/test/report/html/html.spec.mjs
+++ b/test/report/html/html.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import render from "../../../src/report/html/index.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
 
@@ -15,7 +15,7 @@ describe("[I] report/html reporter", () => {
   it("renders html - modules in the root don't come in a cluster; and one module could not be resolved", () => {
     const lReturnValue = render(deps);
 
-    expect(lReturnValue.output).to.deep.equal(elementFixture);
-    expect(lReturnValue.exitCode).to.equal(0);
+    deepStrictEqual(lReturnValue.output, elementFixture);
+    strictEqual(lReturnValue.exitCode, 0);
   });
 });

--- a/test/report/markdown/markdown.spec.mjs
+++ b/test/report/markdown/markdown.spec.mjs
@@ -1,4 +1,5 @@
-import { expect } from "chai";
+/* eslint-disable prefer-regex-literals */
+import { match, doesNotMatch, strictEqual } from "node:assert";
 import markdown from "../../../src/report/markdown.mjs";
 import everythingFineResult from "./__mocks__/everything-fine.mjs";
 import validationMoreThanOnce from "./__mocks__/violation-more-than-once.mjs";
@@ -14,11 +15,11 @@ describe("[I] report/markdown", () => {
   it("happy day no errors", () => {
     const lResult = markdown(everythingFineResult);
 
-    expect(lResult.output).to.contain(lDefaultTitle);
-    expect(lResult.output).to.contain(lDefaultSummaryHeader);
-    expect(lResult.output).to.contain(lOkeliDokelyKey);
-    expect(lResult.output).to.contain(lOkeliDokelyHeader);
-    expect(lResult.exitCode).to.equal(0);
+    match(lResult.output, new RegExp(lDefaultTitle));
+    match(lResult.output, new RegExp(lDefaultSummaryHeader));
+    match(lResult.output, new RegExp(lOkeliDokelyKey));
+    match(lResult.output, new RegExp(lOkeliDokelyHeader));
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("happy day no errors - custom options", () => {
@@ -28,116 +29,120 @@ describe("[I] report/markdown", () => {
       summaryHeader: lCustomSummaryHeader,
     });
 
-    expect(lResult.output).to.not.contain(lDefaultTitle);
-    expect(lResult.output).to.not.contain(lDefaultSummaryHeader);
-    expect(lResult.output).to.contain(lCustomSummaryHeader);
-    expect(lResult.output).to.contain(lOkeliDokelyKey);
-    expect(lResult.output).to.contain(lOkeliDokelyHeader);
-    expect(lResult.exitCode).to.equal(0);
+    doesNotMatch(lResult.output, new RegExp(lDefaultTitle));
+    doesNotMatch(lResult.output, new RegExp(lDefaultSummaryHeader));
+    match(lResult.output, new RegExp(lCustomSummaryHeader));
+    match(lResult.output, new RegExp(lOkeliDokelyKey));
+    match(lResult.output, new RegExp(lOkeliDokelyHeader));
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report with errors", () => {
-    const lReport = markdown(validationMoreThanOnce);
+    const lResult = markdown(validationMoreThanOnce);
 
-    expect(lReport.output).to.not.contain(lOkeliDokelyKey);
-    expect(lReport.output).to.not.contain(lOkeliDokelyHeader);
-    expect(lReport.output).to.contain("<details>");
-    expect(lReport.output).to.contain("All violations");
-    expect(lReport.output).to.contain("**127** modules");
-    expect(lReport.output).to.contain("**259** dependencies");
-    expect(lReport.output).to.contain("**0** errors");
-    expect(lReport.output).to.contain("**1** warnings");
-    expect(lReport.output).to.contain("**2** informational");
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
+    match(lResult.output, /<details>/);
+    match(lResult.output, /All violations/);
+    match(lResult.output, /\*\*127\*\* modules/);
+    match(lResult.output, /\*\*259\*\* dependencies/);
+    match(lResult.output, /\*\*0\*\* errors/);
+    match(lResult.output, /\*\*1\*\* warnings/);
+    match(lResult.output, /\*\*2\*\* informational/);
 
-    expect(lReport.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report with errors - custom options", () => {
-    const lReport = markdown(validationMoreThanOnce, {
+    const lResult = markdown(validationMoreThanOnce, {
       collapseDetails: false,
     });
 
-    expect(lReport.output).to.not.contain(lOkeliDokelyKey);
-    expect(lReport.output).to.not.contain(lOkeliDokelyHeader);
-    expect(lReport.output).to.not.contain("<details>");
-    expect(lReport.output).to.contain("All violations");
-    expect(lReport.output).to.contain("**127** modules");
-    expect(lReport.output).to.contain("**259** dependencies");
-    expect(lReport.output).to.contain("**0** errors");
-    expect(lReport.output).to.contain("**1** warnings");
-    expect(lReport.output).to.contain("**2** informational");
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
+    doesNotMatch(lResult.output, /<details>/);
+    match(lResult.output, /All violations/);
+    match(lResult.output, /\*\*127\*\* modules/);
+    match(lResult.output, /\*\*259\*\* dependencies/);
+    match(lResult.output, /\*\*0\*\* errors/);
+    match(lResult.output, /\*\*1\*\* warnings/);
+    match(lResult.output, /\*\*2\*\* informational/);
 
-    expect(lReport.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report with violations and ignored violations", () => {
-    const lReport = markdown(validationMoreThanOnceWithAnIgnore);
+    const lResult = markdown(validationMoreThanOnceWithAnIgnore);
 
-    expect(lReport.output).to.not.contain(lOkeliDokelyKey);
-    expect(lReport.output).to.not.contain(lOkeliDokelyHeader);
-    expect(lReport.output).to.contain("All violations");
-    expect(lReport.output).to.contain("**127** modules");
-    expect(lReport.output).to.contain("**259** dependencies");
-    expect(lReport.output).to.contain("**0** errors");
-    expect(lReport.output).to.contain("**0** warnings");
-    expect(lReport.output).to.contain("**1** informational");
-    expect(lReport.output).to.contain("**2** ignored");
-    expect(lReport.output).to.contain(
-      "|:warning:&nbsp;_cli-to-main-only-warn_|**0**|**1**|",
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
+    match(lResult.output, /All violations/);
+    match(lResult.output, /\*\*127\*\* modules/);
+    match(lResult.output, /\*\*259\*\* dependencies/);
+    match(lResult.output, /\*\*0\*\* errors/);
+    match(lResult.output, /\*\*0\*\* warnings/);
+    match(lResult.output, /\*\*1\*\* informational/);
+    match(lResult.output, /\*\*2\*\* ignored/);
+    match(
+      lResult.output,
+      /|:warning:&nbsp;_cli-to-main-only-warn_|\*\*0\*\*|\*\*1\*\*|/,
     );
-    expect(lReport.output).to.contain(
-      ":see_no_evil:&nbsp;_cli-to-main-only-warn_",
-    );
-    expect(lReport.output).to.contain("src/cli/compileConfig/index.js");
+    match(lResult.output, /:see_no_evil:&nbsp;_cli-to-main-only-warn_/);
+    match(lResult.output, /src\/cli\/compileConfig\/index\.js/);
 
-    expect(lReport.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report with violations and ignored violations hidden", () => {
-    const lReport = markdown(validationMoreThanOnceWithAnIgnore, {
+    const lResult = markdown(validationMoreThanOnceWithAnIgnore, {
       includeIgnoredInSummary: false,
       includeIgnoredInDetails: false,
     });
 
-    expect(lReport.output).to.not.contain(lOkeliDokelyKey);
-    expect(lReport.output).to.not.contain(lOkeliDokelyHeader);
-    expect(lReport.output).to.contain("All violations");
-    expect(lReport.output).to.contain("**127** modules");
-    expect(lReport.output).to.contain("**259** dependencies");
-    expect(lReport.output).to.contain("**0** errors");
-    expect(lReport.output).to.contain("**0** warnings");
-    expect(lReport.output).to.contain("**1** informational");
-    expect(lReport.output).to.contain("**2** ignored");
-    expect(lReport.output).to.not.contain(
-      "|:warning:&nbsp;_cli-to-main-only-warn_|**0**|**1**|",
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
+    match(lResult.output, /All violations/);
+    match(lResult.output, /\*\*127\*\* modules/);
+    match(lResult.output, /\*\*259\*\* dependencies/);
+    match(lResult.output, /\*\*0\*\* errors/);
+    match(lResult.output, /\*\*0\*\* warnings/);
+    match(lResult.output, /\*\*1\*\* informational/);
+    match(lResult.output, /\*\*2\*\* ignored/);
+    doesNotMatch(
+      lResult.output,
+      /\|:warning:&nbsp;_cli-to-main-only-warn_\|\*\*0*\*\|\*\*1*\*\|/,
     );
-    expect(lReport.output).to.not.contain(
-      ":see_no_evil:&nbsp;_cli-to-main-only-warn_",
+    doesNotMatch(
+      lResult.output,
+      new RegExp(":see_no_evil:&nbsp;_cli-to-main-only-warn_"),
     );
-    expect(lReport.output).to.not.contain("src/cli/compileConfig/index.js");
+    doesNotMatch(lResult.output, new RegExp("src/cli/compileConfig/index.js"));
 
-    expect(lReport.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("report nicely on orphans, cycles and metric rules", () => {
     const lResult = markdown(orphansCyclesMetrics);
 
-    expect(lResult.output).to.contain(lDefaultTitle);
-    expect(lResult.output).to.contain(lDefaultSummaryHeader);
-    expect(lResult.output).to.not.contain(lOkeliDokelyKey);
-    expect(lResult.output).to.not.contain(lOkeliDokelyHeader);
+    match(lResult.output, new RegExp(lDefaultTitle));
+    match(lResult.output, new RegExp(lDefaultSummaryHeader));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyKey));
+    doesNotMatch(lResult.output, new RegExp(lOkeliDokelyHeader));
 
     // empty 'to' column for module only rules
-    expect(lResult.output).to.contain(
-      "|:exclamation:&nbsp;_no-orphans_|src/schema/baseline-violations.schema.js||",
+    match(
+      lResult.output,
+      /|:exclamation:&nbsp;_no-orphans_|src\/schema\/baseline-violations.schema.js||/,
     );
     // cycles as cycles in the 'to' column:
-    expect(lResult.output).to.contain(
-      "|:warning:&nbsp;_no-folder-cycles_|src/extract/parse|src/extract/transpile &rightarrow;<br/>src/extract/parse|",
+    match(
+      lResult.output,
+      /|:warning:&nbsp;_no-folder-cycles_|src\/extract\/parse|src\/extract\/transpile &rightarrow;<br\/>src\/extract\/parse|/,
     );
     // metrics violations with the 'instability' for the involved modules in:
-    expect(lResult.output).to.contain(
-      '|:grey_exclamation:&nbsp;_SDP_|src/extract/gather-initial-sources.js&nbsp;<span class="extra">(I: 75%)</span>|src/extract/transpile/meta.js&nbsp;<span class="extra">(I: 80%)</span>|',
+    match(
+      lResult.output,
+      /|:grey_exclamation:&nbsp;_SDP_|src\/extract\/gather-initial-sources.js&nbsp;<span class="extra">(I: 75%)<\/span>|src\/extract\/transpile\/meta.js&nbsp;<span class="extra">(I: 80%)<\/span>|/,
     );
   });
 });

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 // eslint-plugins import and node don't yet understand these 'self references'
 // eslint-disable-next-line import/no-unresolved, node/no-missing-import
 import mermaidReporterPlugin from "dependency-cruiser/mermaid-reporter-plugin";
@@ -22,7 +22,7 @@ const same = (pName, pOptions, pMermaidModule = mermaid) => {
     "utf8",
   );
   const output = pMermaidModule(definition, pOptions).output;
-  expect(output).to.deep.equal(expected);
+  deepStrictEqual(output, expected);
 };
 
 describe("[I] report/mermaid", () => {

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -1,5 +1,7 @@
+/* eslint-disable security/detect-non-literal-regexp */
+/* eslint-disable no-regex-spaces */
 import { EOL } from "node:os";
-import { expect } from "chai";
+import { doesNotMatch, match, strictEqual } from "node:assert";
 import metrics from "../../../src/report/metrics.mjs";
 import cruiseResultWithMetricsForModulesAndFolders from "./__mocks/cruise-result-with-metrics-for-modules-and-folders.mjs";
 
@@ -7,8 +9,8 @@ describe("[I] report/metrics", () => {
   it("errors when the input doesn't contain a 'folders' section", () => {
     const lResult = metrics({ modules: [] });
 
-    expect(lResult.exitCode).to.equal(1);
-    expect(lResult.output).to.contain("ERROR");
+    strictEqual(lResult.exitCode, 1);
+    match(lResult.output, /ERROR/);
   });
 
   it("emits folder metrics", () => {
@@ -25,8 +27,8 @@ describe("[I] report/metrics", () => {
       ],
     });
 
-    expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain("src       1      1      1    50%");
+    strictEqual(lResult.exitCode, 0);
+    match(lResult.output, /src       1      1      1    50%/);
   });
 
   it("does not emit folder metrics when asked to hide them", () => {
@@ -46,8 +48,8 @@ describe("[I] report/metrics", () => {
       { hideFolders: true },
     );
 
-    expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.not.contain("src       1      1      1    50%");
+    strictEqual(lResult.exitCode, 0);
+    doesNotMatch(lResult.output, /src       1      1      1    50%/);
   });
 
   it("emits module metrics (sorted by instability by default)", () => {
@@ -75,9 +77,12 @@ describe("[I] report/metrics", () => {
       folders: [],
     });
 
-    expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain(
-      `src/mies.js      1      1      1    50%${EOL}src/aap.js       1      1      3    25%${EOL}src/noot.js`,
+    strictEqual(lResult.exitCode, 0);
+    match(
+      lResult.output,
+      new RegExp(
+        `src/mies.js      1      1      1    50%${EOL}src/aap.js       1      1      3    25%${EOL}src/noot.js`,
+      ),
     );
   });
 
@@ -109,9 +114,12 @@ describe("[I] report/metrics", () => {
       { orderBy: "name" },
     );
 
-    expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain(
-      `src/aap.js       1      1      3    25%${EOL}src/mies.js      1      1      1    50%${EOL}src/noot.js`,
+    strictEqual(lResult.exitCode, 0);
+    match(
+      lResult.output,
+      new RegExp(
+        `src/aap.js       1      1      3    25%${EOL}src/mies.js      1      1      1    50%${EOL}src/noot.js`,
+      ),
     );
   });
 
@@ -143,9 +151,12 @@ describe("[I] report/metrics", () => {
       { hideModules: true },
     );
 
-    expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.not.contain(
-      `src/mies.js      1      1      1     50%${EOL}src/aap.js       1      1      3     25%${EOL}src/noot.js`,
+    strictEqual(lResult.exitCode, 0);
+    doesNotMatch(
+      lResult.output,
+      new RegExp(
+        `src/mies.js      1      1      1     50%${EOL}src/aap.js       1      1      3     25%${EOL}src/noot.js`,
+      ),
     );
   });
 
@@ -154,9 +165,8 @@ describe("[I] report/metrics", () => {
       hideModules: true,
     });
 
-    expect(lResult.exitCode).to.equal(0);
-    expect(lResult.output).to.contain("src");
-    expect(lResult.output).to.contain("src/report");
-    expect(lResult.output).to.not.contain("node_modules");
+    strictEqual(lResult.exitCode, 0);
+    match(lResult.output, /src\/report/);
+    doesNotMatch(lResult.output, /node_modules/);
   });
 });

--- a/test/report/null/null.spec.mjs
+++ b/test/report/null/null.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import nullReporter from "../../../src/report/null.mjs";
 
 const gSmallOKResult = {
@@ -72,14 +72,14 @@ const gSmallNOKResult = {
 describe("[I] report/null", () => {
   it("happy day no errors", () => {
     const lResult = nullReporter(gSmallOKResult);
-    expect(lResult).to.deep.equal({
+    deepStrictEqual(lResult, {
       output: "",
       exitCode: 0,
     });
   });
   it("happy day some errors", () => {
     const lResult = nullReporter(gSmallNOKResult);
-    expect(lResult).to.deep.equal({
+    deepStrictEqual(lResult, {
       output: "",
       exitCode: 3,
     });

--- a/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
+++ b/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-non-literal-regexp */
 import { match, strictEqual } from "node:assert";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,9 +19,9 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    match(
-      lErrorMessage,
-      new RegExp(`${lNoExitCodePlugin} is not a valid plugin`),
+    strictEqual(
+      lErrorMessage.includes(`${lNoExitCodePlugin} is not a valid plugin`),
+      true,
     );
   });
 
@@ -38,9 +37,9 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    match(
-      lErrorMessage,
-      new RegExp(`${lNoOutputPlugin} is not a valid plugin`),
+    strictEqual(
+      lErrorMessage.includes(`${lNoOutputPlugin} is not a valid plugin`),
+      true,
     );
   });
 

--- a/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
+++ b/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
@@ -1,6 +1,7 @@
+/* eslint-disable security/detect-non-literal-regexp */
+import { match, strictEqual } from "node:assert";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import { getExternalPluginReporter } from "../../../src/report/plugins.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -19,8 +20,9 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    expect(lErrorMessage).to.contain(
-      `${lNoExitCodePlugin} is not a valid plugin`,
+    match(
+      lErrorMessage,
+      new RegExp(`${lNoExitCodePlugin} is not a valid plugin`),
     );
   });
 
@@ -36,8 +38,9 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    expect(lErrorMessage).to.contain(
-      `${lNoOutputPlugin} is not a valid plugin`,
+    match(
+      lErrorMessage,
+      new RegExp(`${lNoOutputPlugin} is not a valid plugin`),
     );
   });
 
@@ -49,16 +52,18 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    expect(lErrorMessage).to.contain(
-      "Could not find reporter plugin 'this-plugin-does-not-exist'",
+    match(
+      lErrorMessage,
+      /Could not find reporter plugin 'this-plugin-does-not-exist'/,
     );
   });
 
   it("returns false when it's not a plugin", async () => {
-    expect(
+    strictEqual(
       await getExternalPluginReporter(`whatever-just-not-a-plugin`),
-    ).to.equal(false);
-    expect(getExternalPluginReporter()).to.equal(false);
+      false,
+    );
+    strictEqual(getExternalPluginReporter(), false);
   });
 
   it("throws when the plugin:reporter is not a valid plugin (package ref)", async () => {
@@ -69,7 +74,7 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    expect(lErrorMessage).to.contain(`watskeburt is not a valid plugin`);
+    match(lErrorMessage, /watskeburt is not a valid plugin/);
   });
 
   it("returns the plugin module when it's valid and exists", async () => {
@@ -81,8 +86,8 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
       summary: { totalCruised: 0 },
     });
 
-    expect(lResults).to.haveOwnProperty("output");
-    expect(lResults).to.haveOwnProperty("exitCode");
-    expect(lResults.exitCode).to.equal(0);
+    strictEqual(hasOwnProperty.call(lResults, "output"), true);
+    strictEqual(hasOwnProperty.call(lResults, "exitCode"), true);
+    strictEqual(lResults.exitCode, 0);
   });
 });

--- a/test/report/plugins/index.is-valid-plugin.spec.mjs
+++ b/test/report/plugins/index.is-valid-plugin.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import { isValidPlugin } from "../../../src/report/plugins.mjs";
 
 describe("[U] report/plugins - isValidPlugin", () => {
@@ -6,32 +6,32 @@ describe("[U] report/plugins - isValidPlugin", () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-no-exit-code-plugin.cjs"
     );
-    expect(isValidPlugin(lCandidatePlugin.default)).to.equal(false);
+    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns false when the plugin's function doesn't return an output attribute", async () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-no-output-plugin.cjs"
     );
-    expect(isValidPlugin(lCandidatePlugin.default)).to.equal(false);
+    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns false when the plugin's function doesn't return an exit code that is not a number", async () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-non-number-exit-code-plugin.cjs"
     );
-    expect(isValidPlugin(lCandidatePlugin.default)).to.equal(false);
+    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns false when the plugin doesn't return a function", async () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-not-a-function-plugin.cjs"
     );
-    expect(isValidPlugin(lCandidatePlugin.default)).to.equal(false);
+    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns true when the plugin doesn't returns a function that takes a minimal cruise result and returns an output attribute + an numerical exitCode attribute", async () => {
     const lCandidatePlugin = await import("./__fixtures__/valid-plugin.cjs");
-    expect(isValidPlugin(lCandidatePlugin.default)).to.equal(true);
+    strictEqual(isValidPlugin(lCandidatePlugin.default), true);
   });
 });

--- a/test/report/teamcity/teamcity.spec.mjs
+++ b/test/report/teamcity/teamcity.spec.mjs
@@ -1,6 +1,6 @@
+import { strictEqual } from "node:assert";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
 import render from "../../../src/report/teamcity.mjs";
 import okdeps from "./__mocks__/everything-fine.mjs";
 import moduleErrs from "./__mocks__/module-errors.mjs";
@@ -28,19 +28,27 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(okdeps);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(lFixture);
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
+      removePerSessionAttributes(lFixture),
+    );
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("renders module only transgressions", () => {
     const lFixture = readFixture("__mocks__/module-errors-teamcity-format.txt");
     const lResult = render(moduleErrs);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
+      removePerSessionAttributes(lFixture),
+    );
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(5);
+    strictEqual(lResult.exitCode, 5);
   });
 
   it("renders 'required' violations", () => {
@@ -49,44 +57,48 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(requiredErrs);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(5);
+    strictEqual(lResult.exitCode, 5);
   });
 
   it("renders circular transgressions", () => {
     const lFixture = readFixture("__mocks__/circular-deps-teamcity-format.txt");
     const lResult = render(circulars);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(3);
+    strictEqual(lResult.exitCode, 3);
   });
 
   it("renders via transgressions", () => {
     const lFixture = readFixture("__mocks__/via-deps-teamcity-format.txt");
     const lResult = render(vias);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(4);
+    strictEqual(lResult.exitCode, 4);
   });
 
   it("renders instability transgressions", () => {
     const lFixture = readFixture("__mocks__/instabilities-teamcity-format.txt");
     const lResult = render(instabilities);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
 
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("renders unsupported error levels (like 'ignore') as 'info'", () => {
@@ -95,11 +107,12 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(unsupportedErrorLevels);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    expect(lResult.exitCode).to.equal(5);
+    strictEqual(lResult.exitCode, 5);
   });
 
   it("renders known errors in a single warning", () => {
@@ -108,9 +121,10 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(knownViolations);
 
-    expect(removePerSessionAttributes(lResult.output)).to.equal(
+    strictEqual(
+      removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(lResult.exitCode, 0);
   });
 });

--- a/test/report/text/text.spec.mjs
+++ b/test/report/text/text.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import chalk from "chalk";
 import normalizeNewline from "normalize-newline";
 import renderText from "../../../src/report/text.mjs";
@@ -29,8 +29,8 @@ describe("[I] report/text", () => {
       ),
     );
 
-    expect(normalizeNewline(lResult.output)).to.equal(lExpectedOutput);
-    expect(lResult.exitCode).to.equal(0);
+    strictEqual(normalizeNewline(lResult.output), lExpectedOutput);
+    strictEqual(lResult.exitCode, 0);
   });
 
   it("renders dependencies - focused modules highlighted when highlightFocused === true", () => {
@@ -46,7 +46,7 @@ describe("[I] report/text", () => {
       "test/enrich/derive/reachable/index.spec.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n" +
       "test/main/rule-set/normalize.spec.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n" +
       "test/validate/parse-ruleset.utl.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n";
-    expect(normalizeNewline(lResult.output)).to.equal(lExpectedOutput);
+    strictEqual(normalizeNewline(lResult.output), lExpectedOutput);
   });
 
   it("renders dependencies - no highlights when highlightFocused === false", () => {
@@ -62,6 +62,6 @@ describe("[I] report/text", () => {
       "test/enrich/derive/reachable/index.spec.mjs → src/main/rule-set/normalize.js\n" +
       "test/main/rule-set/normalize.spec.mjs → src/main/rule-set/normalize.js\n" +
       "test/validate/parse-ruleset.utl.mjs → src/main/rule-set/normalize.js\n";
-    expect(normalizeNewline(lResult.output)).to.equal(lExpectedOutput);
+    strictEqual(normalizeNewline(lResult.output), lExpectedOutput);
   });
 });

--- a/test/report/utl/dependency-to-incidence-transformer.spec.mjs
+++ b/test/report/utl/dependency-to-incidence-transformer.spec.mjs
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import transform from "../../../src/report/utl/dependency-to-incidence-transformer.mjs";
 
 import oneViolation from "./__mocks__/one-violation.mjs";
@@ -11,17 +11,19 @@ const MORE_VIOLATIONS_DEPS_INPUT = moreViolations.modules;
 
 describe("[U] dependencyToIncidenceTransformer", () => {
   it("leaves an empty dependencies list alone", () => {
-    expect(transform([])).to.deep.equal([]);
+    deepStrictEqual(transform([]), []);
   });
 
   it("reports single rule violations at the incidence", () => {
-    expect(transform(ONE_VIOLATION_DEPS_INPUT)).to.deep.equal(
+    deepStrictEqual(
+      transform(ONE_VIOLATION_DEPS_INPUT),
       ONE_VIOLATION_DEPS_FIXTURE,
     );
   });
 
   it("reports multiple rule violations per dependency at the incidence with a hint there's more", () => {
-    expect(transform(MORE_VIOLATIONS_DEPS_INPUT)).to.deep.equal(
+    deepStrictEqual(
+      transform(MORE_VIOLATIONS_DEPS_INPUT),
       MORE_VIOLATIONS_DEPS_FIXTURE,
     );
   });

--- a/test/utl/get-extension.spec.mjs
+++ b/test/utl/get-extension.spec.mjs
@@ -1,32 +1,32 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import getExtension from "../../src/utl/get-extension.mjs";
 
 describe("[U] utl/getExtension", () => {
   it(".coffee.md classifies as .coffee.md", () => {
-    expect(getExtension("./aap/noot/mies.coffee.md")).to.equal(".coffee.md");
+    strictEqual(getExtension("./aap/noot/mies.coffee.md"), ".coffee.md");
   });
 
   it(".tea.md classifies as .md", () => {
-    expect(getExtension("./aap/noot/mies.tes.md")).to.equal(".md");
+    strictEqual(getExtension("./aap/noot/mies.tes.md"), ".md");
   });
 
   it("types.d.ts classifies as .d.ts", () => {
-    expect(getExtension("./types/types.d.ts")).to.equal(".d.ts");
+    strictEqual(getExtension("./types/types.d.ts"), ".d.ts");
   });
 
   it("types.d.mts classifies as .d.mts", () => {
-    expect(getExtension("./types/types.d.mts")).to.equal(".d.mts");
+    strictEqual(getExtension("./types/types.d.mts"), ".d.mts");
   });
 
   it("any extension (e.g. .ts) classifies as that", () => {
-    expect(getExtension("./types/typed.ts")).to.equal(".ts");
+    strictEqual(getExtension("./types/typed.ts"), ".ts");
   });
 
   it("any extension (e.g. .js) classifies as that", () => {
-    expect(getExtension("./aap/noot/mies.js")).to.equal(".js");
+    strictEqual(getExtension("./aap/noot/mies.js"), ".js");
   });
 
   it("no extension classifies as nothing", () => {
-    expect(getExtension("./aap/noot/mies")).to.equal("");
+    strictEqual(getExtension("./aap/noot/mies"), "");
   });
 });

--- a/test/utl/path-to-posix.spec.mjs
+++ b/test/utl/path-to-posix.spec.mjs
@@ -1,51 +1,51 @@
 import { win32, posix } from "node:path";
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
 
 describe("[U] utl/pathToPosix on win32", () => {
   it('transforms win32 style paths to posix ones: ""', () => {
-    expect(pathToPosix("", win32)).to.equal("");
+    strictEqual(pathToPosix("", win32), "");
   });
 
   it("transforms win32 style paths to posix ones: \\root\\sub\\file.txt", () => {
-    expect(pathToPosix("\\root\\sub\\file.txt", win32)).to.equal(
+    strictEqual(
+      pathToPosix("\\root\\sub\\file.txt", win32),
       "/root/sub/file.txt",
     );
   });
 
   it("leaves win32 style paths alone: C:\\root\\sub\\file.txt", () => {
-    expect(pathToPosix("C:\\root\\sub\\file.txt", win32)).to.equal(
+    strictEqual(
+      pathToPosix("C:\\root\\sub\\file.txt", win32),
       "C:/root/sub/file.txt",
     );
   });
 
   it("keep posix style paths alone: /root/sub/file.txt", () => {
-    expect(pathToPosix("/root/sub/file.txt", win32)).to.equal(
-      "/root/sub/file.txt",
-    );
+    strictEqual(pathToPosix("/root/sub/file.txt", win32), "/root/sub/file.txt");
   });
 });
 
 describe("[U] utl/pathToPosix  on posix", () => {
   it('leaves win32 style paths alone: ""', () => {
-    expect(pathToPosix("", posix)).to.equal("");
+    strictEqual(pathToPosix("", posix), "");
   });
 
   it("leaves win32 style paths alone: \\root\\sub\\file.txt", () => {
-    expect(pathToPosix("\\root\\sub\\file.txt", posix)).to.equal(
+    strictEqual(
+      pathToPosix("\\root\\sub\\file.txt", posix),
       "\\root\\sub\\file.txt",
     );
   });
 
   it("leaves win32 style paths alone: C:\\root\\sub\\file.txt", () => {
-    expect(pathToPosix("C:\\root\\sub\\file.txt", posix)).to.equal(
+    strictEqual(
+      pathToPosix("C:\\root\\sub\\file.txt", posix),
       "C:\\root\\sub\\file.txt",
     );
   });
 
   it("keeps posix style paths as-is: /root/sub/file.txt", () => {
-    expect(pathToPosix("/root/sub/file.txt", posix)).to.equal(
-      "/root/sub/file.txt",
-    );
+    strictEqual(pathToPosix("/root/sub/file.txt", posix), "/root/sub/file.txt");
   });
 });

--- a/test/utl/regex-util.spec.mjs
+++ b/test/utl/regex-util.spec.mjs
@@ -1,41 +1,46 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import { replaceGroupPlaceholders } from "../../src/utl/regex-util.mjs";
 
 describe("[U] utl/regex-util", () => {
   it("replaceGroupPlaceholders - leaves re alone if passed empty match result", () => {
-    expect(replaceGroupPlaceholders("$1/aap|noot", [])).to.equal("$1/aap|noot");
+    strictEqual(replaceGroupPlaceholders("$1/aap|noot", []), "$1/aap|noot");
   });
 
   it("replaceGroupPlaceholders - leaves re alone if passed groupless match result", () => {
-    expect(replaceGroupPlaceholders("$1/aap|noot", ["houwoei"])).to.equal(
+    strictEqual(
+      replaceGroupPlaceholders("$1/aap|noot", ["houwoei"]),
       "$1/aap|noot",
     );
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupless match result and a $0", () => {
-    expect(replaceGroupPlaceholders("$0/aap|noot", ["houwoei"])).to.equal(
+    strictEqual(
+      replaceGroupPlaceholders("$0/aap|noot", ["houwoei"]),
       "houwoei/aap|noot",
     );
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupy match result and a $1", () => {
-    expect(
+    strictEqual(
       replaceGroupPlaceholders("$1/aap|noot", ["whole/result/part", "part"]),
-    ).to.equal("part/aap|noot");
+      "part/aap|noot",
+    );
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupy match result and multiple $1", () => {
-    expect(
+    strictEqual(
       replaceGroupPlaceholders("$1|$1/[^/]+/|noot", [
         "whole/result/part",
         "part",
       ]),
-    ).to.equal("part|part/[^/]+/|noot");
+      "part|part/[^/]+/|noot",
+    );
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupy match result and multiple groups", () => {
-    expect(
+    strictEqual(
       replaceGroupPlaceholders("$1|$2", ["start/thing/part", "start", "part"]),
-    ).to.equal("start|part");
+      "start|part",
+    );
   });
 });


### PR DESCRIPTION
## Description

- replaces the chai assertion library use with their native node:assert counterparts
- replaces the chai-json-schema chai plugin with a straight use of ajv
- removes chai-json-schema from the manifest as it ain't used no more

The more laborious parts we'll do in a separate PR, likely with the help of a codemod of sorts.

## Motivation and Context

- less dependencies to manage
- node:assert ships with node anyway and is good enough™️ 

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
