### PR TITLE
Suggest `typings` as a `mainFields` wherever `types` is suggested

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -304,7 +304,7 @@ in that external package package.json e.g. like so:
   // rules: [],
   options: {
     enhancedResolveOptions: {
-      mainFields: ["main", "types"]
+      mainFields: ["main", "types", "typings"]
     }
     // other options ...
   }

--- a/src/cli/init-config/build-config.mjs
+++ b/src/cli/init-config/build-config.mjs
@@ -99,7 +99,7 @@ function buildWebpackConfigAttribute(pInitOptions) {
       // env: {},
       // arguments: {}
     },`
-    : `// webpackConfig: { 
+    : `// webpackConfig: {
     //  fileName: 'webpack.config.js',
     //  env: {},
     //  arguments: {}
@@ -136,8 +136,8 @@ function buildExtensionsAttribute(pInitOptions) {
  */
 function buildMainFieldsAttribute(pInitOptions) {
   return pInitOptions.usesTypeScript
-    ? `mainFields: ["main", "types"],`
-    : `// mainFields: ["main", "types"],`;
+    ? `mainFields: ["main", "types", "typings"],`
+    : `// mainFields: ["main", "types", "typings"],`;
 }
 
 /**

--- a/src/schema/configuration.schema.json
+++ b/src/schema/configuration.schema.json
@@ -561,7 +561,7 @@
             },
             "mainFields": {
               "type": "array",
-              "description": "A list of main fields in manifests (package.json s). Typically you'd want to keep leave this this on its default (['main']) , but if you e.g. use external packages that only expose types, and you still want references to these types to be resolved you could expand this to ['main', 'types']"
+              "description": "A list of main fields in manifests (package.json s). Typically you'd want to keep leave this this on its default (['main']) , but if you e.g. use external packages that only expose types, and you still want references to these types to be resolved you could expand this to ['main', 'types', 'typings']"
             },
             "mainFiles": {
               "type": "array",

--- a/src/schema/cruise-result.schema.json
+++ b/src/schema/cruise-result.schema.json
@@ -962,7 +962,7 @@
             },
             "mainFields": {
               "type": "array",
-              "description": "A list of main fields in manifests (package.json s). Typically you'd want to keep leave this this on its default (['main']) , but if you e.g. use external packages that only expose types, and you still want references to these types to be resolved you could expand this to ['main', 'types']"
+              "description": "A list of main fields in manifests (package.json s). Typically you'd want to keep leave this this on its default (['main']) , but if you e.g. use external packages that only expose types, and you still want references to these types to be resolved you could expand this to ['main', 'types', 'typings']"
             },
             "mainFiles": {
               "type": "array",

--- a/test/cli/__fixtures__/init-config/no-config-files-exist/oeleboele.cjs
+++ b/test/cli/__fixtures__/init-config/no-config-files-exist/oeleboele.cjs
@@ -117,7 +117,7 @@ module.exports = {
     // moduleSystems: ['amd', 'cjs', 'es6', 'tsd'],
 
     /* prefix for links in html and svg output (e.g. 'https://github.com/you/yourrepo/blob/develop/'
-       to open it on your online repo or `vscode://file/${process.cwd()}/` to 
+       to open it on your online repo or `vscode://file/${process.cwd()}/` to
        open it in visual studio code),
      */
     // prefix: '',
