### PR TITLE
fix(report/err-html): makes show/hide ignored violations work again

### DIFF
--- a/src/report/error-html/index.mjs
+++ b/src/report/error-html/index.mjs
@@ -69,8 +69,12 @@ function constructViolatedRulesTable(pResults) {
   </table>`;
 }
 
+/**
+ * @param {import('../../../types/cruise-result.js').IViolation} pViolation
+ * @returns {string}
+ */
 function getViolationRowClass(pViolation) {
-  return pViolation.ignored ? ' class="ignored"' : "";
+  return pViolation.rule.severity === "ignore" ? ' class="ignored"' : "";
 }
 
 /**

--- a/test/report/error-html/error-html.spec.mjs
+++ b/test/report/error-html/error-html.spec.mjs
@@ -51,6 +51,7 @@ describe("[I] report/error-html", () => {
     match(lResult.output, /<strong>2<\/strong> ignored/);
     match(lResult.output, /also show ignored violations/);
     match(lResult.output, /<th>ignored<\/th>/);
+    match(lResult.output, /<tr class="ignored">/);
 
     match(
       lResult.output,


### PR DESCRIPTION
## Description

- corrects the code that puts 'ignored' on rows of ignored violations to actually do that

## Motivation and Context

Fixes bug mentioned in the title

## How Has This Been Tested?

- [x] green ci
- [x] updated automated test
- [x] manual, visual verification


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