@@ -128,10 +128,10 @@ module.exports = {
      */
     // tsPreCompilationDeps: false,
 
-    /* 
-       list of extensions to scan that aren't javascript or compile-to-javascript. 
+    /*
+       list of extensions to scan that aren't javascript or compile-to-javascript.
        Empty by default. Only put extensions in here that you want to take into
-       account that are _not_ parsable. 
+       account that are _not_ parsable.
     */
     // extraExtensionsToScan: [".json", ".jpg", ".png", ".svg", ".webp"],
 
@@ -175,7 +175,7 @@ module.exports = {
     /* Babel config ('.babelrc', '.babelrc.json', '.babelrc.json5', ...) to use
       for compilation (and whatever other naughty things babel plugins do to
       source code). This feature is well tested and usable, but might change
-      behavior a bit over time (e.g. more precise results for used module 
+      behavior a bit over time (e.g. more precise results for used module
       systems) without dependency-cruiser getting a major version bump.
      */
     // babelConfig: {
@@ -217,14 +217,14 @@ module.exports = {
       /*
          The extensions, by default are the same as the ones dependency-cruiser
          can access (run `npx depcruise --info` to see which ones that are in
-         _your_ environment. If that list is larger than what you need (e.g. 
-         it contains .js, .jsx, .ts, .tsx, .cts, .mts - but you don't use 
-         TypeScript you can pass just the extensions you actually use (e.g. 
-         [".js", ".jsx"]). This can speed up the most expensive step in 
+         _your_ environment. If that list is larger than what you need (e.g.
+         it contains .js, .jsx, .ts, .tsx, .cts, .mts - but you don't use
+         TypeScript you can pass just the extensions you actually use (e.g.
+         [".js", ".jsx"]). This can speed up the most expensive step in
          dependency cruising (module resolution) quite a bit.
        */
       // extensions: [".js", ".jsx", ".ts", ".tsx", ".d.ts"],
-      /* 
+      /*
          If your TypeScript project makes use of types specified in 'types'
          fields in package.jsons of external dependencies, specify "types"
          in addition to "main" in here, so enhanced-resolve (the resolver
@@ -232,7 +232,7 @@ module.exports = {
          this if you're not sure, but still use TypeScript. In a future version
          of dependency-cruiser this will likely become the default.
        */
-      // mainFields: ["main", "types"],
+      // mainFields: ["main", "types", "typings"],
     },
     reporterOptions: {
       dot: {

--- a/test/cli/__fixtures__/init-config/no-config-files-exist/oeleboele.js
+++ b/test/cli/__fixtures__/init-config/no-config-files-exist/oeleboele.js
@@ -117,7 +117,7 @@ module.exports = {
     // moduleSystems: ['amd', 'cjs', 'es6', 'tsd'],
 
     /* prefix for links in html and svg output (e.g. 'https://github.com/you/yourrepo/blob/develop/'
-       to open it on your online repo or `vscode://file/${process.cwd()}/` to 
+       to open it on your online repo or `vscode://file/${process.cwd()}/` to
        open it in visual studio code),
      */
     // prefix: '',
@@ -128,10 +128,10 @@ module.exports = {
      */
     // tsPreCompilationDeps: false,
 
-    /* 
-       list of extensions to scan that aren't javascript or compile-to-javascript. 
+    /*
+       list of extensions to scan that aren't javascript or compile-to-javascript.
        Empty by default. Only put extensions in here that you want to take into
-       account that are _not_ parsable. 
+       account that are _not_ parsable.
     */
     // extraExtensionsToScan: [".json", ".jpg", ".png", ".svg", ".webp"],
 
@@ -175,7 +175,7 @@ module.exports = {
     /* Babel config ('.babelrc', '.babelrc.json', '.babelrc.json5', ...) to use
       for compilation (and whatever other naughty things babel plugins do to
       source code). This feature is well tested and usable, but might change
-      behavior a bit over time (e.g. more precise results for used module 
+      behavior a bit over time (e.g. more precise results for used module
       systems) without dependency-cruiser getting a major version bump.
      */
     // babelConfig: {
@@ -217,14 +217,14 @@ module.exports = {
       /*
          The extensions, by default are the same as the ones dependency-cruiser
          can access (run `npx depcruise --info` to see which ones that are in
-         _your_ environment. If that list is larger than what you need (e.g. 
-         it contains .js, .jsx, .ts, .tsx, .cts, .mts - but you don't use 
-         TypeScript you can pass just the extensions you actually use (e.g. 
-         [".js", ".jsx"]). This can speed up the most expensive step in 
+         _your_ environment. If that list is larger than what you need (e.g.
+         it contains .js, .jsx, .ts, .tsx, .cts, .mts - but you don't use
+         TypeScript you can pass just the extensions you actually use (e.g.
+         [".js", ".jsx"]). This can speed up the most expensive step in
          dependency cruising (module resolution) quite a bit.
        */
       // extensions: [".js", ".jsx", ".ts", ".tsx", ".d.ts"],
-      /* 
+      /*
          If your TypeScript project makes use of types specified in 'types'
          fields in package.jsons of external dependencies, specify "types"
          in addition to "main" in here, so enhanced-resolve (the resolver
@@ -232,7 +232,7 @@ module.exports = {
          this if you're not sure, but still use TypeScript. In a future version
          of dependency-cruiser this will likely become the default.
        */
-      // mainFields: ["main", "types"],
+      // mainFields: ["main", "types", "typings"],
     },
     reporterOptions: {
       dot: {

--- a/tools/schema/options.mjs
+++ b/tools/schema/options.mjs
@@ -265,7 +265,7 @@ export default {
                 "want to keep leave this this on its default (['main']) , but if " +
                 "you e.g. use external packages that only expose types, and you " +
                 "still want references to these types to be resolved you could expand " +
-                "this to ['main', 'types']",
+                "this to ['main', 'types', 'typings']",
             },
             mainFiles: {
               type: "array",

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -278,7 +278,8 @@ export interface ICruiseOptions {
      * A list of main fields in manifests (package.json s). Typically you'd want
      * to keep leave this this on its default (['main']) , but if you e.g. use
      * external packages that only expose types, and you still want references
-     * to these types to be resolved you could expand this to ['main', 'types']
+     * to these types to be resolved you could expand this to
+     * ['main', 'types', 'typings']
      */
     mainFields?: string[];
     /**


### PR DESCRIPTION
First off, I just want to say thanks very much for producing and maintaining this tool. I've been amazed at how fast/powerful it is, and the thorough documentation in config and READMEs has been super helpful! Thank you! ❤️ 🙇 

## Description

The FAQs mention that if types from a package cannot be resolved then the user should configure `mainFields` to include the keys that the package is using in its `package.json` file.

The generated config and documentation suggest using `main` and `types` as `mainFields`. However, [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) notes that:

> ... the "typings" field is synonymous with types, and could be used as well.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Rather than make users of this package search through documentation and `node_modules` to discover this issue, this commit changes `dependency-cruiser` to support (or at least, suggest) both of these TypeScript defaults.

## Motivation and Context

One of our dependencies changed how they export types. We spent several confusing hours trying to track down the issue. It was especially confusing because we'd already configured dependency-cruiser to use `["main", "types"]` for `mainFields`, as the documentation suggests.

We were not aware that TypeScript also supported `typings` as a synonym for `types`. It would've saved us a lot of head scratching if `dependency-cruiser` had suggested both these values from the beginning.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] green ci

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Marking as a documentation change as it only affects documentation/the initial config that is generated by the tool.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [X] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
