### PR TITLE
refactor(test): sources assertions from assert/strict to ease strict comparisons

### DIFF
--- a/test/api.spec.mjs
+++ b/test/api.spec.mjs
@@ -1,7 +1,7 @@
 // eslint disable because import/no-unresolved,node/no-missing-import don't
 // know about (local) module imports yet
 /* eslint-disable import/no-unresolved,node/no-missing-import */
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import satisfies from "semver/functions/satisfies.js";
 import dependencyCruiser from "dependency-cruiser";
 import extractBabelConfig from "dependency-cruiser/config-utl/extract-babel-config";
@@ -15,27 +15,27 @@ import extractWebpackResolveConfig from "dependency-cruiser/config-utl/extract-w
 if (satisfies(process.versions.node, "^12.19 || >=14.7")) {
   describe("[E] api from esm (on node ^12.19 || >= 14.7)", () => {
     it("exposes dependency-cruiser main with some functions", () => {
-      strictEqual(typeof dependencyCruiser, "object");
-      strictEqual(typeof dependencyCruiser.cruise, "function");
-      strictEqual(typeof dependencyCruiser.format, "function");
-      strictEqual(Array.isArray(dependencyCruiser.allExtensions), true);
-      strictEqual(typeof dependencyCruiser.getAvailableTranspilers, "function");
+      equal(typeof dependencyCruiser, "object");
+      equal(typeof dependencyCruiser.cruise, "function");
+      equal(typeof dependencyCruiser.format, "function");
+      equal(Array.isArray(dependencyCruiser.allExtensions), true);
+      equal(typeof dependencyCruiser.getAvailableTranspilers, "function");
     });
 
     it("exposes an extract-babel-config function", () => {
-      strictEqual(typeof extractBabelConfig, "function");
+      equal(typeof extractBabelConfig, "function");
     });
 
     it("exposes an extract-depcruise-config function", () => {
-      strictEqual(typeof extractDepcruiseConfig, "function");
+      equal(typeof extractDepcruiseConfig, "function");
     });
 
     it("exposes an extract-ts-config function", () => {
-      strictEqual(typeof extractTsConfig, "function");
+      equal(typeof extractTsConfig, "function");
     });
 
     it("exposes an extract-webpack-resolve-config function", () => {
-      strictEqual(typeof extractWebpackResolveConfig, "function");
+      equal(typeof extractWebpackResolveConfig, "function");
     });
   });
 }

--- a/test/cache/cache.spec.mjs
+++ b/test/cache/cache.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
@@ -10,7 +10,7 @@ const OUTPUTS_FOLDER = "test/cache/__outputs__/";
 describe("[I] cache/cache - readCache", () => {
   it("returns an empty cache when trying to read from a non-existing one", async () => {
     const lCache = new Cache();
-    deepStrictEqual(await lCache.read("this/folder/does/not-exist"), {
+    deepEqual(await lCache.read("this/folder/does/not-exist"), {
       modules: [],
       summary: {},
     });
@@ -18,18 +18,15 @@ describe("[I] cache/cache - readCache", () => {
 
   it("returns an empty cache when trying to read from a file that is invalid JSON", async () => {
     const lCache = new Cache();
-    deepStrictEqual(
-      await lCache.read("test/cache/__mocks__/cache/invalid-json"),
-      {
-        modules: [],
-        summary: {},
-      },
-    );
+    deepEqual(await lCache.read("test/cache/__mocks__/cache/invalid-json"), {
+      modules: [],
+      summary: {},
+    });
   });
 
   it("returns the contents of the cache when trying to read from an existing, valid json", async () => {
     const lCache = new Cache();
-    deepStrictEqual(
+    deepEqual(
       await lCache.read("test/cache/__mocks__/cache/valid-minimal-cache"),
       {
         modules: [],
@@ -57,7 +54,7 @@ describe("[I] cache/cache - writeCache", () => {
     const lCache = new Cache();
 
     await lCache.write(lCacheFolder, lDummyCacheContents);
-    deepStrictEqual(await lCache.read(lCacheFolder), lDummyCacheContents);
+    deepEqual(await lCache.read(lCacheFolder), lDummyCacheContents);
   });
 
   it("writes the passed cruise options to the cache folder (folder already exists -> overwrite)", async () => {
@@ -72,7 +69,7 @@ describe("[I] cache/cache - writeCache", () => {
 
     await lCache.write(lCacheFolder, lDummyCacheContents);
     await lCache.write(lCacheFolder, lSecondDummyCacheContents);
-    deepStrictEqual(await lCache.read(lCacheFolder), lSecondDummyCacheContents);
+    deepEqual(await lCache.read(lCacheFolder), lSecondDummyCacheContents);
   });
 
   it("writes the passed cruise options to the cache folder (which is created when it doesn't exist yet) - content based cached strategy", async () => {
@@ -124,7 +121,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
         changes: [],
       },
     );
-    strictEqual(lResult, false);
+    equal(lResult, false);
   });
 
   it("returns false when the base SHA differs", async () => {
@@ -142,7 +139,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
       },
     );
 
-    strictEqual(lFound, false);
+    equal(lFound, false);
   });
 
   it("returns false when a file was added", async () => {
@@ -166,7 +163,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
       },
     );
 
-    strictEqual(lFound, false);
+    equal(lFound, false);
   });
 
   it("returns false when cache written & revision data equal & options incompatible", async () => {
@@ -184,7 +181,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
       { SHA1: "dummy-sha", changes: [] },
     );
 
-    strictEqual(lFound, false);
+    equal(lFound, false);
   });
 
   it("returns true when cache written & revision data equal & options compatible", async () => {
@@ -198,6 +195,6 @@ describe("[I] cache/cache - canServeFromCache", () => {
       { SHA1: "dummy-sha", changes: [] },
     );
 
-    strictEqual(lFound, true);
+    equal(lFound, true);
   });
 });

--- a/test/cache/content-strategy.spec.mjs
+++ b/test/cache/content-strategy.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import ContentStrategy from "../../src/cache/content-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
@@ -37,7 +37,7 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
       ],
     };
 
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().getRevisionData(
         null,
         null,
@@ -54,7 +54,7 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
   });
 
   it("if there's no changes the change set contains the passed sha & an empty array", () => {
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().getRevisionData(
         null,
         null,
@@ -76,7 +76,7 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
   it("returns only the extensions passed", () => {
     const lLimitedExtensions = new Set([".wim", ".noot"]);
 
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().getRevisionData(
         ".",
         { modules: [] },
@@ -131,7 +131,7 @@ describe("[U] cache/content-strategy - getRevisionData", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().getRevisionData(
         null,
         null,
@@ -186,11 +186,11 @@ describe("[U] cache/content-strategy - revisionDataEqual", () => {
   ];
 
   it("returns false when revision data objects don't exist", () => {
-    strictEqual(new ContentStrategy().revisionDataEqual(null, null), false);
+    equal(new ContentStrategy().revisionDataEqual(null, null), false);
   });
 
   it("returns false when old revision data object doesn't exist", () => {
-    strictEqual(
+    equal(
       new ContentStrategy().revisionDataEqual(null, {
         SHA1: "some-sha",
         changes: [],
@@ -200,7 +200,7 @@ describe("[U] cache/content-strategy - revisionDataEqual", () => {
   });
 
   it("returns false when new revision data object doesn't exist", () => {
-    strictEqual(
+    equal(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         null,
@@ -210,7 +210,7 @@ describe("[U] cache/content-strategy - revisionDataEqual", () => {
   });
 
   it("returns false when changes are not equal", () => {
-    strictEqual(
+    equal(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: lChanges },
@@ -220,7 +220,7 @@ describe("[U] cache/content-strategy - revisionDataEqual", () => {
   });
 
   it("returns true when changes are equal", () => {
-    strictEqual(
+    equal(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: lChanges },
         { SHA1: "some-sha", changes: lChanges },
@@ -230,7 +230,7 @@ describe("[U] cache/content-strategy - revisionDataEqual", () => {
   });
 
   it("returns true when changes are equal  (even when neither contain changes)", () => {
-    strictEqual(
+    equal(
       new ContentStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: [] },
@@ -274,7 +274,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
       revisionData: lEmptyRevisionData,
     };
 
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().prepareRevisionDataForSaving(
         lEmptyCruiseResult,
         lEmptyRevisionData,
@@ -333,7 +333,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
       revisionData: lEmptyRevisionData,
     };
 
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().prepareRevisionDataForSaving(
         lEmptyCruiseResult,
         lEmptyRevisionData,
@@ -422,7 +422,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
       },
     };
 
-    deepStrictEqual(
+    deepEqual(
       new ContentStrategy().prepareRevisionDataForSaving(
         lCruiseResult,
         lRevisionData,

--- a/test/cache/find-content-changes.spec.mjs
+++ b/test/cache/find-content-changes.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import findContentChanges from "../../src/cache/find-content-changes.mjs";
 
 describe("[U] cache/find-content-changes - cached vs new", () => {
   it("returns files not in directory but in cache as 'ignored' when they're not interesting for diffing", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         {
@@ -55,7 +55,7 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
   });
 
   it("returns files not in directory but in cache as 'deleted'", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         { modules: [{ source: "only-in-cache-ends-up-as-deleted.js" }] },
@@ -76,7 +76,7 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
   });
 
   it("returns files that have been earmarked as not followable as 'ignored'", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         {
@@ -105,7 +105,7 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
   });
 
   it("returns files both in directory and in cache that are different as 'modified'", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         {
@@ -142,7 +142,7 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
   });
 
   it("returns files both in directory and in cache that are the same as 'unmodified'", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         {
@@ -173,7 +173,7 @@ describe("[U] cache/find-content-changes - cached vs new", () => {
 
 describe("[U] cache/find-content-changes - new vs cached", () => {
   it("returns an empty set when the directory and modules are empty", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -189,7 +189,7 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
   });
 
   it("returns changes when there's file in the directory and modules is empty (extensions only)", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -211,7 +211,7 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
   });
 
   it("returns changes when there's file in the directory and modules is empty (missing includeOnly filter)", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -232,7 +232,7 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
   });
 
   it("returns changes when there's file in the directory and modules is empty (exclude filter)", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         { modules: [] },
@@ -254,7 +254,7 @@ describe("[U] cache/find-content-changes - new vs cached", () => {
   });
 
   it("returns changes when there's file in the directory and modules is empty (includeOnly filter)", () => {
-    deepStrictEqual(
+    deepEqual(
       findContentChanges(
         ".",
         { modules: [] },

--- a/test/cache/metadata-strategy.spec.mjs
+++ b/test/cache/metadata-strategy.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual, match } from "node:assert";
+import { deepEqual, equal, match } from "node:assert/strict";
 import MetaDataStrategy from "../../src/cache/metadata-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
@@ -51,7 +51,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "file-does-not-exist.aap",
       },
     ];
-    const lLstrictEqualed = {
+    const lLequaled = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -73,7 +73,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         diffListFn: () => lInputChanges,
       },
     );
-    deepStrictEqual(lFound, lLstrictEqualed);
+    deepEqual(lFound, lLequaled);
   });
 
   it("if a listed change does exist on disk shasum is calculated", async () => {
@@ -84,7 +84,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "test/cache/__mocks__/calculate-shasum-of-this.aap",
       },
     ];
-    const lLstrictEqualed = {
+    const lLequaled = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -105,11 +105,11 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         diffListFn: () => lInputChanges,
       },
     );
-    deepStrictEqual(lFound, lLstrictEqualed);
+    deepEqual(lFound, lLequaled);
   });
 
   it("if there's no changes the change set contains the passed sha & an empty array", async () => {
-    const lLstrictEqualed = {
+    const lLequaled = {
       SHA1: DUMMY_SHA,
       changes: [],
     };
@@ -124,7 +124,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         diffListFn: () => [],
       },
     );
-    deepStrictEqual(lFound, lLstrictEqualed);
+    deepEqual(lFound, lLequaled);
   });
 
   it("returns only the extensions passed", async () => {
@@ -169,7 +169,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         },
       ],
     };
-    const lstrictEqualed = await new MetaDataStrategy().getRevisionData(
+    const lequaled = await new MetaDataStrategy().getRevisionData(
       null,
       null,
       { exclude: {}, includeOnly: {} },
@@ -181,7 +181,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         checksumFn: dummyCheckSumFunction,
       },
     );
-    deepStrictEqual(lstrictEqualed, lFound);
+    deepEqual(lequaled, lFound);
   });
 
   it("returns only the changeTypes passed", async () => {
@@ -214,7 +214,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "untracked-hence-ignored.aap",
       },
     ];
-    const lLstrictEqualed = {
+    const lLequaled = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -248,7 +248,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
       },
     );
 
-    deepStrictEqual(lLstrictEqualed, lFound);
+    deepEqual(lLequaled, lFound);
   });
 
   it("by default only returns a subset of change types", async () => {
@@ -300,7 +300,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
         name: "ignored-hence-ignored.aap",
       },
     ];
-    const lLstrictEqualed = {
+    const lLequaled = {
       SHA1: DUMMY_SHA,
       changes: [
         {
@@ -354,7 +354,7 @@ describe("[U] cache/metadata-strategy - getRevisionData", () => {
       },
     );
 
-    deepStrictEqual(lLstrictEqualed, lFound);
+    deepEqual(lLequaled, lFound);
   });
 });
 
@@ -379,11 +379,11 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   ];
 
   it("returns false when revision data objects are don't exist", () => {
-    strictEqual(new MetaDataStrategy().revisionDataEqual(null, null), false);
+    equal(new MetaDataStrategy().revisionDataEqual(null, null), false);
   });
 
   it("returns false when old revision data object doesn't exist", () => {
-    strictEqual(
+    equal(
       new MetaDataStrategy().revisionDataEqual(null, {
         SHA1: "some-sha",
         changes: [],
@@ -393,7 +393,7 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   });
 
   it("returns false when new revision data object doesn't exist", () => {
-    strictEqual(
+    equal(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         null,
@@ -403,7 +403,7 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   });
 
   it("returns false when sha-sums aren't equal", () => {
-    strictEqual(
+    equal(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-other-sha", changes: [] },
@@ -413,7 +413,7 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   });
 
   it("returns false when sha-sums are equal, but changes are not", () => {
-    strictEqual(
+    equal(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: lChanges },
@@ -423,7 +423,7 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   });
 
   it("returns true when sha-sums are equal, and changes are as well", () => {
-    strictEqual(
+    equal(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: lChanges },
         { SHA1: "some-sha", changes: lChanges },
@@ -433,7 +433,7 @@ describe("[U] cache/metadata-strategy - revisionDataEqual", () => {
   });
 
   it("returns true when sha-sums are equal, and changes are as well (even when neither contain changes)", () => {
-    strictEqual(
+    equal(
       new MetaDataStrategy().revisionDataEqual(
         { SHA1: "some-sha", changes: [] },
         { SHA1: "some-sha", changes: [] },

--- a/test/cache/options-compatible.spec.mjs
+++ b/test/cache/options-compatible.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import {
   optionIsCompatible,
   filterOptionIsCompatible,
@@ -12,11 +12,11 @@ import {
 
 describe("[U] cache/options-compatible - optionIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {
-    strictEqual(optionIsCompatible(), true);
+    equal(optionIsCompatible(), true);
   });
 
   it("if the old option doesn't exist, the new one is not compatible, whatever it is", () => {
-    strictEqual(
+    equal(
       // eslint-disable-next-line no-undefined
       optionIsCompatible(undefined, { path: ["aap", "noot", "mies"] }),
       false,
@@ -24,7 +24,7 @@ describe("[U] cache/options-compatible - optionIsCompatible", () => {
   });
 
   it("if the old option exists, the new one is compatible when it's _exactly_ the same", () => {
-    strictEqual(
+    equal(
       optionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "noot", "mies"] },
@@ -34,14 +34,11 @@ describe("[U] cache/options-compatible - optionIsCompatible", () => {
   });
 
   it("if the old option exists, the new one is _not_ compatible when it doesn't exist", () => {
-    strictEqual(
-      optionIsCompatible({ path: ["aap", "noot", "mies"] }, null),
-      false,
-    );
+    equal(optionIsCompatible({ path: ["aap", "noot", "mies"] }, null), false);
   });
 
   it("if the old option exists, the new one is _not_ compatible when it isn't exactly the same", () => {
-    strictEqual(
+    equal(
       optionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "mies"] },
@@ -51,21 +48,21 @@ describe("[U] cache/options-compatible - optionIsCompatible", () => {
   });
 
   it("if the old option equals false and the new one is as well, they're compatible", () => {
-    strictEqual(optionIsCompatible(false, false), true);
+    equal(optionIsCompatible(false, false), true);
   });
 
   it("if the old option equals false and the new one is true, they're _not_ compatible", () => {
-    strictEqual(optionIsCompatible(false, true), false);
+    equal(optionIsCompatible(false, true), false);
   });
 });
 
 describe("[U] cache/options-compatible - filterOptionIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {
-    strictEqual(filterOptionIsCompatible(), true);
+    equal(filterOptionIsCompatible(), true);
   });
 
   it("if the old (filter) option doesn't exist, the new one is compatible, whatever it is", () => {
-    strictEqual(
+    equal(
       // eslint-disable-next-line no-undefined
       filterOptionIsCompatible(undefined, { path: ["aap", "noot", "mies"] }),
       true,
@@ -73,14 +70,14 @@ describe("[U] cache/options-compatible - filterOptionIsCompatible", () => {
   });
 
   it("if the old (filter) option is null, the new one is compatible, whatever it is", () => {
-    strictEqual(
+    equal(
       filterOptionIsCompatible(null, { path: ["aap", "noot", "mies"] }),
       true,
     );
   });
 
   it("if the old (filter) option exists, the new one is compatible when it's _exactly_ the same", () => {
-    strictEqual(
+    equal(
       filterOptionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "noot", "mies"] },
@@ -90,14 +87,14 @@ describe("[U] cache/options-compatible - filterOptionIsCompatible", () => {
   });
 
   it("if the old (filter) option exists, the new one is _not_ compatible when it doesn't exist", () => {
-    strictEqual(
+    equal(
       filterOptionIsCompatible({ path: ["aap", "noot", "mies"] }, null),
       false,
     );
   });
 
   it("if the old (filter) option exists, the new one is _not_ compatible when it isn't exactly the same", () => {
-    strictEqual(
+    equal(
       filterOptionIsCompatible(
         { path: ["aap", "noot", "mies"] },
         { path: ["aap", "mies"] },
@@ -107,28 +104,28 @@ describe("[U] cache/options-compatible - filterOptionIsCompatible", () => {
   });
 
   it("if the old (filter) option equals false and the new one is as well, they're compatible", () => {
-    strictEqual(filterOptionIsCompatible(false, false), true);
+    equal(filterOptionIsCompatible(false, false), true);
   });
 
   it("if the old (filter) option equals false and the new one is true, they're compatible", () => {
-    strictEqual(filterOptionIsCompatible(false, true), true);
+    equal(filterOptionIsCompatible(false, true), true);
   });
 });
 
 describe("[U] cache/options-compatible - includeOnlyIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {
-    strictEqual(includeOnlyIsCompatible(), true);
+    equal(includeOnlyIsCompatible(), true);
   });
 
   it("if the old filter doesn't exist, the new one is compatible, whatever it is", () => {
-    strictEqual(
+    equal(
       includeOnlyIsCompatible(null, { path: ["aap", "noot", "mies"] }),
       true,
     );
   });
 
   it("if the old filter exists, the new one is compatible when it's _exactly_ the same", () => {
-    strictEqual(
+    equal(
       includeOnlyIsCompatible(["aap", "noot", "mies"], {
         path: ["aap", "noot", "mies"],
       }),
@@ -137,11 +134,11 @@ describe("[U] cache/options-compatible - includeOnlyIsCompatible", () => {
   });
 
   it("if the old filter exists, the new one is _not_ compatible when it doesn't exist", () => {
-    strictEqual(includeOnlyIsCompatible(["aap", "noot", "mies"], null), false);
+    equal(includeOnlyIsCompatible(["aap", "noot", "mies"], null), false);
   });
 
   it("if the old filter exists, the new one is _not_ compatible when it isn't exactly the same", () => {
-    strictEqual(
+    equal(
       includeOnlyIsCompatible(["aap", "noot", "mies"], {
         path: ["aap", "mies"],
       }),
@@ -152,57 +149,57 @@ describe("[U] cache/options-compatible - includeOnlyIsCompatible", () => {
 
 describe("[U] cache/options-compatible - limitIsCompatible", () => {
   it("if neither limit exists they're compatible", () => {
-    strictEqual(limitIsCompatible(), true);
+    equal(limitIsCompatible(), true);
   });
 
   it("if the old limit doesn't exist compatible", () => {
-    strictEqual(limitIsCompatible(null, 1), true);
+    equal(limitIsCompatible(null, 1), true);
   });
 
   it("if the old limit exists and it's not infinite ('0') it's compatible when it's >= the new value", () => {
-    strictEqual(limitIsCompatible(3, 3), true);
-    strictEqual(limitIsCompatible(3, 2), true);
+    equal(limitIsCompatible(3, 3), true);
+    equal(limitIsCompatible(3, 2), true);
   });
 
   it("if the old limit exists and it's not infinite ('0') it's not compatible when it's < the new value", () => {
-    strictEqual(limitIsCompatible(3, 4), false);
-    strictEqual(limitIsCompatible(3, 0), false);
+    equal(limitIsCompatible(3, 4), false);
+    equal(limitIsCompatible(3, 0), false);
   });
 
   it("if the old limit exists and it's infinite ('0') it's compatible whatever the new value is", () => {
-    strictEqual(limitIsCompatible(0, null), true);
-    strictEqual(limitIsCompatible(0, 0), true);
-    strictEqual(limitIsCompatible(0, 1), true);
-    strictEqual(limitIsCompatible(0, 99), true);
+    equal(limitIsCompatible(0, null), true);
+    equal(limitIsCompatible(0, 0), true);
+    equal(limitIsCompatible(0, 1), true);
+    equal(limitIsCompatible(0, 99), true);
   });
 });
 
 describe("[U] cache/options-compatible - metricsIsCompatible", () => {
   it("if neither metrics exist they're compatible", () => {
-    strictEqual(metricsIsCompatible(), true);
+    equal(metricsIsCompatible(), true);
   });
 
   it("is compatible when the old results have metrics and the new options don't", () => {
-    strictEqual(metricsIsCompatible(true, false), true);
+    equal(metricsIsCompatible(true, false), true);
   });
 
   it("is compatible when the old results have metrics and the new options also do", () => {
-    strictEqual(metricsIsCompatible(true, true), true);
+    equal(metricsIsCompatible(true, true), true);
   });
   it("is not compatible when the old results don't have metrics and the new options  do", () => {
-    strictEqual(metricsIsCompatible(false, true), false);
+    equal(metricsIsCompatible(false, true), false);
   });
   it("is compatible when the old results don't have metrics and the new options don't either", () => {
-    strictEqual(metricsIsCompatible(false, false), true);
+    equal(metricsIsCompatible(false, false), true);
   });
 });
 
 describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
   it("returns true when both equal 'true'", () => {
-    strictEqual(cacheOptionIsCompatible(true, true), true);
+    equal(cacheOptionIsCompatible(true, true), true);
   });
   it("returns true when are objects & they're 100% equal", () => {
-    strictEqual(
+    equal(
       cacheOptionIsCompatible(
         { folder: "x", strategy: "metadata" },
         { folder: "x", strategy: "metadata" },
@@ -211,7 +208,7 @@ describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
     );
   });
   it("returns false when are objects & the folders differ", () => {
-    strictEqual(
+    equal(
       cacheOptionIsCompatible(
         { folder: "x", strategy: "metadata" },
         { folder: "not-x", strategy: "metadata" },
@@ -220,7 +217,7 @@ describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
     );
   });
   it("returns false when both cache options are objects & the strategies differ", () => {
-    strictEqual(
+    equal(
       cacheOptionIsCompatible(
         { folder: "x", strategy: "metadata" },
         { folder: "x", strategy: "content" },
@@ -229,11 +226,11 @@ describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
     );
   });
   it("returns false when one cache option is an object and the other one isn't", () => {
-    strictEqual(
+    equal(
       cacheOptionIsCompatible(true, { folder: "x", strategy: "metadata" }),
       false,
     );
-    strictEqual(
+    equal(
       cacheOptionIsCompatible("x", { folder: "x", strategy: "metadata" }),
       false,
     );
@@ -242,13 +239,13 @@ describe("[U] cache/options-compatible - cacheOptionIsCompatible", () => {
 
 describe("[U] cache/options-compatible - optionsAreCompatible", () => {
   it("options are not compatible when there's none in either", () => {
-    strictEqual(optionsAreCompatible({}, {}), false);
+    equal(optionsAreCompatible({}, {}), false);
   });
   it("options are compatible when there's none in either (except a cache option)", () => {
-    strictEqual(optionsAreCompatible({ cache: true }, { cache: true }), true);
+    equal(optionsAreCompatible({ cache: true }, { cache: true }), true);
   });
   it("options are compatible when args are exactly equal", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         { args: "aap noot mies", cache: true },
         { args: "aap noot mies", cache: true },
@@ -257,7 +254,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
     );
   });
   it("options are not compatible when args are not exactly equal", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         { args: "aap noot mies", cache: true },
         { args: "aap noot", cache: true },
@@ -266,7 +263,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
     );
   });
   it("options are compatible when also rulesFiles are exactly equal", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         {
           args: "aap",
@@ -285,7 +282,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
     );
   });
   it("options are not compatible when also tsPreCompilationDeps are not exactly equal", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         {
           args: "aap",
@@ -305,7 +302,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
   });
 
   it("options are compatible when also includeOnly filters are exactly equal", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         {
           args: "aap",
@@ -327,7 +324,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
   });
 
   it("options are not compatible when also collapse filters are not compatible equal", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         { args: "aap", rulesFile: "thing.js", collapse: "zus", cache: true },
         { args: "aap", rulesFile: "thing.js", collapse: "jet", cache: true },
@@ -337,7 +334,7 @@ describe("[U] cache/options-compatible - optionsAreCompatible", () => {
   });
 
   it("options are compatible when also collapse filters are compatible", () => {
-    strictEqual(
+    equal(
       optionsAreCompatible(
         {
           args: "aap",

--- a/test/cli/asserthelpers.utl.mjs
+++ b/test/cli/asserthelpers.utl.mjs
@@ -1,16 +1,16 @@
 import { readFileSync } from "node:fs";
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import normalizeNewline from "normalize-newline";
 import normBaseDirectory from "../main/norm-base-directory.utl.mjs";
 
 export function assertFileEqual(pActualFileName, pExpectedFileName) {
-  deepStrictEqual(
+  deepEqual(
     normalizeNewline(readFileSync(pActualFileName, { encoding: "utf8" })),
     normalizeNewline(readFileSync(pExpectedFileName, { encoding: "utf8" })),
   );
 }
 export function assertJSONFileEqual(pActualFileName, pExpectedFileName) {
-  deepStrictEqual(
+  deepEqual(
     JSON.parse(readFileSync(pActualFileName, { encoding: "utf8" })),
     normBaseDirectory(
       JSON.parse(readFileSync(pExpectedFileName, { encoding: "utf8" })),

--- a/test/cli/format-meta-info.spec.mjs
+++ b/test/cli/format-meta-info.spec.mjs
@@ -1,9 +1,9 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import meta from "../../src/cli/format-meta-info.mjs";
 
 describe("[U] cli/formatMetaInfo - transpiler formatted meta information", () => {
   it("tells which extensions can be scanned", () => {
-    strictEqual(
+    equal(
       meta().includes("If you need a supported, but not enabled transpiler"),
       true,
     );

--- a/test/cli/format.spec.mjs
+++ b/test/cli/format.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import { readFileSync } from "node:fs";
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import format from "../../src/cli/format.mjs";
 import deleteDammit from "./delete-dammit.utl.cjs";
@@ -18,11 +18,11 @@ describe("[E] cli/format", () => {
       outputTo: lOutFile,
     });
 
-    strictEqual(
+    equal(
       readFileSync(lOutFile, "utf8").includes("dependencies cruised"),
       true,
     );
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     deleteDammit(lOutFile);
   });
 
@@ -40,35 +40,35 @@ describe("[E] cli/format", () => {
       },
     );
     const lResult = JSON.parse(readFileSync(lOutFile, "utf8"));
-    strictEqual(lResult.summary.error, 0);
-    strictEqual(lResult.summary.totalCruised < 175, true);
-    strictEqual(lResult.summary.totalDependenciesCruised < 298, true);
-    strictEqual(lResult.summary.violations.length, 1);
-    strictEqual(
+    equal(lResult.summary.error, 0);
+    equal(lResult.summary.totalCruised < 175, true);
+    equal(lResult.summary.totalDependenciesCruised < 298, true);
+    equal(lResult.summary.violations.length, 1);
+    equal(
       lResult.modules
         .map((pModule) => pModule.source)
         .includes("bin/depcruise-fmt.mjs"),
       false,
     );
-    strictEqual(
+    equal(
       lResult.modules
         .map((pModule) => pModule.source)
         .includes("src/main/index.js"),
       true,
     );
-    strictEqual(
+    equal(
       lResult.modules
         .map((pModule) => pModule.source)
         .includes("src/cli/index.js"),
       true,
     );
-    strictEqual(
+    equal(
       lResult.modules
         .map((pModule) => pModule.source)
         .includes("src/cli/init-config/index.js"),
       false,
     );
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     deleteDammit(lOutFile);
   });
 
@@ -88,7 +88,7 @@ describe("[E] cli/format", () => {
     );
     const lResult = JSON.parse(readFileSync(lOutFile, "utf8"));
 
-    strictEqual(lResult.summary.optionsUsed.prefix, lAlternatePrefix);
+    equal(lResult.summary.optionsUsed.prefix, lAlternatePrefix);
 
     deleteDammit(lOutFile);
   });
@@ -105,7 +105,7 @@ describe("[E] cli/format", () => {
       },
     );
 
-    strictEqual(lExitCode, 2);
+    equal(lExitCode, 2);
     deleteDammit(lOutFile);
   });
 });

--- a/test/cli/index.spec.mjs
+++ b/test/cli/index.spec.mjs
@@ -1,7 +1,7 @@
 import { readFileSync, unlinkSync } from "node:fs";
 // path.posix instead of path because otherwise on win32 the resulting
 // outputTo would contain \\ instead of / which for this unit test doesn't matter
-import { doesNotThrow, strictEqual, throws } from "node:assert";
+import { doesNotThrow, equal, throws } from "node:assert/strict";
 import { join, posix as path } from "node:path";
 import chalk from "chalk";
 import intercept from "intercept-stdout";
@@ -183,7 +183,7 @@ function runFileBasedTests(pModuleType) {
     it(pPair.description, async () => {
       const lExitCode = await cli([pPair.dirOrFile], pPair.options);
 
-      strictEqual(lExitCode, pPair.expectExitCode);
+      equal(lExitCode, pPair.expectExitCode);
       if (pPair.options.outputType === "json") {
         assertJSONFileEqual(
           pPair.options.outputTo,
@@ -232,7 +232,7 @@ describe("[E] cli/index", () => {
         },
       );
 
-      strictEqual(lExitCode, 0);
+      equal(lExitCode, 0);
       assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
     });
 
@@ -246,7 +246,7 @@ describe("[E] cli/index", () => {
       });
       const lExpectedTransgressions = 0;
 
-      strictEqual(lExitCode, lExpectedTransgressions);
+      equal(lExitCode, lExpectedTransgressions);
     });
 
     it("returns the number of transgressions if outputType === 'error' ", async () => {
@@ -259,7 +259,7 @@ describe("[E] cli/index", () => {
       });
       const lExpectedTransgressions = 3;
 
-      strictEqual(lExitCode, lExpectedTransgressions);
+      equal(lExitCode, lExpectedTransgressions);
     });
 
     it("dependency-cruise -i shows meta info about the current environment", async () => {
@@ -271,8 +271,8 @@ describe("[E] cli/index", () => {
 
       unhookIntercept();
 
-      strictEqual(lExitCode, 0);
-      strictEqual(
+      equal(lExitCode, 0);
+      equal(
         lCapturedStdout.includes(
           "If you need a supported, but not enabled transpiler",
         ),
@@ -295,8 +295,8 @@ describe("[E] cli/index", () => {
       unhookInterceptStdOut();
       unhookInterceptStdError();
 
-      strictEqual(lExitCode, 1);
-      strictEqual(
+      equal(lExitCode, 1);
+      equal(
         lCapturedStderr.includes(
           "ERROR: Can't open 'this-doesnot-exist' for reading. Does it exist?\n",
         ),
@@ -322,8 +322,8 @@ describe("[E] cli/index", () => {
         lCapturedStderr += pText;
       })();
 
-      strictEqual(lExitCode, 1);
-      strictEqual(
+      equal(lExitCode, 1);
+      equal(
         lCapturedStderr.includes(
           "didn't work. Error: ENOENT: no such file or directory, open",
         ),
@@ -347,11 +347,8 @@ describe("[E] cli/index", () => {
         lCapturedStderr += pText;
       })();
 
-      strictEqual(lExitCode, 0);
-      strictEqual(
-        lCapturedStderr.includes("no dependency violations found"),
-        true,
-      );
+      equal(lExitCode, 0);
+      equal(lCapturedStderr.includes("no dependency violations found"), true);
     });
 
     it("dependency-cruise --init will generate a rules file and tells that back on stdout", async () => {
@@ -375,8 +372,8 @@ describe("[E] cli/index", () => {
         lCapturedStdout += pText;
       })();
 
-      strictEqual(lExitCode, 0);
-      strictEqual(
+      equal(lExitCode, 0);
+      equal(
         lCapturedStdout.includes(
           `Successfully created '${lValidationFileName}'`,
         ),
@@ -398,7 +395,7 @@ describe("[E] cli/index", () => {
         },
       );
 
-      strictEqual(lExitCode, 0);
+      equal(lExitCode, 0);
       assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
     });
 
@@ -415,7 +412,7 @@ describe("[E] cli/index", () => {
         },
       );
 
-      strictEqual(lExitCode, 0);
+      equal(lExitCode, 0);
       assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
     });
   });
@@ -435,7 +432,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
   });
 
@@ -454,7 +451,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
   });
 
@@ -474,7 +471,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     assertJSONFileEqual(lOutputTo, path.join(FIX_DIR, lOutputFileName));
   });
 
@@ -490,7 +487,7 @@ describe("[E] cli/index", () => {
         "test/cli/__fixtures__/babel/es6/webpack-cache-bust.config.js",
     });
 
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     assertJSONFileEqual(
       lOutputTo,
       path.join(FIX_DIR, "babel", lOutputFileName),
@@ -509,7 +506,7 @@ describe("[E] cli/index", () => {
         "test/cli/__fixtures__/babel/ts/webpack-cache-bust.config.js",
     });
 
-    strictEqual(lExitCode, 0);
+    equal(lExitCode, 0);
     assertJSONFileEqual(
       lOutputTo,
       path.join(FIX_DIR, "babel", lOutputFileName),
@@ -530,7 +527,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    strictEqual(lExitCode, lExpectedAmountOfErrors);
+    equal(lExitCode, lExpectedAmountOfErrors);
 
     // assertJSONFileEqual(
     //   lOutputTo,
@@ -554,17 +551,17 @@ describe("[E] cli/index", () => {
       },
     );
 
-    strictEqual(lExitCode, lExpectedAmountOfErrors);
+    equal(lExitCode, lExpectedAmountOfErrors);
     doesNotThrow(() => {
       lResult = readFileSync(lOutputTo, { encoding: "utf8" });
     });
-    strictEqual(
+    equal(
       lResult.includes(
         "1 dependency violations (1 errors, 0 warnings). 6 modules, 3 dependencies cruised",
       ),
       true,
     );
-    strictEqual(lResult.includes("1 known violations ignored"), true);
+    equal(lResult.includes("1 known violations ignored"), true);
   });
 
   it("will barf when the known violations file is invalid", async () => {
@@ -583,7 +580,7 @@ describe("[E] cli/index", () => {
       },
     );
 
-    strictEqual(lExitCode, lExpectedAmountOfErrors);
+    equal(lExitCode, lExpectedAmountOfErrors);
     throws(() => {
       readFileSync(lOutputTo, { encoding: "utf8" });
     });

--- a/test/cli/init-config/build-config.spec.mjs
+++ b/test/cli/init-config/build-config.spec.mjs
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path/posix";
-import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { deepEqual, ok, equal } from "node:assert/strict";
 import Ajv from "ajv";
 import buildConfig from "../../../src/cli/init-config/build-config.mjs";
 import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";
@@ -50,7 +50,7 @@ describe("[I] cli/init-config/build-config", () => {
 
     ajv.validate(configurationSchema, lResult);
     ok(lResult.hasOwnProperty("forbidden"));
-    strictEqual(
+    equal(
       lResult.forbidden.some((pRule) => pRule.name === "not-to-test"),
       false,
     );
@@ -66,7 +66,7 @@ describe("[I] cli/init-config/build-config", () => {
 
     ajv.validate(configurationSchema, lResult);
     ok(lResult.hasOwnProperty("forbidden"));
-    strictEqual(
+    equal(
       lResult.forbidden.some((pRule) => pRule.name === "not-to-test"),
       true,
     );
@@ -82,7 +82,7 @@ describe("[I] cli/init-config/build-config", () => {
 
     ajv.validate(configurationSchema, lResult);
     ok(lResult.hasOwnProperty("options"));
-    deepStrictEqual(lResult.options.webpackConfig, {
+    deepEqual(lResult.options.webpackConfig, {
       fileName: "./webpack.prod.js",
     });
   });
@@ -97,7 +97,7 @@ describe("[I] cli/init-config/build-config", () => {
 
     ajv.validate(configurationSchema, lResult);
     ok(lResult.hasOwnProperty("options"));
-    deepStrictEqual(lResult.options.tsConfig, {
+    deepEqual(lResult.options.tsConfig, {
       fileName: "./tsconfig.json",
     });
   });

--- a/test/cli/init-config/environment-helpers-matching-filenames.spec.mjs
+++ b/test/cli/init-config/environment-helpers-matching-filenames.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import {
   hasTSConfigCandidates,
   getJSConfigCandidates,
@@ -20,25 +20,25 @@ describe("[U] cli/init-config/environment-helpers - getBabelConfigCandidates", (
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    deepStrictEqual(getBabelConfigCandidates(), []);
+    deepEqual(getBabelConfigCandidates(), []);
   });
   it("Returns an empty array when there's only ts configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    deepStrictEqual(getBabelConfigCandidates(), []);
+    deepEqual(getBabelConfigCandidates(), []);
   });
   it("Returns an empty array when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    deepStrictEqual(getBabelConfigCandidates(), []);
+    deepEqual(getBabelConfigCandidates(), []);
   });
   it("Returns all babel config variants present in a folder", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    deepStrictEqual(getBabelConfigCandidates(), [
+    deepEqual(getBabelConfigCandidates(), [
       ".babelrc",
       ".babelrc.json",
       "babel.blabla-config.json",
@@ -50,7 +50,7 @@ describe("[U] cli/init-config/environment-helpers - getBabelConfigCandidates", (
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel-manifest",
     );
-    deepStrictEqual(getBabelConfigCandidates(), [
+    deepEqual(getBabelConfigCandidates(), [
       "package.json",
       ".babelrc",
       ".babelrc.json",
@@ -70,25 +70,25 @@ describe("[U] cli/init-config/environment-helpers - hasBabelConfigCandidates", (
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    strictEqual(hasBabelConfigCandidates(), false);
+    equal(hasBabelConfigCandidates(), false);
   });
   it("Returns false when there's only ts configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    strictEqual(hasBabelConfigCandidates(), false);
+    equal(hasBabelConfigCandidates(), false);
   });
   it("Returns false when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    strictEqual(hasBabelConfigCandidates(), false);
+    equal(hasBabelConfigCandidates(), false);
   });
   it("Returns true when there's only babel configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    strictEqual(hasBabelConfigCandidates(), true);
+    equal(hasBabelConfigCandidates(), true);
   });
 });
 
@@ -101,25 +101,25 @@ describe("[U] cli/init-config/environment-helpers - getTSConfigCandidates", () =
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    deepStrictEqual(getTSConfigCandidates(), []);
+    deepEqual(getTSConfigCandidates(), []);
   });
   it("Returns an empty array when there's only ts configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    deepStrictEqual(getTSConfigCandidates(), []);
+    deepEqual(getTSConfigCandidates(), []);
   });
   it("Returns an empty array when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    deepStrictEqual(getTSConfigCandidates(), []);
+    deepEqual(getTSConfigCandidates(), []);
   });
   it("Returns all ts config variants present in a folder", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    deepStrictEqual(getTSConfigCandidates(), [
+    deepEqual(getTSConfigCandidates(), [
       "extended-tsconfig-from-base.json",
       "tsconfig.base.json",
       "tsconfig.json",
@@ -136,25 +136,25 @@ describe("[U] cli/init-config/environment-helpers - getJSConfigCandidates", () =
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    deepStrictEqual(getJSConfigCandidates(), []);
+    deepEqual(getJSConfigCandidates(), []);
   });
   it("Returns an empty array when there's only babel configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    deepStrictEqual(getJSConfigCandidates(), []);
+    deepEqual(getJSConfigCandidates(), []);
   });
   it("Returns an empty array when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    deepStrictEqual(getJSConfigCandidates(), []);
+    deepEqual(getJSConfigCandidates(), []);
   });
   it("Returns all js config variants present in a folder", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    deepStrictEqual(getJSConfigCandidates(), [
+    deepEqual(getJSConfigCandidates(), [
       "jsconfig.json",
       "thingie-jsconfig.json",
     ]);
@@ -170,25 +170,25 @@ describe("[U] cli/init-config/environment-helpers - hasTSConfigCandidates", () =
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    strictEqual(hasTSConfigCandidates(), false);
+    equal(hasTSConfigCandidates(), false);
   });
   it("Returns true when there's only ts configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    strictEqual(hasTSConfigCandidates(), true);
+    equal(hasTSConfigCandidates(), true);
   });
   it("Returns false when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    strictEqual(hasTSConfigCandidates(), false);
+    equal(hasTSConfigCandidates(), false);
   });
   it("Returns false when there's only babel configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    strictEqual(hasTSConfigCandidates(), false);
+    equal(hasTSConfigCandidates(), false);
   });
 });
 
@@ -201,19 +201,19 @@ describe("[U] cli/init-config/environment-helpers - getWebpackConfigCandidates",
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    deepStrictEqual(getWebpackConfigCandidates(), []);
+    deepEqual(getWebpackConfigCandidates(), []);
   });
   it("Returns an empty array when there's only ts configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    deepStrictEqual(getWebpackConfigCandidates(), []);
+    deepEqual(getWebpackConfigCandidates(), []);
   });
   it("Returns an empty array when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    deepStrictEqual(getWebpackConfigCandidates(), [
+    deepEqual(getWebpackConfigCandidates(), [
       "spiderwebpackconfig.cjs",
       "webpack-base-config.js",
       "webpack.conf.json",
@@ -224,7 +224,7 @@ describe("[U] cli/init-config/environment-helpers - getWebpackConfigCandidates",
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    deepStrictEqual(getWebpackConfigCandidates(), []);
+    deepEqual(getWebpackConfigCandidates(), []);
   });
 });
 
@@ -237,25 +237,25 @@ describe("[U] cli/init-config/environment-helpers - hasWebpackConfigCandidates",
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-empty",
     );
-    strictEqual(hasWebpackConfigCandidates(), false);
+    equal(hasWebpackConfigCandidates(), false);
   });
   it("Returns false when there's only ts configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-ts",
     );
-    strictEqual(hasWebpackConfigCandidates(), false);
+    equal(hasWebpackConfigCandidates(), false);
   });
   it("Returns true when there's only webpack configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-webpack",
     );
-    strictEqual(hasWebpackConfigCandidates(), true);
+    equal(hasWebpackConfigCandidates(), true);
   });
   it("Returns false when there's only babel configs", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/get-matching-filenames-babel",
     );
-    strictEqual(hasWebpackConfigCandidates(), false);
+    equal(hasWebpackConfigCandidates(), false);
   });
 });
 
@@ -266,21 +266,21 @@ describe("[U] cli/init-config/environment-helpers - isTypeModule", () => {
   });
   it("Returns false when there is no manifest", () => {
     process.chdir("test/cli/init-config/__fixtures__/is-type-module-empty");
-    strictEqual(isTypeModule(), false);
+    equal(isTypeModule(), false);
   });
   it("Returns false when there's no type in the manifest", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/is-type-module-not-present",
     );
-    strictEqual(isTypeModule(), false);
+    equal(isTypeModule(), false);
   });
   it("Returns false when the type in the manifest equals commonjs", () => {
     process.chdir("test/cli/init-config/__fixtures__/is-type-module-commonjs");
-    strictEqual(isTypeModule(), false);
+    equal(isTypeModule(), false);
   });
   it("Returns true when the type in the manifest equals module", () => {
     process.chdir("test/cli/init-config/__fixtures__/is-type-module");
-    strictEqual(isTypeModule(), true);
+    equal(isTypeModule(), true);
   });
 });
 
@@ -291,20 +291,20 @@ describe("[U] cli/init-config/environment-helpers - getDefaultConfigFileName", (
   });
   it("Returns false when there is no manifest", () => {
     process.chdir("test/cli/init-config/__fixtures__/is-type-module-empty");
-    strictEqual(getDefaultConfigFileName(), ".dependency-cruiser.js");
+    equal(getDefaultConfigFileName(), ".dependency-cruiser.js");
   });
   it("Returns false when there's no type in the manifest", () => {
     process.chdir(
       "test/cli/init-config/__fixtures__/is-type-module-not-present",
     );
-    strictEqual(getDefaultConfigFileName(), ".dependency-cruiser.js");
+    equal(getDefaultConfigFileName(), ".dependency-cruiser.js");
   });
   it("Returns false when the type in the manifest equals commonjs", () => {
     process.chdir("test/cli/init-config/__fixtures__/is-type-module-commonjs");
-    strictEqual(getDefaultConfigFileName(), ".dependency-cruiser.js");
+    equal(getDefaultConfigFileName(), ".dependency-cruiser.js");
   });
   it("Returns true when the type in the manifest equals module", () => {
     process.chdir("test/cli/init-config/__fixtures__/is-type-module");
-    strictEqual(getDefaultConfigFileName(), ".dependency-cruiser.cjs");
+    equal(getDefaultConfigFileName(), ".dependency-cruiser.cjs");
   });
 });

--- a/test/cli/init-config/environment-helpers.spec.mjs
+++ b/test/cli/init-config/environment-helpers.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import {
   isLikelyMonoRepo,
   hasTestsWithinSource,
@@ -7,44 +7,41 @@ import {
 
 describe("[U] cli/init-config/environment-helpers - isLikelyMonoRepo", () => {
   it("declares the current folder to be not a mono repo", () => {
-    strictEqual(isLikelyMonoRepo(), false);
+    equal(isLikelyMonoRepo(), false);
   });
   it("no folders => no mono repo", () => {
-    strictEqual(isLikelyMonoRepo([]), false);
+    equal(isLikelyMonoRepo([]), false);
   });
   it("no packages in the array of folders => no mono repo", () => {
-    strictEqual(
-      isLikelyMonoRepo(["bin", "src", "node_modules", "test"]),
-      false,
-    );
+    equal(isLikelyMonoRepo(["bin", "src", "node_modules", "test"]), false);
   });
   it("packages in the array of folders => mono repo", () => {
-    strictEqual(isLikelyMonoRepo(["packages"]), true);
+    equal(isLikelyMonoRepo(["packages"]), true);
   });
 });
 
 describe("[U] cli/init-config/environment-helpers - hasTestsWithinSource", () => {
   it("When there's no sign of a separate test directory - tests are in the source", () => {
-    strictEqual(hasTestsWithinSource([]), true);
+    equal(hasTestsWithinSource([]), true);
   });
 
   it("When there's a separate test directory - tests are separate", () => {
-    strictEqual(hasTestsWithinSource(["spec"], ["src"]), false);
+    equal(hasTestsWithinSource(["spec"], ["src"]), false);
   });
 
   it("When one test directory is also a source directy - tests are in the source", () => {
-    strictEqual(hasTestsWithinSource(["src"], ["bin", "src", "types"]), true);
+    equal(hasTestsWithinSource(["src"], ["bin", "src", "types"]), true);
   });
 
   it("When all test directories are also in the source directory array - tests are in the source", () => {
-    strictEqual(
+    equal(
       hasTestsWithinSource(["src", "lib"], ["bin", "src", "types", "lib"]),
       true,
     );
   });
 
   it("When only a part of  test directories are also in the source directory array - tests not in the source (for now)", () => {
-    strictEqual(
+    equal(
       hasTestsWithinSource(
         ["src", "lib", "spec"],
         ["bin", "src", "types", "lib"],
@@ -59,6 +56,6 @@ describe("[U] cli/init-config/environment-helpers - getFolderCandidates", () => 
     const lCandidates = ["src", "bin"];
     const lRealFolders = ["src", "lib", "node_modules"];
 
-    deepStrictEqual(getFolderCandidates(lCandidates)(lRealFolders), ["src"]);
+    deepEqual(getFolderCandidates(lCandidates)(lRealFolders), ["src"]);
   });
 });

--- a/test/cli/init-config/find-extensions.spec.mjs
+++ b/test/cli/init-config/find-extensions.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual, throws } from "node:assert";
+import { deepEqual, throws } from "node:assert/strict";
 import findExtensions from "../../../src/cli/init-config/find-extensions.mjs";
 
 describe("[U] cli/init-config/find-extensions", () => {
   it("returns an empty array of extensions when passed no directories", () => {
-    deepStrictEqual(findExtensions([]), []);
+    deepEqual(findExtensions([]), []);
   });
 
   it("throws when passed non-existent folders", () => {
@@ -18,7 +18,7 @@ describe("[U] cli/init-config/find-extensions", () => {
       scannableExtensions: [".js", ".mjs", ".cjs", ".jsx"],
     });
 
-    deepStrictEqual(lFound, []);
+    deepEqual(lFound, []);
   });
 
   it("filters scannable extensions from all extensions", () => {
@@ -27,7 +27,7 @@ describe("[U] cli/init-config/find-extensions", () => {
       scannableExtensions: [".js", ".mjs", ".cjs", ".jsx"],
     });
 
-    deepStrictEqual(lFound, [".js", ".cjs"]);
+    deepEqual(lFound, [".js", ".cjs"]);
   });
 
   it("sorts by the number of times the extension occurs", () => {
@@ -48,7 +48,7 @@ describe("[U] cli/init-config/find-extensions", () => {
       ],
     });
 
-    deepStrictEqual(lFound, [".js", ".ts", ".cjs", ".d.mts"]);
+    deepEqual(lFound, [".js", ".ts", ".cjs", ".d.mts"]);
   });
 
   it("ignores path elements that aren't worth scanning", () => {
@@ -71,6 +71,6 @@ describe("[U] cli/init-config/find-extensions", () => {
       ],
     });
 
-    deepStrictEqual(lFound, [".ts", ".d.mts"]);
+    deepEqual(lFound, [".ts", ".d.mts"]);
   });
 });

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import Ajv from "ajv";
 import deleteDammit from "../delete-dammit.utl.cjs";
 import initConfig from "../../../src/cli/init-config/index.mjs";
@@ -29,7 +29,7 @@ describe("[I] cli/init-config/index", () => {
       const lResult = await import(lConfigResultFileName);
 
       ajv.validate(configurationSchema, lResult.default);
-      strictEqual(lResult.default.hasOwnProperty("extends"), false);
+      equal(lResult.default.hasOwnProperty("extends"), false);
     } finally {
       deleteDammit(RULES_FILE_JS);
     }
@@ -48,8 +48,8 @@ describe("[I] cli/init-config/index", () => {
       const lResult = await import(lConfigResultFileName);
 
       ajv.validate(configurationSchema, lResult.default);
-      strictEqual(lResult.default.hasOwnProperty("extends"), false);
-      strictEqual(lResult.default.options.hasOwnProperty("tsConfig"), false);
+      equal(lResult.default.hasOwnProperty("extends"), false);
+      equal(lResult.default.options.hasOwnProperty("tsConfig"), false);
     } finally {
       deleteDammit(lConfig);
     }
@@ -67,9 +67,9 @@ describe("[I] cli/init-config/index", () => {
       const lResult = await import(lConfigResultFileName);
 
       ajv.validate(configurationSchema, lResult.default);
-      strictEqual(lResult.default.hasOwnProperty("extends"), false);
-      strictEqual(lResult.default.options.hasOwnProperty("tsConfig"), true);
-      deepStrictEqual(lResult.default.options.tsConfig, {
+      equal(lResult.default.hasOwnProperty("extends"), false);
+      equal(lResult.default.options.hasOwnProperty("tsConfig"), true);
+      deepEqual(lResult.default.options.tsConfig, {
         fileName: "tsconfig.json",
       });
     } finally {
@@ -89,12 +89,9 @@ describe("[I] cli/init-config/index", () => {
       const lResult = await import(lConfigResultFileName);
 
       ajv.validate(configurationSchema, lResult.default);
-      strictEqual(lResult.default.hasOwnProperty("extends"), false);
-      strictEqual(
-        lResult.default.options.hasOwnProperty("webpackConfig"),
-        true,
-      );
-      deepStrictEqual(lResult.default.options.webpackConfig, {
+      equal(lResult.default.hasOwnProperty("extends"), false);
+      equal(lResult.default.options.hasOwnProperty("webpackConfig"), true);
+      deepEqual(lResult.default.options.webpackConfig, {
         fileName: "webpack.config.js",
       });
     } finally {
@@ -120,7 +117,7 @@ describe("[I] cli/init-config/index", () => {
       ajv.validate(configurationSchema, lResult.default);
 
       const lManifest = JSON.parse(readFileSync(lManifestFilename, "utf8"));
-      strictEqual(lManifest.hasOwnProperty("scripts"), true);
+      equal(lManifest.hasOwnProperty("scripts"), true);
     } finally {
       deleteDammit(RULES_FILE_JS);
       deleteDammit(lManifestFilename);
@@ -144,10 +141,10 @@ describe("[I] cli/init-config/index", () => {
       const lResult = await import(lConfigResultFileName);
 
       ajv.validate(configurationSchema, lResult.default);
-      deepStrictEqual(lResult.default, {});
+      deepEqual(lResult.default, {});
 
       const lManifest = JSON.parse(readFileSync(lManifestFilename, "utf8"));
-      strictEqual(lManifest.hasOwnProperty("scripts"), true);
+      equal(lManifest.hasOwnProperty("scripts"), true);
     } finally {
       deleteDammit(lManifestFilename);
     }

--- a/test/cli/init-config/normalize-init-options.spec.mjs
+++ b/test/cli/init-config/normalize-init-options.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";
 
 describe("[U] cli/init-config/normalize-init-options", () => {
@@ -13,14 +13,11 @@ describe("[U] cli/init-config/normalize-init-options", () => {
   });
 
   it("If it's a mono repo, doesn't return a testLocation array", () => {
-    deepStrictEqual(
-      normalizeInitOptions({ isMonoRepo: true }).testLocation,
-      [],
-    );
+    deepEqual(normalizeInitOptions({ isMonoRepo: true }).testLocation, []);
   });
 
   it("If it's a mono repo, hasTestOutsideSource is false", () => {
-    strictEqual(
+    equal(
       normalizeInitOptions({ isMonoRepo: true }).hasTestsOutsideSource,
       false,
     );
@@ -28,7 +25,7 @@ describe("[U] cli/init-config/normalize-init-options", () => {
 
   it("If it's a mono repo, foo bar", () => {
     process.chdir("test/cli/init-config/__mocks__/mono-repo-with-other-files");
-    deepStrictEqual(
+    deepEqual(
       normalizeInitOptions({
         isMonoRepo: true,
         specifyResolutionExtensions: true,
@@ -39,12 +36,12 @@ describe("[U] cli/init-config/normalize-init-options", () => {
 
   it("If there's NO TypeScript-ish files in the source folder (nor a tsConfig or tsPreCompilationDeps specified) usesTypeScript is false", () => {
     process.chdir("test/cli/init-config/__mocks__/no-typescript-here");
-    strictEqual(normalizeInitOptions({}).usesTypeScript, false);
+    equal(normalizeInitOptions({}).usesTypeScript, false);
   });
 
   it("If there's NO TypeScript-ish files in the source folder, but a tsConfig is specified usesTypeScript is true", () => {
     process.chdir("test/cli/init-config/__mocks__/no-typescript-here");
-    strictEqual(
+    equal(
       normalizeInitOptions({ tsConfig: "./tsconfig.json" }).usesTypeScript,
       true,
     );
@@ -52,21 +49,18 @@ describe("[U] cli/init-config/normalize-init-options", () => {
 
   it("If there's NO TypeScript-ish files in the source folder, but a tsPreCompilationDeps is specified usesTypeScript is true", () => {
     process.chdir("test/cli/init-config/__mocks__/no-typescript-here");
-    strictEqual(
+    equal(
       normalizeInitOptions({ tsPreCompilationDeps: true }).usesTypeScript,
       true,
     );
   });
   it("If there's TypeScript-ish files in the source folder usesTypeScript is true", () => {
     process.chdir("test/cli/init-config/__mocks__/typescript-here");
-    strictEqual(
-      normalizeInitOptions({ sourceLocation: "src" }).usesTypeScript,
-      true,
-    );
+    equal(normalizeInitOptions({ sourceLocation: "src" }).usesTypeScript, true);
   });
   it("If there's no TypeScript-ish files in the source folder, but there are in the test folder, usesTypeScript is true", () => {
     process.chdir("test/cli/init-config/__mocks__/typescript-in-test-only");
-    strictEqual(
+    equal(
       normalizeInitOptions({
         sourceLocation: "src",
         hasTestsOutsideSource: true,

--- a/test/cli/init-config/utl.spec.mjs
+++ b/test/cli/init-config/utl.spec.mjs
@@ -1,14 +1,14 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { folderNameArrayToRE } from "../../../src/cli/init-config/utl.mjs";
 
 describe("[U] cli/init-config/utl - folderNameArrayToRE", () => {
   it("transforms an array of folder names into a regex string - empty", () => {
-    strictEqual(folderNameArrayToRE([]), "^()");
+    equal(folderNameArrayToRE([]), "^()");
   });
   it("transforms an array of folder names into a regex string - one entry", () => {
-    strictEqual(folderNameArrayToRE(["src"]), "^(src)");
+    equal(folderNameArrayToRE(["src"]), "^(src)");
   });
   it("transforms an array of folder names into a regex string - more than one entry", () => {
-    strictEqual(folderNameArrayToRE(["bin", "src", "lib"]), "^(bin|src|lib)");
+    equal(folderNameArrayToRE(["bin", "src", "lib"]), "^(bin|src|lib)");
   });
 });

--- a/test/cli/init-config/validators.spec.mjs
+++ b/test/cli/init-config/validators.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { validateLocation } from "../../../src/cli/init-config/validators.mjs";
 
 describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
@@ -11,15 +11,12 @@ describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
   });
 
   it("returns an error message when provided with an empty string", () => {
-    strictEqual(
-      validateLocation(""),
-      "'' doesn't seem to exist - please try again",
-    );
+    equal(validateLocation(""), "'' doesn't seem to exist - please try again");
   });
 
   it("returns an error message when provided with a non-existing folder name", () => {
     process.chdir(lFixturesDirectory);
-    strictEqual(
+    equal(
       validateLocation("non-existing-folder"),
       "'non-existing-folder' doesn't seem to exist - please try again",
     );
@@ -27,7 +24,7 @@ describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
 
   it("returns an error message when provided with a name of a file that is not a folder", () => {
     process.chdir(lFixturesDirectory);
-    strictEqual(
+    equal(
       validateLocation("existing-file"),
       "'existing-file' doesn't seem to be a folder - please try again",
     );
@@ -35,20 +32,17 @@ describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
 
   it("returns true when provided with an existing folder", () => {
     process.chdir(lFixturesDirectory);
-    strictEqual(validateLocation("existing-folder"), true);
+    equal(validateLocation("existing-folder"), true);
   });
 
   it("returns true when provided with a c.s.l. of existing folders", () => {
     process.chdir(lFixturesDirectory);
-    strictEqual(
-      validateLocation("existing-folder, another-existing-folder"),
-      true,
-    );
+    equal(validateLocation("existing-folder, another-existing-folder"), true);
   });
 
   it("returns an error message when provided with a c.s.l. of existing + non-existing folders", () => {
     process.chdir(lFixturesDirectory);
-    strictEqual(
+    equal(
       validateLocation(
         "existing-folder, non-existing-folder, another-existing-folder",
       ),
@@ -58,7 +52,7 @@ describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
 
   it("returns true when provided with an array of existing folders", () => {
     process.chdir(lFixturesDirectory);
-    strictEqual(
+    equal(
       validateLocation(["existing-folder", "another-existing-folder"]),
       true,
     );

--- a/test/cli/init-config/write-config.spec.mjs
+++ b/test/cli/init-config/write-config.spec.mjs
@@ -1,4 +1,4 @@
-import { ok, strictEqual } from "node:assert";
+import { ok, equal } from "node:assert/strict";
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import deleteDammit from "../delete-dammit.utl.cjs";
@@ -59,8 +59,8 @@ describe("[U] cli/init-config/write-config", () => {
       ok(pError.message.includes("already exists here - leaving it be"));
     }
 
-    strictEqual(lStillHere, false);
+    equal(lStillHere, false);
 
-    strictEqual(readFileSync(RULES_FILE_JS, "utf8"), "module.exports = {}");
+    equal(readFileSync(RULES_FILE_JS, "utf8"), "module.exports = {}");
   });
 });

--- a/test/cli/init-config/write-run-scripts-to-manifest.spec.mjs
+++ b/test/cli/init-config/write-run-scripts-to-manifest.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import {
   addRunScriptsToManifest,
   compileRunScripts,
@@ -6,24 +6,23 @@ import {
 
 describe("[U] cli/init-config/write-run-scripts-to-manifest - logic", () => {
   it("no manifest and no scripts retain the empty manifest with a scripts section", () => {
-    deepStrictEqual(addRunScriptsToManifest(), { scripts: {} });
+    deepEqual(addRunScriptsToManifest(), { scripts: {} });
   });
 
   it("empty manifest and empty scripts object retain the empty manifest with a scripts section", () => {
-    deepStrictEqual(addRunScriptsToManifest({}, {}), {
+    deepEqual(addRunScriptsToManifest({}, {}), {
       scripts: {},
     });
   });
 
   it("manifest with scripts and empty script object retain the original manifest", () => {
-    deepStrictEqual(
-      addRunScriptsToManifest({ scripts: { test: "jest" } }, {}),
-      { scripts: { test: "jest" } },
-    );
+    deepEqual(addRunScriptsToManifest({ scripts: { test: "jest" } }, {}), {
+      scripts: { test: "jest" },
+    });
   });
 
   it("manifest with scripts and a new script appears in the new manifest", () => {
-    deepStrictEqual(
+    deepEqual(
       addRunScriptsToManifest(
         { scripts: { test: "jest" } },
         { depcruise: "depcruise src -v" },
@@ -35,7 +34,7 @@ describe("[U] cli/init-config/write-run-scripts-to-manifest - logic", () => {
   });
 
   it("manifest with scripts and a update script doesn't overwrite in the manifest", () => {
-    deepStrictEqual(
+    deepEqual(
       addRunScriptsToManifest(
         {
           scripts: {
@@ -59,14 +58,14 @@ describe("[U] cli/init-config/write-run-scripts-to-manifest - logic", () => {
 
 describe("[U] cli/init-config/write-run-scripts-to-manifest - compile run script", () => {
   it("no sourcelocation no extra scripts (no init options object)", () => {
-    deepStrictEqual(compileRunScripts(), {});
+    deepEqual(compileRunScripts(), {});
   });
   it("no sourcelocation no extra scripts (empty init options object)", () => {
-    deepStrictEqual(compileRunScripts({}, []), {});
+    deepEqual(compileRunScripts({}, []), {});
   });
   it("sourcelocation => bunch of extra scripts (empty init options object)", () => {
     const lRunScripts = compileRunScripts({ sourceLocation: ["src"] });
-    deepStrictEqual(Object.keys(lRunScripts), [
+    deepEqual(Object.keys(lRunScripts), [
       "depcruise",
       "depcruise:graph",
       "depcruise:graph:dev",

--- a/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { match, strictEqual } from "node:assert";
+import { match, equal } from "node:assert/strict";
 import chalk from "chalk";
 import {
   formatTime,
@@ -24,27 +24,27 @@ import {
 
 describe("[U] cli/listeners/performance-log/format-helpers - formatTime", () => {
   it("converts to ms, left pads & adds the unit at the end", () => {
-    strictEqual(formatTime(14.88041018), "     14,880ms ");
+    equal(formatTime(14.88041018), "     14,880ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (0)", () => {
-    strictEqual(formatTime(0), "          0ms ");
+    equal(formatTime(0), "          0ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (negative numbers)", () => {
-    strictEqual(formatTime(-3.1415926535), "     -3,142ms ");
+    equal(formatTime(-3.1415926535), "     -3,142ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (null treatment => 0)", () => {
-    strictEqual(formatTime(null), "          0ms ");
+    equal(formatTime(null), "          0ms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (undefined treatment => NaN)", () => {
-    strictEqual(formatTime(), "        NaNms ");
+    equal(formatTime(), "        NaNms ");
   });
 
   it("converts to ms, left pads & adds the unit at the end (non-number treatment => NaN)", () => {
-    strictEqual(formatTime("not a number"), "        NaNms ");
+    equal(formatTime("not a number"), "        NaNms ");
   });
 });
 
@@ -60,27 +60,27 @@ describe("[U] cli/listeners/performance-log/format-helpers - formatMemory", () =
   });
 
   it("converts to kB, left pads & adds the unit at the end", () => {
-    strictEqual(formatMemory(4033856), "     +3,939kB ");
+    equal(formatMemory(4033856), "     +3,939kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (0)", () => {
-    strictEqual(formatMemory(0), "          0kB ");
+    equal(formatMemory(0), "          0kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (negative numbers)", () => {
-    strictEqual(formatMemory(-403385623), "   -393,931kB ");
+    equal(formatMemory(-403385623), "   -393,931kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (null)", () => {
-    strictEqual(formatMemory(0), "          0kB ");
+    equal(formatMemory(0), "          0kB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (undefined)", () => {
-    strictEqual(formatMemory(), "        NaNkB ");
+    equal(formatMemory(), "        NaNkB ");
   });
 
   it("converts to kB, left pads & adds the unit at the end (not a number)", () => {
-    strictEqual(formatMemory("not a number"), "        NaNkB ");
+    equal(formatMemory("not a number"), "        NaNkB ");
   });
 });
 

--- a/test/cli/listeners/performance-log-listener/handlers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/handlers.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { match, notStrictEqual, ok, strictEqual } from "node:assert";
+import { match, notStrictEqual, ok, equal } from "node:assert/strict";
 import {
   getHeader,
   getEndText,
@@ -10,7 +10,7 @@ const MAX_LEVEL = 20;
 
 describe("[U] cli/listeners/performance-log/handlers - getHeader", () => {
   it("when the level is > the max => empty string", () => {
-    strictEqual(getHeader(30, MAX_LEVEL), "");
+    equal(getHeader(30, MAX_LEVEL), "");
   });
   it("when the level === the max => non-empty string", () => {
     ok(getHeader(20, MAX_LEVEL));
@@ -26,7 +26,7 @@ describe("[U] cli/listeners/performance-log/handlers - getProgressLine", () => {
     previousMessage: "previous message",
   };
   it("when the level is > the max => empty string", () => {
-    strictEqual(getProgressLine("message", lStateMock, 30, MAX_LEVEL), "");
+    equal(getProgressLine("message", lStateMock, 30, MAX_LEVEL), "");
   });
   it("when the level === the max => non-empty string", () => {
     ok(getProgressLine("message", lStateMock, 20, MAX_LEVEL));
@@ -45,7 +45,7 @@ describe("[U] cli/listeners/performance-log/handlers - getProgressLine", () => {
       getProgressLine("next message", lUpdatableStateMock, 10, MAX_LEVEL),
       /previous message/,
     );
-    strictEqual(lUpdatableStateMock.previousMessage, "next message");
+    equal(lUpdatableStateMock.previousMessage, "next message");
     notStrictEqual(lUpdatableStateMock.previousTime, lPreviousTime);
   });
 });
@@ -56,7 +56,7 @@ describe("[U] cli/listeners/performance-log/handlers - getEndText", () => {
     previousHeapUsed: process.memoryUsage().heapUsed - 1000,
   };
   it("when the level is > the max => empty string", () => {
-    strictEqual(getEndText(lStateMock, 30, MAX_LEVEL), "");
+    equal(getEndText(lStateMock, 30, MAX_LEVEL), "");
   });
   it("when the level === the max => non-empty string", () => {
     ok(getEndText(lStateMock, 20, MAX_LEVEL));

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import normalizeCliOptions, {
   determineRulesFileName,
 } from "../../src/cli/normalize-cli-options.mjs";
@@ -13,7 +13,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("normalizes empty options to no exclude, stdout, json and 'cjs, amd, es6'", async () => {
-    deepStrictEqual(await normalizeCliOptions({}), {
+    deepEqual(await normalizeCliOptions({}), {
       outputTo: "-",
       outputType: "err",
       validate: false,
@@ -21,7 +21,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("normalizes --module-systems cjs,es6 to [cjs, es6]", async () => {
-    deepStrictEqual(await normalizeCliOptions({ moduleSystems: "cjs,es6" }), {
+    deepEqual(await normalizeCliOptions({ moduleSystems: "cjs,es6" }), {
       outputTo: "-",
       outputType: "err",
       moduleSystems: ["cjs", "es6"],
@@ -33,12 +33,12 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
     const lNormalizedCliOptions = await normalizeCliOptions({
       moduleSystems: " amd,cjs ,  es6 ",
     });
-    deepStrictEqual(lNormalizedCliOptions.moduleSystems, ["amd", "cjs", "es6"]);
+    deepEqual(lNormalizedCliOptions.moduleSystems, ["amd", "cjs", "es6"]);
   });
 
   it("-c / --config without params gets translated to -v/ --validate.", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/json-only");
-    deepStrictEqual(await normalizeCliOptions({ config: true }), {
+    deepEqual(await normalizeCliOptions({ config: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.json",
@@ -50,7 +50,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("-c / --config with something gets translated to -v/ --validate.", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/json-only");
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({ config: ".dependency-cruiser.json" }),
       {
         outputTo: "-",
@@ -68,13 +68,13 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
     try {
       await normalizeCliOptions({ validate: true });
     } catch (pError) {
-      strictEqual(pError.message.includes(".dependency-cruiser.(c)js"), true);
+      equal(pError.message.includes(".dependency-cruiser.(c)js"), true);
     }
   });
 
   it("-v finds .dependency-cruiser.js when no parameters to it are passed and it exists", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/js-only");
-    deepStrictEqual(await normalizeCliOptions({ validate: true }), {
+    deepEqual(await normalizeCliOptions({ validate: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.js",
@@ -85,7 +85,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("-v finds .dependency-cruiser.json when no parameters to it are passed and it exists", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/json-only");
-    deepStrictEqual(await normalizeCliOptions({ validate: true }), {
+    deepEqual(await normalizeCliOptions({ validate: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.json",
@@ -96,7 +96,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("-v finds .dependency-cruiser.json when no parameters to it are passed and also the .js variant exists", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/both-js-and-json");
-    deepStrictEqual(await normalizeCliOptions({ validate: true }), {
+    deepEqual(await normalizeCliOptions({ validate: true }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: ".dependency-cruiser.json",
@@ -111,15 +111,12 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
         validate: "./non-existing-config-file-name",
       });
     } catch (pError) {
-      strictEqual(
-        pError.message.includes("non-existing-config-file-name"),
-        true,
-      );
+      equal(pError.message.includes("non-existing-config-file-name"), true);
     }
   });
 
   it("-v with parameter uses that parameter as rules file", async () => {
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.empty.json",
       }),
@@ -134,7 +131,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("a rules file with comments gets the comments stripped out & parsed", async () => {
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.withcomments.json",
       }),
@@ -160,7 +157,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("accepts and interprets a javascript rule file (relative path)", async () => {
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.withcomments.js",
       }),
@@ -190,7 +187,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       new URL("__fixtures__/rules.withcomments.js", import.meta.url),
     );
 
-    deepStrictEqual(await normalizeCliOptions({ validate: lRulesFileName }), {
+    deepEqual(await normalizeCliOptions({ validate: lRulesFileName }), {
       outputTo: "-",
       outputType: "err",
       rulesFile: lRulesFileName,
@@ -211,7 +208,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("defaults tsConfig.fileName to 'tsconfig.json' if it wasn't specified", async () => {
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.tsConfigNoFileName.json",
       }),
@@ -232,7 +229,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
   });
 
   it("defaults webpackConfig.fileName to 'tsconfig.json' if it wasn't specified", async () => {
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({
         validate: "./test/cli/__fixtures__/rules.webpackConfigNoFileName.json",
       }),
@@ -254,47 +251,47 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
 
   it("progress without parameter defaults to cli-feedback", async () => {
     const lResult = await normalizeCliOptions({ progress: true });
-    strictEqual(lResult.progress, "cli-feedback");
+    equal(lResult.progress, "cli-feedback");
   });
 
   it("progress with parameter none ends up as progress: none", async () => {
     const lResult = await normalizeCliOptions({ progress: "none" });
-    strictEqual(lResult.progress, "none");
+    equal(lResult.progress, "none");
   });
 
   it("cache with value true translates to {}", async () => {
     const lResult = await normalizeCliOptions({ cache: true });
-    deepStrictEqual(lResult.cache, {});
+    deepEqual(lResult.cache, {});
   });
 
   it("cache with a string value translates to the folder name in the cache option", async () => {
     const lResult = await normalizeCliOptions({ cache: "some-string" });
-    deepStrictEqual(lResult.cache, { folder: "some-string" });
+    deepEqual(lResult.cache, { folder: "some-string" });
   });
 
   it("cache with an numerical value (which is invalid) translates to explicitly false cache option", async () => {
     const lResult = await normalizeCliOptions({ cache: 481 });
-    strictEqual(lResult.cache, false);
+    equal(lResult.cache, false);
   });
 
   it("cache with value false translates explicitly false cache option", async () => {
     const lResult = await normalizeCliOptions({ cache: false });
-    strictEqual(lResult.cache, false);
+    equal(lResult.cache, false);
   });
 
   it("no cache option translates to still not having a cache option", async () => {
     const lResult = await normalizeCliOptions({ "not-a-cache-option": true });
-    strictEqual(lResult.hasOwnProperty("cache"), false);
+    equal(lResult.hasOwnProperty("cache"), false);
   });
 
   it("cache-strategy with a string value == 'content' translates to the strategy 'content' in the cache option", async () => {
     const lResult = await normalizeCliOptions({ cacheStrategy: "content" });
-    deepStrictEqual(lResult.cache, { strategy: "content" });
+    deepEqual(lResult.cache, { strategy: "content" });
   });
 
   it("cache-strategy with a string value !== 'content' translates to the strategy 'metadata' in the cache option", async () => {
     const lResult = await normalizeCliOptions({ cacheStrategy: "some-string" });
-    deepStrictEqual(lResult.cache, { strategy: "metadata" });
+    deepEqual(lResult.cache, { strategy: "metadata" });
   });
 
   it("cache with a string value & cache-strategy with a string value translates both present in the cache option", async () => {
@@ -302,7 +299,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       cache: "somewhere",
       cacheStrategy: "some-string",
     });
-    deepStrictEqual(lResult.cache, {
+    deepEqual(lResult.cache, {
       folder: "somewhere",
       strategy: "metadata",
     });
@@ -313,7 +310,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       cache: true,
       cacheStrategy: "metadata",
     });
-    deepStrictEqual(lResult.cache, { strategy: "metadata" });
+    deepEqual(lResult.cache, { strategy: "metadata" });
   });
 
   it("cache with a value of false & cache-strategy with a string value translates to a cache option with that strategy", async () => {
@@ -321,7 +318,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       cache: false,
       cacheStrategy: "metadata",
     });
-    deepStrictEqual(lResult.cache, { strategy: "metadata" });
+    deepEqual(lResult.cache, { strategy: "metadata" });
   });
 
   it("cache with a value of true & cache-strategy with a string value translates to a cache option with that strategy x", async () => {
@@ -329,7 +326,7 @@ describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
       cache: true,
       cacheStrategy: "content",
     });
-    deepStrictEqual(lResult.cache, { strategy: "content" });
+    deepEqual(lResult.cache, { strategy: "content" });
   });
 });
 
@@ -342,7 +339,7 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
 
   it("--ignore-known without params gets the default known-violations json", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
-    deepStrictEqual(await normalizeCliOptions({ ignoreKnown: true }), {
+    deepEqual(await normalizeCliOptions({ ignoreKnown: true }), {
       outputTo: "-",
       outputType: "err",
       knownViolationsFile: ".dependency-cruiser-known-violations.json",
@@ -353,7 +350,7 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
 
   it("--ignore-known with params gets the mentioned known-violations", async () => {
     process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
-    deepStrictEqual(
+    deepEqual(
       await normalizeCliOptions({
         ignoreKnown: "custom-known-violations.json",
       }),
@@ -378,7 +375,7 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
     } catch (pError) {
       lError = pError.toString();
     }
-    strictEqual(
+    equal(
       lError.includes(
         `Can't open 'this-file-does-not-exist' for reading. Does it exist?`,
       ),
@@ -389,14 +386,14 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
 
 describe("[U] cli/determineRulesFileName", () => {
   it("returns '.dependency-cruiser.json' when no file name is passed", () => {
-    strictEqual(determineRulesFileName(), ".dependency-cruiser.json");
+    equal(determineRulesFileName(), ".dependency-cruiser.json");
   });
 
   it("returns '.dependency-cruiser.json' when a non-string is passed", () => {
-    strictEqual(determineRulesFileName(true), ".dependency-cruiser.json");
+    equal(determineRulesFileName(true), ".dependency-cruiser.json");
   });
 
   it("returns string passed when a string is passed", () => {
-    strictEqual(determineRulesFileName("a string"), "a string");
+    equal(determineRulesFileName("a string"), "a string");
   });
 });

--- a/test/cli/tools/wrap-stream-in-html.spec.mjs
+++ b/test/cli/tools/wrap-stream-in-html.spec.mjs
@@ -1,6 +1,6 @@
 import { createReadStream } from "node:fs";
 import { Writable } from "node:stream";
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import wrapStreamInHTML from "../../../src/cli/tools/wrap-stream-in-html.mjs";
 
 class WriteableExpectStream extends Writable {
@@ -13,10 +13,10 @@ class WriteableExpectStream extends Writable {
   }
 
   end() {
-    strictEqual(this.buffer.includes("<html"), true);
-    strictEqual(this.buffer.includes("</style>"), true);
-    strictEqual(this.buffer.includes('"name": "dependency-cruiser"'), true);
-    strictEqual(this.buffer.includes("</html"), true);
+    equal(this.buffer.includes("<html"), true);
+    equal(this.buffer.includes("</style>"), true);
+    equal(this.buffer.includes('"name": "dependency-cruiser"'), true);
+    equal(this.buffer.includes("</html"), true);
   }
 }
 

--- a/test/cli/utl/io.spec.mjs
+++ b/test/cli/utl/io.spec.mjs
@@ -1,7 +1,7 @@
 import { ReadStream } from "node:fs";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, notDeepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, notDeepStrictEqual, equal } from "node:assert/strict";
 import { getInStream } from "../../../src/cli/utl/io.mjs";
 
 describe("[U] cli/utl/io", () => {
@@ -10,21 +10,21 @@ describe("[U] cli/utl/io", () => {
   );
 
   it("getInStream(OUTFILE) yields a readable stream", () => {
-    strictEqual(getInStream(OUTFILE) instanceof Readable, true);
+    equal(getInStream(OUTFILE) instanceof Readable, true);
   });
   it("getInStream(OUTFILE) yields a readable file stream", () => {
-    strictEqual(getInStream(OUTFILE) instanceof ReadStream, true);
+    equal(getInStream(OUTFILE) instanceof ReadStream, true);
   });
   it("getInStream(OUTFILE) does not yield stdin", () => {
     notDeepStrictEqual(getInStream(OUTFILE), process.stdin);
   });
   it("getInStream('-') is a readable stream", () => {
-    strictEqual(getInStream("-") instanceof Readable, true);
+    equal(getInStream("-") instanceof Readable, true);
   });
   it("getInStream('-') yields stdin", () => {
-    deepStrictEqual(getInStream("-"), process.stdin);
+    deepEqual(getInStream("-"), process.stdin);
   });
   it("getInStream('-') does not yield a file stream", () => {
-    strictEqual(getInStream("-") instanceof ReadStream, false);
+    equal(getInStream("-") instanceof ReadStream, false);
   });
 });

--- a/test/cli/utl/validate-file-existence.spec.mjs
+++ b/test/cli/utl/validate-file-existence.spec.mjs
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "node:assert";
+import { doesNotThrow, throws } from "node:assert/strict";
 import validateFileExistence from "../../../src/cli/utl/validate-file-existence.mjs";
 
 describe("[U] cli/utl/validateFileExistence", () => {

--- a/test/cli/validate-node-environment.spec.mjs
+++ b/test/cli/validate-node-environment.spec.mjs
@@ -1,4 +1,4 @@
-import { doesNotThrow, throws } from "node:assert";
+import { doesNotThrow, throws } from "node:assert/strict";
 import validateNodeEnvironment from "../../src/cli/validate-node-environment.mjs";
 
 describe("[U] cli/validateNodeEnv", () => {

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { deepEqual, ok, equal } from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import omit from "lodash/omit.js";
 import extractBabelConfig from "../../src/config-utl/extract-babel-config.mjs";
@@ -32,7 +32,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws when a non-existing config file is passed", async () => {
@@ -42,7 +42,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws when a config file is passed that does not contain valid json5", async () => {
@@ -54,7 +54,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws when a config file is passed contains a non-babel option", async () => {
@@ -66,7 +66,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("returns a default options object when an empty config file is passed", async () => {
@@ -79,7 +79,7 @@ describe("[I] config-utl/extract-babel-config", () => {
         "/__mocks__/babelconfig/babelrc.empty.json",
       ),
     );
-    deepStrictEqual(
+    deepEqual(
       omit(lBabelConfig, "filename"),
       DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT,
     );
@@ -89,7 +89,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     const lBabelKey = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig/package.json"),
     );
-    strictEqual(lBabelKey.plugins.length, 1);
+    equal(lBabelKey.plugins.length, 1);
   });
 
   it("returns an empty (/ default) options object when package.json without a babel key is passed", async () => {
@@ -104,7 +104,7 @@ describe("[I] config-utl/extract-babel-config", () => {
         "/__mocks__/babelconfig/no-babel-config-in-this-package.json",
       ),
     );
-    deepStrictEqual(
+    deepEqual(
       omit(lBabelConfig, "filename"),
       DEFAULT_EMPTY_BABEL_OPTIONS_OBJECT,
     );
@@ -114,15 +114,15 @@ describe("[I] config-utl/extract-babel-config", () => {
     const lModule = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig-js/babel.object-export.config.js"),
     );
-    strictEqual(lModule.plugins.length, 1);
+    equal(lModule.plugins.length, 1);
   });
 
   it("returns a babel config _including_ the array of plugins when a config with presets is passed", async () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig/babelrc.with-a-preset.json"),
     );
-    strictEqual(lFoundConfig.presets.length, 1);
-    deepStrictEqual(lFoundConfig.presets, ["@babel/preset-typescript"]);
+    equal(lFoundConfig.presets.length, 1);
+    deepEqual(lFoundConfig.presets, ["@babel/preset-typescript"]);
   });
 
   it("throws when a javascript file with a function export is passed", async () => {
@@ -136,7 +136,7 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws when a config with an unsupported extension is passed", async () => {
@@ -150,21 +150,21 @@ describe("[I] config-utl/extract-babel-config", () => {
     } catch (pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("returns a babel config even when an es module is passed (.js extension)", async () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig-js/babel.es-module.config.mjs"),
     );
-    strictEqual(lFoundConfig.plugins.length, 1);
-    deepStrictEqual(lFoundConfig.plugins[0].key, "transform-modules-commonjs");
+    equal(lFoundConfig.plugins.length, 1);
+    deepEqual(lFoundConfig.plugins[0].key, "transform-modules-commonjs");
   });
   it("returns a babel config even when an es module is passed (.mjs extension)", async () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig-js/babel.es-module.config.mjs"),
     );
-    strictEqual(lFoundConfig.plugins.length, 1);
-    deepStrictEqual(lFoundConfig.plugins[0].key, "transform-modules-commonjs");
+    equal(lFoundConfig.plugins.length, 1);
+    deepEqual(lFoundConfig.plugins[0].key, "transform-modules-commonjs");
   });
 });

--- a/test/config-utl/extract-depcruise-config/index.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/index.spec.mjs
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
-import { ok, deepStrictEqual } from "node:assert";
+import { ok, deepEqual } from "node:assert/strict";
 import loadConfig from "../../../src/config-utl/extract-depcruise-config/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -14,7 +14,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
         assert: { type: "json" },
       }
     );
-    deepStrictEqual(
+    deepEqual(
       await loadConfig(join(mockDirectory, "rules.sub-not-allowed-error.json")),
       fixture.default,
     );
@@ -24,14 +24,14 @@ describe("[I] config-utl/extract-depcruise-config", () => {
     const mergedFixture = await import("./__mocks__/extends/merged.json", {
       assert: { type: "json" },
     });
-    deepStrictEqual(
+    deepEqual(
       await loadConfig(join(mockDirectory, "extends/extending.json")),
       mergedFixture.default,
     );
   });
 
   it("a rule set with an extends array (0 members) returns that rule set", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadConfig(
         join(mockDirectory, "extends/extending-array-with-zero-members.json"),
       ),
@@ -54,7 +54,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
         assert: { type: "json" },
       }
     );
-    deepStrictEqual(
+    deepEqual(
       await loadConfig(
         join(mockDirectory, "extends/extending-array-with-one-member.json"),
       ),
@@ -69,7 +69,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
         assert: { type: "json" },
       }
     );
-    deepStrictEqual(
+    deepEqual(
       await loadConfig(
         join(mockDirectory, "extends/extending-array-with-two-members.json"),
       ),
@@ -78,7 +78,7 @@ describe("[I] config-utl/extract-depcruise-config", () => {
   });
 
   it("a rule set with an extends from node_modules gets merged properly as well", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadConfig(
         join(mockDirectory, "extends/extending-from-node-modules.json"),
       ),

--- a/test/config-utl/extract-depcruise-config/merge-rule-sets.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/merge-rule-sets.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import merge from "../../../src/config-utl/extract-depcruise-config/merge-configs.mjs";
 
 describe("[U] config-utl/mergeRuleSets - general", () => {
   it("two empty rule sets yield an empty rule set with named attributes", () => {
-    deepStrictEqual(merge({}, {}), {
+    deepEqual(merge({}, {}), {
       options: {},
     });
   });
@@ -11,14 +11,14 @@ describe("[U] config-utl/mergeRuleSets - general", () => {
 
 describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   it("extending empty forbidden yields that forbidden", () => {
-    deepStrictEqual(merge({ forbidden: [{ from: "src", to: "test" }] }, {}), {
+    deepEqual(merge({ forbidden: [{ from: "src", to: "test" }] }, {}), {
       forbidden: [{ from: "src", to: "test" }],
       options: {},
     });
   });
 
   it("extending forbidden with something already in yields that forbidden (dedup)", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { forbidden: [{ from: "src", to: "test" }] },
         { forbidden: [{ from: "src", to: "test" }] },
@@ -31,14 +31,14 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   });
 
   it("extending forbidden with nothing yields that the base forbidden (dedup)", () => {
-    deepStrictEqual(merge({}, { forbidden: [{ from: "src", to: "test" }] }), {
+    deepEqual(merge({}, { forbidden: [{ from: "src", to: "test" }] }), {
       forbidden: [{ from: "src", to: "test" }],
       options: {},
     });
   });
 
   it("extending forbidden with something not yet in yields that forbidden + the extension", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { forbidden: [{ from: "bin", to: "test" }] },
         { forbidden: [{ from: "src", to: "test" }] },
@@ -54,7 +54,7 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   });
 
   it("extending an existing named rule - the extended wins", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { forbidden: [{ name: "already-in-base", from: "bin", to: "test" }] },
         { forbidden: [{ name: "already-in-base", from: "src", to: "test" }] },
@@ -67,7 +67,7 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   });
 
   it("extending an existing named rule - keep attributes not in extended", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         {
           forbidden: [
@@ -104,7 +104,7 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   });
 
   it("extending an existing named rule - adds attributes only in extended", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         {
           forbidden: [
@@ -141,7 +141,7 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   });
 
   it("extending an existing named rule - adds attributes only in extended (which is very partial only)", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { forbidden: [{ name: "already-in-base", severity: "info" }] },
         {
@@ -169,7 +169,7 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
   });
 
   it("extending forbidden with a named rule not in there adds it", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { forbidden: [{ name: "not-in-base", from: "bin", to: "test" }] },
         { forbidden: [{ name: "already-in-base", from: "src", to: "test" }] },
@@ -187,7 +187,7 @@ describe("[U] config-utl/mergeRuleSets - forbidden", () => {
 
 describe("[U] config-utl/mergeRuleSets - allowed", () => {
   it("extending empty allowed yields that allowed", () => {
-    deepStrictEqual(merge({ allowed: [{ from: "test", to: "src" }] }, {}), {
+    deepEqual(merge({ allowed: [{ from: "test", to: "src" }] }, {}), {
       allowed: [{ from: "test", to: "src" }],
       allowedSeverity: "warn",
       options: {},
@@ -195,7 +195,7 @@ describe("[U] config-utl/mergeRuleSets - allowed", () => {
   });
 
   it("extending allowed with something already in yields that allowed (dedup)", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { allowed: [{ from: "test", to: "src" }] },
         { allowed: [{ from: "test", to: "src" }] },
@@ -209,7 +209,7 @@ describe("[U] config-utl/mergeRuleSets - allowed", () => {
   });
 
   it("extending allowed with nothing yields that the base allowed (dedup)", () => {
-    deepStrictEqual(merge({}, { allowed: [{ from: "test", to: "src" }] }), {
+    deepEqual(merge({}, { allowed: [{ from: "test", to: "src" }] }), {
       allowed: [{ from: "test", to: "src" }],
       allowedSeverity: "warn",
       options: {},
@@ -217,7 +217,7 @@ describe("[U] config-utl/mergeRuleSets - allowed", () => {
   });
 
   it("extending allowed with something not yet in yields that allowed + the extension", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { allowed: [{ from: "bin", to: "test" }] },
         { allowed: [{ from: "src", to: "test" }] },
@@ -236,13 +236,13 @@ describe("[U] config-utl/mergeRuleSets - allowed", () => {
 
 describe("[U] config-utl/mergeRuleSets - allowedSeverity", () => {
   it("extending empty set with only an allowedSeverity error yields no allowedSeverity", () => {
-    deepStrictEqual(merge({ allowedSeverity: "error" }, {}), {
+    deepEqual(merge({ allowedSeverity: "error" }, {}), {
       options: {},
     });
   });
 
   it("extending empty set with allowed + allowedSeverity error yields allowedSeverity error", () => {
-    deepStrictEqual(
+    deepEqual(
       merge({}, { allowed: [{ from: {}, to: {} }], allowedSeverity: "error" }),
       {
         allowed: [{ from: {}, to: {} }],
@@ -253,7 +253,7 @@ describe("[U] config-utl/mergeRuleSets - allowedSeverity", () => {
   });
 
   it("extending allowedSeverity error with nothing yields allowedSeverity error", () => {
-    deepStrictEqual(
+    deepEqual(
       merge({ allowed: [{ from: {}, to: {} }], allowedSeverity: "error" }, {}),
       {
         allowed: [{ from: {}, to: {} }],
@@ -264,7 +264,7 @@ describe("[U] config-utl/mergeRuleSets - allowedSeverity", () => {
   });
 
   it("extending allowedSeverity error with info yields allowedSeverity info", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { allowedSeverity: "info" },
         { allowed: [{ from: {}, to: {} }], allowedSeverity: "error" },
@@ -280,7 +280,7 @@ describe("[U] config-utl/mergeRuleSets - allowedSeverity", () => {
 
 describe("[U] config-utl/mergeRuleSets - required", () => {
   it("extending an existing named rule - the extended wins", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { required: [{ name: "already-in-base", from: "bin", to: "test" }] },
         { required: [{ name: "already-in-base", from: "src", to: "test" }] },
@@ -293,7 +293,7 @@ describe("[U] config-utl/mergeRuleSets - required", () => {
   });
 
   it("merging two disjunct required rule sets", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { required: [{ name: "only-in-base", from: "bin", to: "test" }] },
         { required: [{ name: "only-in-extends", from: "src", to: "test" }] },
@@ -310,7 +310,7 @@ describe("[U] config-utl/mergeRuleSets - required", () => {
 });
 describe("[U] config-utl/mergeRuleSets - options", () => {
   it("extending empty options with some options yield those options", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         {
           options: {
@@ -332,7 +332,7 @@ describe("[U] config-utl/mergeRuleSets - options", () => {
   });
 
   it("extending some options with empty options yield those options", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         {},
         {
@@ -354,7 +354,7 @@ describe("[U] config-utl/mergeRuleSets - options", () => {
   });
 
   it("extending some options with some other options yield those options", () => {
-    deepStrictEqual(
+    deepEqual(
       merge(
         { options: { tsConfig: {} } },
         {

--- a/test/config-utl/extract-depcruise-config/read-config.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/read-config.spec.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import readConfig from "../../../src/config-utl/extract-depcruise-config/read-config.mjs";
 
 function getFullPath(pRelativePath) {
@@ -11,30 +11,30 @@ describe("[U] config-utl/extract-depcruise-config/read-config", () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.js"),
     );
-    deepStrictEqual(lConfig, {});
+    deepEqual(lConfig, {});
   });
   it("imports when it encounters .cjs", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.cjs"),
     );
-    deepStrictEqual(lConfig, {});
+    deepEqual(lConfig, {});
   });
   it("imports when it encounters .mjs", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.mjs"),
     );
-    deepStrictEqual(lConfig, {});
+    deepEqual(lConfig, {});
   });
   it("json5 parse when it encounters .json", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.json"),
     );
-    deepStrictEqual(lConfig, {});
+    deepEqual(lConfig, {});
   });
   it("json5 parse when it encounters something alien", async () => {
     const lConfig = await readConfig(
       getFullPath("__mocks__/read-config/dc.alien"),
     );
-    deepStrictEqual(lConfig, {});
+    deepEqual(lConfig, {});
   });
 });

--- a/test/config-utl/extract-known-violations.spec.mjs
+++ b/test/config-utl/extract-known-violations.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, ok } from "node:assert";
+import { deepEqual, ok } from "node:assert/strict";
 import extractKnownViolations from "../../src/config-utl/extract-known-violations.mjs";
 
 describe("[I] config-utl/extractKnownViolations", () => {
@@ -36,7 +36,7 @@ describe("[I] config-utl/extractKnownViolations", () => {
 
   it("Return the parsed json content of the violations file", async () => {
     process.chdir("./test/config-utl/__mocks__/known-violations");
-    deepStrictEqual(await extractKnownViolations("known-violations.json"), [
+    deepEqual(await extractKnownViolations("known-violations.json"), [
       {
         from: "src/schema/baseline-violations.schema.js",
         to: "src/schema/baseline-violations.schema.js",

--- a/test/config-utl/extract-ts-config.spec.mjs
+++ b/test/config-utl/extract-ts-config.spec.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, throws } from "node:assert";
+import { deepEqual, throws } from "node:assert/strict";
 import loadTSConfig from "../../src/config-utl/extract-ts-config.mjs";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
 
@@ -28,7 +28,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - simple 
   });
 
   it("returns an empty object when an empty config file is passed", () => {
-    deepStrictEqual(
+    deepEqual(
       loadTSConfig(
         getFullPath("./__mocks__/typescriptconfig/tsconfig.empty.json"),
       ).options,
@@ -41,7 +41,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - simple 
   });
 
   it("returns an empty object when an empty config file with comments is passed", () => {
-    deepStrictEqual(
+    deepEqual(
       loadTSConfig(
         getFullPath("./__mocks__/typescriptconfig/tsconfig.withcomments.json"),
       ).options,
@@ -56,7 +56,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - simple 
   });
 
   it("returns an object with a bunch of options when the default ('--init') config file is passed", () => {
-    deepStrictEqual(
+    deepEqual(
       loadTSConfig(
         getFullPath(
           "./__mocks__/typescriptconfig/tsconfig.asgeneratedbydefault.json",
@@ -97,7 +97,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - 'extend
   });
 
   it("returns an empty object (even no 'extend') when a config with an extend to an empty base is passed", () => {
-    deepStrictEqual(
+    deepEqual(
       loadTSConfig(
         getFullPath("./__mocks__/typescriptconfig/tsconfig.simpleextends.json"),
       ).options,
@@ -127,7 +127,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - 'extend
     ] = 1;
 
     /* eslint no-undefined:0 */
-    deepStrictEqual(lParseResult, {
+    deepEqual(lParseResult, {
       // only in the base
       // filesSpecs: ["./dummysrc.ts"],
       options: {
@@ -162,11 +162,11 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - 'extend
     // reason or other typescript's TSConfig parser overrides this again with false
     // even though it isn't specified in the file that extends it =>
     // I suspect a bug in typescripts' TSConfig parser ...
-    // strictEqual(lParseResult.compileOnSave, true);
+    // equal(lParseResult.compileOnSave, true);
   });
 
   it("returns an object with properties from base, extends & overrides from extends - compilerOptions", () => {
-    deepStrictEqual(
+    deepEqual(
       loadTSConfig(
         getFullPath(
           "./__mocks__/typescriptconfig/tsconfig.compileroptionsextends.json",
@@ -193,7 +193,7 @@ describe("[I] config-utl/extract-ts-config - flatten typescript config - 'extend
   });
 
   it("returns an object with properties from base, extends compilerOptions.lib array", () => {
-    deepStrictEqual(
+    deepEqual(
       loadTSConfig(
         getFullPath(
           "./__mocks__/typescriptconfig/tsconfig.compileroptionsextendslib.json",

--- a/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 
 import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
 
@@ -14,7 +14,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     } catch (_pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws when a non-existing config file is passed", async () => {
@@ -24,7 +24,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     } catch (_pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws when a config file is passed that does not contain valid javascript", async () => {
@@ -36,11 +36,11 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
     } catch (_pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("returns an empty object when a config file is passed without a 'resolve' section", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath("./__mocks__/webpackconfig/noresolve.config.js"),
       ),
@@ -49,7 +49,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the resolve section of the webpack config if there's any", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath("./__mocks__/webpackconfig/hasaresolve.config.js"),
       ),
@@ -63,7 +63,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the resolve section of the webpack config if there's any (.mjs variant)", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath("./__mocks__/webpackconfig/webpack.config.mjs"),
       ),
@@ -77,7 +77,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the production resolve section of the webpack config if that's an environment specific", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/hastwoseparateresolves.config.js",
@@ -94,7 +94,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the 'other' resolve section of the webpack config if development environment is requested", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/hastwoseparateresolves.config.js",
@@ -111,7 +111,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the resolve section of the function returning webpack config if there's any", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/aliassy/webpack.functionexport.config.js",
@@ -127,7 +127,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the resolve section of the first element of the array returning webpack config if there's any", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/aliassy/webpack.arrayexport.config.js",
@@ -143,7 +143,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - native formats", () =>
   });
 
   it("returns the resolve section of the result of the first element of the array if that's a function", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         getFullPath(
           "./__mocks__/webpackconfig/aliassy/webpack.functionarrayexport.config.js",

--- a/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, match, strictEqual } from "node:assert";
+import { deepEqual, match, equal } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
@@ -23,7 +23,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - non-native formats", (
     } catch (_pError) {
       lThrown = true;
     }
-    strictEqual(lThrown, true);
+    equal(lThrown, true);
   });
 
   it("throws an error with suggested modules when there's a known loader for the extension, but it isn't installed (livescript)", async () => {
@@ -54,7 +54,7 @@ describe("[I] config-utl/extract-webpack-resolve-config - non-native formats", (
   });
 
   it("returns contents of the webpack config when the non-native extension _is_ registered", async () => {
-    deepStrictEqual(
+    deepEqual(
       await loadResolveConfig(
         join(__dirname, "__mocks__", "webpackconfig", "webpack.config.json5"),
       ),

--- a/test/config-utl/make-absolute.spec.mjs
+++ b/test/config-utl/make-absolute.spec.mjs
@@ -1,16 +1,16 @@
 import { join } from "node:path";
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import makeAbsolute from "../../src/config-utl/make-absolute.mjs";
 
 describe("[U] cli/utl/makeAbsolute", () => {
   it("leaves absolute path names alone", () => {
-    strictEqual(
+    equal(
       makeAbsolute("/hallo/dit/is/een/absoluut/pad"),
       "/hallo/dit/is/een/absoluut/pad",
     );
   });
 
   it("puts the current working directory in front of non-absolute paths", () => {
-    strictEqual(makeAbsolute("pad"), join(process.cwd(), "pad"));
+    equal(makeAbsolute("pad"), join(process.cwd(), "pad"));
   });
 });

--- a/test/configs/no-orphans.spec.mjs
+++ b/test/configs/no-orphans.spec.mjs
@@ -1,10 +1,10 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import noOrphansRule from "../../configs/rules/no-orphans.js";
 import matchModuleRule from "../../src/validate/match-module-rule.mjs";
 
 describe("[I] configs/rules/no-orphans", () => {
   it("flags non-excepted orphans as orphan rule transgression", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "Rémi.js",
         orphan: true,
@@ -14,7 +14,7 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("flags files ending on a dotfile as orphan rule transgression", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "looks-like-a-dot-sorta.Rémi.js",
         orphan: true,
@@ -24,7 +24,7 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("does not flag dot files as orphan rule transgressions", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: ".Rémi.js",
         orphan: true,
@@ -34,7 +34,7 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("does not flag dot files in the tree as orphan rule transgressions", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/.Rémi.js",
         orphan: true,
@@ -44,7 +44,7 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("does not flag dot files in the tree as orphan rule transgressions, regardless extension", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/.Rémi.ts",
         orphan: true,
@@ -54,14 +54,14 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("does not flag any .d.ts not as orphan rule transgressions", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/types/lalalal.d.ts",
         orphan: true,
       }),
       false,
     );
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "lalalal.d.ts",
         orphan: true,
@@ -71,7 +71,7 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("does not flag babel config files in the tree not as orphan rule transgressions", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/babel.config.mjs",
         orphan: true,
@@ -81,7 +81,7 @@ describe("[I] configs/rules/no-orphans", () => {
   });
 
   it("does not flag babel config files as orphan rule transgressions", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(noOrphansRule, {
         source: "babel.config.mjs",
         orphan: true,

--- a/test/enrich/de-duplicate-violations.spec.mjs
+++ b/test/enrich/de-duplicate-violations.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import uniqWith from "lodash/uniqWith.js";
 import isSameViolation from "../../src/enrich/summarize/is-same-violation.mjs";
 
@@ -6,7 +6,7 @@ const deDuplicateViolations = (pViolations) =>
   uniqWith(pViolations, isSameViolation);
 describe("[U] enrich/de-duplicate-violations", () => {
   it("no violations => no violations", () => {
-    deepStrictEqual(deDuplicateViolations([]), []);
+    deepEqual(deDuplicateViolations([]), []);
   });
   it("non-cyclic violations => same non-cyclic violations", () => {
     const lViolations = [
@@ -27,7 +27,7 @@ describe("[U] enrich/de-duplicate-violations", () => {
         },
       },
     ];
-    deepStrictEqual(deDuplicateViolations(lViolations), lViolations);
+    deepEqual(deDuplicateViolations(lViolations), lViolations);
   });
 
   it("2 violations from different cycles => the 2 same violations", () => {
@@ -51,7 +51,7 @@ describe("[U] enrich/de-duplicate-violations", () => {
         cycle: ["src/report/dot/index.js", "src/report/dot/module-utl.js"],
       },
     ];
-    deepStrictEqual(deDuplicateViolations(lViolations), lViolations);
+    deepEqual(deDuplicateViolations(lViolations), lViolations);
   });
 
   it("2 violations from the same cycle => 1 violation", () => {
@@ -86,10 +86,7 @@ describe("[U] enrich/de-duplicate-violations", () => {
         cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
       },
     ];
-    deepStrictEqual(
-      deDuplicateViolations(lViolations),
-      lDeDuplicatedViolations,
-    );
+    deepEqual(deDuplicateViolations(lViolations), lDeDuplicatedViolations);
   });
 
   it("2 violations from the same cycle, but of different name => no changes", () => {
@@ -113,7 +110,7 @@ describe("[U] enrich/de-duplicate-violations", () => {
         cycle: ["src/report/dot/index.js", "src/report/dot/module-utl.js"],
       },
     ];
-    deepStrictEqual(deDuplicateViolations(lViolations), lViolations);
+    deepEqual(deDuplicateViolations(lViolations), lViolations);
   });
 
   it("does not mix up cyclic & non-cyclic violations when de-duplicating", () => {
@@ -164,9 +161,6 @@ describe("[U] enrich/de-duplicate-violations", () => {
         cycle: ["src/report/dot/module-utl.js", "src/report/dot/index.js"],
       },
     ];
-    deepStrictEqual(
-      deDuplicateViolations(lViolations),
-      lDeDuplicatedViolations,
-    );
+    deepEqual(deDuplicateViolations(lViolations), lDeDuplicatedViolations);
   });
 });

--- a/test/enrich/derive/dependents/get-dependents.spec.mjs
+++ b/test/enrich/derive/dependents/get-dependents.spec.mjs
@@ -1,18 +1,18 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 
 import getDependents from "../../../../src/enrich/derive/dependents/get-dependents.mjs";
 
 describe("[U] enrich/derive/dependents/get-dependents", () => {
   it("empty module without a source name & no modules yield no modules", () => {
-    deepStrictEqual(getDependents({}, []), []);
+    deepEqual(getDependents({}, []), []);
   });
 
   it("module & no modules yield no modules", () => {
-    deepStrictEqual(getDependents({ source: "itsme" }, []), []);
+    deepEqual(getDependents({ source: "itsme" }, []), []);
   });
 
   it("module & modules without any dependencies yield no modules", () => {
-    deepStrictEqual(
+    deepEqual(
       getDependents({ source: "itsme" }, [
         {
           source: "someoneelse",
@@ -24,7 +24,7 @@ describe("[U] enrich/derive/dependents/get-dependents", () => {
   });
 
   it("module & modules with non-matching dependencies yield no modules", () => {
-    deepStrictEqual(
+    deepEqual(
       getDependents({ source: "itsme" }, [
         {
           source: "someoneelse",
@@ -36,7 +36,7 @@ describe("[U] enrich/derive/dependents/get-dependents", () => {
   });
 
   it("module & module that's dependent yields that other module", () => {
-    deepStrictEqual(
+    deepEqual(
       getDependents({ source: "itsme" }, [
         {
           source: "someoneelse",
@@ -48,7 +48,7 @@ describe("[U] enrich/derive/dependents/get-dependents", () => {
   });
 
   it("module & modules that are dependent yields those other modules", () => {
-    deepStrictEqual(
+    deepEqual(
       getDependents({ source: "itsme" }, [
         {
           source: "someoneelse",

--- a/test/enrich/derive/folders/aggregate-to-folders.spec.mjs
+++ b/test/enrich/derive/folders/aggregate-to-folders.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 
 import aggregateToFolders from "../../../../src/enrich/derive/folders/aggregate-to-folders.mjs";
 
@@ -8,11 +8,11 @@ function compareFolders(pLeftFolder, pRightFolder) {
 
 describe("[U] enrich/derive/folders/aggregate-to-folders - folder stability metrics derivation", () => {
   it("no modules no metrics", () => {
-    deepStrictEqual(aggregateToFolders([]), []);
+    deepEqual(aggregateToFolders([]), []);
   });
 
   it("no dependencies no dependents", () => {
-    deepStrictEqual(
+    deepEqual(
       aggregateToFolders([
         { source: "src/folder/index.js", dependencies: [], dependents: [] },
       ]).sort(compareFolders),
@@ -40,7 +40,7 @@ describe("[U] enrich/derive/folders/aggregate-to-folders - folder stability metr
   });
 
   it("dependencies no dependents", () => {
-    deepStrictEqual(
+    deepEqual(
       aggregateToFolders([
         {
           source: "src/folder/index.js",
@@ -92,7 +92,7 @@ describe("[U] enrich/derive/folders/aggregate-to-folders - folder stability metr
   });
 
   it("dependencies no dependents - non-zero instability", () => {
-    deepStrictEqual(
+    deepEqual(
       aggregateToFolders([
         {
           source: "src/folder/index.js",
@@ -180,7 +180,7 @@ describe("[U] enrich/derive/folders/aggregate-to-folders - folder stability metr
   });
 
   it("no dependencies but dependents", () => {
-    deepStrictEqual(
+    deepEqual(
       aggregateToFolders([
         {
           source: "src/folder/index.js",
@@ -212,7 +212,7 @@ describe("[U] enrich/derive/folders/aggregate-to-folders - folder stability metr
   });
 
   it("handling core modules", () => {
-    deepStrictEqual(
+    deepEqual(
       aggregateToFolders([
         {
           source: "src/index.js",

--- a/test/enrich/derive/folders/index.spec.mjs
+++ b/test/enrich/derive/folders/index.spec.mjs
@@ -1,13 +1,13 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 
 import deriveFolders from "../../../../src/enrich/derive/folders/index.mjs";
 
 describe("[U] enrich/derive/folders - folder stability metrics derivation", () => {
   it("doesn't do anything when we're not asking for metrics (metrics nor outputType)", () => {
-    deepStrictEqual(deriveFolders([], {}), {});
+    deepEqual(deriveFolders([], {}), {});
   });
 
   it("emits folders when we're asking for metrics", () => {
-    deepStrictEqual(deriveFolders([], { metrics: true }), { folders: [] });
+    deepEqual(deriveFolders([], { metrics: true }), { folders: [] });
   });
 });

--- a/test/enrich/derive/folders/utl.spec.mjs
+++ b/test/enrich/derive/folders/utl.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 
 import {
   getAfferentCouplings,
@@ -9,14 +9,11 @@ import {
 
 describe("[U] enrich/derive/folders/utl - getAfferentCouplings", () => {
   it("no dependents => 0", () => {
-    strictEqual(
-      getAfferentCouplings({ dependents: [] }, "src/whoopla").length,
-      0,
-    );
+    equal(getAfferentCouplings({ dependents: [] }, "src/whoopla").length, 0);
   });
 
   it("dependents from the current folder => 0", () => {
-    strictEqual(
+    equal(
       getAfferentCouplings(
         { dependents: ["src/folder/do-things.mjs"] },
         "src/folder",
@@ -26,7 +23,7 @@ describe("[U] enrich/derive/folders/utl - getAfferentCouplings", () => {
   });
 
   it("dependents from another folder => 1", () => {
-    strictEqual(
+    equal(
       getAfferentCouplings(
         { dependents: ["src/somewhere-else/do-things.mjs"] },
         "src/whoopla",
@@ -36,7 +33,7 @@ describe("[U] enrich/derive/folders/utl - getAfferentCouplings", () => {
   });
 
   it("dependent from another folder that starts with a similar name => 1", () => {
-    strictEqual(
+    equal(
       getAfferentCouplings(
         { dependents: ["src/folder-some-more/do-things.mjs"] },
         "src/folder",
@@ -46,7 +43,7 @@ describe("[U] enrich/derive/folders/utl - getAfferentCouplings", () => {
   });
 
   it("all together now", () => {
-    strictEqual(
+    equal(
       getAfferentCouplings(
         {
           dependents: [
@@ -65,37 +62,34 @@ describe("[U] enrich/derive/folders/utl - getAfferentCouplings", () => {
 
 describe("[U] enrich/derive/folders/utl - getEfferentCouplings", () => {
   it("no dependencies => 0", () => {
-    strictEqual(
-      getEfferentCouplings({ dependencies: [] }, "src/whoopla").length,
-      0,
-    );
+    equal(getEfferentCouplings({ dependencies: [] }, "src/whoopla").length, 0);
   });
 });
 
 describe("[U] enrich/derive/folders/utl - getParentFolders", () => {
   it("for a parent-less folder just returns that folder", () => {
-    deepStrictEqual(getParentFolders("src"), ["src"]);
+    deepEqual(getParentFolders("src"), ["src"]);
   });
 
   it("for folder with parents return the parent folder and the folder itself (in that order)", () => {
-    deepStrictEqual(getParentFolders("src/reprot"), ["src", "src/reprot"]);
+    deepEqual(getParentFolders("src/reprot"), ["src", "src/reprot"]);
   });
   it("for empty folder names return that", () => {
-    deepStrictEqual(getParentFolders(""), [""]);
+    deepEqual(getParentFolders(""), [""]);
   });
 });
 
 describe("[U] enrich/derive/folders/utl - objectToArray", () => {
   it("no folders in object => empty array", () => {
-    deepStrictEqual(object2Array({}), []);
+    deepEqual(object2Array({}), []);
   });
 
   it("slaps keys into a name attribute in objects", () => {
-    deepStrictEqual(object2Array({ thename: {} }), [{ name: "thename" }]);
+    deepEqual(object2Array({ thename: {} }), [{ name: "thename" }]);
   });
 
   it("slaps keys into a name attribute in objects (multiple)", () => {
-    deepStrictEqual(
+    deepEqual(
       object2Array({
         "folder/one": {},
         "folder/two": { attribute: "yes" },

--- a/test/enrich/derive/metrics/module.spec.mjs
+++ b/test/enrich/derive/metrics/module.spec.mjs
@@ -1,14 +1,14 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 
 import deriveModuleMetrics from "../../../../src/enrich/derive/metrics/index.mjs";
 
 describe("[U] enrich/derive/metrics/module - module stability metrics derivation", () => {
   it("doesn't do anything when we're not asking for metrics (metrics nor outputType)", () => {
-    deepStrictEqual(deriveModuleMetrics([], {}), []);
+    deepEqual(deriveModuleMetrics([], {}), []);
   });
 
   it("emits an instability metric when we're asking for metrics", () => {
-    deepStrictEqual(
+    deepEqual(
       deriveModuleMetrics(
         [
           {
@@ -31,7 +31,7 @@ describe("[U] enrich/derive/metrics/module - module stability metrics derivation
   });
 
   it("emits an instability metric when we're asking for outputType === metrics", () => {
-    deepStrictEqual(
+    deepEqual(
       deriveModuleMetrics(
         [
           {
@@ -54,7 +54,7 @@ describe("[U] enrich/derive/metrics/module - module stability metrics derivation
   });
 
   it("emits an instability metric when we're asking for metrics (only dependents)", () => {
-    deepStrictEqual(
+    deepEqual(
       deriveModuleMetrics(
         [
           {
@@ -77,7 +77,7 @@ describe("[U] enrich/derive/metrics/module - module stability metrics derivation
   });
 
   it("emits an instability metric when we're asking for metrics (only dependencies)", () => {
-    strictEqual(
+    equal(
       deriveModuleMetrics(
         [
           {
@@ -93,7 +93,7 @@ describe("[U] enrich/derive/metrics/module - module stability metrics derivation
   });
 
   it("emits an instability metric when we're asking for metrics (dependents as well as dependencies)", () => {
-    strictEqual(
+    equal(
       deriveModuleMetrics(
         [
           {
@@ -110,7 +110,7 @@ describe("[U] enrich/derive/metrics/module - module stability metrics derivation
   });
 
   it("doesn't emit an instability metric when we're asking for metrics on something we don't want to calc them on", () => {
-    deepStrictEqual(
+    deepEqual(
       deriveModuleMetrics(
         [
           {

--- a/test/enrich/derive/orphan/index.spec.mjs
+++ b/test/enrich/derive/orphan/index.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 
 import orphan from "../../../../src/enrich/derive/orphan/index.mjs";
 import ONE_MODULE_FIXTURE from "./__mocks__/one-module.mjs";
@@ -8,14 +8,11 @@ import TWO_MODULES_AFTER_PROCESSING from "./__mocks__/two-module.afterprocessing
 
 describe("[U] enrich/derive/orphan/index - orphan detection", () => {
   it('attaches the "orphan" boolean to orphan modules by default', () => {
-    deepStrictEqual(
-      orphan(ONE_MODULE_FIXTURE, {}),
-      ONE_MODULE_AFTER_PROCESSING,
-    );
+    deepEqual(orphan(ONE_MODULE_FIXTURE, {}), ONE_MODULE_AFTER_PROCESSING);
   });
 
   it('attaches the "orphan" boolean to orphan modules if the ruleset requires an orphan check', () => {
-    deepStrictEqual(
+    deepEqual(
       orphan(ONE_MODULE_FIXTURE, {
         validate: true,
         ruleSet: {
@@ -34,6 +31,6 @@ describe("[U] enrich/derive/orphan/index - orphan detection", () => {
   });
 
   it('does attachs the "orphan" boolean to non-orphan modules with the value "false"', () => {
-    deepStrictEqual(orphan(TWO_MODULES_FIXTURE), TWO_MODULES_AFTER_PROCESSING);
+    deepEqual(orphan(TWO_MODULES_FIXTURE), TWO_MODULES_AFTER_PROCESSING);
   });
 });

--- a/test/enrich/derive/orphan/is-orphan.spec.mjs
+++ b/test/enrich/derive/orphan/is-orphan.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 
 import isOrphan from "../../../../src/enrich/derive/orphan/is-orphan.mjs";
 import ONE_MODULE_FIXTURE from "./__mocks__/one-module.mjs";
@@ -6,14 +6,14 @@ import TWO_MODULES_FIXTURE from "./__mocks__/two-module.mjs";
 
 describe("[U] enrich/derive/orphan/isOrphan", () => {
   it("flags a single module dependency graph as orphan", () => {
-    strictEqual(
+    equal(
       isOrphan({ source: "./lonely.js", dependencies: [] }, ONE_MODULE_FIXTURE),
       true,
     );
   });
 
   it("dismisses modules with at least one dependency", () => {
-    strictEqual(
+    equal(
       isOrphan(
         {
           source: "./snok.js",
@@ -37,7 +37,7 @@ describe("[U] enrich/derive/orphan/isOrphan", () => {
   });
 
   it("dismisses modules with at least one dependent", () => {
-    strictEqual(
+    equal(
       isOrphan(
         {
           source: "snak.js",

--- a/test/enrich/derive/reachable.spec.mjs
+++ b/test/enrich/derive/reachable.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import normalize from "../../../src/main/rule-set/normalize.mjs";
 import addReachability from "../../../src/enrich/derive/reachable.mjs";
 import clearExtractCaches from "../../../src/extract/clear-caches.mjs";
@@ -106,11 +106,11 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
     clearExtractCaches();
   });
   it("does not explode when passed an empty graph & an empty rule set", () => {
-    deepStrictEqual(addReachability([], normalize({})), []);
+    deepEqual(addReachability([], normalize({})), []);
   });
 
   it("returns the input graph when passed an empty rule set", () => {
-    deepStrictEqual(addReachability(GRAPH, normalize({})), GRAPH);
+    deepEqual(addReachability(GRAPH, normalize({})), GRAPH);
   });
 
   it('returns the reachability annotated graph when a rule set with forbidden "reachable" in it', () => {
@@ -123,7 +123,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
       ],
     };
 
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH, normalize(lForbiddenReachabilityRuleSetHajoo)),
       ANNOTATED_GRAPH_FOR_HAJOO,
     );
@@ -196,7 +196,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
         ],
       },
     ];
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH, normalize(lForbiddenReachabilityRuleSetHajoo)),
       lAnnotatedGraphForHajooAllowed,
     );
@@ -269,7 +269,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
         ],
       },
     ];
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH, normalize(lForbiddenReachabilityRuleSetHajoo)),
       lAnnotatedGraphForHajooAllowed,
     );
@@ -368,7 +368,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
         ],
       },
     ];
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH_TWO, normalize(lForbiddenReachabilityRuleSetHajoo)),
       lAnnotatedGraphForHajooAllowed,
     );
@@ -384,7 +384,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
       ],
     };
 
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH, normalize(lForbiddenReachabilityRuleSetHajoo)),
       ANNOTATED_GRAPH_FOR_HAJOO,
     );
@@ -432,7 +432,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH, normalize(lForbiddenReachabilityRuleSetHajoo)),
       lAnnotatedGraphForHajooNoIntermediate,
     );
@@ -480,7 +480,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       addReachability(GRAPH, normalize(lForbiddenReachabilityRuleSetHajoo)),
       lAnnotatedGraphForHajooNoIntermediate,
     );
@@ -605,7 +605,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       addReachability(lSourceGraph, normalize(lPoorMansTestCoverageRule)),
       lResultGraph,
     );
@@ -745,7 +745,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       addReachability(lSourceGraph, normalize(lTwoDifferentRules)),
       lResultGraph,
     );
@@ -844,7 +844,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
         dependencies: [{ resolved: "./src/index.js" }],
       },
     ];
-    deepStrictEqual(
+    deepEqual(
       addReachability(lSourceGraph, normalize(lTwoDifferentRules)),
       lResultGraph,
     );
@@ -1039,7 +1039,7 @@ describe("[U] enrich/derive/reachable/index - reachability detection", () => {
         dependencies: [],
       },
     ];
-    deepStrictEqual(
+    deepEqual(
       addReachability(lDependencyGraph, normalize(lRuleSetWithCaptureGroup)),
       lExpectedGraph,
     );

--- a/test/enrich/soften-known-violations.spec.mjs
+++ b/test/enrich/soften-known-violations.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import softenKnownViolations from "../../src/enrich/soften-known-violations.mjs";
 
 describe("[U] enrich/soften-known-violations - modules violations", () => {
@@ -15,7 +15,7 @@ describe("[U] enrich/soften-known-violations - modules violations", () => {
   ];
 
   it("no violations => no violations", () => {
-    deepStrictEqual(softenKnownViolations([], lKnownModuleViolations), []);
+    deepEqual(softenKnownViolations([], lKnownModuleViolations), []);
   });
 
   it("valid modules are kept alone", () => {
@@ -24,7 +24,7 @@ describe("[U] enrich/soften-known-violations - modules violations", () => {
       { source: "alez-houpe.js", valid: true, dependencies: [] },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownModuleViolations),
       lModules,
     );
@@ -41,7 +41,7 @@ describe("[U] enrich/soften-known-violations - modules violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownModuleViolations),
       lModules,
     );
@@ -67,7 +67,7 @@ describe("[U] enrich/soften-known-violations - modules violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownModuleViolations),
       lSoftenedModules,
     );
@@ -93,7 +93,7 @@ describe("[U] enrich/soften-known-violations - modules violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownModuleViolations, "info"),
       lSoftenedModules,
     );
@@ -125,7 +125,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
   ];
 
   it("no violations => no violations", () => {
-    deepStrictEqual(softenKnownViolations([], lKnownDependencyViolations), []);
+    deepEqual(softenKnownViolations([], lKnownDependencyViolations), []);
   });
 
   it("valid dependencies are left alone", () => {
@@ -143,7 +143,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownDependencyViolations),
       lModules,
     );
@@ -165,7 +165,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownDependencyViolations),
       lModules,
     );
@@ -187,7 +187,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownDependencyViolations),
       lModules,
     );
@@ -223,7 +223,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownDependencyViolations),
       lSoftenedModules,
     );
@@ -259,7 +259,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownDependencyViolations, "warn"),
       lSoftenedModules,
     );
@@ -357,7 +357,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownCyclicViolations, "info"),
       lSoftenedModules,
     );
@@ -476,7 +476,7 @@ describe("[U] enrich/soften-known-violations - dependency violations", () => {
         valid: true,
       },
     ];
-    deepStrictEqual(
+    deepEqual(
       softenKnownViolations(lModules, lKnownSelfReferenceViolation, "ignore"),
       lSoftenedModules,
     );

--- a/test/enrich/summarize-folders.spec.mjs
+++ b/test/enrich/summarize-folders.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import summarizeFolders from "../../src/enrich/summarize/summarize-folders.mjs";
 
 const FIXTURE_WITHOUT_VIOLATIONS = [
@@ -187,75 +187,66 @@ const CYCLE_RULE_SET = {
 
 describe("[I] enrich/summarize/summarize-folders", () => {
   it("returns an empty array when presented with an empty array of folders", () => {
-    deepStrictEqual(summarizeFolders([], SDP_RULE_SET), []);
+    deepEqual(summarizeFolders([], SDP_RULE_SET), []);
   });
 
   it("returns an empty array when presented with an array of folders that have no violations on them", () => {
-    deepStrictEqual(
-      summarizeFolders(FIXTURE_WITHOUT_VIOLATIONS, SDP_RULE_SET),
-      [],
-    );
+    deepEqual(summarizeFolders(FIXTURE_WITHOUT_VIOLATIONS, SDP_RULE_SET), []);
   });
 
   it("returns a summary of the violations when presented with an array of folders with violations (SDP)", () => {
-    deepStrictEqual(
-      summarizeFolders(FIXTURE_WITH_SDP_VIOLATION, SDP_RULE_SET),
-      [
-        {
-          type: "instability",
-          from: "src/cli",
-          to: "src/main",
-          rule: {
-            name: "sdp-folder-level",
-            severity: "info",
+    deepEqual(summarizeFolders(FIXTURE_WITH_SDP_VIOLATION, SDP_RULE_SET), [
+      {
+        type: "instability",
+        from: "src/cli",
+        to: "src/main",
+        rule: {
+          name: "sdp-folder-level",
+          severity: "info",
+        },
+        metrics: {
+          from: {
+            instability: 0.6666666666666666,
           },
-          metrics: {
-            from: {
-              instability: 0.6666666666666666,
-            },
-            to: {
-              instability: 0.7894736842105263,
-            },
+          to: {
+            instability: 0.7894736842105263,
           },
         },
-        {
-          type: "folder",
-          from: "src/cli",
-          to: "src/main",
-          rule: {
-            name: "non-sdp-rule",
-            severity: "info",
-          },
+      },
+      {
+        type: "folder",
+        from: "src/cli",
+        to: "src/main",
+        rule: {
+          name: "non-sdp-rule",
+          severity: "info",
         },
-      ],
-    );
+      },
+    ]);
   });
 
   it("returns a summary of the violations when presented with an array of folders with violations (cycles)", () => {
-    deepStrictEqual(
-      summarizeFolders(FIXTURE_WITH_CYCLE_VIOLATION, CYCLE_RULE_SET),
-      [
-        {
-          type: "cycle",
-          from: "src",
-          to: "bin",
-          rule: {
-            name: "no-folder-cycles",
-            severity: "warn",
-          },
-          cycle: ["bin", "src"],
+    deepEqual(summarizeFolders(FIXTURE_WITH_CYCLE_VIOLATION, CYCLE_RULE_SET), [
+      {
+        type: "cycle",
+        from: "src",
+        to: "bin",
+        rule: {
+          name: "no-folder-cycles",
+          severity: "warn",
         },
-        {
-          type: "cycle",
-          from: "bin",
-          to: "src",
-          rule: {
-            name: "no-folder-cycles",
-            severity: "warn",
-          },
-          cycle: ["src", "bin"],
+        cycle: ["bin", "src"],
+      },
+      {
+        type: "cycle",
+        from: "bin",
+        to: "src",
+        rule: {
+          name: "no-folder-cycles",
+          severity: "warn",
         },
-      ],
-    );
+        cycle: ["src", "bin"],
+      },
+    ]);
   });
 });

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import summarize from "../../src/enrich/summarize/index.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -11,7 +11,7 @@ const ajv = new Ajv();
 describe("[I] enrich/summarize", () => {
   it("doesn't add a rule set when there isn't one", () => {
     const lSummary = summarize([], {}, []);
-    deepStrictEqual(lSummary, {
+    deepEqual(lSummary, {
       error: 0,
       info: 0,
       ignore: 0,
@@ -27,7 +27,7 @@ describe("[I] enrich/summarize", () => {
   });
   it("adds a rule set when there is one", () => {
     const lSummary = summarize([], { ruleSet: { required: [] } }, []);
-    deepStrictEqual(lSummary, {
+    deepEqual(lSummary, {
       error: 0,
       info: 0,
       ignore: 0,
@@ -63,7 +63,7 @@ describe("[I] enrich/summarize", () => {
     const lResult1 = summarize(cycleStartsOnOne, lOptions, ["src"]);
     const lResult2 = summarize(cycleStartsOnTwo, lOptions, ["src"]);
 
-    deepStrictEqual(lResult1, lResult2);
+    deepEqual(lResult1, lResult2);
     ajv.validate(cruiseResultSchema, { modules: [], summary: lResult1 });
   });
 
@@ -138,7 +138,7 @@ describe("[I] enrich/summarize", () => {
       },
     };
     const lSummary = summarize(cycleFest, lOptions, ["src"]);
-    deepStrictEqual(lSummary, lExpected);
+    deepEqual(lSummary, lExpected);
     ajv.validate(cruiseResultSchema, { modules: [], summary: lSummary });
   });
 
@@ -161,7 +161,7 @@ describe("[I] enrich/summarize", () => {
         },
       },
     ];
-    deepStrictEqual(summarize([], { knownViolations: lKnownViolations }, []), {
+    deepEqual(summarize([], { knownViolations: lKnownViolations }, []), {
       error: 0,
       info: 0,
       ignore: 0,
@@ -177,7 +177,7 @@ describe("[I] enrich/summarize", () => {
   });
 
   it("doesn't include known violations key when none exist", () => {
-    deepStrictEqual(summarize([], { knownViolations: [] }, []), {
+    deepEqual(summarize([], { knownViolations: [] }, []), {
       error: 0,
       info: 0,
       ignore: 0,
@@ -220,7 +220,7 @@ describe("[I] enrich/summarize", () => {
       [],
     );
 
-    deepStrictEqual(lSummary, {
+    deepEqual(lSummary, {
       violations: [
         {
           type: "instability",

--- a/test/extract/ast-extractors/extract-amd-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-amd-deps.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractAMDDeps from "../../../src/extract/ast-extractors/extract-amd-deps.mjs";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
 
@@ -21,7 +21,7 @@ describe("[U] ast-extractors/extract-AMD-deps", () => {
       `define(["./root_one", "./root_two"], function(root_one){ /* do stuff */ });`,
       lDeps,
     );
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./root_one",
         moduleSystem: "amd",
@@ -45,7 +45,7 @@ describe("[U] ast-extractors/extract-AMD-deps", () => {
   });`;
 
     extractAMD(lInput, lDeps);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./one-with-require",
         moduleSystem: "amd",
@@ -69,7 +69,7 @@ describe("[U] ast-extractors/extract-AMD-deps", () => {
   });`;
 
     extractAMD(lInput, lDeps, ["want"]);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./one-with-want",
         moduleSystem: "amd",

--- a/test/extract/ast-extractors/extract-cjs-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-cjs-deps.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractcommonJSDeps from "../../../src/extract/ast-extractors/extract-cjs-deps.mjs";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
 
@@ -19,7 +19,7 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
     let lDeps = [];
 
     extractcommonJS("const x = require('./static')", lDeps);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./static",
         moduleSystem: "cjs",
@@ -37,7 +37,7 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
       lDeps,
       ["need"],
     );
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./static-required-with-need",
         moduleSystem: "cjs",
@@ -56,7 +56,7 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
       lDeps,
       ["window.require"],
     );
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./static-required-with-need",
         moduleSystem: "cjs",
@@ -74,14 +74,14 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
       "const need = require; const x = need('./static-required-with-need')",
       lDeps,
     );
-    deepStrictEqual(lDeps, []);
+    deepEqual(lDeps, []);
   });
 
   it("require with in an assignment - template literal argument", () => {
     let lDeps = [];
 
     extractcommonJS("const x = require(`template-literal`)", lDeps);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "template-literal",
         moduleSystem: "cjs",
@@ -95,7 +95,7 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
     let lDeps = [];
 
     extractcommonJS("require(42);", lDeps);
-    deepStrictEqual(lDeps, []);
+    deepEqual(lDeps, []);
   });
 
   it("non-string argument doesn't yield a dependency (function call)", () => {
@@ -108,6 +108,6 @@ describe("[U] ast-extractors/extract-cjs-deps", () => {
         `,
       lDeps,
     );
-    deepStrictEqual(lDeps, []);
+    deepEqual(lDeps, []);
   });
 });

--- a/test/extract/ast-extractors/extract-es6-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-es6-deps.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractES6Deps from "../../../src/extract/ast-extractors/extract-es6-deps.mjs";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
 
@@ -13,7 +13,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
     let lDeps = [];
 
     extractES6("import('./dynamic').then(pModule => pModule.x);", lDeps);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./dynamic",
         moduleSystem: "es6",
@@ -27,7 +27,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
     let lDeps = [];
 
     extractES6("import(`./dynamic`).then(pModule => pModule.x);", lDeps);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "./dynamic",
         moduleSystem: "es6",
@@ -45,7 +45,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
       "import(`./dynamic/${enhop}`).then(pModule => pModule.x);",
       lDeps,
     );
-    deepStrictEqual(lDeps, []);
+    deepEqual(lDeps, []);
   });
 
   it("yield a dynamic import yields an import", () => {
@@ -55,7 +55,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
         }`;
 
     extractES6(lYieldImport, lDeps);
-    deepStrictEqual(lDeps, [
+    deepEqual(lDeps, [
       {
         module: "http",
         moduleSystem: "es6",
@@ -69,7 +69,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
     let lDeps = [];
 
     extractES6("import(42).then(pModule => pModule.x);", lDeps);
-    deepStrictEqual(lDeps, []);
+    deepEqual(lDeps, []);
   });
 
   it("dynamic imports of a function call doesn't yield an import", () => {
@@ -82,7 +82,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
         `,
       lDeps,
     );
-    deepStrictEqual(lDeps, []);
+    deepEqual(lDeps, []);
   });
 
   it("doesn't get confused about import keywords in jsx components", () => {
@@ -98,7 +98,7 @@ describe("[U] ast-extractors/extract-ES6-deps", () => {
     }`;
 
     extractES6(lInput, lDependencies, ".jsx");
-    deepStrictEqual(lDependencies, [
+    deepEqual(lDependencies, [
       {
         module: "react",
         moduleSystem: "es6",
@@ -128,7 +128,7 @@ export class ReplicateIssueComponent extends React.Component {
   );
 }`;
     extractES6(lInput, lDependencies, ".jsx");
-    deepStrictEqual(lDependencies, [
+    deepEqual(lDependencies, [
       {
         module: "react",
         moduleSystem: "es6",

--- a/test/extract/ast-extractors/extract-typescript-commonjs.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-commonjs.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - regular commonjs require", () => {
   it("extracts require of a module that uses an export-equals'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import thing = require('./thing-that-uses-export-equals');",
       ),
@@ -19,7 +19,7 @@ describe("[U] ast-extractors/extract-typescript - regular commonjs require", () 
   });
 
   it("extracts regular require as a const, let or var", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         `const lala1 = require('legit-one');
                  let lala2 = require('legit-two');
@@ -49,7 +49,7 @@ describe("[U] ast-extractors/extract-typescript - regular commonjs require", () 
   });
 
   it("extracts regular requires that are not on the top level in the AST", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         `function f(x) {
                     if(x > 0) {
@@ -88,7 +88,7 @@ describe("[U] ast-extractors/extract-typescript - regular commonjs require", () 
   });
 
   it("extracts regular require with a template string without placeholders", () => {
-    deepStrictEqual(extractTypescript("const lala = require(`thunderscore`)"), [
+    deepEqual(extractTypescript("const lala = require(`thunderscore`)"), [
       {
         module: "thunderscore",
         moduleSystem: "cjs",
@@ -99,15 +99,15 @@ describe("[U] ast-extractors/extract-typescript - regular commonjs require", () 
   });
 
   it("ignores regular require without parameters", () => {
-    deepStrictEqual(extractTypescript("const lala = require()"), []);
+    deepEqual(extractTypescript("const lala = require()"), []);
   });
 
   it("ignores regular require with a non-string argument", () => {
-    deepStrictEqual(extractTypescript("const lala = require(666)"), []);
+    deepEqual(extractTypescript("const lala = require(666)"), []);
   });
 
   it("ignores regular require with a template literal with placeholders", () => {
-    deepStrictEqual(
+    deepEqual(
       // eslint-disable-next-line no-template-curly-in-string
       extractTypescript("const lala = require(`shwoooop/${blabla}`)"),
       [],
@@ -115,6 +115,6 @@ describe("[U] ast-extractors/extract-typescript - regular commonjs require", () 
   });
 
   it("ignores regular require with a function for a parameter", () => {
-    deepStrictEqual(extractTypescript("const lala = require(helvete())"), []);
+    deepEqual(extractTypescript("const lala = require(helvete())"), []);
   });
 });

--- a/test/extract/ast-extractors/extract-typescript-dynamic-imports.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-dynamic-imports.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - dynamic imports", () => {
   it("correctly detects a dynamic import statement", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import('judeljo').then(judeljo => { judeljo.hochik() })",
       ),
@@ -19,7 +19,7 @@ describe("[U] ast-extractors/extract-typescript - dynamic imports", () => {
   });
 
   it("correctly detects a dynamic import statement with a template that has no placeholders", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import(`judeljo`).then(judeljo => { judeljo.hochik() })",
       ),
@@ -35,7 +35,7 @@ describe("[U] ast-extractors/extract-typescript - dynamic imports", () => {
   });
 
   it("ignores dynamic import statements with a template that has placeholders", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         // eslint-disable-next-line no-template-curly-in-string
         "import(`judeljo/${vlap}`).then(judeljo => { judeljo.hochik() })",
@@ -45,7 +45,7 @@ describe("[U] ast-extractors/extract-typescript - dynamic imports", () => {
   });
 
   it("ignores dynamic import statements with a non-string parameter", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import(elaborateFunctionCall()).then(judeljo => { judeljo.hochik() })",
       ),
@@ -54,7 +54,7 @@ describe("[U] ast-extractors/extract-typescript - dynamic imports", () => {
   });
 
   it("ignores dynamic import statements without a parameter", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import(/* nothing */).then(judeljo => { judeljo.hochik() })",
       ),

--- a/test/extract/ast-extractors/extract-typescript-exotics.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-exotics.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - exotics", () => {
   it("doesn't detects 'exotic' dependencies when no exoticRequireStrings were passed", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "const want = require; const yo = want('./required-with-want');",
         [],
@@ -13,7 +13,7 @@ describe("[U] ast-extractors/extract-typescript - exotics", () => {
   });
 
   it("detects dependencies declared with one function names passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "const want = need = require; const yo = want('./required-with-want'); const nope = need('./required-with-need');",
         ["want"],
@@ -31,7 +31,7 @@ describe("[U] ast-extractors/extract-typescript - exotics", () => {
   });
 
   it("detects dependencies declared with member expression passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "const yo = window.require('./required-with-window-require')",
         ["window.require"],
@@ -49,7 +49,7 @@ describe("[U] ast-extractors/extract-typescript - exotics", () => {
   });
 
   it("detects dependencies declared with multiple function names passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "const want = need = require; const yo = want('./required-with-want'); const nope = need('./required-with-need');",
         ["want", "need"],

--- a/test/extract/ast-extractors/extract-typescript-exports.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-exports.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - re-exports", () => {
   it("extracts 're-export everything'", () => {
-    deepStrictEqual(extractTypescript("export * from './ts-thing';"), [
+    deepEqual(extractTypescript("export * from './ts-thing';"), [
       {
         module: "./ts-thing",
         moduleSystem: "es6",
@@ -14,7 +14,7 @@ describe("[U] ast-extractors/extract-typescript - re-exports", () => {
   });
 
   it("extracts 're-export and rename a thing from a re-export'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "export { ReExport as RenamedReExport } from './ts-thing'",
       ),
@@ -30,23 +30,17 @@ describe("[U] ast-extractors/extract-typescript - re-exports", () => {
   });
 
   it("leaves exports that are not re-exports alone", () => {
-    deepStrictEqual(
-      extractTypescript("export { ReExport as RenamedReExport };"),
-      [],
-    );
+    deepEqual(extractTypescript("export { ReExport as RenamedReExport };"), []);
   });
 
   it("extracts re-export under a different name (typescript 3.8+, ecmascript 2020)", () => {
-    deepStrictEqual(
-      extractTypescript("export * as woehahaha from './damodule'"),
-      [
-        {
-          module: "./damodule",
-          moduleSystem: "es6",
-          dynamic: false,
-          exoticallyRequired: false,
-        },
-      ],
-    );
+    deepEqual(extractTypescript("export * as woehahaha from './damodule'"), [
+      {
+        module: "./damodule",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
   });
 });

--- a/test/extract/ast-extractors/extract-typescript-imports.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-imports.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - regular imports", () => {
   it("extracts 'import for side effects only'", () => {
-    deepStrictEqual(extractTypescript("import './import-for-side-effects';"), [
+    deepEqual(extractTypescript("import './import-for-side-effects';"), [
       {
         module: "./import-for-side-effects",
         moduleSystem: "es6",
@@ -14,7 +14,7 @@ describe("[U] ast-extractors/extract-typescript - regular imports", () => {
   });
 
   it("extracts 'import some stuff only'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript("import { SomeSingleExport } from './ts-thing';"),
       [
         {
@@ -28,7 +28,7 @@ describe("[U] ast-extractors/extract-typescript - regular imports", () => {
   });
 
   it("extracts 'import some stuff only and rename that'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import { SomeSingleExport as RenamedSingleExport } from './ts-thing';",
       ),
@@ -44,7 +44,7 @@ describe("[U] ast-extractors/extract-typescript - regular imports", () => {
   });
 
   it("extracts 'import everything into a variable'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import * as entireTsOtherThingAsVariable from './ts-thing';",
       ),

--- a/test/extract/ast-extractors/extract-typescript-others.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-others.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import extractTypescriptFromAST from "../../../src/extract/ast-extractors/extract-typescript-deps.mjs";
@@ -8,7 +8,7 @@ describe("[U] ast-extractors/extract-typescript - others", () => {
   // recognize union types - which made dependency-cruiser 4.27.1 choke
   // this ut ensures it won't regress
   it("doesn't barf on output from old compiler versions", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescriptFromAST(
         JSON.parse(
           readFileSync(

--- a/test/extract/ast-extractors/extract-typescript-triple-slash-directives.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-triple-slash-directives.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - triple slash directives", () => {
   it("path", () => {
-    deepStrictEqual(extractTypescript('/// <reference path="./ts-thing" />'), [
+    deepEqual(extractTypescript('/// <reference path="./ts-thing" />'), [
       {
         module: "./ts-thing",
         moduleSystem: "tsd",
@@ -14,21 +14,18 @@ describe("[U] ast-extractors/extract-typescript - triple slash directives", () =
   });
 
   it("types", () => {
-    deepStrictEqual(
-      extractTypescript('/// <reference types="./ts-thing-types" />'),
-      [
-        {
-          module: "./ts-thing-types",
-          moduleSystem: "tsd",
-          dynamic: false,
-          exoticallyRequired: false,
-        },
-      ],
-    );
+    deepEqual(extractTypescript('/// <reference types="./ts-thing-types" />'), [
+      {
+        module: "./ts-thing-types",
+        moduleSystem: "tsd",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
   });
 
   it("amd-dependencies", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript('/// <amd-dependency path="./ts-thing-types" />'),
       [
         {

--- a/test/extract/ast-extractors/extract-typescript-type-imports-and-exports.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-type-imports-and-exports.spec.mjs
@@ -1,37 +1,31 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTypescript from "./extract-typescript.utl.mjs";
 
 describe("[U] ast-extractors/extract-typescript - type imports and exports", () => {
   it("extracts type imports in const declarations", () => {
-    deepStrictEqual(
-      extractTypescript("const tiepetjes: import('./types').T;"),
-      [
-        {
-          module: "./types",
-          moduleSystem: "es6",
-          dynamic: false,
-          exoticallyRequired: false,
-        },
-      ],
-    );
+    deepEqual(extractTypescript("const tiepetjes: import('./types').T;"), [
+      {
+        module: "./types",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
   });
 
   it("extracts type imports in const declarations (template literal argument)", () => {
-    deepStrictEqual(
-      extractTypescript("const tiepetjes: import(`./types`).T;"),
-      [
-        {
-          module: "./types",
-          moduleSystem: "es6",
-          dynamic: false,
-          exoticallyRequired: false,
-        },
-      ],
-    );
+    deepEqual(extractTypescript("const tiepetjes: import(`./types`).T;"), [
+      {
+        module: "./types",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
   });
 
   it("extracts type imports in parameter declarations", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "function f(snort: import('./vypes').T){console.log(snort.bla)}",
       ),
@@ -47,7 +41,7 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("extracts type imports in class members", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "class Klass{ private membert: import('./wypes').T; constructor() { membert = 'x'}}",
       ),
@@ -63,7 +57,7 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("leaves type imports with template literals with placeholders alone", () => {
-    deepStrictEqual(
+    deepEqual(
       // typescript/lib/protocol.d.ts has this thing
       // eslint-disable-next-line no-template-curly-in-string
       extractTypescript("const tiepetjes: import(`./types/${lalala()}`).T;"),
@@ -72,7 +66,7 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("leaves 'import equals' of variables alone", () => {
-    deepStrictEqual(
+    deepEqual(
       // typescript/lib/protocol.d.ts has this thing
       extractTypescript("import protocol = ts.server.protocol"),
       [],
@@ -80,22 +74,19 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("extracts imports that explicitly state they only import a type - default import", () => {
-    deepStrictEqual(
-      extractTypescript("import type slork from './ts-typical';"),
-      [
-        {
-          module: "./ts-typical",
-          moduleSystem: "es6",
-          dynamic: false,
-          exoticallyRequired: false,
-          dependencyTypes: ["type-only"],
-        },
-      ],
-    );
+    deepEqual(extractTypescript("import type slork from './ts-typical';"), [
+      {
+        module: "./ts-typical",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+        dependencyTypes: ["type-only"],
+      },
+    ]);
   });
 
   it("extracts imports that explicitly state they only import a type - just a part of the module", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript("import type {IZwabbernoot} from './ts-typical';"),
       [
         {
@@ -110,7 +101,7 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("extracts imports that explicitly state they only import a type - default import plus parts", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript(
         "import type Robbedoes, {IZwabbernoot} from './ts-typical';",
       ),
@@ -127,7 +118,7 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("extracts re-exports that explicitly state they only re-export a type", () => {
-    deepStrictEqual(
+    deepEqual(
       extractTypescript("export type * as vehicles from './vehicles';"),
       [
         {
@@ -142,7 +133,7 @@ describe("[U] ast-extractors/extract-typescript - type imports and exports", () 
   });
 
   it("extracts re-exports that explicitly state they only re-export a type (without aliases)", () => {
-    deepStrictEqual(extractTypescript("export type * from './vehicles';"), [
+    deepEqual(extractTypescript("export type * from './vehicles';"), [
       {
         module: "./vehicles",
         moduleSystem: "es6",

--- a/test/extract/ast-extractors/extract-with-swc-commonjs.spec.mjs
+++ b/test/extract/ast-extractors/extract-with-swc-commonjs.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
   it("extracts require of a module that uses an export-equals'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "import thing = require('./thing-that-uses-export-equals');",
       ),
@@ -19,7 +19,7 @@ describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
   });
 
   it("extracts regular require as a const, let or var", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         `const lala1 = require('legit-one');
                  let lala2 = require('legit-two');
@@ -49,7 +49,7 @@ describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
   });
 
   it("extracts regular requires that are not on the top level in the AST", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         `function f(x) {
                     if(x > 0) {
@@ -88,7 +88,7 @@ describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
   });
 
   it("extracts regular require with a template string without placeholders", () => {
-    deepStrictEqual(extractWithSwc("const lala = require(`thunderscore`)"), [
+    deepEqual(extractWithSwc("const lala = require(`thunderscore`)"), [
       {
         module: "thunderscore",
         moduleSystem: "cjs",
@@ -99,15 +99,15 @@ describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
   });
 
   it("ignores regular require without parameters", () => {
-    deepStrictEqual(extractWithSwc("const lala = require()"), []);
+    deepEqual(extractWithSwc("const lala = require()"), []);
   });
 
   it("ignores regular require with a non-string argument", () => {
-    deepStrictEqual(extractWithSwc("const lala = require(666)"), []);
+    deepEqual(extractWithSwc("const lala = require(666)"), []);
   });
 
   it("ignores regular require with a template literal with placeholders", () => {
-    deepStrictEqual(
+    deepEqual(
       // eslint-disable-next-line no-template-curly-in-string
       extractWithSwc("const lala = require(`shwoooop/${blabla}`)"),
       [],
@@ -115,6 +115,6 @@ describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
   });
 
   it("ignores regular require with a function for a parameter", () => {
-    deepStrictEqual(extractWithSwc("const lala = require(helvete())"), []);
+    deepEqual(extractWithSwc("const lala = require(helvete())"), []);
   });
 });

--- a/test/extract/ast-extractors/extract-with-swc-dynamic-imports.spec.mjs
+++ b/test/extract/ast-extractors/extract-with-swc-dynamic-imports.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] ast-extractors/extract-swc - dynamic imports", () => {
   it("correctly detects a dynamic import statement", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "import('judeljo').then(someModule => { someModule.hochik() })",
       ),
@@ -19,7 +19,7 @@ describe("[U] ast-extractors/extract-swc - dynamic imports", () => {
   });
 
   it("correctly detects a dynamic import statement with a template that has no placeholders", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc("import(`judeljo`).then(judeljo => { judeljo.hochik() })"),
       [
         {
@@ -33,7 +33,7 @@ describe("[U] ast-extractors/extract-swc - dynamic imports", () => {
   });
 
   it("ignores dynamic import statements with a template that has placeholders", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         // eslint-disable-next-line no-template-curly-in-string
         "import(`judeljo/${vlap}`).then(judeljo => { judeljo.hochik() })",
@@ -43,7 +43,7 @@ describe("[U] ast-extractors/extract-swc - dynamic imports", () => {
   });
 
   it("ignores dynamic import statements with a non-string parameter", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "import(elaborateFunctionCall()).then(judeljo => { judeljo.hochik() })",
       ),
@@ -52,7 +52,7 @@ describe("[U] ast-extractors/extract-swc - dynamic imports", () => {
   });
 
   it("ignores dynamic import statements without a parameter", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "import(/* nothing */).then(judeljo => { judeljo.hochik() })",
       ),

--- a/test/extract/ast-extractors/extract-with-swc-exotics.spec.mjs
+++ b/test/extract/ast-extractors/extract-with-swc-exotics.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] ast-extractors/extract-swc - exotics", () => {
   it("doesn't detects 'exotic' dependencies when no exoticRequireStrings were passed", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "const want = require; const yo = want('./required-with-want');",
         [],
@@ -13,7 +13,7 @@ describe("[U] ast-extractors/extract-swc - exotics", () => {
   });
 
   it("detects dependencies declared with one function names passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "const want = need = require; const yo = want('./required-with-want'); const nope = need('./required-with-need');",
         ["want"],
@@ -31,7 +31,7 @@ describe("[U] ast-extractors/extract-swc - exotics", () => {
   });
 
   it("detects dependencies declared with member expression passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "const yo = window.require('./required-with-window-require')",
         ["window.require"],
@@ -49,7 +49,7 @@ describe("[U] ast-extractors/extract-swc - exotics", () => {
   });
 
   it("ignores dependencies declared with member expressions that are not passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "const yo = window.require('./required-with-window-require')",
         ["document.want"],
@@ -59,7 +59,7 @@ describe("[U] ast-extractors/extract-swc - exotics", () => {
   });
 
   it("detects dependencies declared with multiple function names passed as exoticRequireStrings", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "const want = need = require; const yo = want('./required-with-want'); const nope = need('./required-with-need');",
         ["want", "need"],

--- a/test/extract/ast-extractors/extract-with-swc-exports.spec.mjs
+++ b/test/extract/ast-extractors/extract-with-swc-exports.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] ast-extractors/extract-swc - re-exports", () => {
   it("extracts 're-export everything'", () => {
-    deepStrictEqual(extractWithSwc("export * from './ts-thing';"), [
+    deepEqual(extractWithSwc("export * from './ts-thing';"), [
       {
         module: "./ts-thing",
         moduleSystem: "es6",
@@ -14,7 +14,7 @@ describe("[U] ast-extractors/extract-swc - re-exports", () => {
   });
 
   it("extracts 're-export and rename a thing from a re-export'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "export { ReExport as RenamedReExport } from './ts-thing'",
       ),
@@ -30,14 +30,11 @@ describe("[U] ast-extractors/extract-swc - re-exports", () => {
   });
 
   it("leaves exports that are not re-exports alone", () => {
-    deepStrictEqual(
-      extractWithSwc("export { ReExport as RenamedReExport };"),
-      [],
-    );
+    deepEqual(extractWithSwc("export { ReExport as RenamedReExport };"), []);
   });
 
   it("extracts re-export under a different name (typescript 3.8+, ecmascript 2020)", () => {
-    deepStrictEqual(extractWithSwc("export * as woehahaha from './damodule'"), [
+    deepEqual(extractWithSwc("export * as woehahaha from './damodule'"), [
       {
         module: "./damodule",
         moduleSystem: "es6",

--- a/test/extract/ast-extractors/extract-with-swc-imports.spec.mjs
+++ b/test/extract/ast-extractors/extract-with-swc-imports.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] ast-extractors/extract-swc - regular imports", () => {
   it("extracts 'import for side effects only'", () => {
-    deepStrictEqual(extractWithSwc("import './import-for-side-effects';"), [
+    deepEqual(extractWithSwc("import './import-for-side-effects';"), [
       {
         module: "./import-for-side-effects",
         moduleSystem: "es6",
@@ -14,7 +14,7 @@ describe("[U] ast-extractors/extract-swc - regular imports", () => {
   });
 
   it("extracts 'import some stuff only'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc("import { SomeSingleExport } from './ts-thing';"),
       [
         {
@@ -28,7 +28,7 @@ describe("[U] ast-extractors/extract-swc - regular imports", () => {
   });
 
   it("extracts 'import some stuff only and rename that'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "import { SomeSingleExport as RenamedSingleExport } from './ts-thing';",
       ),
@@ -44,7 +44,7 @@ describe("[U] ast-extractors/extract-swc - regular imports", () => {
   });
 
   it("extracts 'import everything into a variable'", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "import * as entireTsOtherThingAsVariable from './ts-thing';",
       ),

--- a/test/extract/ast-extractors/extract-with-swc-type-imports.spec.mjs
+++ b/test/extract/ast-extractors/extract-with-swc-type-imports.spec.mjs
@@ -1,10 +1,10 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] ast-extractors/extract-swc - type imports", () => {
   // normal fail, but Visitor.visitTsTypeAnnotation doesn't seem to get called
   // it("extracts type imports in const declarations", () => {
-  //   deepStrictEqual(
+  //   deepEqual(
   //     extractWithSwc("const tiepetjes: import('./types').T;"),
   //   [
   //     {
@@ -18,7 +18,7 @@ describe("[U] ast-extractors/extract-swc - type imports", () => {
 
   // swc barfs with: Error: internal error: entered unreachable code: parse_lit should not be called
   // it("extracts type imports in const declarations (template literal argument)", () => {
-  //   deepStrictEqual(
+  //   deepEqual(
   //     extractWithSwc("const tiepetjes: import(`./types`).T;"),
   //   [
   //     {
@@ -32,7 +32,7 @@ describe("[U] ast-extractors/extract-swc - type imports", () => {
 
   // normal fail, but pNode in Visitor.visitTsTypeAnnotation(pNode) equals null
   // it("extracts type imports in parameter declarations", () => {
-  //   deepStrictEqual(
+  //   deepEqual(
   //     extractWithSwc(
   //       "function f(snort: import('./vypes').T){console.log(snort.bla)}"
   //     ),
@@ -47,7 +47,7 @@ describe("[U] ast-extractors/extract-swc - type imports", () => {
   // });
 
   it("extracts type imports in class members", () => {
-    deepStrictEqual(
+    deepEqual(
       extractWithSwc(
         "class Klass{ private membert: import('./wypes').T; constructor() { membert = 'x'}}",
       ),
@@ -64,7 +64,7 @@ describe("[U] ast-extractors/extract-swc - type imports", () => {
 
   // swc fails with: "Error: internal error: entered unreachable code: parse_lit should not be called"
   // it("leaves type imports with template literals with placeholders alone", () => {
-  //   deepStrictEqual(
+  //   deepEqual(
   //     // typescript/lib/protocol.d.ts has this thing
   //     // eslint-disable-next-line no-template-curly-in-string
   //     extractWithSwc("const tiepetjes: import(`./types/${lalala()}`).T;")
@@ -72,7 +72,7 @@ describe("[U] ast-extractors/extract-swc - type imports", () => {
   // });
 
   it("leaves 'import equals' of variables alone", () => {
-    deepStrictEqual(
+    deepEqual(
       // typescript/lib/protocol.d.ts has this thing
       extractWithSwc("import protocol = ts.server.protocol"),
       [],
@@ -80,16 +80,13 @@ describe("[U] ast-extractors/extract-swc - type imports", () => {
   });
 
   it("extracts type imports (typescript 3.8+)", () => {
-    deepStrictEqual(
-      extractWithSwc("import type { SomeType } from './some-module'"),
-      [
-        {
-          module: "./some-module",
-          moduleSystem: "es6",
-          dynamic: false,
-          exoticallyRequired: false,
-        },
-      ],
-    );
+    deepEqual(extractWithSwc("import type { SomeType } from './some-module'"), [
+      {
+        module: "./some-module",
+        moduleSystem: "es6",
+        dynamic: false,
+        exoticallyRequired: false,
+      },
+    ]);
   });
 });

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import { lstatSync } from "node:fs";
 import gatherInitialSources from "../../src/extract/gather-initial-sources.mjs";
 import p2p from "../../src/utl/path-to-posix.mjs";
@@ -14,7 +14,7 @@ const EMPTYOPTIONS = normalizeCruiseOptions({});
 
 describe("[I] extract/gatherInitialSources", () => {
   it("one file stays one file", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         ["test/extract/__mocks__/cjs/root_one.js"],
         EMPTYOPTIONS,
@@ -24,7 +24,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("two files from different folders", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         [
           "test/extract/__mocks__/cjs/root_one.js",
@@ -40,7 +40,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("expands the scannable files in a folder", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(["test/extract/__mocks__/ts"], EMPTYOPTIONS).map(
         pathToPosix,
       ),
@@ -55,7 +55,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("expands and concats the scannable files in two folders", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         ["test/extract/__mocks__/ts", "test/extract/__mocks__/coffee"],
         EMPTYOPTIONS,
@@ -76,7 +76,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("expands and concats the scannable files in two folders + a separate file", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         [
           "test/extract/__mocks__/ts",
@@ -102,7 +102,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("filters the 'excluded' pattern from the collection", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         [
           "test/extract/__mocks__/ts",
@@ -124,7 +124,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("filters the 'excluded' pattern from the collection - regexp", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(["test/extract/__mocks__/ts"], {
         exclude: { path: "^[a-z]+$" },
       }).map(pathToPosix),
@@ -139,7 +139,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("expands glob patterns (**/*.js)", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         ["test/extract/__mocks__/gather-globbing/packages/**/*.js"],
         EMPTYOPTIONS,
@@ -161,7 +161,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("expands glob patterns (**/src/**/*.js)", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         ["test/extract/__mocks__/gather-globbing/**/src/**/*.js"],
         EMPTYOPTIONS,
@@ -178,7 +178,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("filters out the stuff in the exclude pattern", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(["test/extract/__mocks__/gather-globbing/**/src"], {
         exclude: { path: "/deep/ly/" },
       }).map(pathToPosix),
@@ -196,7 +196,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("filters out the stuff in the doNotFollow pattern", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(["test/extract/__mocks__/gather-globbing/**/src"], {
         doNotFollow: { path: "/deep/ly/" },
       }).map(pathToPosix),
@@ -214,7 +214,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("only gathers stuff in the includeOnly pattern", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         ["test/extract/__mocks__/gather-globbing/packages"],
         {
@@ -232,7 +232,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("also gathers files with extensions in the extra extensions to scan array", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(["test/extract/__mocks__/extra-extensions"], {
         extraExtensionsToScan: [".ratm", ".yolo"],
       }).map(pathToPosix),
@@ -246,7 +246,7 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("heeds the baseDir", () => {
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(
         ["**/src/**/*.js"],
         normalizeCruiseOptions({
@@ -265,13 +265,13 @@ describe("[I] extract/gatherInitialSources", () => {
   });
 
   it("filters invalid symlinks", () => {
-    strictEqual(
+    equal(
       lstatSync(
         "./test/extract/__mocks__/invalid-symlink/index.js",
       ).isSymbolicLink(),
       true,
     );
-    deepStrictEqual(
+    deepEqual(
       gatherInitialSources(["test/extract/__mocks__/invalid-symlink"]),
       [],
     );

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import { unlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -52,7 +52,7 @@ describe("[I] extract/getDependencies - AMD - with bangs", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "test/extract/__mocks__/amd-bangs/root_one.js",
         lOptions,
@@ -69,7 +69,7 @@ describe("[I] extract/getDependencies - AMD - with bangs", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "test/extract/__mocks__/amd-bangs/simplified-commonjs-wrapper.js",
         lOptions,

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import { unlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -31,7 +31,7 @@ function runFixture(pFixture, pParser = "acorn") {
   }
 
   it(`${pFixture.title} (with '${pParser}' as parser)`, async () => {
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         pFixture.input.fileName,
         normalizeCruiseOptions(lOptions),
@@ -78,7 +78,7 @@ describe("[I] extract/getDependencies - CommonJS - with bangs", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "test/extract/__mocks__/cjs-bangs/index.js",
         lOptions,
@@ -108,7 +108,7 @@ describe("[I] extract/getDependencies - CommonJS - with bangs", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "test/extract/__mocks__/cjs-multi-bangs/index.js",
         lOptions,

--- a/test/extract/get-dependencies.odds-and-ends.spec.mjs
+++ b/test/extract/get-dependencies.odds-and-ends.spec.mjs
@@ -1,9 +1,4 @@
-import {
-  deepStrictEqual,
-  doesNotThrow,
-  strictEqual,
-  throws,
-} from "node:assert";
+import { deepEqual, doesNotThrow, equal, throws } from "node:assert/strict";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
@@ -60,7 +55,7 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
   });
 
   it("Just skips require(481)", () => {
-    strictEqual(
+    equal(
       getDependencies(
         "./test/extract/__mocks__/cjs-require-non-strings/require-a-number.js",
         lOptions,
@@ -71,7 +66,7 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
   });
 
   it("Just skips require(a function)", () => {
-    strictEqual(
+    equal(
       getDependencies(
         "./test/extract/__mocks__/cjs-require-non-strings/require-a-function.js",
         lOptions,
@@ -82,7 +77,7 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
   });
 
   it("Just skips require(an iife)", () => {
-    strictEqual(
+    equal(
       getDependencies(
         "./test/extract/__mocks__/cjs-require-non-strings/require-an-iife.js",
         normalizeCruiseOptions({}),
@@ -103,7 +98,7 @@ describe("[I] extract/getDependencies - include", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "./test/extract/__mocks__/include/src/index.js",
         lOptions,
@@ -120,7 +115,7 @@ describe("[I] extract/getDependencies - include", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "./test/extract/__mocks__/include/src/index.js",
         lOptions,
@@ -150,7 +145,7 @@ describe("[I] extract/getDependencies - include", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "./test/extract/__mocks__/include/src/index.js",
         lOptions,
@@ -192,7 +187,7 @@ describe("[I] extract/getDependencies - include", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "./test/extract/__mocks__/exotic-require/index.js",
         lOptions,
@@ -226,7 +221,7 @@ describe("[I] extract/getDependencies - include", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "./test/extract/__mocks__/extra-extensions/not-parsed-when-in-extra-extensions.yolo",
         lOptions,
@@ -245,7 +240,7 @@ describe("[I] extract/getDependencies - include", () => {
       lOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         "./test/extract/__mocks__/specifyTsPreCompilationDeps/index.ts",
         lOptions,

--- a/test/extract/helpers-dependencies-equal.spec.mjs
+++ b/test/extract/helpers-dependencies-equal.spec.mjs
@@ -1,13 +1,13 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { dependenciesEqual } from "../../src/extract/helpers.mjs";
 
 describe("[U] extract/helpers - dependencyEqual", () => {
   it("two empty dependencies are equal", () => {
-    strictEqual(dependenciesEqual({})({}), true);
+    equal(dependenciesEqual({})({}), true);
   });
 
   it("same module name, same module system => equal", () => {
-    strictEqual(
+    equal(
       dependenciesEqual({ module: "foo", moduleSystem: "es6" })({
         module: "foo",
         moduleSystem: "es6",
@@ -17,7 +17,7 @@ describe("[U] extract/helpers - dependencyEqual", () => {
   });
 
   it("same module name, same module system, dynamicmoduleness, exotic require => equal", () => {
-    strictEqual(
+    equal(
       dependenciesEqual({
         module: "foo",
         moduleSystem: "cjs",
@@ -34,7 +34,7 @@ describe("[U] extract/helpers - dependencyEqual", () => {
   });
 
   it("same module name, different module system => eq", () => {
-    strictEqual(
+    equal(
       dependenciesEqual({
         module: "foo",
         moduleSystem: "es6",
@@ -47,7 +47,7 @@ describe("[U] extract/helpers - dependencyEqual", () => {
   });
 
   it("different module name, same module system => neq", () => {
-    strictEqual(
+    equal(
       dependenciesEqual({
         module: "foo",
         moduleSystem: "es6",
@@ -60,7 +60,7 @@ describe("[U] extract/helpers - dependencyEqual", () => {
   });
 
   it("same module name, same module system, not dynamically required => neq", () => {
-    strictEqual(
+    equal(
       dependenciesEqual({
         module: "foo",
         moduleSystem: "es6",
@@ -74,7 +74,7 @@ describe("[U] extract/helpers - dependencyEqual", () => {
   });
 
   it("same module name, same module system, not different exotic require => neq", () => {
-    strictEqual(
+    equal(
       dependenciesEqual({
         module: "foo",
         moduleSystem: "es6",

--- a/test/extract/helpers-detect-pre-compilation-ness.spec.mjs
+++ b/test/extract/helpers-detect-pre-compilation-ness.spec.mjs
@@ -1,20 +1,20 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { detectPreCompilationNess } from "../../src/extract/helpers.mjs";
 
 describe("[U] extract/helpers - detectPreCompilationNess", () => {
   it("empty dependency lists yield an empty one", () => {
-    deepStrictEqual(detectPreCompilationNess([], []), []);
+    deepEqual(detectPreCompilationNess([], []), []);
   });
 
   it("deps in the first not in the second get the isPreCompilationOnly attribute", () => {
-    deepStrictEqual(
+    deepEqual(
       detectPreCompilationNess([{ module: "foo", moduleSystem: "es6" }], []),
       [{ module: "foo", moduleSystem: "es6", preCompilationOnly: true }],
     );
   });
 
   it("deps in the first and in the second get the isPreCompilationOnly attribute with value false", () => {
-    deepStrictEqual(
+    deepEqual(
       detectPreCompilationNess(
         [{ module: "foo", moduleSystem: "es6" }],
         [{ module: "foo", moduleSystem: "es6" }],
@@ -24,7 +24,7 @@ describe("[U] extract/helpers - detectPreCompilationNess", () => {
   });
 
   it("deps in the first but not in the second (moduleSystem mismatch only) get the isPreCompilationOnly attribute with value true", () => {
-    deepStrictEqual(
+    deepEqual(
       detectPreCompilationNess(
         [{ module: "foo", moduleSystem: "es6" }],
         [{ module: "foo", moduleSystem: "cjs" }],
@@ -34,7 +34,7 @@ describe("[U] extract/helpers - detectPreCompilationNess", () => {
   });
 
   it("deps only in the second list vanish", () => {
-    deepStrictEqual(
+    deepEqual(
       detectPreCompilationNess([], [{ module: "foo", moduleSystem: "es6" }]),
       [],
     );

--- a/test/extract/helpers-extract-module-attributes.spec.mjs
+++ b/test/extract/helpers-extract-module-attributes.spec.mjs
@@ -1,63 +1,57 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { extractModuleAttributes } from "../../src/extract/helpers.mjs";
 
 describe("[U] extract/helpers - extractModuleAttributes", () => {
   it("leaves regular module specifications alone", () => {
-    deepStrictEqual(extractModuleAttributes("protodash"), {
+    deepEqual(extractModuleAttributes("protodash"), {
       module: "protodash",
     });
   });
 
   it("extracts the protocol if there is one", () => {
-    deepStrictEqual(extractModuleAttributes("node:fs"), {
+    deepEqual(extractModuleAttributes("node:fs"), {
       module: "fs",
       protocol: "node:",
     });
   });
 
   it("leaves things alone the protocol is unknown", () => {
-    deepStrictEqual(extractModuleAttributes("nod:fs"), {
+    deepEqual(extractModuleAttributes("nod:fs"), {
       module: "nod:fs",
     });
   });
 
   it("manages empty strings gracefully", () => {
-    deepStrictEqual(extractModuleAttributes(""), {
+    deepEqual(extractModuleAttributes(""), {
       module: "",
     });
   });
 
   it("extracts both protocol and mimeType when they're in the URI", () => {
-    deepStrictEqual(
-      extractModuleAttributes("data:application/json,gegevens.json"),
-      {
-        module: "gegevens.json",
-        protocol: "data:",
-        mimeType: "application/json",
-      },
-    );
+    deepEqual(extractModuleAttributes("data:application/json,gegevens.json"), {
+      module: "gegevens.json",
+      protocol: "data:",
+      mimeType: "application/json",
+    });
   });
 
   it("handles emtpy mimeTypes gracefulley", () => {
-    deepStrictEqual(extractModuleAttributes("data:,gegevens.json"), {
+    deepEqual(extractModuleAttributes("data:,gegevens.json"), {
       module: ",gegevens.json",
       protocol: "data:",
     });
   });
 
   it("treats comma's without a (known) protocol as part of the filename", () => {
-    deepStrictEqual(extractModuleAttributes("a com, ma.json"), {
+    deepEqual(extractModuleAttributes("a com, ma.json"), {
       module: "a com, ma.json",
     });
   });
 
   it("when protocol separator is mistyped, returns it as part of the module name", () => {
-    deepStrictEqual(
-      extractModuleAttributes("data:application/json;gegevens.json"),
-      {
-        module: "application/json;gegevens.json",
-        protocol: "data:",
-      },
-    );
+    deepEqual(extractModuleAttributes("data:application/json;gegevens.json"), {
+      module: "application/json;gegevens.json",
+      protocol: "data:",
+    });
   });
 });

--- a/test/extract/helpers-strip-query-parameters.spec.mjs
+++ b/test/extract/helpers-strip-query-parameters.spec.mjs
@@ -1,20 +1,20 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { stripQueryParameters } from "../../src/extract/helpers.mjs";
 
 describe("[U] extract/helpers - stripQueryParams", () => {
   it("leaves the empty string alone", () => {
-    strictEqual(stripQueryParameters(""), "");
+    equal(stripQueryParameters(""), "");
   });
 
   it("leaves paths without query parameters alone", () => {
-    strictEqual(
+    equal(
       stripQueryParameters("normal/path/would/say.js"),
       "normal/path/would/say.js",
     );
   });
 
   it("strips query parameters from paths", () => {
-    strictEqual(
+    equal(
       stripQueryParameters(
         "normal/path/would/say.js?these=are&query=parameters",
       ),

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -1,5 +1,5 @@
 import { renameSync } from "node:fs";
-import { deepStrictEqual, notDeepStrictEqual } from "node:assert";
+import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
 import extract from "../../src/extract/index.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
@@ -75,8 +75,8 @@ describe("[I] extract/index - cache busting", () => {
       "./test/extract/__mocks__/cache-busting-second-tree",
     );
 
-    deepStrictEqual(lFirstResult, lFirstResultFixture);
-    deepStrictEqual(lSecondResult, lSecondResultFixture);
+    deepEqual(lFirstResult, lFirstResultFixture);
+    deepEqual(lSecondResult, lSecondResultFixture);
     notDeepStrictEqual(lSecondResult, lFirstResult);
   });
 });

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
@@ -25,7 +25,7 @@ describe("[I] extract/index - do not follow", () => {
       lResolveOptions,
     );
 
-    deepStrictEqual(lResult, requireJSON("./__fixtures__/donotfollow.json"));
+    deepEqual(lResult, requireJSON("./__fixtures__/donotfollow.json"));
   });
 
   it("do not follow - doNotFollow.dependencyTypes", async () => {
@@ -46,7 +46,7 @@ describe("[I] extract/index - do not follow", () => {
       lResolveOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       lResult,
       requireJSON("./__fixtures__/donotfollow-dependency-types.json"),
     );

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
@@ -25,10 +25,7 @@ describe("[I] extract/index - exclude", () => {
       lResolveOptions,
     );
 
-    deepStrictEqual(
-      lResult,
-      requireJSON("./__mocks__/exclude/path/es/output.json"),
-    );
+    deepEqual(lResult, requireJSON("./__mocks__/exclude/path/es/output.json"));
   });
 
   it("exclude - exclude.dynamic", async () => {
@@ -49,7 +46,7 @@ describe("[I] extract/index - exclude", () => {
       lResolveOptions,
     );
 
-    deepStrictEqual(
+    deepEqual(
       lResult,
       requireJSON("./__mocks__/exclude/dynamic/es/output.json"),
     );

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
@@ -26,7 +26,7 @@ describe("[I] extract/index - max depth", () => {
       );
       /* eslint import/no-dynamic-require:0, security/detect-non-literal-require:0 */
 
-      deepStrictEqual(
+      deepEqual(
         lResult,
         requireJSON(`./__fixtures__/max-depth-${pDepth}.json`),
       );

--- a/test/extract/parse/to-javascript-ast.spec.mjs
+++ b/test/extract/parse/to-javascript-ast.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import get from "lodash/get.js";
 import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
 
@@ -37,7 +37,7 @@ describe("[U] extract/parse/to-javascript-ast", () => {
         },
       },
     );
-    strictEqual(
+    equal(
       get(
         lFoundAST,
         "body[0].declarations[0].init.body.type",
@@ -74,8 +74,8 @@ describe("[U] extract/parse/to-javascript-ast", () => {
       "body[0].declarations.[0].init",
       {},
     );
-    strictEqual(likelyTheArrowExpression.type, "ArrowFunctionExpression");
-    strictEqual(
+    equal(likelyTheArrowExpression.type, "ArrowFunctionExpression");
+    equal(
       get(
         likelyTheArrowExpression,
         "body.callee.type",
@@ -83,11 +83,11 @@ describe("[U] extract/parse/to-javascript-ast", () => {
       ),
       "MemberExpression",
     );
-    strictEqual(
+    equal(
       get(likelyTheArrowExpression, "body.callee.object.name", "not react"),
       "React",
     );
-    strictEqual(
+    equal(
       get(
         likelyTheArrowExpression,
         "body.callee.property.name",

--- a/test/extract/resolve/classify.is-external-module.spec.mjs
+++ b/test/extract/resolve/classify.is-external-module.spec.mjs
@@ -1,30 +1,30 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { isExternalModule } from "../../../src/extract/resolve/module-classifiers.mjs";
 
 describe("[U] extract/resolve/module-classifiers - isExternalModule", () => {
   it("returns false when passed nothing", () => {
-    strictEqual(isExternalModule(), false);
+    equal(isExternalModule(), false);
   });
   it("returns false when passed null", () => {
-    strictEqual(isExternalModule(null), false);
+    equal(isExternalModule(null), false);
   });
   it("returns false when passed an empty string", () => {
-    strictEqual(isExternalModule(""), false);
+    equal(isExternalModule(""), false);
   });
   it("returns false when passed a path ", () => {
-    strictEqual(isExternalModule("a-path"), false);
+    equal(isExternalModule("a-path"), false);
   });
   it("returns false when passed a path that doesn't include one of the passed external module folders", () => {
-    strictEqual(isExternalModule("a-path", ["node_modules"]), false);
+    equal(isExternalModule("a-path", ["node_modules"]), false);
   });
   it("returns true when passed a path that includes the one passed external module folder", () => {
-    strictEqual(
+    equal(
       isExternalModule("node_modules/a-path-to/index.js", ["node_modules"]),
       true,
     );
   });
   it("returns true when passed a path that includes one of the passed external module folders", () => {
-    strictEqual(
+    equal(
       isExternalModule("shwok/a-path-to/index.js", [
         "node_modules",
         "node_modules/@types",

--- a/test/extract/resolve/classify.is-relative-module-name.spec.mjs
+++ b/test/extract/resolve/classify.is-relative-module-name.spec.mjs
@@ -1,4 +1,4 @@
-import { throws, strictEqual } from "node:assert";
+import { throws, equal } from "node:assert/strict";
 import { isRelativeModuleName } from "../../../src/extract/resolve/module-classifiers.mjs";
 
 describe("[U] extract/resolve/module-classifiers - isRelativeModuleName", () => {
@@ -15,30 +15,30 @@ describe("[U] extract/resolve/module-classifiers - isRelativeModuleName", () => 
   });
 
   it("returns false when passed an empty string", () => {
-    strictEqual(isRelativeModuleName(""), false);
+    equal(isRelativeModuleName(""), false);
   });
 
   it("returns false when passed an external module", () => {
-    strictEqual(isRelativeModuleName("externaldash"), false);
+    equal(isRelativeModuleName("externaldash"), false);
   });
 
   it("returns false when passed an external module name that starts with a dot", () => {
-    strictEqual(isRelativeModuleName(".external-starts-with-a-dot"), false);
+    equal(isRelativeModuleName(".external-starts-with-a-dot"), false);
   });
 
   it("returns true when passed a local module in the same folder", () => {
-    strictEqual(isRelativeModuleName("./path"), true);
+    equal(isRelativeModuleName("./path"), true);
   });
 
   it("returns true when passed a local module in a sub folder", () => {
-    strictEqual(isRelativeModuleName("../../halikidee"), true);
+    equal(isRelativeModuleName("../../halikidee"), true);
   });
 
   it("returns true when passed the current folder", () => {
-    strictEqual(isRelativeModuleName("."), true);
+    equal(isRelativeModuleName("."), true);
   });
 
   it("returns true when passed the parent folder", () => {
-    strictEqual(isRelativeModuleName(".."), true);
+    equal(isRelativeModuleName(".."), true);
   });
 });

--- a/test/extract/resolve/determine-dependency-types.spec.mjs
+++ b/test/extract/resolve/determine-dependency-types.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import determineDependencyTypes from "../../../src/extract/resolve/determine-dependency-types.mjs";
@@ -7,7 +7,7 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTypes", () => {
   it("sorts local dependencies into 'local'", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -20,7 +20,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts core modules into 'core'", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -34,7 +34,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts unresolvable modules into 'unknown'", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: true,
@@ -47,7 +47,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm-unknown' when no package dependencies were supplied", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -60,7 +60,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm-no-pkg' when they're not in the supplied package dependencies", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           module: "cool-module",
@@ -75,7 +75,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm' when they're in the supplied package dependencies", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           module: "cool-module",
@@ -94,7 +94,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm-dev' when they're in the supplied package devDependencies", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -112,7 +112,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm-dev' when they're in the supplied package devDependencies with an @types scope", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -130,7 +130,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("Only picks the 'npm' dependency-type when it's in the manifest as a regular dependency and a devDependencies @types dependency ", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -151,7 +151,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm-no-pkg' when they're in the supplied package devDependencies with an @types scope, but the resolve modules don't include 'node_modules/@types'", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -173,7 +173,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm' and 'npm-dev' when they're both the deps and the devDeps", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -194,7 +194,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("only sorts up to the first / ", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -215,7 +215,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("sorts node_modules into 'npm-no-pkg' when they're in a weird *Dependencies in the package.json", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -233,7 +233,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("classifies aliased modules as aliased", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -253,7 +253,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("has a fallback for weirdistan situations", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -271,7 +271,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("classifies local, non-node_modules modules as localmodule", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -289,7 +289,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("classifies local, non-node_modules modules with an absolute path as localmodule (posix & win32 paths)", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -311,7 +311,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("classifies local, non-node_modules non-modules as undetermined", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           couldNotResolve: false,
@@ -329,7 +329,7 @@ describe("[U] extract/resolve/determineDependencyTypes - determine dependencyTyp
   });
 
   it("classifies a type only import as a type-only dependency", () => {
-    deepStrictEqual(
+    deepEqual(
       determineDependencyTypes(
         {
           dependencyTypes: ["type-only"],

--- a/test/extract/resolve/external-module-helpers.spec.mjs
+++ b/test/extract/resolve/external-module-helpers.spec.mjs
@@ -1,4 +1,4 @@
-import { ok, strictEqual } from "node:assert";
+import { ok, equal } from "node:assert/strict";
 import clearCaches from "../../../src/extract/clear-caches.mjs";
 import {
   getPackageJson,
@@ -22,7 +22,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
     clearCaches();
   });
   it("returns null if the module does not exist", () => {
-    strictEqual(
+    equal(
       getPackageJson(
         "./module-does-not-exist",
         process.cwd(),
@@ -33,7 +33,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
   });
 
   it("returns null if there's no package.json for the module (no basePath specified)", () => {
-    strictEqual(
+    equal(
       getPackageJson(
         "test/extract/fixtures/deprecated-node-module/require-something-deprecated",
         process.cwd(),
@@ -44,7 +44,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
   });
 
   it("returns null if there's no package.json for the module (basePath specified)", () => {
-    strictEqual(
+    equal(
       getPackageJson(
         "./require-something-deprecated",
         "./fixtures/deprecated-node-module/",
@@ -62,16 +62,16 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
     );
 
     ok(lPackageJson);
-    strictEqual(lPackageJson.hasOwnProperty("name"), true);
-    strictEqual(lPackageJson.name, "acorn");
+    equal(lPackageJson.hasOwnProperty("name"), true);
+    equal(lPackageJson.name, "acorn");
   });
 
   it("returns a package.json when there is one (root) - base dir defaults to current working dir", () => {
     let lPackageJson = getPackageJson("acorn", null, BASIC_RESOLVE_OPTIONS);
 
     ok(lPackageJson);
-    strictEqual(lPackageJson.hasOwnProperty("name"), true);
-    strictEqual(lPackageJson.name, "acorn");
+    equal(lPackageJson.hasOwnProperty("name"), true);
+    equal(lPackageJson.name, "acorn");
   });
 
   it("returns a package.json when there is one ('local' node_modules)", () => {
@@ -82,8 +82,8 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
     );
 
     ok(lPackageJson);
-    strictEqual(lPackageJson.hasOwnProperty("name"), true);
-    strictEqual(lPackageJson.name, "deprecated-at-the-start-for-test-purposes");
+    equal(lPackageJson.hasOwnProperty("name"), true);
+    equal(lPackageJson.name, "deprecated-at-the-start-for-test-purposes");
   });
 
   it("returns a package.json even when it's not specified in the node modules exports and the regular resolver is supposed to heed those exports", () => {
@@ -94,58 +94,55 @@ describe("[U] extract/resolve/externalModuleHelpers.getPackageJson", () => {
     );
 
     ok(lPackageJson);
-    strictEqual(lPackageJson.hasOwnProperty("name"), true);
-    strictEqual(lPackageJson.description, "testinga 2");
+    equal(lPackageJson.hasOwnProperty("name"), true);
+    equal(lPackageJson.description, "testinga 2");
   });
 });
 
 describe("[U] extract/resolve/externalModuleHelpers.getPackageRoot", () => {
   it("returns undefined if called without parameters", () => {
-    strictEqual(typeof getPackageRoot(), "undefined");
+    equal(typeof getPackageRoot(), "undefined");
   });
 
   it("returns null if called with null", () => {
-    strictEqual(getPackageRoot(null), null);
+    equal(getPackageRoot(null), null);
   });
 
   it("locals unchanged: './localThing' => './localThing'", () => {
-    strictEqual(getPackageRoot("./localThing"), "./localThing");
+    equal(getPackageRoot("./localThing"), "./localThing");
   });
 
   it("returns the module name unchanged if called with a module name without a '/'", () => {
-    strictEqual(getPackageRoot("lodash"), "lodash");
+    equal(getPackageRoot("lodash"), "lodash");
   });
 
   it("returns the 'root' of the name when called with a module name with a '/'", () => {
-    strictEqual(getPackageRoot("lodash/fp"), "lodash");
+    equal(getPackageRoot("lodash/fp"), "lodash");
   });
 
   it("@scoped/bla => @scoped/bla", () => {
-    strictEqual(getPackageRoot("@scoped/bla"), "@scoped/bla");
+    equal(getPackageRoot("@scoped/bla"), "@scoped/bla");
   });
 
   it("@scoped/bla/subthing => @scoped/bla", () => {
-    strictEqual(
-      getPackageRoot("@scoped/bla/subthing/sub/bla.json"),
-      "@scoped/bla",
-    );
+    equal(getPackageRoot("@scoped/bla/subthing/sub/bla.json"), "@scoped/bla");
   });
 
   it("@scoped => @scoped (note: weird edge case - shouldn't occur)", () => {
-    strictEqual(getPackageRoot("@scoped"), "@scoped");
+    equal(getPackageRoot("@scoped"), "@scoped");
   });
 });
 
 describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
   it("returns '' if the module does not exist", () => {
-    strictEqual(
+    equal(
       getLicense("this-module-does-not-exist", ".", BASIC_RESOLVE_OPTIONS),
       "",
     );
   });
 
   it("returns '' if the module does exist but has no associated package.json", () => {
-    strictEqual(
+    equal(
       getLicense(
         "./test/extract/resolve/fixtures/no-package-json",
         ".",
@@ -156,7 +153,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
   });
 
   it("returns '' if the module does exist, has a package.json, but no license field", () => {
-    strictEqual(
+    equal(
       getLicense(
         "no-license",
         "./test/extract/resolve/fixtures/licenses/",
@@ -167,7 +164,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
   });
 
   it("returns '' if the module exists, has a package.json, and a license field that is a boolean", () => {
-    strictEqual(
+    equal(
       getLicense(
         "boolean-license",
         "./test/extract/resolve/fixtures/licenses/",
@@ -178,7 +175,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
   });
 
   it("returns '' if the module exists, has a package.json, and a license field that is an object", () => {
-    strictEqual(
+    equal(
       getLicense(
         "object-license",
         "./test/extract/resolve/fixtures/licenses/",
@@ -189,7 +186,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
   });
 
   it("returns '' package.json has a licenses field that is an array (and no license field)", () => {
-    strictEqual(
+    equal(
       getLicense(
         "array-licenses",
         "./test/extract/resolve/fixtures/licenses/",
@@ -200,7 +197,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
   });
 
   it("returns the license if the module exists, has a package.json, and a string license field", () => {
-    strictEqual(
+    equal(
       getLicense(
         "GPL-license",
         "./test/extract/resolve/__mocks__/licenses/",
@@ -213,7 +210,7 @@ describe("[U] extract/resolve/externalModuleHelpers.getLicense", () => {
 
 describe("[U] extract/resolve/externalModuleHelpers.dependencyIsDeprecated", () => {
   it("returns false if the module does not exist", () => {
-    strictEqual(
+    equal(
       dependencyIsDeprecated(
         "this-module-does-not-exist",
         ".",

--- a/test/extract/resolve/get-manifest.spec.mjs
+++ b/test/extract/resolve/get-manifest.spec.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { parse, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, strictEqual, throws } from "node:assert";
+import { deepEqual, equal, throws } from "node:assert/strict";
 import { getManifest } from "../../../src/extract/resolve/get-manifest.mjs";
 
 const rootPackageJson = JSON.parse(
@@ -21,26 +21,26 @@ describe("[I] extract/resolve/get-manifest - classic strategy", () => {
 
   it("returns 'null' if the package.json does not exist over there", () => {
     process.chdir("test/extract/resolve/__fixtures__/no-package-json-here");
-    strictEqual(getManifest(parse(process.cwd()).root), null);
+    equal(getManifest(parse(process.cwd()).root), null);
   });
 
   it("returns 'null' if the package.json is invalid", () => {
-    strictEqual(getManifest(join(FIXTUREDIR, "invalid-package-json")), null);
+    equal(getManifest(join(FIXTUREDIR, "invalid-package-json")), null);
   });
 
   it("returns '{}' if the package.json is empty (which is - strictly speaking - not allowed", () => {
-    deepStrictEqual(getManifest(join(FIXTUREDIR, "empty-package-json")), {});
+    deepEqual(getManifest(join(FIXTUREDIR, "empty-package-json")), {});
   });
 
   it("returns an object with the package.json", () => {
-    deepStrictEqual(getManifest(join(FIXTUREDIR, "minimal-package-json")), {
+    deepEqual(getManifest(join(FIXTUREDIR, "minimal-package-json")), {
       name: "the-absolute-bare-minimum-package-json",
       version: "481.0.0",
     });
   });
 
   it("looks up the closest package.json", () => {
-    deepStrictEqual(
+    deepEqual(
       getManifest(join(FIXTUREDIR, "no-package-json")),
       rootPackageJson,
     );
@@ -54,11 +54,11 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
 
   it("returns 'null' if the package.json does not exist over there", () => {
     process.chdir("test/extract/resolve/__fixtures__/no-package-json-here");
-    strictEqual(getManifest(process.cwd(), process.cwd(), true), null);
+    equal(getManifest(process.cwd(), process.cwd(), true), null);
   });
 
   it("returns 'null' if the package.json is invalid", () => {
-    strictEqual(
+    equal(
       getManifest(
         join(FIXTUREDIR, "invalid-package-json"),
         join(FIXTUREDIR),
@@ -70,7 +70,7 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
 
   it("returns the deps if the package.json exists in the baseDir", () => {
     process.chdir("test/extract/resolve/__fixtures__/package-json-in-here");
-    deepStrictEqual(getManifest(process.cwd(), process.cwd(), true), {
+    deepEqual(getManifest(process.cwd(), process.cwd(), true), {
       dependencies: {
         modash: "11.11.11",
       },
@@ -79,7 +79,7 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
 
   it("returns the combined deps if there's a package.json in both base and sub package", () => {
     process.chdir("test/extract/resolve/__fixtures__/two-level-package-jsons");
-    deepStrictEqual(
+    deepEqual(
       getManifest(
         join(process.cwd(), "packages", "subthing"),
         process.cwd(),
@@ -106,7 +106,7 @@ describe("[I] extract/resolve/get-manifest - combined dependencies strategy", ()
 
   it("returns the combined deps if there's a package.json in both base and sub package - subdir of sub", () => {
     process.chdir("test/extract/resolve/__fixtures__/two-level-package-jsons");
-    deepStrictEqual(
+    deepEqual(
       getManifest(
         join(process.cwd(), "packages", "subthing", "src", "somefunctionality"),
         process.cwd(),

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import resolve from "../../../src/extract/resolve/index.mjs";
@@ -32,7 +32,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves a local dependency to a file on disk", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./hots",
@@ -53,7 +53,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves a core module as core module", () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "path",
@@ -74,7 +74,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves the 'test'  core module as core module", () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "test",
@@ -95,7 +95,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves the 'node:test' core module as core module", () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "node:test",
@@ -116,7 +116,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves to the moduleName input (and depType 'unknown') when not resolvable on disk", () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./doesnotexist",
@@ -139,7 +139,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves known non-followables as not followable: json", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./something.json",
@@ -160,7 +160,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves known non-followables as not followable, even when it's a resolve registered extension: json", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./something.json",
@@ -187,7 +187,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("resolves known non-followables as not followable, even when it's a resolve registered extension: sass", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./something.scss",
@@ -214,7 +214,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("considers passed (webpack) aliases", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "hoepla/hoi",
@@ -243,7 +243,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("considers a passed (webpack) modules array", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "shared",
@@ -278,7 +278,7 @@ describe("[I] extract/resolve/index - general", () => {
   });
 
   it("strips query parameters from file names", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./hots.js?blah",
@@ -300,7 +300,7 @@ describe("[I] extract/resolve/index - general", () => {
 
   it("by default does not look at 'exports' fields in package.json", async () => {
     process.chdir("test/extract/resolve/__mocks__/package-json-with-exports");
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "export-testinga/conditionalExports",
         moduleSystem: "cjs",
@@ -317,7 +317,7 @@ describe("[I] extract/resolve/index - general", () => {
 
   it("looks at the 'exports' fields in package.json when enhanced-resolve is instructed to", async () => {
     process.chdir("test/extract/resolve/__mocks__/package-json-with-exports");
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "export-testinga/conditionalExports",
@@ -346,7 +346,7 @@ describe("[I] extract/resolve/index - general", () => {
 
   it("Correctly resolves file names with #'s in it (formerly an upstream issue in enhanced-resolve)", async () => {
     process.chdir("test/extract/resolve/__mocks__/resolve-hashmarks");
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./#/hashmark.js",
         moduleSystem: "cjs",
@@ -363,7 +363,7 @@ describe("[I] extract/resolve/index - general", () => {
 
   it("Correctly resolves file names that _correctly_ use #'s (in the 'URL' fashion) in it (formerly an upstream issue in enhanced-resolve)", async () => {
     process.chdir("test/extract/resolve/__mocks__/resolve-hashmarks");
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./hashmark-after-this.js#this-is-extra",
         moduleSystem: "cjs",
@@ -381,7 +381,7 @@ describe("[I] extract/resolve/index - general", () => {
 
   it("Passes mainFields correctly so it's possible to resolve type-only packages", async () => {
     process.chdir("test/extract/resolve/__mocks__/resolve-type-only-packages");
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "lalala-interfaces",

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import extractTSConfig from "../../../src/config-utl/extract-ts-config.mjs";
 import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
@@ -24,7 +24,7 @@ const PARSED_TSCONFIG_RESOLUTIONS = extractTSConfig(TSCONFIG);
 
 describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
   it("considers a typescript config - non-* alias", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "shared",
@@ -52,7 +52,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
   });
 
   it("considers a typescript config - combined/* alias", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "gewoon/wood/tree",
@@ -80,7 +80,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
   });
 
   it("considers a typescript config - * alias", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "daddayaddaya",
@@ -115,7 +115,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
       "tsconfig-no-paths.json",
     );
     const PARSED_TSCONFIG_NO_PATHS = extractTSConfig(TSCONFIG_NO_PATHS);
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "common/wood/tree",
@@ -143,7 +143,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
   });
 
   it("for aliases resolves in the same fashion as the typescript compiler - dts-vs-ts", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "things/dts-before-ts",
@@ -176,7 +176,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
   });
 
   it("for aliases resolves in the same fashion as the typescript compiler - js-vs-ts", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "things/js-before-ts",
@@ -209,7 +209,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
   });
 
   it("gives a different result for the same input without a webpack config", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "shared",

--- a/test/extract/resolve/index.typescript.spec.mjs
+++ b/test/extract/resolve/index.typescript.spec.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
 
@@ -32,7 +32,7 @@ describe("[I] extract/resolve/index - typescript", () => {
   });
 
   it("resolves to ts before it considers vue", async () => {
-    deepStrictEqual(
+    deepEqual(
       resolve(
         {
           module: "./x",
@@ -61,7 +61,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-ts-even-when-imported-as-js",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-secretly-typescript.js",
         moduleSystem: "es6",
@@ -80,7 +80,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-js-even-when-imported-as-js",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-genuinely-javascript.js",
         moduleSystem: "es6",
@@ -99,7 +99,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-ts-even-when-imported-as-js",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-secretly-typescript.cjs",
         moduleSystem: "es6",
@@ -118,7 +118,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-cts-even-when-imported-as-cjs",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-secretly-typescript.cjs",
         moduleSystem: "es6",
@@ -137,7 +137,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-d-cts-even-when-imported-as-cjs",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-secretly-typescript.cjs",
         moduleSystem: "es6",
@@ -156,7 +156,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-cjs-when-imported-as-cjs",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-just-commonjs.cjs",
         moduleSystem: "es6",
@@ -175,7 +175,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-mts-even-when-imported-as-mjs",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-secretly-typescript.mjs",
         moduleSystem: "es6",
@@ -194,7 +194,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-d-mts-even-when-imported-as-mjs",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-secretly-typescript.mjs",
         moduleSystem: "es6",
@@ -213,7 +213,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(
       "test/extract/resolve/__mocks__/resolve-to-mjs-when-imported-as-mjs",
     );
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./i-am-just-esm.mjs",
         moduleSystem: "es6",
@@ -230,7 +230,7 @@ describe("[I] extract/resolve/index - typescript", () => {
 
   it("Does NOT resolve to something non-typescript-ish when the import includes a (non-existing) .js with explicit extension", async () => {
     process.chdir("test/extract/resolve/__mocks__/donot-resolve-to-non-ts");
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./there-is-a-cjs-variant-of-me-but-you-will-not-find-it.js",
         moduleSystem: "es6",
@@ -247,7 +247,7 @@ describe("[I] extract/resolve/index - typescript", () => {
 
   it("resolves triple slash directives - local", async () => {
     process.chdir("test/extract/resolve/__mocks__/triple-slash-directives");
-    deepStrictEqual(
+    deepEqual(
       await wrappedResolve({
         module: "./hello",
         moduleSystem: "tsd",
@@ -264,7 +264,7 @@ describe("[I] extract/resolve/index - typescript", () => {
 
   it("resolves triple slash directives - external", async () => {
     process.chdir("test/extract/resolve/__mocks__/triple-slash-directives");
-    deepStrictEqual(
+    deepEqual(
       await await wrappedResolve({
         module: "something",
         moduleSystem: "tsd",

--- a/test/extract/resolve/merge-manifests.spec.mjs
+++ b/test/extract/resolve/merge-manifests.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import mergePackages from "../../../src/extract/resolve/merge-manifests.mjs";
 
 const INPUT = {
@@ -60,27 +60,27 @@ const FIXTURE_MERGED = {
 
 describe("[U] extract/resolve/get-manifest-dependencies/merge-manifests", () => {
   it("merging empty packages yields {}", () => {
-    deepStrictEqual(mergePackages({}, {}), {});
+    deepEqual(mergePackages({}, {}), {});
   });
 
   it("merging close package with a further {} yields close package (without non-dependency-keys)", () => {
-    deepStrictEqual(mergePackages(INPUT, {}), FIXTURE);
+    deepEqual(mergePackages(INPUT, {}), FIXTURE);
   });
 
   it("merging close {} package with a further yields further package (without non-dependency-keys)", () => {
-    deepStrictEqual(mergePackages({}, INPUT), FIXTURE);
+    deepEqual(mergePackages({}, INPUT), FIXTURE);
   });
 
   it("merging two identical packages yields the package (without non-dependency-keys)", () => {
-    deepStrictEqual(mergePackages(INPUT, INPUT), FIXTURE);
+    deepEqual(mergePackages(INPUT, INPUT), FIXTURE);
   });
 
   it("merging a close package with a further one yields merged packages, where the close package wins", () => {
-    deepStrictEqual(mergePackages(INPUT, INPUT_FURTHER), FIXTURE_MERGED);
+    deepEqual(mergePackages(INPUT, INPUT_FURTHER), FIXTURE_MERGED);
   });
 
   it("merges bundleDependencies and bundledDependencies into one", () => {
-    deepStrictEqual(
+    deepEqual(
       mergePackages(
         {
           bundleDependencies: ["foo", "bar"],

--- a/test/extract/resolve/resolve-helpers.spec.mjs
+++ b/test/extract/resolve/resolve-helpers.spec.mjs
@@ -1,24 +1,21 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { stripToModuleName } from "../../../src/extract/resolve/resolve-helpers.mjs";
 
 describe("[U] extract/resolve/resolveHelpers - stripToModuleName", () => {
   it("yields the empty string when stripping the empty string", () => {
-    strictEqual(stripToModuleName(""), "");
+    equal(stripToModuleName(""), "");
   });
   it("leaves imports without inline loaders alone", () => {
-    strictEqual(stripToModuleName("some_module"), "some_module");
-    strictEqual(stripToModuleName("./local/module"), "./local/module");
-    strictEqual(stripToModuleName("@some/module"), "@some/module");
-    strictEqual(stripToModuleName("/abso/lute/path"), "/abso/lute/path");
+    equal(stripToModuleName("some_module"), "some_module");
+    equal(stripToModuleName("./local/module"), "./local/module");
+    equal(stripToModuleName("@some/module"), "@some/module");
+    equal(stripToModuleName("/abso/lute/path"), "/abso/lute/path");
   });
   it("takes the name after the last ! when there's inline loaders involved", () => {
-    strictEqual(stripToModuleName("!some_module"), "some_module");
-    strictEqual(stripToModuleName("hello!./local/module"), "./local/module");
-    strictEqual(stripToModuleName("wim!zus!jet!@some/module"), "@some/module");
-    strictEqual(
-      stripToModuleName("!!taa!tuu!taa!tuu!!!./thing.js"),
-      "./thing.js",
-    );
-    strictEqual(stripToModuleName("edge-case!!"), "");
+    equal(stripToModuleName("!some_module"), "some_module");
+    equal(stripToModuleName("hello!./local/module"), "./local/module");
+    equal(stripToModuleName("wim!zus!jet!@some/module"), "@some/module");
+    equal(stripToModuleName("!!taa!tuu!taa!tuu!!!./thing.js"), "./thing.js");
+    equal(stripToModuleName("edge-case!!"), "");
   });
 });

--- a/test/extract/run-get-dependencies-fixture.utl.mjs
+++ b/test/extract/run-get-dependencies-fixture.utl.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import getDependencies from "../../src/extract/get-dependencies.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
@@ -20,7 +20,7 @@ export function runFixture(pFixture, pParser = "acorn") {
   }
 
   it(`${pFixture.title} (with '${pParser}' as parser)`, async () => {
-    deepStrictEqual(
+    deepEqual(
       getDependencies(
         pFixture.input.fileName,
         normalizeCruiseOptions(lOptions),

--- a/test/extract/transpile/babel-wrap.spec.mjs
+++ b/test/extract/transpile/babel-wrap.spec.mjs
@@ -1,11 +1,11 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import normalizeSource from "../normalize-source.utl.mjs";
 import wrap from "../../../src/extract/transpile/babel-wrap.mjs";
 
 describe("[I] extract/transpile/babel-wrap", () => {
   it("tells the babel transpiler is available", () => {
-    strictEqual(wrap.isAvailable(), true);
+    equal(wrap.isAvailable(), true);
   });
 
   it("transpiles with babel when no babel options are passed", async () => {
@@ -14,7 +14,7 @@ describe("[I] extract/transpile/babel-wrap", () => {
         readFileSync("./test/extract/transpile/__mocks__/babel-in.js", "utf8"),
       ),
     );
-    strictEqual(
+    equal(
       lOutput,
       readFileSync(
         "./test/extract/transpile/__fixtures__/babel-out-no-options.js",
@@ -46,6 +46,6 @@ describe("[I] extract/transpile/babel-wrap", () => {
       "utf8",
     );
 
-    strictEqual(lOutput, lExpected);
+    equal(lOutput, lExpected);
   });
 });

--- a/test/extract/transpile/coffeescript-wrap.spec.mjs
+++ b/test/extract/transpile/coffeescript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import normalizeNewline from "normalize-newline";
 import coffeescriptWrap from "../../../src/extract/transpile/coffeescript-wrap.mjs";
@@ -8,15 +8,15 @@ const litWrap = coffeescriptWrap(true);
 
 describe("[I] coffeescript transpiler", () => {
   it("tells the coffeescript transpiler is available", () => {
-    strictEqual(wrap.isAvailable(), true);
+    equal(wrap.isAvailable(), true);
   });
 
   it("tells the transpiler for literate coffeescript is available", () => {
-    strictEqual(litWrap.isAvailable(), true);
+    equal(litWrap.isAvailable(), true);
   });
 
   it("transpiles coffeescript", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(
@@ -31,7 +31,7 @@ describe("[I] coffeescript transpiler", () => {
   });
 
   it("transpiles literate coffeescript", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         litWrap.transpile(
           readFileSync(
@@ -49,7 +49,7 @@ describe("[I] coffeescript transpiler", () => {
   });
 
   it("transpiles literate coffeescript in markdown", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         litWrap.transpile(
           readFileSync(
@@ -67,7 +67,7 @@ describe("[I] coffeescript transpiler", () => {
   });
 
   it("transpiles jsx'y coffeescript", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync("./test/extract/transpile/__mocks__/csx.cjsx", "utf8"),

--- a/test/extract/transpile/index.spec.mjs
+++ b/test/extract/transpile/index.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { deepEqual, ok, equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,14 +16,14 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("[I] transpile", () => {
   it("As the 'livescript' transpiler is not available, returns the original source", () => {
-    strictEqual(
+    equal(
       transpile({ extension: ".ls", source: "whatever the bever" }),
       "whatever the bever",
     );
   });
 
   it("As the 'bf-script' transpiler is not supported at all, returns the original source", () => {
-    strictEqual(
+    equal(
       transpile({
         extension: ".bfs",
         source: "'brane-fuchs-skrybd'|#$'nicht unterstutzt'|^^^",
@@ -44,7 +44,7 @@ describe("[I] transpile", () => {
       readFileSync(join(__dirname, "__fixtures__", "svelte.js"), "utf8"),
     );
 
-    strictEqual(lObservedOutput, lExpectedOutput);
+    equal(lObservedOutput, lExpectedOutput);
   });
 
   it("Does not confuse .ts for .tsx", async () => {
@@ -63,7 +63,7 @@ describe("[I] transpile", () => {
     const lFound = await normalizeSource(
       transpile({ extension: ".ts", source: lInputFixture }),
     );
-    strictEqual(lExpected, lFound);
+    equal(lExpected, lFound);
   });
 
   it("Takes a tsconfig and takes that into account on transpilation", async () => {
@@ -94,47 +94,47 @@ describe("[I] transpile", () => {
         lTranspilerOptions,
       ),
     );
-    strictEqual(lExpected, lTranspiledFixture);
+    equal(lExpected, lTranspiledFixture);
   });
 });
 
 describe("[I] transpile/wrapper", () => {
   it("returns the 'js' wrapper for unknown extensions", () => {
-    deepStrictEqual(getWrapper(""), jsWrap);
+    deepEqual(getWrapper(""), jsWrap);
   });
 
   it("returns the 'ls' wrapper for livescript", () => {
-    deepStrictEqual(getWrapper(".ls"), lsWrap);
+    deepEqual(getWrapper(".ls"), lsWrap);
   });
 
   it("returns the 'javascript' wrapper for javascript when the babel config is not passed", () => {
-    deepStrictEqual(getWrapper(".js", {}), jsWrap);
+    deepEqual(getWrapper(".js", {}), jsWrap);
   });
 
   it("returns the 'javascript' wrapper for javascript when there's just a typscript config", () => {
-    deepStrictEqual(getWrapper(".js", { tsConfig: {} }), jsWrap);
+    deepEqual(getWrapper(".js", { tsConfig: {} }), jsWrap);
   });
 
   it("returns the 'babel' wrapper for javascript when the babel config is empty", () => {
-    deepStrictEqual(getWrapper(".js", { babelConfig: {} }), jsWrap);
+    deepEqual(getWrapper(".js", { babelConfig: {} }), jsWrap);
   });
 
   it("returns the 'babel' wrapper for javascript when the babel config is not empty", () => {
-    deepStrictEqual(
+    deepEqual(
       getWrapper(".js", { babelConfig: { babelrc: false } }),
       babelWrap,
     );
   });
 
   it("returns the 'babel' wrapper for typescript when the babel config is not empty", () => {
-    deepStrictEqual(
+    deepEqual(
       getWrapper(".ts", { babelConfig: { babelrc: false } }),
       babelWrap,
     );
   });
 
   it("returns the 'vue' wrapper for vue templates even when the babel config is not empty", () => {
-    deepStrictEqual(
+    deepEqual(
       getWrapper(".vue", { babelConfig: { babelrc: false } }),
       vueTemplateWrap,
     );

--- a/test/extract/transpile/javascript-wrap.spec.mjs
+++ b/test/extract/transpile/javascript-wrap.spec.mjs
@@ -1,14 +1,14 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import wrap from "../../../src/extract/transpile/javascript-wrap.mjs";
 
 describe("[I] javascript transpiler", () => {
   it("tells the jsx transpiler is available", () => {
-    strictEqual(wrap.isAvailable(), true);
+    equal(wrap.isAvailable(), true);
   });
 
   it("'transpiles' jsx", () => {
-    strictEqual(
+    equal(
       wrap.transpile(
         readFileSync("./test/extract/transpile/__mocks__/jsx.jsx", "utf8"),
       ),
@@ -18,7 +18,7 @@ describe("[I] javascript transpiler", () => {
   });
 
   it("transpiles mjs", () => {
-    strictEqual(
+    equal(
       wrap.transpile(
         readFileSync("./test/extract/transpile/__mocks__/mjs.mjs", "utf8"),
       ),

--- a/test/extract/transpile/livescript-wrap.spec.mjs
+++ b/test/extract/transpile/livescript-wrap.spec.mjs
@@ -1,8 +1,8 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import wrap from "../../../src/extract/transpile/livescript-wrap.mjs";
 
 describe("[I] livescript transpiler", () => {
   it("tells the livescript transpiler is not available", () => {
-    strictEqual(wrap.isAvailable(), false);
+    equal(wrap.isAvailable(), false);
   });
 });

--- a/test/extract/transpile/meta.spec.mjs
+++ b/test/extract/transpile/meta.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import {
   getAvailableTranspilers,
   scannableExtensions,
@@ -6,7 +6,7 @@ import {
 
 describe("[U] extract/transpile/meta", () => {
   it("tells which extensions can be scanned", () => {
-    deepStrictEqual(scannableExtensions, [
+    deepEqual(scannableExtensions, [
       ".js",
       ".cjs",
       ".mjs",
@@ -29,7 +29,7 @@ describe("[U] extract/transpile/meta", () => {
   });
 
   it("returns the available transpilers", () => {
-    deepStrictEqual(getAvailableTranspilers(), [
+    deepEqual(getAvailableTranspilers(), [
       {
         name: "babel",
         version: ">=7.0.0 <8.0.0",

--- a/test/extract/transpile/svelte-preprocess.spec.mjs
+++ b/test/extract/transpile/svelte-preprocess.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 // eslint-disable-next-line node/file-extension-in-import
 import * as svelteCompiler from "svelte/compiler";
 import normalizeNewline from "normalize-newline";
@@ -43,7 +43,7 @@ describe("[U] sync svelte pre-processor", () => {
         },
       });
 
-      strictEqual(lSyncResult, lAsyncResult.code);
+      equal(lSyncResult, lAsyncResult.code);
     });
   });
   it("pre-processes svelte like svelte, but sync (with an unavailable wrapper)", async () => {
@@ -51,7 +51,7 @@ describe("[U] sync svelte pre-processor", () => {
     const lSyncResult = sveltePreProcess(lInput, {}, {});
     const lAsyncResult = await svelteCompiler.preprocess(lInput, {});
 
-    strictEqual(lSyncResult, lAsyncResult.code);
+    equal(lSyncResult, lAsyncResult.code);
   });
   it("ignores style tags that require a pre-processor", () => {
     const lInput = `<script lang="ts">console.log(713)</script>
@@ -74,6 +74,6 @@ describe("[U] sync svelte pre-processor", () => {
       </button>`;
     const lResult = sveltePreProcess(lInput, typeScriptWrap, {});
 
-    strictEqual(normalizeNewline(lResult), normalizeNewline(lExpected));
+    equal(normalizeNewline(lResult), normalizeNewline(lExpected));
   });
 });

--- a/test/extract/transpile/svelte-wrap.spec.mjs
+++ b/test/extract/transpile/svelte-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import svelteWrap from "../../../src/extract/transpile/svelte-wrap.mjs";
 import normalizeSource from "../normalize-source.utl.mjs";
@@ -8,7 +8,7 @@ const wrap = svelteWrap(typescriptWrap(true));
 
 describe("[I] svelte transpiler", () => {
   it("tells the svelte transpiler is available", () => {
-    strictEqual(wrap.isAvailable(), true);
+    equal(wrap.isAvailable(), true);
   });
   [
     ["ts", (pSource) => pSource],
@@ -36,7 +36,7 @@ describe("[I] svelte transpiler", () => {
         ),
       );
 
-      strictEqual(lObserved, lExpected);
+      equal(lObserved, lExpected);
     });
   });
 });

--- a/test/extract/transpile/try-import-available.spec.mjs
+++ b/test/extract/transpile/try-import-available.spec.mjs
@@ -1,27 +1,27 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import tryImportAvailable from "../../../src/extract/transpile/try-import-available.mjs";
 
 describe("[U] extract/transpile/try-import-available", () => {
   it("returns true when the module can be resolved", () => {
-    strictEqual(tryImportAvailable("acorn"), true);
+    equal(tryImportAvailable("acorn"), true);
   });
   it("returns true when the module can be resolved & its version range matches", () => {
-    strictEqual(tryImportAvailable("acorn", "^8"), true);
+    equal(tryImportAvailable("acorn", "^8"), true);
   });
   it("returns false when the module can be resolved & its version range does not match", () => {
-    strictEqual(tryImportAvailable("acorn", "<8"), false);
+    equal(tryImportAvailable("acorn", "<8"), false);
   });
   it("returns false when the module cannot be resolved", () => {
-    strictEqual(tryImportAvailable("not-an-existing-module"), false);
+    equal(tryImportAvailable("not-an-existing-module"), false);
   });
   it("returns false when the module cannot be resolved (with version range)", () => {
-    strictEqual(tryImportAvailable("not-an-existing-module", ">0"), false);
+    equal(tryImportAvailable("not-an-existing-module", ">0"), false);
   });
   it("does not bork when confronted with a local import (resolvable)", () => {
-    strictEqual(tryImportAvailable("./try-import-available.mjs"), true);
+    equal(tryImportAvailable("./try-import-available.mjs"), true);
   });
   it("does not bork when confronted with a local import (resolvable, with a version number)", () => {
     // weirdo country
-    strictEqual(tryImportAvailable("./try-import-available.mjs", ">=0"), false);
+    equal(tryImportAvailable("./try-import-available.mjs", ">=0"), false);
   });
 });

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import normalizeSource from "../normalize-source.utl.mjs";
 import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.mjs";
@@ -9,7 +9,7 @@ const typeScriptESMWrap = typescriptWrap("esm");
 
 describe("[I] typescript transpiler", () => {
   it("tells the typescript transpiler is available", () => {
-    strictEqual(typeScriptRegularWrap.isAvailable(), true);
+    equal(typeScriptRegularWrap.isAvailable(), true);
   });
 
   it("transpiles typescript", async () => {
@@ -27,13 +27,13 @@ describe("[I] typescript transpiler", () => {
         "utf8",
       ),
     );
-    strictEqual(lExpected, lFound);
+    equal(lExpected, lFound);
   });
 });
 
 describe("[I] typescript transpiler (tsx)", () => {
   it("tells the tsx transpiler is available", () => {
-    strictEqual(typeScriptTsxWrap.isAvailable(), true);
+    equal(typeScriptTsxWrap.isAvailable(), true);
   });
 
   it("transpiles tsx", async () => {
@@ -45,13 +45,13 @@ describe("[I] typescript transpiler (tsx)", () => {
     const lFound = await normalizeSource(
       readFileSync("./test/extract/transpile/__fixtures__/tsx.js", "utf8"),
     );
-    strictEqual(lExpected, lFound);
+    equal(lExpected, lFound);
   });
 });
 
 describe("[I] typescript transpiler (esm)", () => {
   it("tells the ts transpiler is available for mts (esm) modules", () => {
-    strictEqual(typeScriptESMWrap.isAvailable(), true);
+    equal(typeScriptESMWrap.isAvailable(), true);
   });
 
   it("transpiles mts", async () => {
@@ -63,6 +63,6 @@ describe("[I] typescript transpiler (esm)", () => {
     const lFound = await normalizeSource(
       readFileSync("./test/extract/transpile/__fixtures__/mts.mjs", "utf8"),
     );
-    strictEqual(lExpected, lFound);
+    equal(lExpected, lFound);
   });
 });

--- a/test/extract/transpile/vue-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue-template-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,7 +9,7 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("[I] vue transpiler", () => {
   it("extracts the script content from a vue SFC", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(join(__dirname, "__mocks__/vue.vue"), "utf8"),
@@ -23,7 +23,7 @@ describe("[I] vue transpiler", () => {
   });
 
   it("returns the empty string from a vue SFC without a script part", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(join(__dirname, "__mocks__/vue-noscript.vue"), "utf8"),
@@ -34,7 +34,7 @@ describe("[I] vue transpiler", () => {
   });
 
   it("handles invalid vue (silently - as per the vue-template-compiler)", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(join(__dirname, "__mocks__/vue-invalid.vue"), "utf8"),

--- a/test/extract/transpile/vue3-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue3-template-wrap.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createRequire } from "node:module";
@@ -27,7 +27,7 @@ const wrap = proxyquire.load(
 
 describe("[I] vue transpiler", () => {
   it("extracts the script content from a vue SFC", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(join(__dirname, "__mocks__/vue.vue"), "utf8"),
@@ -40,7 +40,7 @@ describe("[I] vue transpiler", () => {
   });
 
   it("returns the empty string from a vue SFC without a script part", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(join(__dirname, "__mocks__/vue-noscript.vue"), "utf8"),
@@ -51,7 +51,7 @@ describe("[I] vue transpiler", () => {
   });
 
   it("handles invalid vue (silently - for backwards compatibility with Vue 2)", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(join(__dirname, "__mocks__/vue-invalid.vue"), "utf8"),
@@ -62,7 +62,7 @@ describe("[I] vue transpiler", () => {
   });
 
   it("extracts the script setup content from a vue SFC", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(
@@ -81,7 +81,7 @@ describe("[I] vue transpiler", () => {
   });
 
   it("extracts the script setup content and script content from a vue SFC", () => {
-    strictEqual(
+    equal(
       normalizeNewline(
         wrap.transpile(
           readFileSync(

--- a/test/graph-utl/add-focus.spec.mjs
+++ b/test/graph-utl/add-focus.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-useless-undefined */
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import addFocus from "../../src/graph-utl/add-focus.mjs";
 import $input from "./__fixtures__/focus/dependency-cruiser-only-src.mjs";
 import focusOnMainDepthOne from "./__fixtures__/focus/dependency-cruiser-focus-on-main.mjs";
@@ -7,23 +7,20 @@ import focusOnMainDepthTwo from "./__fixtures__/focus/dependency-cruiser-focus-o
 
 describe("[U] graph-utl/add-focus", () => {
   it("returns the input modules when there's no pattern", () => {
-    deepStrictEqual(addFocus($input), $input);
+    deepEqual(addFocus($input), $input);
   });
   it("returns the input modules when there's an undefined pattern", () => {
     // eslint-disable-next-line no-undefined
-    deepStrictEqual(addFocus($input, undefined), $input);
+    deepEqual(addFocus($input, undefined), $input);
   });
   it("returns the input modules when there's a null pattern", () => {
-    deepStrictEqual(addFocus($input, null), $input);
+    deepEqual(addFocus($input, null), $input);
   });
   it("mangles the modules to focus on ^src/main if prodded so", () => {
-    deepStrictEqual(
-      addFocus($input, { path: "^src/main" }),
-      focusOnMainDepthOne,
-    );
+    deepEqual(addFocus($input, { path: "^src/main" }), focusOnMainDepthOne);
   });
   it("mangles the modules to focus on ^src/main if prodded with a depth of two", () => {
-    deepStrictEqual(
+    deepEqual(
       addFocus($input, { path: "^src/main", depth: 2 }),
       focusOnMainDepthTwo,
     );

--- a/test/graph-utl/compare.rules.spec.mjs
+++ b/test/graph-utl/compare.rules.spec.mjs
@@ -1,9 +1,9 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { rules } from "../../src/graph-utl/compare.mjs";
 
 describe("[U] graph-utl/compare - rules", () => {
   it("samesies yield 0", () => {
-    strictEqual(
+    equal(
       rules(
         { severity: "error", name: "thing" },
         { severity: "error", name: "thing" },
@@ -13,7 +13,7 @@ describe("[U] graph-utl/compare - rules", () => {
   });
 
   it("unknown severity > error", () => {
-    strictEqual(
+    equal(
       rules(
         { severity: "not defined", name: "thing" },
         { severity: "error", name: "thing" },
@@ -23,7 +23,7 @@ describe("[U] graph-utl/compare - rules", () => {
   });
 
   it("same name, different severity sorts on severity", () => {
-    strictEqual(
+    equal(
       rules(
         { severity: "info", name: "thing" },
         { severity: "warn", name: "thing" },
@@ -33,7 +33,7 @@ describe("[U] graph-utl/compare - rules", () => {
   });
 
   it("differnt name, different severity sorts on severity", () => {
-    strictEqual(
+    equal(
       rules(
         { severity: "info", name: "aaa" },
         { severity: "warn", name: "zzz" },
@@ -43,7 +43,7 @@ describe("[U] graph-utl/compare - rules", () => {
   });
 
   it("same severity, different name sorts on name", () => {
-    strictEqual(
+    equal(
       rules(
         { severity: "info", name: "thing" },
         { severity: "info", name: "thang" },

--- a/test/graph-utl/compare.severities.spec.mjs
+++ b/test/graph-utl/compare.severities.spec.mjs
@@ -1,28 +1,28 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { severities } from "../../src/graph-utl/compare.mjs";
 
 describe("[U] graph-utl/compare - severities", () => {
   it("returns 0 for identical severities", () => {
-    strictEqual(severities("warn", "warn"), 0);
+    equal(severities("warn", "warn"), 0);
   });
 
   it("returns 0 for identical severities - even unknown ones", () => {
-    strictEqual(severities("unknown", "unknown"), 0);
+    equal(severities("unknown", "unknown"), 0);
   });
 
   it("returns -1 when comparing an unknown severity with a known one", () => {
-    strictEqual(severities("unknown", "error"), -1);
+    equal(severities("unknown", "error"), -1);
   });
 
   it("returns 1 when comparing a known severity with an unknown one", () => {
-    strictEqual(severities("info", "unknown"), 1);
+    equal(severities("info", "unknown"), 1);
   });
 
   it("returns 1 when comparing a less severe severity with a more severe one", () => {
-    strictEqual(severities("info", "error"), 1);
+    equal(severities("info", "error"), 1);
   });
 
   it("returns -1 when comparing a more severe severity with a less severe one", () => {
-    strictEqual(severities("error", "info"), -1);
+    equal(severities("error", "info"), -1);
   });
 });

--- a/test/graph-utl/compare.violations.spec.mjs
+++ b/test/graph-utl/compare.violations.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { violations } from "../../src/graph-utl/compare.mjs";
 
 describe("[U] graph-utl/compare - violations", () => {
@@ -48,26 +48,26 @@ describe("[U] graph-utl/compare - violations", () => {
   };
 
   it("returns 0 for identical violations", () => {
-    strictEqual(violations(lViolation, lViolation), 0);
+    equal(violations(lViolation, lViolation), 0);
   });
 
   it("returns -1 when severity > the one compared against", () => {
-    strictEqual(violations(lViolation, lLessSevereViolation), -1);
+    equal(violations(lViolation, lLessSevereViolation), -1);
   });
 
   it("returns 1 when severity < the one compared against", () => {
-    strictEqual(violations(lLessSevereViolation, lViolation), 1);
+    equal(violations(lLessSevereViolation, lViolation), 1);
   });
 
   it("returns -1 when rule name < the one compared against", () => {
-    strictEqual(violations(lViolation, lLaterNameViolation), -1);
+    equal(violations(lViolation, lLaterNameViolation), -1);
   });
 
   it("returns -1 when rule 'from' < the one compared against", () => {
-    strictEqual(violations(lViolation, lLaterFromViolation), -1);
+    equal(violations(lViolation, lLaterFromViolation), -1);
   });
 
   it("returns -1 when rule 'to' < the one compared against", () => {
-    strictEqual(violations(lViolation, lLaterToViolation), -1);
+    equal(violations(lViolation, lLaterToViolation), -1);
   });
 });

--- a/test/graph-utl/consolidate-to-folder.spec.mjs
+++ b/test/graph-utl/consolidate-to-folder.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import consolidateToFolder from "../../src/graph-utl/consolidate-to-folder.mjs";
 
 describe("[U] graph-utl/consolidateToFolder", () => {
@@ -21,7 +21,7 @@ describe("[U] graph-utl/consolidateToFolder", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToFolder(lInput), lOutput);
+    deepEqual(consolidateToFolder(lInput), lOutput);
   });
 
   it("files in the root go to '.'", () => {
@@ -43,7 +43,7 @@ describe("[U] graph-utl/consolidateToFolder", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToFolder(lInput), lOutput);
+    deepEqual(consolidateToFolder(lInput), lOutput);
   });
 
   it("dependencies' resolved names go to their dirname as well ", () => {
@@ -92,6 +92,6 @@ describe("[U] graph-utl/consolidateToFolder", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToFolder(lInput), lOutput);
+    deepEqual(consolidateToFolder(lInput), lOutput);
   });
 });

--- a/test/graph-utl/consolidate-to-pattern.spec.mjs
+++ b/test/graph-utl/consolidate-to-pattern.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import consolidateToPattern from "../../src/graph-utl/consolidate-to-pattern.mjs";
 
 describe("[U] graph-utl/consolidateToPattern", () => {
@@ -21,7 +21,7 @@ describe("[U] graph-utl/consolidateToPattern", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToPattern(lInput, "^$"), lOutput);
+    deepEqual(consolidateToPattern(lInput, "^$"), lOutput);
   });
 
   it("no match => no squashing", () => {
@@ -43,7 +43,7 @@ describe("[U] graph-utl/consolidateToPattern", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToPattern(lInput, "src/[^/]+"), lOutput);
+    deepEqual(consolidateToPattern(lInput, "src/[^/]+"), lOutput);
   });
 
   it("source gets squashed to pattern", () => {
@@ -65,7 +65,7 @@ describe("[U] graph-utl/consolidateToPattern", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToPattern(lInput, "[^/]+"), lOutput);
+    deepEqual(consolidateToPattern(lInput, "[^/]+"), lOutput);
   });
 
   it("dependencies' resolved names get squashed as well", () => {
@@ -139,7 +139,7 @@ describe("[U] graph-utl/consolidateToPattern", () => {
       },
     ];
 
-    deepStrictEqual(consolidateToPattern(lInput, "[^/]+/[^/]+"), lOutput);
+    deepEqual(consolidateToPattern(lInput, "[^/]+/[^/]+"), lOutput);
   });
 
   it("reconsolidation with the same pattern yields the same result", () => {
@@ -214,9 +214,6 @@ describe("[U] graph-utl/consolidateToPattern", () => {
     ];
 
     const lConsolidated = consolidateToPattern(lInput, "[^/]+/[^/]+");
-    deepStrictEqual(
-      consolidateToPattern(lConsolidated, "[^/]+/[^/]+"),
-      lOutput,
-    );
+    deepEqual(consolidateToPattern(lConsolidated, "[^/]+/[^/]+"), lOutput);
   });
 });

--- a/test/graph-utl/filter-bank.spec.mjs
+++ b/test/graph-utl/filter-bank.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { applyFilters } from "../../src/graph-utl/filter-bank.mjs";
 import reportModules from "./__mocks__/report-modules.mjs";
 import reportIndexModule from "./__fixtures__/reaches/report-index-module.mjs";
@@ -55,15 +55,15 @@ const MODULES = [
 
 describe("[U] graph-utl/filter-bank - null's, naughts, and zeros", () => {
   it("returns the input when no filter passed ", () => {
-    deepStrictEqual(applyFilters(MODULES), MODULES);
+    deepEqual(applyFilters(MODULES), MODULES);
   });
 
   it("returns the input when an empty collection of filters is passed ", () => {
-    deepStrictEqual(applyFilters(MODULES, {}), MODULES);
+    deepEqual(applyFilters(MODULES, {}), MODULES);
   });
 
   it("returns the input when empty filters are passed (exclude)", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(MODULES, {
         exclude: {},
       }),
@@ -71,7 +71,7 @@ describe("[U] graph-utl/filter-bank - null's, naughts, and zeros", () => {
     );
   });
   it("returns the input when empty filters are passed (includeOnly)", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(MODULES, {
         includeOnly: {},
       }),
@@ -79,7 +79,7 @@ describe("[U] graph-utl/filter-bank - null's, naughts, and zeros", () => {
     );
   });
   it("returns the input when empty filters are passed (focus)", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(MODULES, {
         focus: {},
       }),
@@ -90,7 +90,7 @@ describe("[U] graph-utl/filter-bank - null's, naughts, and zeros", () => {
 
 describe("[U] graph-utl/filter-bank - exclude, includeOnly, reaches, highlight", () => {
   it("returns the input without excluded modules when exclude is passed ", () => {
-    deepStrictEqual(applyFilters(MODULES, { exclude: { path: "^excluded" } }), [
+    deepEqual(applyFilters(MODULES, { exclude: { path: "^excluded" } }), [
       {
         source: "included/index.js",
         dependencies: [
@@ -131,41 +131,38 @@ describe("[U] graph-utl/filter-bank - exclude, includeOnly, reaches, highlight",
   });
 
   it("returns the input with only the included modules when includeOnly is passed ", () => {
-    deepStrictEqual(
-      applyFilters(MODULES, { includeOnly: { path: "included" } }),
-      [
-        {
-          source: "included/index.js",
-          dependencies: [
-            { resolved: "also-included/index.js" },
-            { resolved: "included/hoepla.js" },
-          ],
-        },
-        {
-          source: "also-included/index.js",
-          dependencies: [
-            { resolved: "also-included/one-step-down.js" },
-            { resolved: "included/one-step-down-too.js" },
-          ],
-        },
-        {
-          source: "also-included/one-step-down.js",
-          dependencies: [],
-        },
-        {
-          source: "also-included/one-step-down-too.js",
-          dependencies: [],
-        },
-        {
-          source: "included/hoepla.js",
-          dependencies: [],
-        },
-      ],
-    );
+    deepEqual(applyFilters(MODULES, { includeOnly: { path: "included" } }), [
+      {
+        source: "included/index.js",
+        dependencies: [
+          { resolved: "also-included/index.js" },
+          { resolved: "included/hoepla.js" },
+        ],
+      },
+      {
+        source: "also-included/index.js",
+        dependencies: [
+          { resolved: "also-included/one-step-down.js" },
+          { resolved: "included/one-step-down-too.js" },
+        ],
+      },
+      {
+        source: "also-included/one-step-down.js",
+        dependencies: [],
+      },
+      {
+        source: "also-included/one-step-down-too.js",
+        dependencies: [],
+      },
+      {
+        source: "included/hoepla.js",
+        dependencies: [],
+      },
+    ]);
   });
 
   it("reaches: regex selecting no existing module yields an empty array", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(reportModules, {
         reaches: { path: "this-module-does-not-exist" },
       }),
@@ -174,7 +171,7 @@ describe("[U] graph-utl/filter-bank - exclude, includeOnly, reaches, highlight",
   });
 
   it("reaches: regex selecting only a module without any dependents yields just that module", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(reportModules, {
         reaches: { path: "src/report/index.js" },
       }),
@@ -183,7 +180,7 @@ describe("[U] graph-utl/filter-bank - exclude, includeOnly, reaches, highlight",
   });
 
   it("reaches: regex selecting a without any dependents yields just that module", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(reportModules, {
         reaches: { path: "src/report/(utl/|anon/anonymize-path-element)" },
       }),
@@ -191,7 +188,7 @@ describe("[U] graph-utl/filter-bank - exclude, includeOnly, reaches, highlight",
     );
   });
   it("highlight: labels modules with matchesHighlight when they match the highlight", () => {
-    deepStrictEqual(
+    deepEqual(
       applyFilters(reportModules, {
         highlight: { path: "src/report/(utl/|anon/anonymize-path-element)" },
       }),

--- a/test/graph-utl/indexed-module-graph.spec.mjs
+++ b/test/graph-utl/indexed-module-graph.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers, no-undefined */
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import IndexedModuleGraph from "../../src/graph-utl/indexed-module-graph.mjs";
 import unIndexedModules from "./__mocks__/un-indexed-modules.mjs";
 import unIndexedModulesWithoutDependents from "./__mocks__/un-indexed-modules-without-dependents.mjs";
@@ -9,18 +9,18 @@ describe("[U] graph-utl/indexed-module-graph - findModuleByName", () => {
   it("searching any module in an empty graph yields undefined", () => {
     const graph = new IndexedModuleGraph([]);
 
-    strictEqual(graph.findModuleByName("any-name"), undefined);
+    equal(graph.findModuleByName("any-name"), undefined);
   });
 
   it("searching a non-exiting module in a real graph yields undefined", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
 
-    strictEqual(graph.findModuleByName("any-name"), undefined);
+    equal(graph.findModuleByName("any-name"), undefined);
   });
 
   it("searching for an existing module yields that module", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(graph.findModuleByName("src/report/dot/default-theme.js"), {
+    deepEqual(graph.findModuleByName("src/report/dot/default-theme.js"), {
       source: "src/report/dot/default-theme.js",
       dependencies: [],
       dependents: ["src/report/dot/theming.js"],
@@ -40,7 +40,7 @@ describe("[U] graph-utl/indexed-module-graph - findModuleByName", () => {
 describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => {
   it("returns an empty array when asking for a non-existing module", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("this-module-does-not-exist.mjs"),
       [],
     );
@@ -48,7 +48,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 
   it("returns just the module itself when the 'dependents' de-normalized attribute isn't in the graph", () => {
     const graph = new IndexedModuleGraph(unIndexedModulesWithoutDependents);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("src/report/dot/default-theme.js"),
       ["src/report/dot/default-theme.js"],
     );
@@ -56,14 +56,14 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 
   it("finds just the module itself when there's no transitive dependents", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(graph.findTransitiveDependents("src/report/index.js"), [
+    deepEqual(graph.findTransitiveDependents("src/report/index.js"), [
       "src/report/index.js",
     ]);
   });
 
   it("finds transitive dependents for an existing module with actual transitive dependents", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("src/report/dot/default-theme.js"),
       [
         "src/report/dot/default-theme.js",
@@ -80,7 +80,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 
   it("same, but with a max depth of 1", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("src/report/dot/default-theme.js", 1),
       ["src/report/dot/default-theme.js", "src/report/dot/theming.js"],
     );
@@ -88,7 +88,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 
   it("same, but with a max depth of 2", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("src/report/dot/default-theme.js", 2),
       [
         "src/report/dot/default-theme.js",
@@ -101,7 +101,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 
   it("same, but with a max depth of 3", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("src/report/dot/default-theme.js", 3),
       [
         "src/report/dot/default-theme.js",
@@ -118,7 +118,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 
   it("same, but with a max depth of 4 (as there's nothing beyond depth 3 - will yield same as max depth 3", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependents("src/report/dot/default-theme.js", 4),
       [
         "src/report/dot/default-theme.js",
@@ -137,7 +137,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependents", () => 
 describe("[U] graph-utl/indexed-module-graph - findTransitiveDependencies", () => {
   it("returns an empty array when asking for a non-existing module", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependencies("this-module-does-not-exist.mjs"),
       [],
     );
@@ -145,7 +145,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependencies", () =
 
   it("finds just the module itself when there's no transitive dependencies", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependencies("src/report/dot/default-theme.js"),
       ["src/report/dot/default-theme.js"],
     );
@@ -153,7 +153,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependencies", () =
 
   it("finds transitive dependencies for an existing module with actual transitive dependents", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependencies("src/report/error-html/index.js"),
       [
         "src/report/error-html/index.js",
@@ -168,7 +168,7 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependencies", () =
     const graph = new IndexedModuleGraph(unIndexedModules);
     const lDirectDependenciesOnlyDepth = 1;
 
-    deepStrictEqual(
+    deepEqual(
       graph.findTransitiveDependencies(
         "src/report/error-html/index.js",
         lDirectDependenciesOnlyDepth,
@@ -184,57 +184,48 @@ describe("[U] graph-utl/indexed-module-graph - findTransitiveDependencies", () =
   it(" ... max depth 1", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
 
-    deepStrictEqual(
-      graph.findTransitiveDependencies("src/report/anon/index.js", 1),
-      ["src/report/anon/index.js", "src/report/anon/anonymize-path.js"],
-    );
+    deepEqual(graph.findTransitiveDependencies("src/report/anon/index.js", 1), [
+      "src/report/anon/index.js",
+      "src/report/anon/anonymize-path.js",
+    ]);
   });
 
   it(" ... max depth 2", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
 
-    deepStrictEqual(
-      graph.findTransitiveDependencies("src/report/anon/index.js", 2),
-      [
-        "src/report/anon/index.js",
-        "src/report/anon/anonymize-path.js",
-        "src/report/anon/anonymize-path-element.js",
-      ],
-    );
+    deepEqual(graph.findTransitiveDependencies("src/report/anon/index.js", 2), [
+      "src/report/anon/index.js",
+      "src/report/anon/anonymize-path.js",
+      "src/report/anon/anonymize-path-element.js",
+    ]);
   });
 
   it(" ... max depth 3", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
 
-    deepStrictEqual(
-      graph.findTransitiveDependencies("src/report/anon/index.js", 3),
-      [
-        "src/report/anon/index.js",
-        "src/report/anon/anonymize-path.js",
-        "src/report/anon/anonymize-path-element.js",
-        "src/report/anon/random-string.js",
-      ],
-    );
+    deepEqual(graph.findTransitiveDependencies("src/report/anon/index.js", 3), [
+      "src/report/anon/index.js",
+      "src/report/anon/anonymize-path.js",
+      "src/report/anon/anonymize-path-element.js",
+      "src/report/anon/random-string.js",
+    ]);
   });
 
   it(" ... max depth 4 (where there's nothing beyond 3, so should yield the same as max depth 3", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
 
-    deepStrictEqual(
-      graph.findTransitiveDependencies("src/report/anon/index.js", 4),
-      [
-        "src/report/anon/index.js",
-        "src/report/anon/anonymize-path.js",
-        "src/report/anon/anonymize-path-element.js",
-        "src/report/anon/random-string.js",
-      ],
-    );
+    deepEqual(graph.findTransitiveDependencies("src/report/anon/index.js", 4), [
+      "src/report/anon/index.js",
+      "src/report/anon/anonymize-path.js",
+      "src/report/anon/anonymize-path-element.js",
+      "src/report/anon/random-string.js",
+    ]);
   });
 });
 
 describe("[U] graph-utl/indexed-module-graph - getPath", () => {
   it("does not explode when passed an empty graph", () => {
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph([]).getPath("./src/index.js", "./src/hajoo.js"),
       [],
     );
@@ -248,7 +239,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/hajoo.js",
@@ -269,7 +260,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/hajoo.js",
@@ -290,7 +281,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/index.js",
@@ -311,7 +302,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/hajoo.js",
@@ -340,7 +331,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/hajoo.js",
@@ -369,7 +360,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/hajoo.js",
@@ -405,7 +396,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
       },
     ];
 
-    deepStrictEqual(
+    deepEqual(
       new IndexedModuleGraph(lGraph).getPath(
         "./src/index.js",
         "./src/hajoo.js",
@@ -422,77 +413,67 @@ function getCycle(pGraph, pFrom, pToDep) {
 
 describe("[U] graph-utl/indexed-module-graph - getCycle", () => {
   it("leaves non circular dependencies alone", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.A_B, "a", "b"), []);
+    deepEqual(getCycle(cycleInputGraphs.A_B, "a", "b"), []);
   });
   it("detects self circular (c <-> c)", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.C_C, "c", "c"), ["c", "c"]);
+    deepEqual(getCycle(cycleInputGraphs.C_C, "c", "c"), ["c", "c"]);
   });
   it("detects 1 step circular (d <-> e)", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.D_E_D, "d", "e"), ["e", "d"]);
+    deepEqual(getCycle(cycleInputGraphs.D_E_D, "d", "e"), ["e", "d"]);
   });
   it("detects 2 step circular (q -> r -> s -> q)", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.Q_R_S_Q, "q", "r"), [
-      "r",
-      "s",
-      "q",
-    ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.Q_R_S_Q, "r", "s"), [
-      "s",
-      "q",
-      "r",
-    ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.Q_R_S_Q, "s", "q"), [
-      "q",
-      "r",
-      "s",
-    ]);
+    deepEqual(getCycle(cycleInputGraphs.Q_R_S_Q, "q", "r"), ["r", "s", "q"]);
+    deepEqual(getCycle(cycleInputGraphs.Q_R_S_Q, "r", "s"), ["s", "q", "r"]);
+    deepEqual(getCycle(cycleInputGraphs.Q_R_S_Q, "s", "q"), ["q", "r", "s"]);
   });
   it("does not get confused because another circular (t -> u -> t, t -> v)", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.T_U_T_V, "t", "u"), ["u", "t"]);
-    deepStrictEqual(getCycle(cycleInputGraphs.T_U_T_V, "t", "v"), []);
+    deepEqual(getCycle(cycleInputGraphs.T_U_T_V, "t", "u"), ["u", "t"]);
+    deepEqual(getCycle(cycleInputGraphs.T_U_T_V, "t", "v"), []);
   });
   it("detects two circles (a -> b -> c -> a, a -> d -> e -> a)", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "a", "b"), [
+    deepEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "a", "b"), [
       "b",
       "c",
       "a",
     ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "b", "c"), [
+    deepEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "b", "c"), [
       "c",
       "a",
       "b",
     ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "c", "a"), [
+    deepEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "c", "a"), [
       "a",
       "b",
       "c",
     ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "a", "d"), [
+    deepEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "a", "d"), [
       "d",
       "e",
       "a",
     ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "d", "e"), [
+    deepEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "d", "e"), [
       "e",
       "a",
       "d",
     ]);
-    deepStrictEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "e", "a"), [
+    deepEqual(getCycle(cycleInputGraphs.TWO_CIRCLES, "e", "a"), [
       "a",
       "d",
       "e",
     ]);
   });
   it("it goes to a circle but isn't in it itself (z -> a -> b -> c -> a)", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.TO_A_CIRCLE, "z", "a"), []);
+    deepEqual(getCycle(cycleInputGraphs.TO_A_CIRCLE, "z", "a"), []);
   });
   it("it goes to a circle; isn't in it itself, but also to one where it is (z -> a -> b -> c -> a, c -> z)", () => {
-    deepStrictEqual(
-      getCycle(cycleInputGraphs.TO_A_CIRCLE_AND_IN_IT, "z", "a"),
-      ["a", "b", "c", "z"],
-    );
+    deepEqual(getCycle(cycleInputGraphs.TO_A_CIRCLE_AND_IN_IT, "z", "a"), [
+      "a",
+      "b",
+      "c",
+      "z",
+    ]);
   });
   it("just returns one cycle when querying a hub node", () => {
-    deepStrictEqual(getCycle(cycleInputGraphs.FLOWER, "a", "b"), ["b", "a"]);
+    deepEqual(getCycle(cycleInputGraphs.FLOWER, "a", "b"), ["b", "a"]);
   });
 });

--- a/test/graph-utl/rule-set.spec.mjs
+++ b/test/graph-utl/rule-set.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-undefined  */
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import {
   findRuleByName,
   ruleSetHasLicenseRule,
@@ -12,22 +12,22 @@ describe("[U] graph-utl/rule-set - findRuleByName", () => {
   };
 
   it("returns undefined for null rule set/ null rule name", () => {
-    strictEqual(findRuleByName(null, null), undefined);
+    equal(findRuleByName(null, null), undefined);
   });
   it("returns undefined for empty rule set/ null rule name", () => {
-    strictEqual(findRuleByName({}, null), undefined);
+    equal(findRuleByName({}, null), undefined);
   });
   it("returns undefined for empty rule set/ non-null rule name", () => {
-    strictEqual(findRuleByName({}, "non-null-rule-name"), undefined);
+    equal(findRuleByName({}, "non-null-rule-name"), undefined);
   });
   it("returns undefined for undefined rule set/ non-null rule name", () => {
-    strictEqual(findRuleByName(undefined, "non-null-rule-name"), undefined);
+    equal(findRuleByName(undefined, "non-null-rule-name"), undefined);
   });
   it("returns undefined if the rule is not in there", () => {
-    strictEqual(findRuleByName(lRuleSet, "another-rule"), undefined);
+    equal(findRuleByName(lRuleSet, "another-rule"), undefined);
   });
   it("returns the rule if the rule is in there", () => {
-    deepStrictEqual(findRuleByName(lRuleSet, "a-rule"), {
+    deepEqual(findRuleByName(lRuleSet, "a-rule"), {
       name: "a-rule",
       severity: "warn",
       from: {},
@@ -38,10 +38,10 @@ describe("[U] graph-utl/rule-set - findRuleByName", () => {
 
 describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
   it("returns false for an empty rule set", () => {
-    strictEqual(ruleSetHasLicenseRule({}), false);
+    equal(ruleSetHasLicenseRule({}), false);
   });
   it("returns false when rule set no rules with license-like attributes", () => {
-    strictEqual(
+    equal(
       ruleSetHasLicenseRule({
         forbidden: [{ from: {}, to: {} }],
         allowed: [{ from: {}, to: {} }],
@@ -50,7 +50,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
     );
   });
   it("returns true when rule set has a forbidden rule with a license attribute", () => {
-    strictEqual(
+    equal(
       ruleSetHasLicenseRule({
         forbidden: [{ from: {}, to: { license: "commercial" } }],
       }),
@@ -58,7 +58,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
     );
   });
   it("returns true when rule set doesn't have a forbidden rule with license like attributes", () => {
-    strictEqual(
+    equal(
       ruleSetHasLicenseRule({
         forbidden: [{ from: {}, to: { licenseNot: "" } }],
       }),
@@ -66,7 +66,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
     );
   });
   it("returns true when rule set has a forbidden rule with a licenseNot attribute", () => {
-    strictEqual(
+    equal(
       ruleSetHasLicenseRule({
         forbidden: [{ from: {}, to: { licenseNot: "MIT" } }],
       }),
@@ -74,7 +74,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
     );
   });
   it("returns true when rule set has an allowed rule with a license attribute", () => {
-    strictEqual(
+    equal(
       ruleSetHasLicenseRule({
         allowed: [{ from: {}, to: { license: "commercial" } }],
       }),
@@ -82,7 +82,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
     );
   });
   it("returns true when rule set has an allowed rule with a licenseNot attribute", () => {
-    strictEqual(
+    equal(
       ruleSetHasLicenseRule({
         allowed: [{ from: {}, to: { licenseNot: "MIT" } }],
       }),
@@ -93,10 +93,10 @@ describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {
 
 describe("[U] graph-utl/rule-set - ruleSetHasDeprecation", () => {
   it("returns false for an empty rule set", () => {
-    strictEqual(ruleSetHasDeprecationRule({}), false);
+    equal(ruleSetHasDeprecationRule({}), false);
   });
   it("returns false when rule set no rules with license-like attributes", () => {
-    strictEqual(
+    equal(
       ruleSetHasDeprecationRule({
         forbidden: [{ from: {}, to: { dependencyTypes: ["npm"] } }],
         allowed: [{ from: {}, to: {} }],
@@ -105,7 +105,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasDeprecation", () => {
     );
   });
   it("returns true when there's a 'forbidden' rule that checks for external module deprecation", () => {
-    strictEqual(
+    equal(
       ruleSetHasDeprecationRule({
         forbidden: [{ from: {}, to: { dependencyTypes: ["deprecated"] } }],
         allowed: [{ from: {}, to: {} }],
@@ -114,7 +114,7 @@ describe("[U] graph-utl/rule-set - ruleSetHasDeprecation", () => {
     );
   });
   it("returns true when there's an 'allowed' rule that checks for external module deprecation", () => {
-    strictEqual(
+    equal(
       ruleSetHasDeprecationRule({
         forbidden: [{ from: {}, to: {} }],
         allowed: [{ from: {}, to: { dependencyTypes: ["deprecated"] } }],

--- a/test/main/files-and-dirs/normalize.spec.mjs
+++ b/test/main/files-and-dirs/normalize.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { win32, posix } from "node:path";
 import { fileURLToPath } from "node:url";
 import normalizeFilesAndDirectories from "../../../src/main/files-and-dirs/normalize.mjs";
@@ -7,31 +7,30 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("[U] main/files-and-dirs", () => {
   it("Keeps an empty file dir array as is", () => {
-    deepStrictEqual(normalizeFilesAndDirectories([]), []);
+    deepEqual(normalizeFilesAndDirectories([]), []);
   });
 
   it("Keeps relative paths as is", () => {
-    deepStrictEqual(normalizeFilesAndDirectories(["./src", "./test"]), [
+    deepEqual(normalizeFilesAndDirectories(["./src", "./test"]), [
       "./src",
       "./test",
     ]);
   });
 
   it("Keeps relative paths as is - keeping globs in tact", () => {
-    deepStrictEqual(normalizeFilesAndDirectories(["{src,test}/**/*.js"]), [
+    deepEqual(normalizeFilesAndDirectories(["{src,test}/**/*.js"]), [
       "{src,test}/**/*.js",
     ]);
   });
 
   it("Normalizes absolute paths to paths relative to the current working dir", () => {
-    deepStrictEqual(
-      normalizeFilesAndDirectories([__dirname]).map(win32.normalize),
-      ["test\\main\\files-and-dirs"],
-    );
+    deepEqual(normalizeFilesAndDirectories([__dirname]).map(win32.normalize), [
+      "test\\main\\files-and-dirs",
+    ]);
   });
 
   it("Normalizes absolute paths to paths relative to the current working dir keeping globs in tact", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFilesAndDirectories([
         posix.join(__dirname, "**", "*.{js,ts}"),
       ]).map(win32.normalize),
@@ -40,7 +39,7 @@ describe("[U] main/files-and-dirs", () => {
   });
 
   it("Normalizes the current working dir passed as an absolute path to '.'", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFilesAndDirectories([process.cwd()]).map(win32.normalize),
       ["."],
     );

--- a/test/main/helpers.spec.mjs
+++ b/test/main/helpers.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { normalizeREProperties } from "../../src/main/helpers.mjs";
 
 const POTENTIAL_ARRAY_PROPERTIES = ["aap", "noot", "mies", "wim"];
@@ -22,19 +22,19 @@ const DE_ARRAYED_OBJECT = {
 
 describe("[U] main/utl/normalize-re-properties", () => {
   it("returns the input when an empty object and an empty array of properties input is passed", () => {
-    deepStrictEqual(normalizeREProperties({}, []), {});
+    deepEqual(normalizeREProperties({}, []), {});
   });
 
   it("returns the input when an any object and an empty array of properties input is passed", () => {
-    deepStrictEqual(normalizeREProperties(ARRAYED_OBJECT, []), ARRAYED_OBJECT);
+    deepEqual(normalizeREProperties(ARRAYED_OBJECT, []), ARRAYED_OBJECT);
   });
 
   it("returns the input when an empty input is passed", () => {
-    deepStrictEqual(normalizeREProperties({}, POTENTIAL_ARRAY_PROPERTIES), {});
+    deepEqual(normalizeREProperties({}, POTENTIAL_ARRAY_PROPERTIES), {});
   });
 
   it("returns the de-arrayed input when an empty input is passed", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeREProperties(ARRAYED_OBJECT, POTENTIAL_ARRAY_PROPERTIES),
       DE_ARRAYED_OBJECT,
     );

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -46,9 +46,9 @@ function runFixture(pFixture) {
       );
 
       ajv.validate(cruiseResultSchema, lResult.output);
-      deepStrictEqual(lResult.output.modules, pFixture.expected);
+      deepEqual(lResult.output.modules, pFixture.expected);
       if (lResult.output.folders) {
-        deepStrictEqual(lResult.output.folders, pFixture.expectedFolders);
+        deepEqual(lResult.output.folders, pFixture.expectedFolders);
       }
     });
   }

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, notDeepStrictEqual } from "node:assert";
+import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
 import { rmSync } from "node:fs";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -31,7 +31,7 @@ describe("[E] main.cruise - cache", () => {
     const lCache = await lCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lCache, "revisionData");
 
-    deepStrictEqual(lResult.output, lCache);
+    deepEqual(lResult.output, lCache);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -48,7 +48,7 @@ describe("[E] main.cruise - cache", () => {
     const lCache = await lCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lCache, "revisionData");
 
-    deepStrictEqual(lResult.output, lCache);
+    deepEqual(lResult.output, lCache);
 
     const lResultTwo = await cruise(
       ["test/main/__mocks__/cache"],
@@ -59,7 +59,7 @@ describe("[E] main.cruise - cache", () => {
       {},
     );
     Reflect.deleteProperty(lResultTwo.output, "revisionData");
-    deepStrictEqual(lResultTwo.output, lResult.output);
+    deepEqual(lResultTwo.output, lResult.output);
     ajv.validate(cruiseResultSchema, lResultTwo.output);
   });
 
@@ -76,7 +76,7 @@ describe("[E] main.cruise - cache", () => {
     const lOldCache = await lCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lOldCache, "revisionData");
 
-    deepStrictEqual(lResult.output, lOldCache);
+    deepEqual(lResult.output, lOldCache);
 
     const lResultTwo = await cruise(
       ["test/main/__mocks__/cache test/main/__mocks__/cache-too "],
@@ -90,7 +90,7 @@ describe("[E] main.cruise - cache", () => {
     const lNewCache = await lNewCacheInstance.read(CACHE_FOLDER);
     Reflect.deleteProperty(lNewCache, "revisionData");
     notDeepStrictEqual(lNewCache, lOldCache);
-    deepStrictEqual(lNewCache, lResultTwo.output);
+    deepEqual(lNewCache, lResultTwo.output);
     ajv.validate(cruiseResultSchema, lNewCache);
   });
 });

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
@@ -63,7 +63,7 @@ describe("[E] main.cruise - dynamic imports", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(lResult.output, esOut);
+    deepEqual(lResult.output, esOut);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -98,7 +98,7 @@ describe("[E] main.cruise - dynamic imports", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(lResult.output, tsOut);
+    deepEqual(lResult.output, tsOut);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -134,7 +134,7 @@ describe("[E] main.cruise - dynamic imports", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(lResult.output, tsOutpre);
+    deepEqual(lResult.output, tsOutpre);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
@@ -28,7 +28,7 @@ describe("[E] main.cruise - reachable integration", () => {
       }),
     );
     const lResult = JSON.parse(lCruiseResult.output);
-    deepStrictEqual(lResult.summary.violations, [
+    deepEqual(lResult.summary.violations, [
       {
         type: "reachability",
         from: "src/schema-declarations/naughty.info.js",
@@ -76,7 +76,7 @@ describe("[E] main.cruise - reachable integration", () => {
     );
     const lResult = JSON.parse(lCruiseResult.output);
 
-    deepStrictEqual(lResult.summary.violations, [
+    deepEqual(lResult.summary.violations, [
       {
         type: "module",
         from: "src/utilities/insula.js",
@@ -111,7 +111,7 @@ describe("[E] main.cruise - reachable integration", () => {
 
     const lResult = JSON.parse(lCruiseResult.output);
 
-    deepStrictEqual(lResult.summary.violations, [
+    deepEqual(lResult.summary.violations, [
       {
         type: "module",
         from: "src/db/admin.js",

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { posix as path } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -33,7 +33,7 @@ describe("[E] main.cruise - main", () => {
   it("Returns an object when no options are passed", async () => {
     const lResult = await cruise(["test/main/__mocks__/ts"]);
 
-    deepStrictEqual(pathPosixify(lResult.output), tsFixture);
+    deepEqual(pathPosixify(lResult.output), tsFixture);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -44,7 +44,7 @@ describe("[E] main.cruise - main", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(pathPosixify(lResult.output), tsFixture);
+    deepEqual(pathPosixify(lResult.output), tsFixture);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -55,7 +55,7 @@ describe("[E] main.cruise - main", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(pathPosixify(lResult.output), tsxFixture);
+    deepEqual(pathPosixify(lResult.output), tsxFixture);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -66,7 +66,7 @@ describe("[E] main.cruise - main", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(pathPosixify(lResult.output), jsxFixture);
+    deepEqual(pathPosixify(lResult.output), jsxFixture);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("process rulesets in the form a an object instead of json", async () => {
@@ -78,7 +78,7 @@ describe("[E] main.cruise - main", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(pathPosixify(lResult.output), jsxAsObjectFixture);
+    deepEqual(pathPosixify(lResult.output), jsxAsObjectFixture);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("Collapses to a pattern when a collapse pattern is passed", async () => {
@@ -91,7 +91,7 @@ describe("[E] main.cruise - main", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(
+    deepEqual(
       pathPosixify(lResult.output),
       normBaseDirectory(
         JSON.parse(

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
@@ -43,7 +43,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    deepStrictEqual(lResult.output, tsPreCompFixtureCJS);
+    deepEqual(lResult.output, tsPreCompFixtureCJS);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: on, target ES", async () => {
@@ -66,7 +66,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    deepStrictEqual(lResult.output, tsPreCompFixtureES);
+    deepEqual(lResult.output, tsPreCompFixtureES);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: off, target CJS", async () => {
@@ -89,7 +89,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    deepStrictEqual(lResult.output, tsNoPrecompFixtureCJS);
+    deepEqual(lResult.output, tsNoPrecompFixtureCJS);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
   it("ts-pre-compilation-deps: off, target ES", async () => {
@@ -112,7 +112,7 @@ describe("[E] main.cruise - tsPreCompilationDeps", () => {
       },
     );
 
-    deepStrictEqual(lResult.output, tsNoPrecompFixtureES);
+    deepEqual(lResult.output, tsNoPrecompFixtureES);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -38,7 +38,7 @@ describe("[E] main.cruise - explicitly type only imports", () => {
       { bustTheCache: true, resolveLicenses: false },
     );
 
-    deepStrictEqual(lResult.output, output);
+    deepEqual(lResult.output, output);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -65,7 +65,7 @@ describe("[E] main.cruise - explicitly type only imports", () => {
       { bustTheCache: true, resolveLicenses: false },
     );
 
-    deepStrictEqual(lResult.output, outputWithRules);
+    deepEqual(lResult.output, outputWithRules);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
@@ -38,7 +38,7 @@ describe("[E] main.cruise - type only module references", () => {
       { bustTheCache: true, resolveLicenses: true },
     );
 
-    deepStrictEqual(lResult.output, output);
+    deepEqual(lResult.output, output);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 
@@ -53,7 +53,7 @@ describe("[E] main.cruise - type only module references", () => {
       { bustTheCache: true },
     );
 
-    deepStrictEqual(lResult.output, outputNoTS);
+    deepEqual(lResult.output, outputNoTS);
     ajv.validate(cruiseResultSchema, lResult.output);
   });
 });

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { deepEqual, ok, equal } from "node:assert/strict";
 import format from "../../src/main/format.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 
@@ -79,7 +79,7 @@ describe("[E] main.format - format", () => {
 
   it("returns an json reporter formatted report when presented with a legal result", async () => {
     const lResult = await format(MINIMAL_RESULT, { outputType: "json" });
-    deepStrictEqual(JSON.parse(lResult.output), MINIMAL_RESULT);
+    deepEqual(JSON.parse(lResult.output), MINIMAL_RESULT);
   });
 
   it("returns a collapsed version of the report when passed a collapse option", async () => {
@@ -88,7 +88,7 @@ describe("[E] main.format - format", () => {
     });
     const lCollapsedResult = lResult.output;
 
-    deepStrictEqual(lCollapsedResult.summary.violations, [
+    deepEqual(lCollapsedResult.summary.violations, [
       {
         type: "dependency",
         from: "src/cli/",
@@ -99,8 +99,8 @@ describe("[E] main.format - format", () => {
         },
       },
     ]);
-    strictEqual(lCollapsedResult.summary.totalCruised, 19);
-    strictEqual(lCollapsedResult.summary.totalDependenciesCruised, 18);
+    equal(lCollapsedResult.summary.totalCruised, 19);
+    equal(lCollapsedResult.summary.totalDependenciesCruised, 18);
   });
 
   it("returns string with error explanations when asked for the err-long report", async () => {
@@ -133,10 +133,10 @@ describe("[E] main.format - format", () => {
       includeOnly: "^src/",
     });
     const lJSONResult = JSON.parse(lResult.output);
-    strictEqual(Object.keys(lJSONResult.summary.optionsUsed).length, 16);
-    strictEqual(lJSONResult.summary.optionsUsed.outputType, "anon");
-    strictEqual(lJSONResult.summary.optionsUsed.includeOnly, "^src/");
+    equal(Object.keys(lJSONResult.summary.optionsUsed).length, 16);
+    equal(lJSONResult.summary.optionsUsed.outputType, "anon");
+    equal(lJSONResult.summary.optionsUsed.includeOnly, "^src/");
     // without includeOnly it'd be 53
-    strictEqual(lJSONResult.modules.length, 33);
+    equal(lJSONResult.modules.length, 33);
   });
 });

--- a/test/main/options/normalize.cruise-options.spec.mjs
+++ b/test/main/options/normalize.cruise-options.spec.mjs
@@ -1,28 +1,28 @@
-import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { deepEqual, ok, equal } from "node:assert/strict";
 import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
 
 describe("[U] main/options/normalize - cruise options", () => {
   it("ensures maxDepth is an int when passed an int", () => {
-    strictEqual(normalizeCruiseOptions({ maxDepth: 42 }).maxDepth, 42);
+    equal(normalizeCruiseOptions({ maxDepth: 42 }).maxDepth, 42);
   });
 
   it("ensures maxDepth is an int when passed a string", () => {
-    strictEqual(normalizeCruiseOptions({ maxDepth: "42" }).maxDepth, 42);
+    equal(normalizeCruiseOptions({ maxDepth: "42" }).maxDepth, 42);
   });
 
   it("makes doNotFollow strings into an object", () => {
-    deepStrictEqual(normalizeCruiseOptions({ doNotFollow: "42" }).doNotFollow, {
+    deepEqual(normalizeCruiseOptions({ doNotFollow: "42" }).doNotFollow, {
       path: "42",
     });
   });
   it("makes focus strings into an object", () => {
-    deepStrictEqual(normalizeCruiseOptions({ focus: "42" }).focus, {
+    deepEqual(normalizeCruiseOptions({ focus: "42" }).focus, {
       path: "42",
     });
   });
 
   it("makes exclude arrays into an object with a string", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({
         exclude: ["^aap", "^noot", "mies$"],
       }).exclude,
@@ -33,7 +33,7 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("makes exclude object with an array for path into an exclude path with a string for path", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({
         exclude: { path: ["^aap", "^noot", "mies$"] },
       }).exclude,
@@ -44,7 +44,7 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("de-arrayify's archi reporter options' collapsePattern", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({
         reporterOptions: {
           archi: {
@@ -61,7 +61,7 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("de-arrayify's dot reporter options' filters", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({
         reporterOptions: {
           dot: {
@@ -82,28 +82,28 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("collapse: normalizes a single digit for collapse to a folder depth regex", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({ collapse: 2 }, ["collapse"]).collapse,
       "node_modules/[^/]+|^[^/]+/[^/]+/",
     );
   });
 
   it("collapse: normalizes a single digit for collapse to a folder depth regex (digit in a string)", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({ collapse: "2" }).collapse,
       "node_modules/[^/]+|^[^/]+/[^/]+/",
     );
   });
 
   it("collapse: leaves non-single digits alone", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({ collapse: "22" }, ["collapse"]).collapse,
       "22",
     );
   });
 
   it("collapse: leaves a normal string/ regex like alone", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({ collapse: "^packages/[^/]+" }, ["collapse"])
         .collapse,
       "^packages/[^/]+",
@@ -111,7 +111,7 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("calculates metrics when the selected reporter specifies to show metrics", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({
         outputType: "dot",
         reporterOptions: { dot: { showMetrics: true } },
@@ -121,7 +121,7 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("calculates metrics when the selected reporter specifies to not show metrics", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({
         outputType: "dot",
         reporterOptions: { dot: { showMetrics: false } },
@@ -131,7 +131,7 @@ describe("[U] main/options/normalize - cruise options", () => {
   });
 
   it("calculates metrics when the selected reporter doesn't specify to show metrics", () => {
-    strictEqual(
+    equal(
       normalizeCruiseOptions({
         outputType: "dot",
       }).metrics,
@@ -142,13 +142,13 @@ describe("[U] main/options/normalize - cruise options", () => {
 
 describe("[I] normalize cache options", () => {
   it("normalizes cache options into an object - true", () => {
-    deepStrictEqual(normalizeCruiseOptions({ cache: true }).cache, {
+    deepEqual(normalizeCruiseOptions({ cache: true }).cache, {
       folder: "node_modules/.cache/dependency-cruiser",
       strategy: "metadata",
     });
   });
   it("normalizes cache options into an object - string", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({ cache: "some/alternate/folder" }).cache,
       {
         folder: "some/alternate/folder",
@@ -157,14 +157,14 @@ describe("[I] normalize cache options", () => {
     );
   });
   it("normalizes cache options into an object - empty object", () => {
-    deepStrictEqual(normalizeCruiseOptions({ cache: {} }).cache, {
+    deepEqual(normalizeCruiseOptions({ cache: {} }).cache, {
       folder: "node_modules/.cache/dependency-cruiser",
       strategy: "metadata",
     });
   });
 
   it("normalizes cache options into an object - partial object (strategy only)", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({ cache: { strategy: "content" } }).cache,
       {
         folder: "node_modules/.cache/dependency-cruiser",
@@ -173,7 +173,7 @@ describe("[I] normalize cache options", () => {
     );
   });
   it("normalizes cache options into an object - partial object (folder only)", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeCruiseOptions({
         cache: { folder: "some/alternate/folder" },
       }).cache,
@@ -184,7 +184,7 @@ describe("[I] normalize cache options", () => {
     );
   });
   it("passed false for cache - remains false (no object)", () => {
-    strictEqual(normalizeCruiseOptions({ cache: false }).cache, false);
+    equal(normalizeCruiseOptions({ cache: false }).cache, false);
   });
   it("passed no cache - no cache property", () => {
     ok(!normalizeCruiseOptions({}).hasOwnProperty("cache"));

--- a/test/main/options/normalize.format-options.spec.mjs
+++ b/test/main/options/normalize.format-options.spec.mjs
@@ -1,9 +1,9 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import { normalizeFormatOptions } from "../../../src/main/options/normalize.mjs";
 
 describe("[U] main/options/normalize - format options", () => {
   it("makes focus strings into an object", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFormatOptions({
         focus: "42",
       }).focus,
@@ -14,7 +14,7 @@ describe("[U] main/options/normalize - format options", () => {
   });
 
   it("makes focus strings into an object - with addition of focus depth if it's there", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFormatOptions({
         focus: "42",
         focusDepth: 10,
@@ -27,7 +27,7 @@ describe("[U] main/options/normalize - format options", () => {
   });
 
   it("ignores focus depth when there's not also a focus attribute", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFormatOptions({
         focusDepth: 10,
       }),
@@ -36,7 +36,7 @@ describe("[U] main/options/normalize - format options", () => {
   });
 
   it("makes exclude arrays into an object with a string", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFormatOptions({
         exclude: ["^aap", "^noot", "mies$"],
       }).exclude,
@@ -47,7 +47,7 @@ describe("[U] main/options/normalize - format options", () => {
   });
 
   it("makes exclude object with an array for path into an exclude path with a string for path", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFormatOptions({
         exclude: { path: ["^aap", "^noot", "mies$"] },
       }).exclude,
@@ -58,19 +58,19 @@ describe("[U] main/options/normalize - format options", () => {
   });
 
   it("collapse: normalizes a single digit for collapse to a folder depth regex", () => {
-    deepStrictEqual(normalizeFormatOptions({ collapse: "2" }, ["collapse"]), {
+    deepEqual(normalizeFormatOptions({ collapse: "2" }, ["collapse"]), {
       collapse: "node_modules/[^/]+|^[^/]+/[^/]+/",
     });
   });
 
   it("collapse: leaves non-single digits alone", () => {
-    deepStrictEqual(normalizeFormatOptions({ collapse: "22" }, ["collapse"]), {
+    deepEqual(normalizeFormatOptions({ collapse: "22" }, ["collapse"]), {
       collapse: "22",
     });
   });
 
   it("collapse: leaves a normal string/ regex like alone", () => {
-    deepStrictEqual(
+    deepEqual(
       normalizeFormatOptions({ collapse: "^packages/[^/]+" }, ["collapse"]),
       {
         collapse: "^packages/[^/]+",

--- a/test/main/options/validate.spec.mjs
+++ b/test/main/options/validate.spec.mjs
@@ -1,4 +1,4 @@
-import { doesNotThrow, strictEqual, throws } from "node:assert";
+import { doesNotThrow, equal, throws } from "node:assert/strict";
 import { validateCruiseOptions } from "../../../src/main/options/validate.mjs";
 
 describe("[U] main/options/validate - module systems", () => {
@@ -172,7 +172,7 @@ describe("[U] main/options/validate - exclude", () => {
       ruleSet: { options: { exclude: "from the ruleset" } },
     });
 
-    strictEqual(lOptions.exclude, "from the commandline");
+    equal(lOptions.exclude, "from the commandline");
   });
 
   it("options passed in --validate rule-set drip down to the proper options", () => {
@@ -181,7 +181,7 @@ describe("[U] main/options/validate - exclude", () => {
       ruleSet: { options: { exclude: "from the ruleset" } },
     });
 
-    strictEqual(lOptions.exclude, "from the ruleset");
-    strictEqual(lOptions.doNotFollow, "from the commandline");
+    equal(lOptions.exclude, "from the ruleset");
+    equal(lOptions.doNotFollow, "from the commandline");
   });
 });

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -1,4 +1,4 @@
-import { ok, strictEqual } from "node:assert";
+import { ok, equal } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
@@ -20,16 +20,13 @@ describe("[I] main/resolve-options/normalize", () => {
       normalizeCruiseOptions({}),
     );
 
-    strictEqual(
-      Object.keys(lNormalizedOptions).length,
-      lDefaultNoOfResolveOptions,
-    );
-    strictEqual(lNormalizedOptions.symlinks, false);
-    strictEqual(lNormalizedOptions.tsConfig, null);
-    strictEqual(lNormalizedOptions.combinedDependencies, false);
+    equal(Object.keys(lNormalizedOptions).length, lDefaultNoOfResolveOptions);
+    equal(lNormalizedOptions.symlinks, false);
+    equal(lNormalizedOptions.tsConfig, null);
+    equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
+    equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
   it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", async () => {
@@ -41,17 +38,14 @@ describe("[I] main/resolve-options/normalize", () => {
       lTsconfigContents,
     );
 
-    strictEqual(
-      Object.keys(lNormalizedOptions).length,
-      lDefaultNoOfResolveOptions,
-    );
-    strictEqual(lNormalizedOptions.symlinks, false);
-    strictEqual(lNormalizedOptions.tsConfig, null);
-    strictEqual(lNormalizedOptions.combinedDependencies, false);
+    equal(Object.keys(lNormalizedOptions).length, lDefaultNoOfResolveOptions);
+    equal(lNormalizedOptions.symlinks, false);
+    equal(lNormalizedOptions.tsConfig, null);
+    equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    strictEqual((lNormalizedOptions.plugins || []).length, 0);
-    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
+    equal((lNormalizedOptions.plugins || []).length, 0);
+    equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
   it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", async () => {
@@ -63,17 +57,17 @@ describe("[I] main/resolve-options/normalize", () => {
       lTsconfigContents,
     );
 
-    strictEqual(
+    equal(
       Object.keys(lNormalizedOptions).length,
       lDefaultNoOfResolveOptions + 1,
     );
-    strictEqual(lNormalizedOptions.symlinks, false);
-    strictEqual(lNormalizedOptions.tsConfig, TEST_TSCONFIG);
-    strictEqual(lNormalizedOptions.combinedDependencies, false);
+    equal(lNormalizedOptions.symlinks, false);
+    equal(lNormalizedOptions.tsConfig, TEST_TSCONFIG);
+    equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    strictEqual((lNormalizedOptions.plugins || []).length, 1);
-    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
+    equal((lNormalizedOptions.plugins || []).length, 1);
+    equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
   it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", async () => {
@@ -85,16 +79,16 @@ describe("[I] main/resolve-options/normalize", () => {
       lTsconfigContentsWithBaseURLAndPaths,
     );
 
-    strictEqual(
+    equal(
       Object.keys(lNormalizedOptions).length,
       lDefaultNoOfResolveOptions + 1,
     );
-    strictEqual(lNormalizedOptions.symlinks, false);
-    strictEqual(lNormalizedOptions.tsConfig, TEST_TSCONFIG);
-    strictEqual(lNormalizedOptions.combinedDependencies, false);
+    equal(lNormalizedOptions.symlinks, false);
+    equal(lNormalizedOptions.tsConfig, TEST_TSCONFIG);
+    equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    strictEqual(lNormalizedOptions.plugins.length, 1);
-    strictEqual(lNormalizedOptions.useSyncFileSystemCalls, true);
+    equal(lNormalizedOptions.plugins.length, 1);
+    equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 });

--- a/test/main/rule-set/normalize.spec.mjs
+++ b/test/main/rule-set/normalize.spec.mjs
@@ -1,13 +1,13 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import normalize from "../../../src/main/rule-set/normalize.mjs";
 
 describe("[U] main/rule-set/normalize", () => {
   it("leaves the empty ruleset alone", () => {
-    deepStrictEqual(normalize({}), {});
+    deepEqual(normalize({}), {});
   });
 
   it("allowed: adds allowedSeverity when it wasn't filled out; adds the 'not-in-allowed' name to the rule", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         allowed: [
           {
@@ -30,7 +30,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("allowed: leaves allowedSeverity alone when it wasn't filled; doesn't add severity, but does add name 'not-in-allowed' to the rule", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         allowed: [
           {
@@ -54,7 +54,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("corrects the severity to a default when it's not a recognized one", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {
@@ -80,7 +80,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("keeps the severity if it's a recognized one", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {
@@ -106,7 +106,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("also works for 'forbidden' rules", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {
@@ -134,7 +134,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("filters out forbidden rules with severity 'ignore'", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {
@@ -153,7 +153,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("filters out required rules with severity 'ignore'", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         required: [
           {
@@ -172,7 +172,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("removes the allowed rules & allowedSeverity when allowedSeverity === 'ignore'", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         allowed: [
           {
@@ -187,7 +187,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("normalizes arrays of re's in paths to regular regular expressions (forbidden)", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {
@@ -225,7 +225,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("normalizes arrays of re's in paths to regular regular expressions (required)", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         required: [
           {
@@ -261,7 +261,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("normalizes arrays of re's in paths to regular regular expressions (allowed)", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         allowed: [
           {
@@ -296,7 +296,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("normalizes arrays of re's in licenses to regular regular expressions", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {
@@ -344,7 +344,7 @@ describe("[U] main/rule-set/normalize", () => {
   });
 
   it("normalizes arrays of re's in exoticRequires to regular regular expressions", () => {
-    deepStrictEqual(
+    deepEqual(
       normalize({
         forbidden: [
           {

--- a/test/main/rule-set/validate.spec.mjs
+++ b/test/main/rule-set/validate.spec.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { deepStrictEqual, throws } from "node:assert";
+import { deepEqual, throws } from "node:assert/strict";
 import validate from "../../../src/main/rule-set/validate.mjs";
 
 function shouldBarfWithMessage(pRulesFile, pMessage) {
@@ -14,7 +14,7 @@ function shouldBarfWithMessage(pRulesFile, pMessage) {
 function shouldBeOK(pRulesFile) {
   const lRulesObject = JSON.parse(readFileSync(pRulesFile, "utf8"));
 
-  deepStrictEqual(validate(lRulesObject), lRulesObject);
+  deepEqual(validate(lRulesObject), lRulesObject);
 }
 
 describe("[I] main/rule-set/validate - regular", () => {

--- a/test/report/anon/anonymize-path-element.spec.mjs
+++ b/test/report/anon/anonymize-path-element.spec.mjs
@@ -1,9 +1,9 @@
-import { match, notDeepStrictEqual, strictEqual } from "node:assert";
+import { match, notDeepStrictEqual, equal } from "node:assert/strict";
 import { anonymizePathElement } from "../../../src/report/anon/anonymize-path-element.mjs";
 
 describe("[U] report/anon/anonymizePathElement - uncached", () => {
   it("'' => ''", () => {
-    strictEqual(anonymizePathElement("", [], /^$/, false), "");
+    equal(anonymizePathElement("", [], /^$/, false), "");
   });
 
   it("'string' => random string", () => {
@@ -13,27 +13,24 @@ describe("[U] report/anon/anonymizePathElement - uncached", () => {
   it("consecutive calls with a word list yield words from that list, until empty", () => {
     const lWordlist = ["aap", "noot"];
 
-    strictEqual(anonymizePathElement("one", lWordlist, /^$/, false), "aap");
-    strictEqual(anonymizePathElement("two", lWordlist, /^$/, false), "noot");
+    equal(anonymizePathElement("one", lWordlist, /^$/, false), "aap");
+    equal(anonymizePathElement("two", lWordlist, /^$/, false), "noot");
     match(anonymizePathElement("three", lWordlist, /^$/, false), /[a-z]{5}/);
   });
 
   it("returns the passed string when it matches the whitelist", () => {
-    strictEqual(
-      anonymizePathElement("package", [], /^packages?$/, false),
-      "package",
-    );
+    equal(anonymizePathElement("package", [], /^packages?$/, false), "package");
   });
 
   it("returns the passed string when it does not match the whitelist", () => {
-    strictEqual(
+    equal(
       anonymizePathElement("thing", ["aap", "noot"], /^packages?$/, false),
       "aap",
     );
   });
 
   it("only replaces the string up till the fist dot", () => {
-    strictEqual(
+    equal(
       anonymizePathElement(
         "thing.spec.js",
         ["aap", "noot"],
@@ -49,7 +46,7 @@ describe("[U] report/anon/anonymizePathElement - cached", () => {
   it("subsequent calls with the same string yield the same result", () => {
     const lFirstResult = anonymizePathElement("yudelyo");
 
-    strictEqual(anonymizePathElement("yudelyo"), lFirstResult);
+    equal(anonymizePathElement("yudelyo"), lFirstResult);
   });
 
   it("subsequent calls with different strings yield different results", () => {

--- a/test/report/anon/anonymize-path.spec.mjs
+++ b/test/report/anon/anonymize-path.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { anonymizePath } from "../../../src/report/anon/anonymize-path.mjs";
 import { clearCache } from "../../../src/report/anon/anonymize-path-element.mjs";
 
@@ -8,15 +8,15 @@ describe("[U] report/anon/anonymizePath", () => {
   });
 
   it("'' => ''", () => {
-    strictEqual(anonymizePath(""), "");
+    equal(anonymizePath(""), "");
   });
 
   it("'////' => '////'", () => {
-    strictEqual(anonymizePath("////"), "////");
+    equal(anonymizePath("////"), "////");
   });
 
   it("replaces with words from the word list", () => {
-    strictEqual(
+    equal(
       anonymizePath("src/tien/kleine/geitjes/index.ts", ["foo", "bar", "baz"]),
       "src/foo/bar/baz/index.ts",
     );
@@ -25,22 +25,22 @@ describe("[U] report/anon/anonymizePath", () => {
   it("repeat calls with similar paths yield similar anon paths", () => {
     const lWords = ["aap", "noot", "mies", "wim", "zus", "jet", "heide"];
 
-    strictEqual(
+    equal(
       anonymizePath("src/tien/kleine/geitjes/index.ts", lWords),
       "src/aap/noot/mies/index.ts",
     );
 
-    strictEqual(
+    equal(
       anonymizePath("src/tien/kleine/geitjes/tien.ts", lWords),
       "src/aap/noot/mies/aap.ts",
     );
 
-    strictEqual(
+    equal(
       anonymizePath("shwoop/tien/grote/geiten/index.ts", lWords),
       "wim/aap/zus/jet/index.ts",
     );
 
-    strictEqual(
+    equal(
       anonymizePath("test/tien/kleine/geitjes/tien.spec.ts", lWords),
       "test/aap/noot/mies/aap.spec.ts",
     );

--- a/test/report/anon/anonymize.spec.mjs
+++ b/test/report/anon/anonymize.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual, deepStrictEqual } from "node:assert";
+import { equal, deepEqual } from "node:assert/strict";
 import _clone from "lodash/clone.js";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../../src/schema/cruise-result.schema.mjs";
@@ -53,18 +53,18 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureReport);
+    deepEqual(lOutput, fixtureReport);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("anonymizes a result tree with the word list passed in the result tree", () => {
     const lResult = anonymize(sourceReportWithWordlist);
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureReportWithWordlist);
+    deepEqual(lOutput, fixtureReportWithWordlist);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("anonymizes a result tree with (violated) rules", () => {
@@ -73,9 +73,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureCycle);
+    deepEqual(lOutput, fixtureCycle);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("anonymizes a result tree with (violated) reaches rules", () => {
     const lResult = anonymize(reachesReport, {
@@ -83,9 +83,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureReachesReport);
+    deepEqual(lOutput, fixtureReachesReport);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("anonymizes a result tree with dependents", () => {
     const lResult = anonymize(sourceDependents, {
@@ -93,9 +93,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureDependents);
+    deepEqual(lOutput, fixtureDependents);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("anonymizes a result tree with folders", () => {
     const lResult = anonymize(sourceFolders, {
@@ -103,9 +103,9 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureFolders);
+    deepEqual(lOutput, fixtureFolders);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("anonymizes a result tree with folders that contain folder cycles", () => {
@@ -114,8 +114,8 @@ describe("[I] report/anon", () => {
     });
     const lOutput = JSON.parse(lResult.output);
 
-    deepStrictEqual(lOutput, fixtureFolderCycles);
+    deepEqual(lOutput, fixtureFolderCycles);
     ajv.validate(cruiseResultSchema, lOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 });

--- a/test/report/anon/random-string.spec.mjs
+++ b/test/report/anon/random-string.spec.mjs
@@ -1,9 +1,9 @@
-import { match, strictEqual } from "node:assert";
+import { match, equal } from "node:assert/strict";
 import randomString from "../../../src/report/anon/random-string.mjs";
 
 describe("[U] report/anon/random-string", () => {
   it("returns the empty string when passed the empty string", () => {
-    strictEqual(randomString(""), "");
+    equal(randomString(""), "");
   });
 
   it("returns a lower case ascii character when passed such", () => {
@@ -23,7 +23,7 @@ describe("[U] report/anon/random-string", () => {
   });
 
   it("echoes separators", () => {
-    strictEqual(randomString("-"), "-");
+    equal(randomString("-"), "-");
   });
 
   it("returns a number when passed a number", () => {

--- a/test/report/azure-devops/azure-devops.spec.mjs
+++ b/test/report/azure-devops/azure-devops.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import normalizeNewline from "normalize-newline";
@@ -28,8 +28,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(okdeps);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
-    strictEqual(lResult.exitCode, 0);
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(lResult.exitCode, 0);
   });
 
   it("says there's warnings when there's warnings", () => {
@@ -38,8 +38,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(warndeps);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
-    strictEqual(lResult.exitCode, 0);
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(lResult.exitCode, 0);
   });
 
   it("says there's errors when there's errors", () => {
@@ -48,8 +48,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(errdeps);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
-    strictEqual(lResult.exitCode, 1);
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(lResult.exitCode, 1);
   });
 
   it("renders module only transgressions", () => {
@@ -58,9 +58,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(moduleErrs);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 5);
+    equal(lResult.exitCode, 5);
   });
 
   it("renders 'required' violations", () => {
@@ -69,9 +69,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(requiredErrs);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 5);
+    equal(lResult.exitCode, 5);
   });
 
   it("renders circular transgressions", () => {
@@ -80,18 +80,18 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(circulars);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 3);
+    equal(lResult.exitCode, 3);
   });
 
   it("renders via transgressions", () => {
     const lFixture = readFixture("__mocks__/via-deps-azure-devops-format.txt");
     const lResult = render(vias);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 4);
+    equal(lResult.exitCode, 4);
   });
 
   it("renders instability transgressions", () => {
@@ -100,9 +100,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(instabilities);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("renders unsupported error levels (like 'ignore') as 'info'", () => {
@@ -111,9 +111,9 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(unsupportedErrorLevels);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 5);
+    equal(lResult.exitCode, 5);
   });
 
   it("renders known errors in a single warning", () => {
@@ -122,8 +122,8 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(knownViolations);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
-    strictEqual(lResult.exitCode, 0);
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(lResult.exitCode, 0);
   });
 
   it("renders known errors along with other errors", () => {
@@ -132,7 +132,7 @@ describe("[I] report/azure-devops", () => {
     );
     const lResult = render(errorsAndKnownViolations);
 
-    strictEqual(normalizeNewline(lResult.output), normalizeNewline(lFixture));
-    strictEqual(lResult.exitCode, 1);
+    equal(normalizeNewline(lResult.output), normalizeNewline(lFixture));
+    equal(lResult.exitCode, 1);
   });
 });

--- a/test/report/baseline/baseline.spec.mjs
+++ b/test/report/baseline/baseline.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import Ajv from "ajv";
 import baseline from "../../../src/report/baseline.mjs";
 import { createRequireJSON } from "../../backwards.utl.mjs";
@@ -13,8 +13,8 @@ describe("[I] report/baseline", () => {
     const lExpected = [];
     const lResult = baseline(lInput);
 
-    deepStrictEqual(JSON.parse(lResult.output), lExpected);
-    strictEqual(lResult.exitCode, 0);
+    deepEqual(JSON.parse(lResult.output), lExpected);
+    equal(lResult.exitCode, 0);
     ajv.validate(baselineSchema, JSON.parse(lResult.output));
   });
 
@@ -23,8 +23,8 @@ describe("[I] report/baseline", () => {
     const lExpected = requireJSON("./__fixtures__/baseline-result.json");
     const lResult = baseline(lInput);
 
-    deepStrictEqual(JSON.parse(lResult.output), lExpected);
-    strictEqual(lResult.exitCode, 0);
+    deepEqual(JSON.parse(lResult.output), lExpected);
+    equal(lResult.exitCode, 0);
     ajv.validate(baselineSchema, JSON.parse(lResult.output));
   });
 });

--- a/test/report/csv/csv.spec.mjs
+++ b/test/report/csv/csv.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import normalizeNewline from "normalize-newline";
 import render from "../../../src/report/csv.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
@@ -18,7 +18,7 @@ describe("[I] report/csv reporter", () => {
   it("renders csv", () => {
     const lReturnValue = render(deps);
 
-    deepStrictEqual(normalizeNewline(lReturnValue.output), elementFixture);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(normalizeNewline(lReturnValue.output), elementFixture);
+    equal(lReturnValue.exitCode, 0);
   });
 });

--- a/test/report/dot/custom-level/index.spec.mjs
+++ b/test/report/dot/custom-level/index.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,21 +29,21 @@ describe("[I] report/dot/custom-level reporter", () => {
   it("consolidates to custome levels", () => {
     const lReturnValue = render(deps);
 
-    deepStrictEqual(lReturnValue.output, consolidatedDot);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, consolidatedDot);
+    equal(lReturnValue.exitCode, 0);
   });
 
   it("consolidates module only transgressions correctly", () => {
     const lReturnValue = render(orphans);
 
-    deepStrictEqual(lReturnValue.output, consolidatedOrphansDot);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, consolidatedOrphansDot);
+    equal(lReturnValue.exitCode, 0);
   });
 
   it("consolidates a slightly larger code base in a timely fashion", () => {
     const lReturnValue = render(rxjs);
 
-    deepStrictEqual(lReturnValue.output, consolidatedRxJs);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, consolidatedRxJs);
+    equal(lReturnValue.exitCode, 0);
   });
 });

--- a/test/report/dot/flat-level/index.spec.mjs
+++ b/test/report/dot/flat-level/index.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,22 +29,22 @@ describe("[I] report/dot/flat-level reporter", () => {
   it("consolidates to flat levels", () => {
     const lReturnValue = render(deps);
 
-    strictEqual(lReturnValue.output, flatDot);
-    strictEqual(lReturnValue.exitCode, 0);
+    equal(lReturnValue.output, flatDot);
+    equal(lReturnValue.exitCode, 0);
   });
 
   it("consolidates module only transgressions correctly", () => {
     const lReturnValue = render(orphans);
 
-    strictEqual(lReturnValue.output, flatOrphansDot);
-    strictEqual(lReturnValue.exitCode, 0);
+    equal(lReturnValue.output, flatOrphansDot);
+    equal(lReturnValue.exitCode, 0);
   });
 
   it("consolidates a slightly larger code base in a timely fashion", () => {
     const lReturnValue = render(rxjs);
 
-    strictEqual(lReturnValue.output, flatRxJs);
-    strictEqual(lReturnValue.exitCode, 0);
+    equal(lReturnValue.output, flatRxJs);
+    equal(lReturnValue.exitCode, 0);
   });
 });
 

--- a/test/report/dot/folder-level/folder-level.spec.mjs
+++ b/test/report/dot/folder-level/folder-level.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,22 +29,22 @@ describe("[I] report/dot/folder-level reporter", () => {
   it("consolidates to folder level", () => {
     const lReturnValue = render(deps);
 
-    deepStrictEqual(lReturnValue.output, consolidatedDot);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, consolidatedDot);
+    equal(lReturnValue.exitCode, 0);
   });
 
   it("consolidates module only transgressions correctly", () => {
     const lReturnValue = render(orphans);
 
-    deepStrictEqual(lReturnValue.output, consolidatedOrphansDot);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, consolidatedOrphansDot);
+    equal(lReturnValue.exitCode, 0);
   });
 
   it("consolidates a slightly larger code base in a timely fashion", () => {
     const lReturnValue = render(rxjs);
 
-    deepStrictEqual(lReturnValue.output, consolidatedRxJs);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, consolidatedRxJs);
+    equal(lReturnValue.exitCode, 0);
   });
 });
 

--- a/test/report/dot/module-level/index.spec.mjs
+++ b/test/report/dot/module-level/index.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -72,82 +72,73 @@ const focusMeModulesFixture = readFileSync(
 
 describe("[I] report/dot/module-level reporter", () => {
   it("renders a dot - modules in the root don't come in a cluster", () => {
-    strictEqual(
-      render(clusterLess, { theme: bareTheme }).output,
-      clusterLessFixture,
-    );
+    equal(render(clusterLess, { theme: bareTheme }).output, clusterLessFixture);
   });
 
   it("renders a dot - unresolvable in a sub folder (either existing or not) get labeled as unresolvable", () => {
-    strictEqual(
+    equal(
       render(unresolvableDeps, { theme: bareTheme }).output,
       unresolvableFixture,
     );
   });
 
   it("renders a dot - bare theme matchesDoNotFollow NOT rendered as folders", () => {
-    strictEqual(
+    equal(
       render(doNotFollowDeps, { theme: bareTheme }).output,
       doNotFollowFixture,
     );
   });
 
   it("renders a dot - default color theme matchesDoNotFollow rendered as folders", () => {
-    strictEqual(render(doNotFollowDeps).output, doNotFollowFixtureDefaultTheme);
+    equal(render(doNotFollowDeps).output, doNotFollowFixtureDefaultTheme);
   });
 
   it("renders a dot - bare theme renders modules with module level transgression with NO severity deduced colors", () => {
-    strictEqual(
-      render(orphanDeps, { theme: bareTheme }).output,
-      orphanFixtureBoring,
-    );
+    equal(render(orphanDeps, { theme: bareTheme }).output, orphanFixtureBoring);
   });
 
   it("renders a dot - default theme renders modules with module level transgression with severity deduced colors", () => {
-    strictEqual(render(orphanDeps).output, orphanFixture);
+    equal(render(orphanDeps).output, orphanFixture);
   });
 
   it("renders a dot - uri prefix get concatenated", () => {
-    strictEqual(
-      render(prefixUri, { theme: bareTheme }).output,
-      prefixUriFixture,
-    );
+    equal(render(prefixUri, { theme: bareTheme }).output, prefixUriFixture);
   });
 
   it("renders a dot - non-uri prefixes get path.posix.joined", () => {
-    strictEqual(
+    equal(
       render(prefixNonUri, { theme: bareTheme }).output,
       prefixNonUriFixture,
     );
   });
 
   it("richly colors modules when passed the default theme", () => {
-    strictEqual(
+    equal(
       render(bunchOfModules, { theme: defaultTheme }).output,
       defaultColorFixture,
     );
   });
 
   it("richly colors modules when passed no theme", () => {
-    strictEqual(render(bunchOfModules).output, defaultColorFixture);
+    equal(render(bunchOfModules).output, defaultColorFixture);
   });
 
   it("colors boringly when passed a bare theme", () => {
-    strictEqual(
+    equal(
       render(bunchOfModules, { theme: bareTheme }).output,
       bareColorFixture,
     );
   });
 
   it("Also renders on module level when the reporter granularity isn't specified", () => {
-    strictEqual(
+    equal(
       defaultRender(bunchOfModules, { theme: bareTheme }).output,
       bareColorFixture,
     );
   });
 
   it("applies filter when passed", () => {
-    strictEqual(
+    equal(
       render(focusMeModules, { theme: bareTheme }).output,
       focusMeModulesFixture,
     );

--- a/test/report/dot/module-utl.spec.mjs
+++ b/test/report/dot/module-utl.spec.mjs
@@ -1,15 +1,15 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import moduleUtl from "../../../src/report/dot/module-utl.mjs";
 
 describe("[U] report/dot/module-utl", () => {
   it("extractFirstTransgression - keeps as is when there's no transgressions", () => {
-    deepStrictEqual(moduleUtl.extractFirstTransgression({ dependencies: [] }), {
+    deepEqual(moduleUtl.extractFirstTransgression({ dependencies: [] }), {
       dependencies: [],
     });
   });
 
   it("extractFirstTransgression - adds the first module rule if there's at least one", () => {
-    deepStrictEqual(
+    deepEqual(
       moduleUtl.extractFirstTransgression({
         dependencies: [],
         rules: [
@@ -29,7 +29,7 @@ describe("[U] report/dot/module-utl", () => {
   });
 
   it("extractFirstTransgression - adds the first dependency rule if there's at least one", () => {
-    deepStrictEqual(
+    deepEqual(
       moduleUtl.extractFirstTransgression({
         dependencies: [
           {
@@ -55,7 +55,7 @@ describe("[U] report/dot/module-utl", () => {
   });
 
   it("flatLabel - returns the value of source as label", () => {
-    deepStrictEqual(
+    deepEqual(
       moduleUtl.flatLabel(true)({ source: "aap/noot/mies/wim/zus.jet" }),
       {
         source: "aap/noot/mies/wim/zus.jet",
@@ -66,7 +66,7 @@ describe("[U] report/dot/module-utl", () => {
   });
 
   it("flatLabel - returns the value of source & instability metric as label when instability is known", () => {
-    deepStrictEqual(
+    deepEqual(
       moduleUtl.flatLabel(true)({
         source: "aap/noot/mies/wim/zus.jet",
         instability: "0.481",
@@ -81,7 +81,7 @@ describe("[U] report/dot/module-utl", () => {
   });
 
   it("flatLabel - returns the value of source when instability is known, but showMetrics is false", () => {
-    deepStrictEqual(
+    deepEqual(
       moduleUtl.flatLabel(false)({
         source: "aap/noot/mies/wim/zus.jet",
         instability: "0.481",

--- a/test/report/dot/theming.spec.mjs
+++ b/test/report/dot/theming.spec.mjs
@@ -1,17 +1,17 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import _cloneDeep from "lodash/cloneDeep.js";
 import theming from "../../../src/report/dot/theming.mjs";
 
 describe("[U] report/dot/theming - determineModuleColors - default theme", () => {
   it("empty module => no colors", () => {
-    deepStrictEqual(
+    deepEqual(
       theming.determineAttributes({}, theming.normalizeTheme({}).module),
       {},
     );
   });
 
   it("core module => grey", () => {
-    deepStrictEqual(
+    deepEqual(
       theming.determineAttributes(
         { coreModule: true },
         theming.normalizeTheme({}).modules,
@@ -21,7 +21,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
   });
 
   it("couldNotResolve => red", () => {
-    deepStrictEqual(
+    deepEqual(
       theming.determineAttributes(
         { couldNotResolve: true },
         theming.normalizeTheme({}).modules,
@@ -31,7 +31,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
   });
 
   it("json => darker yellowish fillcolor", () => {
-    deepStrictEqual(
+    deepEqual(
       theming.determineAttributes(
         { source: "package.json" },
         theming.normalizeTheme({}).modules,
@@ -44,6 +44,6 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
     const lOriginalDefaultTheme = _cloneDeep(theming.normalizeTheme());
 
     theming.normalizeTheme({ graph: { someAttribute: 1234 } });
-    deepStrictEqual(theming.normalizeTheme(), lOriginalDefaultTheme);
+    deepEqual(theming.normalizeTheme(), lOriginalDefaultTheme);
   });
 });

--- a/test/report/error-html/error-html.spec.mjs
+++ b/test/report/error-html/error-html.spec.mjs
@@ -1,4 +1,4 @@
-import { match, strictEqual, doesNotMatch } from "node:assert";
+import { match, equal, doesNotMatch } from "node:assert/strict";
 import errorHTML from "../../../src/report/error-html/index.mjs";
 import everythingFineResult from "./__mocks__/everything-fine.mjs";
 import validationMoreThanOnce from "./__mocks__/violation-more-than-once.mjs";
@@ -14,7 +14,7 @@ describe("[I] report/error-html", () => {
 
     match(lResult.output, new RegExp(lOkeliDokelyKey));
     match(lResult.output, new RegExp(lOkeliDokelyHeader));
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report with errors", () => {
@@ -34,7 +34,7 @@ describe("[I] report/error-html", () => {
       lResult.output,
       /<a href="https:\/\/github.com\/sverweij\/dependency-cruiser\/blob\/develop\/src\/cli\/compileConfig\/index.js">/,
     );
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report with violations and ignored violations", () => {
@@ -57,7 +57,7 @@ describe("[I] report/error-html", () => {
       lResult.output,
       /<a href="https:\/\/github.com\/sverweij\/dependency-cruiser\/blob\/develop\/src\/cli\/compileConfig\/index.js">/,
     );
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report nicely on orphans, cycles and metric rules", () => {

--- a/test/report/error-html/utl.spec.mjs
+++ b/test/report/error-html/utl.spec.mjs
@@ -1,23 +1,23 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import utl from "../../../src/report/error-html/utl.mjs";
 
 function summaryHasMinimalAttributes(pResult) {
-  strictEqual(pResult.hasOwnProperty("depcruiseVersion"), true);
-  strictEqual(pResult.hasOwnProperty("runDate"), true);
-  strictEqual(pResult.hasOwnProperty("violations"), true);
+  equal(pResult.hasOwnProperty("depcruiseVersion"), true);
+  equal(pResult.hasOwnProperty("runDate"), true);
+  equal(pResult.hasOwnProperty("violations"), true);
 }
 
 describe("[U] report/error-html/utl", () => {
   it("getFormattedAllowedRule - no allowed rule available returns empty array", () => {
-    deepStrictEqual(utl.getFormattedAllowedRule({}), []);
+    deepEqual(utl.getFormattedAllowedRule({}), []);
   });
 
   it("getFormattedAllowedRule - empty allowed array returns empty array", () => {
-    deepStrictEqual(utl.getFormattedAllowedRule({ allowed: [] }), []);
+    deepEqual(utl.getFormattedAllowedRule({ allowed: [] }), []);
   });
 
   it("getFormattedAllowedRule - one rule with no comment, no severity returns default comment & severity", () => {
-    deepStrictEqual(
+    deepEqual(
       utl.getFormattedAllowedRule({
         allowed: [{ from: {}, to: {} }],
       }),
@@ -30,7 +30,7 @@ describe("[U] report/error-html/utl", () => {
   });
 
   it("getFormattedAllowedRule - a rule with a comment, no severity returns that comment & default severity", () => {
-    deepStrictEqual(
+    deepEqual(
       utl.getFormattedAllowedRule({
         allowed: [
           {
@@ -61,7 +61,7 @@ describe("[U] report/error-html/utl", () => {
   });
 
   it("getFormattedAllowedRule - a rule with a severity, no comment returns a default comment & that severity", () => {
-    deepStrictEqual(
+    deepEqual(
       utl.getFormattedAllowedRule({
         allowed: [
           {
@@ -84,7 +84,7 @@ describe("[U] report/error-html/utl", () => {
   });
 
   it("mergeCountIntoRule - no violation", () => {
-    deepStrictEqual(utl.mergeCountsIntoRule({ name: "blah" }, {}), {
+    deepEqual(utl.mergeCountsIntoRule({ name: "blah" }, {}), {
       name: "blah",
       count: 0,
       ignoredCount: 0,
@@ -93,7 +93,7 @@ describe("[U] report/error-html/utl", () => {
   });
 
   it("mergeCountIntoRule - some violations", () => {
-    deepStrictEqual(
+    deepEqual(
       utl.mergeCountsIntoRule(
         { name: "blah" },
         { blah: { count: 69, ignoredCount: 0 } },
@@ -111,7 +111,7 @@ describe("[U] report/error-html/utl", () => {
     const lResult = utl.formatSummaryForReport({});
 
     summaryHasMinimalAttributes(lResult);
-    deepStrictEqual(lResult.violations, []);
+    deepEqual(lResult.violations, []);
   });
 
   it("formatSummaryForReport - one module violation", () => {
@@ -126,7 +126,7 @@ describe("[U] report/error-html/utl", () => {
     });
 
     summaryHasMinimalAttributes(lResult);
-    deepStrictEqual(lResult.violations, [
+    deepEqual(lResult.violations, [
       {
         type: "dependency",
         from: "aap",
@@ -148,7 +148,7 @@ describe("[U] report/error-html/utl", () => {
     });
 
     summaryHasMinimalAttributes(lResult);
-    deepStrictEqual(lResult.violations, [
+    deepEqual(lResult.violations, [
       {
         type: "module",
         from: "aap",
@@ -169,7 +169,7 @@ describe("[U] report/error-html/utl", () => {
     const lExpectation =
       "thing/a &rightarrow;<br/>b &rightarrow;<br/>thingy/bingy/c &rightarrow;<br/>a";
 
-    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
+    deepEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - via violation", () => {
@@ -183,7 +183,7 @@ describe("[U] report/error-html/utl", () => {
     const lExpectation =
       "thing/a<br/>thing/a &rightarrow;<br/>b &rightarrow;<br/>thingy/bingy/c &rightarrow;<br/>a";
 
-    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
+    deepEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - dependency violation", () => {
@@ -195,7 +195,7 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = "thing/a";
 
-    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
+    deepEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - module violation", () => {
@@ -207,7 +207,7 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = "";
 
-    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
+    deepEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineTo - instability violation", () => {
@@ -220,7 +220,7 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = 'b&nbsp;<span class="extra">(I: 100%)</span>';
 
-    deepStrictEqual(utl.determineTo(lInputViolation), lExpectation);
+    deepEqual(utl.determineTo(lInputViolation), lExpectation);
   });
 
   it("determineFromExtras - instability violation", () => {
@@ -233,6 +233,6 @@ describe("[U] report/error-html/utl", () => {
 
     const lExpectation = '&nbsp;<span class="extra">(I: 10%)</span>';
 
-    deepStrictEqual(utl.determineFromExtras(lInputViolation), lExpectation);
+    deepEqual(utl.determineFromExtras(lInputViolation), lExpectation);
   });
 });

--- a/test/report/error/error-long.spec.mjs
+++ b/test/report/error/error-long.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-non-literal-regexp */
 /* eslint-disable no-magic-numbers */
-import { strictEqual, match } from "node:assert";
+import { equal, match } from "node:assert/strict";
 import { EOL } from "node:os";
 import chalk from "chalk";
 import render from "../../../src/report/error-long.mjs";
@@ -23,7 +23,7 @@ describe("[I] report/error-long", () => {
     const lResult = render(okDeps);
 
     match(lResult.output, /no dependency violations found/);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("renders a bunch of errors", () => {
     const lResult = render(deps);
@@ -34,13 +34,13 @@ describe("[I] report/error-long", () => {
       /2 dependency violations \(2 errors, 0 warnings\)\. 33 modules, 333 dependencies cruised\./,
     );
     match(lResult.output, / {4}comment to no-leesplank/);
-    strictEqual(lResult.exitCode, 2);
+    equal(lResult.exitCode, 2);
   });
   it("renders a bunch of warnings", () => {
     const lResult = render(warnDeps);
 
     match(lResult.output, /1 dependency violations \(0 errors, 1 warnings\)/);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("renders module only violations as module only", () => {
     const lResult = render(orphanErrs);
@@ -50,7 +50,7 @@ describe("[I] report/error-long", () => {
       lResult.output,
       /1 dependency violations \(1 errors, 0 warnings\)\. 1 modules, 0 dependencies cruised\./,
     );
-    strictEqual(lResult.exitCode, 1);
+    equal(lResult.exitCode, 1);
   });
   it("renders a '-' for comment if it couldn't find the rule", () => {
     const lResult = render(errorsAdditionalInfo);

--- a/test/report/error/error.spec.mjs
+++ b/test/report/error/error.spec.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-non-literal-regexp */
 /* eslint-disable no-magic-numbers */
-import { doesNotMatch, match, strictEqual } from "node:assert";
+import { doesNotMatch, match, equal } from "node:assert/strict";
 import { EOL } from "node:os";
 import chalk from "chalk";
 import render from "../../../src/report/error.mjs";
@@ -29,7 +29,7 @@ describe("[I] report/error", () => {
     const lResult = render(okdeps);
 
     match(lResult.output, /no dependency violations found/);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("renders a bunch of errors", () => {
     const lResult = render(dependencies);
@@ -40,13 +40,13 @@ describe("[I] report/error", () => {
       /2 dependency violations \(2 errors, 0 warnings\)\. 33 modules, 333 dependencies cruised\./,
     );
     doesNotMatch(lResult.output, / {4}comment to no-leesplank/);
-    strictEqual(lResult.exitCode, 2);
+    equal(lResult.exitCode, 2);
   });
   it("renders a bunch of warnings", () => {
     const lResult = render(onlyWarningDependencies);
 
     match(lResult.output, /1 dependency violations \(0 errors, 1 warnings\)/);
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
   it("renders module only violations as module only", () => {
     const lResult = render(orphanErrs);
@@ -56,7 +56,7 @@ describe("[I] report/error", () => {
       lResult.output,
       /1 dependency violations \(1 errors, 0 warnings\). 1 modules, 0 dependencies cruised\./,
     );
-    strictEqual(lResult.exitCode, 1);
+    equal(lResult.exitCode, 1);
   });
   it("renders circular violations as circulars", () => {
     const lResult = render(circularErrs);
@@ -77,7 +77,7 @@ describe("[I] report/error", () => {
         `      src/some/folder/loop-a.js →\n      src/some/folder/loop-b.js →\n      src/some/folder/nested/center.js`,
       ),
     );
-    strictEqual(lResult.exitCode, 3);
+    equal(lResult.exitCode, 3);
   });
   it("renders via violations as vias", () => {
     const lResult = render(viaErrs);
@@ -95,7 +95,7 @@ describe("[I] report/error", () => {
       ),
     );
     match(lResult.output, / {6}\(via via\)/);
-    strictEqual(lResult.exitCode, 4);
+    equal(lResult.exitCode, 4);
   });
   it("renders moreUnstable violations with the module & dependents violations", () => {
     const lResult = render(sdpErrors);

--- a/test/report/html/html.spec.mjs
+++ b/test/report/html/html.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepEqual, equal } from "node:assert/strict";
 import render from "../../../src/report/html/index.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
 
@@ -15,7 +15,7 @@ describe("[I] report/html reporter", () => {
   it("renders html - modules in the root don't come in a cluster; and one module could not be resolved", () => {
     const lReturnValue = render(deps);
 
-    deepStrictEqual(lReturnValue.output, elementFixture);
-    strictEqual(lReturnValue.exitCode, 0);
+    deepEqual(lReturnValue.output, elementFixture);
+    equal(lReturnValue.exitCode, 0);
   });
 });

--- a/test/report/markdown/markdown.spec.mjs
+++ b/test/report/markdown/markdown.spec.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-regex-literals */
-import { match, doesNotMatch, strictEqual } from "node:assert";
+import { match, doesNotMatch, equal } from "node:assert/strict";
 import markdown from "../../../src/report/markdown.mjs";
 import everythingFineResult from "./__mocks__/everything-fine.mjs";
 import validationMoreThanOnce from "./__mocks__/violation-more-than-once.mjs";
@@ -19,7 +19,7 @@ describe("[I] report/markdown", () => {
     match(lResult.output, new RegExp(lDefaultSummaryHeader));
     match(lResult.output, new RegExp(lOkeliDokelyKey));
     match(lResult.output, new RegExp(lOkeliDokelyHeader));
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("happy day no errors - custom options", () => {
@@ -34,7 +34,7 @@ describe("[I] report/markdown", () => {
     match(lResult.output, new RegExp(lCustomSummaryHeader));
     match(lResult.output, new RegExp(lOkeliDokelyKey));
     match(lResult.output, new RegExp(lOkeliDokelyHeader));
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report with errors", () => {
@@ -50,7 +50,7 @@ describe("[I] report/markdown", () => {
     match(lResult.output, /\*\*1\*\* warnings/);
     match(lResult.output, /\*\*2\*\* informational/);
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report with errors - custom options", () => {
@@ -68,7 +68,7 @@ describe("[I] report/markdown", () => {
     match(lResult.output, /\*\*1\*\* warnings/);
     match(lResult.output, /\*\*2\*\* informational/);
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report with violations and ignored violations", () => {
@@ -90,7 +90,7 @@ describe("[I] report/markdown", () => {
     match(lResult.output, /:see_no_evil:&nbsp;_cli-to-main-only-warn_/);
     match(lResult.output, /src\/cli\/compileConfig\/index\.js/);
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report with violations and ignored violations hidden", () => {
@@ -118,7 +118,7 @@ describe("[I] report/markdown", () => {
     );
     doesNotMatch(lResult.output, new RegExp("src/cli/compileConfig/index.js"));
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("report nicely on orphans, cycles and metric rules", () => {

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 // eslint-plugins import and node don't yet understand these 'self references'
 // eslint-disable-next-line import/no-unresolved, node/no-missing-import
 import mermaidReporterPlugin from "dependency-cruiser/mermaid-reporter-plugin";
@@ -22,7 +22,7 @@ const same = (pName, pOptions, pMermaidModule = mermaid) => {
     "utf8",
   );
   const output = pMermaidModule(definition, pOptions).output;
-  deepStrictEqual(output, expected);
+  deepEqual(output, expected);
 };
 
 describe("[I] report/mermaid", () => {

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable security/detect-non-literal-regexp */
 /* eslint-disable no-regex-spaces */
 import { EOL } from "node:os";
-import { doesNotMatch, match, strictEqual } from "node:assert";
+import { doesNotMatch, match, equal } from "node:assert/strict";
 import metrics from "../../../src/report/metrics.mjs";
 import cruiseResultWithMetricsForModulesAndFolders from "./__mocks/cruise-result-with-metrics-for-modules-and-folders.mjs";
 
@@ -9,7 +9,7 @@ describe("[I] report/metrics", () => {
   it("errors when the input doesn't contain a 'folders' section", () => {
     const lResult = metrics({ modules: [] });
 
-    strictEqual(lResult.exitCode, 1);
+    equal(lResult.exitCode, 1);
     match(lResult.output, /ERROR/);
   });
 
@@ -27,7 +27,7 @@ describe("[I] report/metrics", () => {
       ],
     });
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
     match(lResult.output, /src       1      1      1    50%/);
   });
 
@@ -48,7 +48,7 @@ describe("[I] report/metrics", () => {
       { hideFolders: true },
     );
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
     doesNotMatch(lResult.output, /src       1      1      1    50%/);
   });
 
@@ -77,7 +77,7 @@ describe("[I] report/metrics", () => {
       folders: [],
     });
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
     match(
       lResult.output,
       new RegExp(
@@ -114,7 +114,7 @@ describe("[I] report/metrics", () => {
       { orderBy: "name" },
     );
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
     match(
       lResult.output,
       new RegExp(
@@ -151,7 +151,7 @@ describe("[I] report/metrics", () => {
       { hideModules: true },
     );
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
     doesNotMatch(
       lResult.output,
       new RegExp(
@@ -165,7 +165,7 @@ describe("[I] report/metrics", () => {
       hideModules: true,
     });
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
     match(lResult.output, /src\/report/);
     doesNotMatch(lResult.output, /node_modules/);
   });

--- a/test/report/null/null.spec.mjs
+++ b/test/report/null/null.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import nullReporter from "../../../src/report/null.mjs";
 
 const gSmallOKResult = {
@@ -72,14 +72,14 @@ const gSmallNOKResult = {
 describe("[I] report/null", () => {
   it("happy day no errors", () => {
     const lResult = nullReporter(gSmallOKResult);
-    deepStrictEqual(lResult, {
+    deepEqual(lResult, {
       output: "",
       exitCode: 0,
     });
   });
   it("happy day some errors", () => {
     const lResult = nullReporter(gSmallNOKResult);
-    deepStrictEqual(lResult, {
+    deepEqual(lResult, {
       output: "",
       exitCode: 3,
     });

--- a/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
+++ b/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
@@ -1,4 +1,4 @@
-import { match, strictEqual } from "node:assert";
+import { match, equal } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getExternalPluginReporter } from "../../../src/report/plugins.mjs";
@@ -19,7 +19,7 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    strictEqual(
+    equal(
       lErrorMessage.includes(`${lNoExitCodePlugin} is not a valid plugin`),
       true,
     );
@@ -37,7 +37,7 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
     } catch (pError) {
       lErrorMessage = pError.message;
     }
-    strictEqual(
+    equal(
       lErrorMessage.includes(`${lNoOutputPlugin} is not a valid plugin`),
       true,
     );
@@ -58,11 +58,8 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
   });
 
   it("returns false when it's not a plugin", async () => {
-    strictEqual(
-      await getExternalPluginReporter(`whatever-just-not-a-plugin`),
-      false,
-    );
-    strictEqual(getExternalPluginReporter(), false);
+    equal(await getExternalPluginReporter(`whatever-just-not-a-plugin`), false);
+    equal(getExternalPluginReporter(), false);
   });
 
   it("throws when the plugin:reporter is not a valid plugin (package ref)", async () => {
@@ -85,8 +82,8 @@ describe("[I] report/plugins - getExternalPluginReporter", () => {
       summary: { totalCruised: 0 },
     });
 
-    strictEqual(hasOwnProperty.call(lResults, "output"), true);
-    strictEqual(hasOwnProperty.call(lResults, "exitCode"), true);
-    strictEqual(lResults.exitCode, 0);
+    equal(hasOwnProperty.call(lResults, "output"), true);
+    equal(hasOwnProperty.call(lResults, "exitCode"), true);
+    equal(lResults.exitCode, 0);
   });
 });

--- a/test/report/plugins/index.is-valid-plugin.spec.mjs
+++ b/test/report/plugins/index.is-valid-plugin.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { isValidPlugin } from "../../../src/report/plugins.mjs";
 
 describe("[U] report/plugins - isValidPlugin", () => {
@@ -6,32 +6,32 @@ describe("[U] report/plugins - isValidPlugin", () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-no-exit-code-plugin.cjs"
     );
-    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
+    equal(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns false when the plugin's function doesn't return an output attribute", async () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-no-output-plugin.cjs"
     );
-    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
+    equal(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns false when the plugin's function doesn't return an exit code that is not a number", async () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-non-number-exit-code-plugin.cjs"
     );
-    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
+    equal(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns false when the plugin doesn't return a function", async () => {
     const lCandidatePlugin = await import(
       "./__fixtures__/invalid-not-a-function-plugin.cjs"
     );
-    strictEqual(isValidPlugin(lCandidatePlugin.default), false);
+    equal(isValidPlugin(lCandidatePlugin.default), false);
   });
 
   it("returns true when the plugin doesn't returns a function that takes a minimal cruise result and returns an output attribute + an numerical exitCode attribute", async () => {
     const lCandidatePlugin = await import("./__fixtures__/valid-plugin.cjs");
-    strictEqual(isValidPlugin(lCandidatePlugin.default), true);
+    equal(isValidPlugin(lCandidatePlugin.default), true);
   });
 });

--- a/test/report/teamcity/teamcity.spec.mjs
+++ b/test/report/teamcity/teamcity.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import render from "../../../src/report/teamcity.mjs";
@@ -28,27 +28,27 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(okdeps);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("renders module only transgressions", () => {
     const lFixture = readFixture("__mocks__/module-errors-teamcity-format.txt");
     const lResult = render(moduleErrs);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 5);
+    equal(lResult.exitCode, 5);
   });
 
   it("renders 'required' violations", () => {
@@ -57,48 +57,48 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(requiredErrs);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 5);
+    equal(lResult.exitCode, 5);
   });
 
   it("renders circular transgressions", () => {
     const lFixture = readFixture("__mocks__/circular-deps-teamcity-format.txt");
     const lResult = render(circulars);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 3);
+    equal(lResult.exitCode, 3);
   });
 
   it("renders via transgressions", () => {
     const lFixture = readFixture("__mocks__/via-deps-teamcity-format.txt");
     const lResult = render(vias);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 4);
+    equal(lResult.exitCode, 4);
   });
 
   it("renders instability transgressions", () => {
     const lFixture = readFixture("__mocks__/instabilities-teamcity-format.txt");
     const lResult = render(instabilities);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
 
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 
   it("renders unsupported error levels (like 'ignore') as 'info'", () => {
@@ -107,12 +107,12 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(unsupportedErrorLevels);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
     // eslint-disable-next-line no-magic-numbers
-    strictEqual(lResult.exitCode, 5);
+    equal(lResult.exitCode, 5);
   });
 
   it("renders known errors in a single warning", () => {
@@ -121,10 +121,10 @@ describe("[I] report/teamcity", () => {
     );
     const lResult = render(knownViolations);
 
-    strictEqual(
+    equal(
       removePerSessionAttributes(lResult.output),
       removePerSessionAttributes(lFixture),
     );
-    strictEqual(lResult.exitCode, 0);
+    equal(lResult.exitCode, 0);
   });
 });

--- a/test/report/text/text.spec.mjs
+++ b/test/report/text/text.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import chalk from "chalk";
 import normalizeNewline from "normalize-newline";
 import renderText from "../../../src/report/text.mjs";
@@ -29,8 +29,8 @@ describe("[I] report/text", () => {
       ),
     );
 
-    strictEqual(normalizeNewline(lResult.output), lExpectedOutput);
-    strictEqual(lResult.exitCode, 0);
+    equal(normalizeNewline(lResult.output), lExpectedOutput);
+    equal(lResult.exitCode, 0);
   });
 
   it("renders dependencies - focused modules highlighted when highlightFocused === true", () => {
@@ -46,7 +46,7 @@ describe("[I] report/text", () => {
       "test/enrich/derive/reachable/index.spec.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n" +
       "test/main/rule-set/normalize.spec.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n" +
       "test/validate/parse-ruleset.utl.mjs → \u001B[4msrc/main/rule-set/normalize.js\u001B[24m\n";
-    strictEqual(normalizeNewline(lResult.output), lExpectedOutput);
+    equal(normalizeNewline(lResult.output), lExpectedOutput);
   });
 
   it("renders dependencies - no highlights when highlightFocused === false", () => {
@@ -62,6 +62,6 @@ describe("[I] report/text", () => {
       "test/enrich/derive/reachable/index.spec.mjs → src/main/rule-set/normalize.js\n" +
       "test/main/rule-set/normalize.spec.mjs → src/main/rule-set/normalize.js\n" +
       "test/validate/parse-ruleset.utl.mjs → src/main/rule-set/normalize.js\n";
-    strictEqual(normalizeNewline(lResult.output), lExpectedOutput);
+    equal(normalizeNewline(lResult.output), lExpectedOutput);
   });
 });

--- a/test/report/utl/dependency-to-incidence-transformer.spec.mjs
+++ b/test/report/utl/dependency-to-incidence-transformer.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import transform from "../../../src/report/utl/dependency-to-incidence-transformer.mjs";
 
 import oneViolation from "./__mocks__/one-violation.mjs";
@@ -11,18 +11,15 @@ const MORE_VIOLATIONS_DEPS_INPUT = moreViolations.modules;
 
 describe("[U] dependencyToIncidenceTransformer", () => {
   it("leaves an empty dependencies list alone", () => {
-    deepStrictEqual(transform([]), []);
+    deepEqual(transform([]), []);
   });
 
   it("reports single rule violations at the incidence", () => {
-    deepStrictEqual(
-      transform(ONE_VIOLATION_DEPS_INPUT),
-      ONE_VIOLATION_DEPS_FIXTURE,
-    );
+    deepEqual(transform(ONE_VIOLATION_DEPS_INPUT), ONE_VIOLATION_DEPS_FIXTURE);
   });
 
   it("reports multiple rule violations per dependency at the incidence with a hint there's more", () => {
-    deepStrictEqual(
+    deepEqual(
       transform(MORE_VIOLATIONS_DEPS_INPUT),
       MORE_VIOLATIONS_DEPS_FIXTURE,
     );

--- a/test/utl/get-extension.spec.mjs
+++ b/test/utl/get-extension.spec.mjs
@@ -1,32 +1,32 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import getExtension from "../../src/utl/get-extension.mjs";
 
 describe("[U] utl/getExtension", () => {
   it(".coffee.md classifies as .coffee.md", () => {
-    strictEqual(getExtension("./aap/noot/mies.coffee.md"), ".coffee.md");
+    equal(getExtension("./aap/noot/mies.coffee.md"), ".coffee.md");
   });
 
   it(".tea.md classifies as .md", () => {
-    strictEqual(getExtension("./aap/noot/mies.tes.md"), ".md");
+    equal(getExtension("./aap/noot/mies.tes.md"), ".md");
   });
 
   it("types.d.ts classifies as .d.ts", () => {
-    strictEqual(getExtension("./types/types.d.ts"), ".d.ts");
+    equal(getExtension("./types/types.d.ts"), ".d.ts");
   });
 
   it("types.d.mts classifies as .d.mts", () => {
-    strictEqual(getExtension("./types/types.d.mts"), ".d.mts");
+    equal(getExtension("./types/types.d.mts"), ".d.mts");
   });
 
   it("any extension (e.g. .ts) classifies as that", () => {
-    strictEqual(getExtension("./types/typed.ts"), ".ts");
+    equal(getExtension("./types/typed.ts"), ".ts");
   });
 
   it("any extension (e.g. .js) classifies as that", () => {
-    strictEqual(getExtension("./aap/noot/mies.js"), ".js");
+    equal(getExtension("./aap/noot/mies.js"), ".js");
   });
 
   it("no extension classifies as nothing", () => {
-    strictEqual(getExtension("./aap/noot/mies"), "");
+    equal(getExtension("./aap/noot/mies"), "");
   });
 });

--- a/test/utl/path-to-posix.spec.mjs
+++ b/test/utl/path-to-posix.spec.mjs
@@ -1,51 +1,45 @@
 import { win32, posix } from "node:path";
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import pathToPosix from "../../src/utl/path-to-posix.mjs";
 
 describe("[U] utl/pathToPosix on win32", () => {
   it('transforms win32 style paths to posix ones: ""', () => {
-    strictEqual(pathToPosix("", win32), "");
+    equal(pathToPosix("", win32), "");
   });
 
   it("transforms win32 style paths to posix ones: \\root\\sub\\file.txt", () => {
-    strictEqual(
-      pathToPosix("\\root\\sub\\file.txt", win32),
-      "/root/sub/file.txt",
-    );
+    equal(pathToPosix("\\root\\sub\\file.txt", win32), "/root/sub/file.txt");
   });
 
   it("leaves win32 style paths alone: C:\\root\\sub\\file.txt", () => {
-    strictEqual(
+    equal(
       pathToPosix("C:\\root\\sub\\file.txt", win32),
       "C:/root/sub/file.txt",
     );
   });
 
   it("keep posix style paths alone: /root/sub/file.txt", () => {
-    strictEqual(pathToPosix("/root/sub/file.txt", win32), "/root/sub/file.txt");
+    equal(pathToPosix("/root/sub/file.txt", win32), "/root/sub/file.txt");
   });
 });
 
 describe("[U] utl/pathToPosix  on posix", () => {
   it('leaves win32 style paths alone: ""', () => {
-    strictEqual(pathToPosix("", posix), "");
+    equal(pathToPosix("", posix), "");
   });
 
   it("leaves win32 style paths alone: \\root\\sub\\file.txt", () => {
-    strictEqual(
-      pathToPosix("\\root\\sub\\file.txt", posix),
-      "\\root\\sub\\file.txt",
-    );
+    equal(pathToPosix("\\root\\sub\\file.txt", posix), "\\root\\sub\\file.txt");
   });
 
   it("leaves win32 style paths alone: C:\\root\\sub\\file.txt", () => {
-    strictEqual(
+    equal(
       pathToPosix("C:\\root\\sub\\file.txt", posix),
       "C:\\root\\sub\\file.txt",
     );
   });
 
   it("keeps posix style paths as-is: /root/sub/file.txt", () => {
-    strictEqual(pathToPosix("/root/sub/file.txt", posix), "/root/sub/file.txt");
+    equal(pathToPosix("/root/sub/file.txt", posix), "/root/sub/file.txt");
   });
 });

--- a/test/utl/regex-util.spec.mjs
+++ b/test/utl/regex-util.spec.mjs
@@ -1,34 +1,31 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import { replaceGroupPlaceholders } from "../../src/utl/regex-util.mjs";
 
 describe("[U] utl/regex-util", () => {
   it("replaceGroupPlaceholders - leaves re alone if passed empty match result", () => {
-    strictEqual(replaceGroupPlaceholders("$1/aap|noot", []), "$1/aap|noot");
+    equal(replaceGroupPlaceholders("$1/aap|noot", []), "$1/aap|noot");
   });
 
   it("replaceGroupPlaceholders - leaves re alone if passed groupless match result", () => {
-    strictEqual(
-      replaceGroupPlaceholders("$1/aap|noot", ["houwoei"]),
-      "$1/aap|noot",
-    );
+    equal(replaceGroupPlaceholders("$1/aap|noot", ["houwoei"]), "$1/aap|noot");
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupless match result and a $0", () => {
-    strictEqual(
+    equal(
       replaceGroupPlaceholders("$0/aap|noot", ["houwoei"]),
       "houwoei/aap|noot",
     );
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupy match result and a $1", () => {
-    strictEqual(
+    equal(
       replaceGroupPlaceholders("$1/aap|noot", ["whole/result/part", "part"]),
       "part/aap|noot",
     );
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupy match result and multiple $1", () => {
-    strictEqual(
+    equal(
       replaceGroupPlaceholders("$1|$1/[^/]+/|noot", [
         "whole/result/part",
         "part",
@@ -38,7 +35,7 @@ describe("[U] utl/regex-util", () => {
   });
 
   it("replaceGroupPlaceholders - replaces if passed groupy match result and multiple groups", () => {
-    strictEqual(
+    equal(
       replaceGroupPlaceholders("$1|$2", ["start/thing/part", "start", "part"]),
       "start|part",
     );

--- a/test/validate/index.core.spec.mjs
+++ b/test/validate/index.core.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -54,7 +54,7 @@ describe("[I] validate/index - core", () => {
   });
 
   it("not to core - ok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToCoreRuleSet,
         { source: "koos koets" },
@@ -65,7 +65,7 @@ describe("[I] validate/index - core", () => {
   });
 
   it("not to core - violation", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToCoreRuleSet,
         { source: "koos koets" },
@@ -79,7 +79,7 @@ describe("[I] validate/index - core", () => {
   });
 
   it("not to core fs os - ok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToCoreSpecificsRuleSet,
         { source: "koos koets" },
@@ -90,7 +90,7 @@ describe("[I] validate/index - core", () => {
   });
 
   it("not to core fs os - violation", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToCoreSpecificsRuleSet,
         { source: "koos koets" },
@@ -115,7 +115,7 @@ describe("[I] validate/index - core", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "koos koets" },
@@ -139,7 +139,7 @@ describe("[I] validate/index - core", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
 
@@ -164,7 +164,7 @@ describe("[I] validate/index - core", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "koos koets" },
@@ -194,7 +194,7 @@ describe("[I] validate/index - core", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "koos koets" },
@@ -208,7 +208,7 @@ describe("[I] validate/index - core", () => {
   });
 
   it("only to core - via 'forbidden' - ok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lOnlyToCoreViaForbiddenRuleSet,
         { source: "koos koets" },
@@ -219,7 +219,7 @@ describe("[I] validate/index - core", () => {
   });
 
   it("only to core - via 'forbidden' - violation", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lOnlyToCoreViaForbiddenRuleSet,
         { source: "koos koets" },

--- a/test/validate/index.could-not-resolve.spec.mjs
+++ b/test/validate/index.could-not-resolve.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -17,7 +17,7 @@ describe("[I] validate/index - couldNotResolve", () => {
   });
 
   it("not to unresolvable - ok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToUnresolvableRuleSet,
         { source: "koos koets" },
@@ -28,7 +28,7 @@ describe("[I] validate/index - couldNotResolve", () => {
   });
 
   it("not to unresolvable - violation", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToUnresolvableRuleSet,
         { source: "koos koets" },

--- a/test/validate/index.cycle-via-not.spec.mjs
+++ b/test/validate/index.cycle-via-not.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -15,7 +15,7 @@ describe("[I] validate/index dependency - cycle viaNot", () => {
     ],
   });
   it("a => ba => bb => bc => a get flagged when none of them is in a viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaNotRuleSet,
         { source: "tmp/a.js" },
@@ -33,7 +33,7 @@ describe("[I] validate/index dependency - cycle viaNot", () => {
   });
 
   it("a => aa => ab => ac => a doesn't get flagged when one of them is in a viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaNotRuleSet,
         { source: "tmp/a.js" },
@@ -62,7 +62,7 @@ describe("[I] validate/index dependency - cycle viaNot - with group matching", (
   };
 
   it("flags when all of the cycle (except the root) is outside the group-matched viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
@@ -84,7 +84,7 @@ describe("[I] validate/index dependency - cycle viaNot - with group matching", (
   });
 
   it("does not flag when only one of the cycle is outside the group-matched viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
@@ -106,7 +106,7 @@ describe("[I] validate/index dependency - cycle viaNot - with group matching", (
   });
 
   it("does not flag when all of the cycle is inside the group-matched viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },

--- a/test/validate/index.cycle-via-some-not.spec.mjs
+++ b/test/validate/index.cycle-via-some-not.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -14,7 +14,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot - with group matching
   };
 
   it("flags when all of the cycle (except the root) is outside the group-matched viaSomeNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
@@ -42,7 +42,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot - with group matching
   });
 
   it("flags when only one of the cycle is outside the group-matched viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
@@ -70,7 +70,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot - with group matching
   });
 
   it("does not flag when all of the cycle is inside the group-matched viaNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
@@ -104,7 +104,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot - with group matching
         },
       ],
     };
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lRuleSet),
         { source: "src/module-a/a.js" },

--- a/test/validate/index.cycle-via.spec.mjs
+++ b/test/validate/index.cycle-via.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -16,7 +16,7 @@ describe("[I] validate/index dependency - cycle via", () => {
   });
 
   it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -33,7 +33,7 @@ describe("[I] validate/index dependency - cycle via", () => {
   });
 
   it("a => aa => ab => ac => a get flagged when one of them is in a via", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -62,7 +62,7 @@ describe("[I] validate/index dependency - cycle via", () => {
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "tmp/a.js" },
@@ -96,7 +96,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
   });
 
   it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -113,7 +113,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
   });
 
   it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via (group match)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -130,7 +130,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
   });
 
   it("a => aa => ab => ac => a get flagged when one of them is in a via", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -159,7 +159,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "tmp/a.js" },
@@ -191,7 +191,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
   });
 
   it("a => ba => bb => bc => a doesn't get flagged when the cycle doesn't go via the viaOnly", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -208,7 +208,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
   });
 
   it("a => aa => ab => ac => does not get flagged when only some of them are not in the viaOnly", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -225,7 +225,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
   });
 
   it("a => ab a gets flagged becaue all of the via's in the cycle are in the viaOnly", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -253,7 +253,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "tmp/a.js" },
@@ -286,7 +286,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
   });
 
   it("a => ba => bb => bc => a doesn't get flagged when the cycle doesn't go via the viaOnly", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -303,7 +303,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
   });
 
   it("a => aa => ab => ac => does not get flagged when only some of them are not in the viaOnly", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -320,7 +320,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
   });
 
   it("a => ab a gets flagged becaue all of the via's in the cycle are in the viaOnly", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
@@ -348,7 +348,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "tmp/a.js" },
@@ -376,7 +376,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "tmp/a.js" },

--- a/test/validate/index.exotic-require.spec.mjs
+++ b/test/validate/index.exotic-require.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -13,7 +13,7 @@ describe("[I] validate/index - exoticallyRequired", () => {
     ],
   });
   it("does not flag dependencies that are required with a regular require or import", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticallyRequiredRuleSet,
         { source: "something" },
@@ -27,7 +27,7 @@ describe("[I] validate/index - exoticallyRequired", () => {
   });
 
   it("does flag dependencies that are required with any exotic require", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticallyRequiredRuleSet,
         { source: "something" },
@@ -56,7 +56,7 @@ describe("[I] validate/index - exoticRequire", () => {
     ],
   });
   it("does not flag dependencies that are required with a regular require or import", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticRequireRuleSet,
         { source: "something" },
@@ -67,7 +67,7 @@ describe("[I] validate/index - exoticRequire", () => {
   });
 
   it("does not flag dependencies that are required with an exotic require not in the forbdidden RE", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticRequireRuleSet,
         { source: "something" },
@@ -81,7 +81,7 @@ describe("[I] validate/index - exoticRequire", () => {
   });
 
   it("flags dependencies that are required with a forbidden exotic require", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticRequireRuleSet,
         { source: "something" },
@@ -106,7 +106,7 @@ describe("[I] validate/index - exoticRequireNot", () => {
     ],
   });
   it("does not flag dependencies that are required with a regular require or import", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticRequireNotRuleSet,
         { source: "something" },
@@ -117,7 +117,7 @@ describe("[I] validate/index - exoticRequireNot", () => {
   });
 
   it("does not flag dependencies that are required with a sanctioned exotic require", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticRequireNotRuleSet,
         { source: "something" },
@@ -131,7 +131,7 @@ describe("[I] validate/index - exoticRequireNot", () => {
   });
 
   it("flags dependencies are required with an unsanctioned exotic require", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lExoticRequireNotRuleSet,
         { source: "something" },

--- a/test/validate/index.groupmatching.spec.mjs
+++ b/test/validate/index.groupmatching.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -21,7 +21,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
   };
 
   it("group-to-pathnot - Disallows dependencies between peer folders", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -40,7 +40,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
   });
 
   it("group-to-pathnot - Allows dependencies within to peer folder 'shared'", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -51,7 +51,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
   });
 
   it("group-to-pathnot - Allows dependencies within own folder", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -62,7 +62,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
   });
 
   it("group-to-pathnot - Allows dependencies to sub folders of own folder", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -73,7 +73,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
   });
 
   it("group-to-pathnot - Allows peer dependencies between sub folders of own folder", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/rekwisieten/touw.ts" },
@@ -103,7 +103,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
   };
 
   it("group-two-to-pathnot - Disallows dependencies between peer folders", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -122,7 +122,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
   });
 
   it("group-two-to-pathnot - Allows dependencies within to peer folder 'shared'", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -133,7 +133,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
   });
 
   it("group-two-to-pathnot - Allows dependencies within own folder", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -144,7 +144,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
   });
 
   it("group-two-to-pathnot - Allows dependencies to sub folders of own folder", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
@@ -155,7 +155,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
   });
 
   it("group-two-to-pathnot - Allows peer dependencies between sub folders of own folder", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/rekwisieten/touw.ts" },

--- a/test/validate/index.license.spec.mjs
+++ b/test/validate/index.license.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -14,7 +14,7 @@ describe("[I] validate/index - license", () => {
   });
 
   it("Skips dependencies that have no license attached", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lLicenseRuleSet,
         { source: "something" },
@@ -25,7 +25,7 @@ describe("[I] validate/index - license", () => {
   });
 
   it("does not flag dependencies that do not match the license expression", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lLicenseRuleSet,
         { source: "something" },
@@ -39,7 +39,7 @@ describe("[I] validate/index - license", () => {
   });
 
   it("flags dependencies that match the license expression", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lLicenseRuleSet,
         { source: "something" },
@@ -68,7 +68,7 @@ describe("[I] validate/index - licenseNot", () => {
   });
 
   it("Skips dependencies that have no license attached", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lLicenseNotRuleSet,
         { source: "something" },
@@ -79,7 +79,7 @@ describe("[I] validate/index - licenseNot", () => {
   });
 
   it("does not flag dependencies that do match the license expression", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lLicenseNotRuleSet,
         { source: "something" },
@@ -93,7 +93,7 @@ describe("[I] validate/index - licenseNot", () => {
   });
 
   it("flags dependencies that do not match the license expression", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lLicenseNotRuleSet,
         { source: "something" },

--- a/test/validate/index.more-than-one-dependency-type.spec.mjs
+++ b/test/validate/index.more-than-one-dependency-type.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -15,7 +15,7 @@ describe("[I] index/validate - moreThanOneDependencyType", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "src/aap/zus/jet.js" },
@@ -49,7 +49,7 @@ describe("[I] index/validate - moreThanOneDependencyType", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "src/aap/zus/jet.js" },

--- a/test/validate/index.more-unstable.spec.mjs
+++ b/test/validate/index.more-unstable.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -28,7 +28,7 @@ describe("[I] validate/index - stability checks", () => {
   });
 
   it("moreUnstable: flags when depending on a module that is more unstable (moreUnstable=true, forbidden)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lForbiddenRuleSet,
         { source: "something", instability: 0 },
@@ -45,7 +45,7 @@ describe("[I] validate/index - stability checks", () => {
   });
 
   it("moreUnstable: does not flag when depending on a module that is more stable (moreUnstable=true, forbidden)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lForbiddenRuleSet,
         { source: "something", instability: 1 },
@@ -61,7 +61,7 @@ describe("[I] validate/index - stability checks", () => {
   });
 
   it("moreUnstable: flags when depending on a module that is more unstable (moreUnstable=false, allowed)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lAllowedRuleSet,
         { source: "something", instability: 0 },
@@ -78,7 +78,7 @@ describe("[I] validate/index - stability checks", () => {
   });
 
   it("moreUnstable: does not flag when depending on a module that is more stable (moreUnstable=false, allowed)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lAllowedRuleSet,
         { source: "something", instability: 1 },

--- a/test/validate/index.orphans.spec.mjs
+++ b/test/validate/index.orphans.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -14,13 +14,13 @@ describe("[I] validate/index - orphans", () => {
   });
 
   it("Skips modules that have no orphan attribute", () => {
-    deepStrictEqual(validate.module(lOrphanRuleSet, { source: "something" }), {
+    deepEqual(validate.module(lOrphanRuleSet, { source: "something" }), {
       valid: true,
     });
   });
 
   it("Flags modules that are orphans", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphanRuleSet, {
         source: "something",
         orphan: true,
@@ -48,7 +48,7 @@ describe("[I] validate/index - orphans in 'allowed' rules", () => {
   });
 
   it("Flags modules that are orphans if they're in the 'allowed' section", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphansAllowedRuleSet, {
         source: "something",
         orphan: true,
@@ -66,7 +66,7 @@ describe("[I] validate/index - orphans in 'allowed' rules", () => {
   });
 
   it("Leaves modules alone that aren't orphans if there's a rule in the 'allowed' section forbidding them", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphansAllowedRuleSet, {
         source: "something",
         orphan: false,
@@ -97,7 +97,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
     ],
   });
   it("Leaves modules that are orphans, but that don't match the rule path", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphanPathRuleSet, {
         source: "something",
         orphan: true,
@@ -107,7 +107,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
   });
 
   it("Flags modules that are orphans and that match the rule's path", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphanPathRuleSet, {
         source: "noorphansallowedhere/blah/something.ts",
         orphan: true,
@@ -125,7 +125,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
   });
 
   it("Leaves modules that are orphans, but that do match the rule's pathNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphanPathNotRuleSet, {
         source: "orphansallowedhere/something",
         orphan: true,
@@ -135,7 +135,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
   });
 
   it("Flags modules that are orphans, but that do not match the rule's pathNot", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lOrphanPathNotRuleSet, {
         source: "blah/something.ts",
         orphan: true,
@@ -153,7 +153,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
   });
 
   it("The 'dependency' validation leaves the module only orphan rule alone", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lOrphanPathRuleSet,
         {

--- a/test/validate/index.pre-compilation-only.spec.mjs
+++ b/test/validate/index.pre-compilation-only.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -15,7 +15,7 @@ describe("[I] validate/index - preCompilationOnly", () => {
     ],
   });
   it("Stuff that still exists after compilation - okeleedokelee", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lPreCompilationOnlyRuleSet,
         { source: "something" },
@@ -26,7 +26,7 @@ describe("[I] validate/index - preCompilationOnly", () => {
   });
 
   it("Stuff that only exists before compilation - flaggeleedaggelee", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lPreCompilationOnlyRuleSet,
         { source: "something" },
@@ -40,7 +40,7 @@ describe("[I] validate/index - preCompilationOnly", () => {
   });
 
   it("Unknown whether stuff that only exists before compilation - okeleedokelee", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lPreCompilationOnlyRuleSet,
         { source: "something" },

--- a/test/validate/index.reachable.spec.mjs
+++ b/test/validate/index.reachable.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -22,21 +22,20 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
     ],
   });
   it("Skips modules that have no reachable attribute (reachable false)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableFalseRuleSet, { source: "something" }),
       { valid: true },
     );
   });
 
   it("Skips modules that have no reachable attribute (reachable true)", () => {
-    deepStrictEqual(
-      validate.module(lReachableTrueRuleSet, { source: "something" }),
-      { valid: true },
-    );
+    deepEqual(validate.module(lReachableTrueRuleSet, { source: "something" }), {
+      valid: true,
+    });
   });
 
   it("Triggers on modules that have a reachable attribute (non-matching, reachable false)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableFalseRuleSet, {
         source: "something",
         reachable: [
@@ -52,7 +51,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
   });
 
   it("Triggers on modules that have a reachable attribute (non-matching, reachable true)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableTrueRuleSet, {
         source: "something",
         reachable: [
@@ -68,7 +67,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
   });
 
   it("Triggers on modules that have a reachable attribute (reachable false)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableFalseRuleSet, {
         source: "something",
         reachable: [
@@ -92,7 +91,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
   });
 
   it("Triggers on modules that have a reachable attribute (reachable true)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableTrueRuleSet, {
         source: "something",
         reachable: [
@@ -116,7 +115,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
   });
 
   it("Triggers on modules that have a reachable attribute (with a path, reachable false)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableFalseRuleSet, {
         source: "something",
         reachable: [
@@ -140,7 +139,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
   });
 
   it("Triggers on modules that have a reachable attribute (with a path, reachable true)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableTrueRuleSet, {
         source: "something",
         reachable: [
@@ -174,7 +173,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableFalsePathNotRuleSet, {
         source: "something",
         reachable: [
@@ -199,7 +198,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableTruePathNotRuleSet, {
         source: "something",
         reachable: [
@@ -224,7 +223,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
     ],
   });
   it("Triggers on modules that have no reachable attribute ('allowed' rule set)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableAllowedRuleSet, {
         source: "something",
       }),
@@ -241,7 +240,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
   });
 
   it("Skips on modules that have a reachable attribute (match - 'allowed' rule set)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableAllowedRuleSet, {
         source: "something",
         reachable: [
@@ -259,7 +258,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
   });
 
   it("Triggers on modules that have a reachable attribute (no match - 'allowed' rule set)", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lReachableAllowedRuleSet, {
         source: "something",
         reachable: [
@@ -308,7 +307,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
       lReachableCapturingGroupsRuleSet,
       lModule,
     );
-    deepStrictEqual(lValidationResult, {
+    deepEqual(lValidationResult, {
       valid: false,
       rules: [
         {

--- a/test/validate/index.required-rules.spec.mjs
+++ b/test/validate/index.required-rules.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -19,7 +19,7 @@ describe("[I] validate/index - required rules", () => {
   });
 
   it("modules not matching the module criteria from the required rule are okeliedokelie", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lRequiredRuleSet, {
         source: "something",
       }),
@@ -28,7 +28,7 @@ describe("[I] validate/index - required rules", () => {
   });
 
   it("modules matching the module criteria with no dependencies bork", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [],
@@ -41,7 +41,7 @@ describe("[I] validate/index - required rules", () => {
   });
 
   it("modules matching the module criteria with no matching dependencies bork", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [
@@ -61,7 +61,7 @@ describe("[I] validate/index - required rules", () => {
   });
 
   it("'required' violations don't get flagged as dependency transgressions", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [
@@ -80,7 +80,7 @@ describe("[I] validate/index - required rules", () => {
   });
 
   it("modules matching the module criteria with matching dependencies are okeliedokelie", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.module(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [

--- a/test/validate/index.spec.mjs
+++ b/test/validate/index.spec.mjs
@@ -1,11 +1,11 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
 describe("[I] validate/index dependency - generic tests", () => {
   it("is ok with the empty validation", () => {
     const lEmptyRuleSet = parseRuleSet({});
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lEmptyRuleSet,
         { source: "koos koets" },
@@ -24,7 +24,7 @@ describe("[I] validate/index dependency - generic tests", () => {
         },
       ],
     });
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lEverythingAllowedRuleSet,
         { source: "koos koets" },
@@ -51,7 +51,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       ],
     });
 
-    deepStrictEqual(validate.module(lRuleSet, { source: "koos koets" }), {
+    deepEqual(validate.module(lRuleSet, { source: "koos koets" }), {
       valid: true,
     });
   });
@@ -70,7 +70,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "koos koets" },
@@ -98,7 +98,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       allowedSeverity: "error",
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "koos koets" },
@@ -123,7 +123,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "koos koets" },
@@ -155,7 +155,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       ],
     });
 
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lRuleSet,
         { source: "something" },
@@ -232,7 +232,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("node_modules inhibition - ok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNodeModulesNotAllowedRuleSet,
         { source: "koos koets" },
@@ -243,7 +243,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("node_modules inhibition - violation", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNodeModulesNotAllowedRuleSet,
         { source: "koos koets" },
@@ -257,7 +257,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not to sub except sub itself - ok - sub to sub", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToSubExceptSubRuleSet,
         { source: "./keek/op/de/sub/week.js" },
@@ -268,7 +268,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not to sub except sub itself - ok - not sub to not sub", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToSubExceptSubRuleSet,
         { source: "./doctor/clavan.js" },
@@ -279,7 +279,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not to sub except sub itself - ok - sub to not sub", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToSubExceptSubRuleSet,
         { source: "./doctor/sub/clavan.js" },
@@ -290,7 +290,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not to sub except sub itself  - violation - not sub to sub", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToSubExceptSubRuleSet,
         { source: "./doctor/clavan.js" },
@@ -304,7 +304,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not to not sub (=> everything must go to 'sub')- ok - sub to sub", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToNotSubRuleSet,
         { source: "./keek/op/de/sub/week.js" },
@@ -315,7 +315,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not to not sub (=> everything must go to 'sub')- violation - not sub to not sub", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToNotSubRuleSet,
         { source: "./amber.js" },
@@ -329,7 +329,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not-to-dev-dep disallows relations to develop dependencies", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToDevelopmentDependencyRuleSet,
         { source: "src/aap/zus/jet.js" },
@@ -352,7 +352,7 @@ describe("[I] validate/index - specific tests", () => {
   });
 
   it("not-to-dev-dep does allow relations to regular dependencies", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lNotToDevelopmentDependencyRuleSet,
         { source: "src/aap/zus/jet.js" },

--- a/test/validate/index.type-only.spec.mjs
+++ b/test/validate/index.type-only.spec.mjs
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert";
+import { deepEqual } from "node:assert/strict";
 import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
 
@@ -17,7 +17,7 @@ describe("[I] [I] validate/index - type-only", () => {
   });
 
   it("only to type-only - with dependencyTypesNot in forbidden, multiple types - ok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lTypeOnlyRuleSet,
         { source: "src/koos-koets.ts" },
@@ -31,7 +31,7 @@ describe("[I] [I] validate/index - type-only", () => {
   });
 
   it("only to type-only - with dependencyTypesNot in forbidden, multiple types - nok", () => {
-    deepStrictEqual(
+    deepEqual(
       validate.dependency(
         lTypeOnlyRuleSet,
         { source: "src/koos-koets.ts" },

--- a/test/validate/match-folder-dependency-rule.spec.mjs
+++ b/test/validate/match-folder-dependency-rule.spec.mjs
@@ -1,11 +1,11 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import matchFolderRule from "../../src/validate/match-folder-dependency-rule.mjs";
 
 describe("[I] validate/match-folder-dependency-rule - match generic", () => {
   const lEmptyRule = { scope: "folder", from: {}, to: {} };
 
   it("empty rule => match all the things (empty from & to)", () => {
-    strictEqual(matchFolderRule.match({}, {})(lEmptyRule), true);
+    equal(matchFolderRule.match({}, {})(lEmptyRule), true);
   });
 });
 
@@ -13,16 +13,16 @@ describe("[I] validate/match-folder-dependency-rule - match SDP", () => {
   const lSdpRule = { scope: "folder", from: {}, to: { moreUnstable: true } };
 
   it("rule with a restriction on the to doesn't match when the criterium is not met (data missing)", () => {
-    strictEqual(matchFolderRule.match({}, {})(lSdpRule), false);
+    equal(matchFolderRule.match({}, {})(lSdpRule), false);
   });
   it("rule with a restriction on the to doesn't match when the criterium is not met (data there)", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({ instability: 1 }, { instability: 0 })(lSdpRule),
       false,
     );
   });
   it("rule with a restriction on the to matches when the criterium is met (data there)", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({ instability: 0 }, { instability: 1 })(lSdpRule),
       true,
     );
@@ -33,19 +33,13 @@ describe("[I] validate/match-folder-dependency-rule - match cycle", () => {
   const lCycleRule = { scope: "folder", from: {}, to: { circular: true } };
 
   it("rule with a restriction on the to doesn't match when the criterium is not met (data missing)", () => {
-    strictEqual(matchFolderRule.match({}, {})(lCycleRule), false);
+    equal(matchFolderRule.match({}, {})(lCycleRule), false);
   });
   it("rule with a restriction on the to doesn't match when the criterium is not met (data there)", () => {
-    strictEqual(
-      matchFolderRule.match({}, { circular: false })(lCycleRule),
-      false,
-    );
+    equal(matchFolderRule.match({}, { circular: false })(lCycleRule), false);
   });
   it("rule with a restriction on the to doesn't match when the criterium is met (data there)", () => {
-    strictEqual(
-      matchFolderRule.match({}, { circular: true })(lCycleRule),
-      true,
-    );
+    equal(matchFolderRule.match({}, { circular: true })(lCycleRule), true);
   });
 });
 
@@ -53,13 +47,13 @@ describe("[I] validate/match-folder-dependency-rule - match from path", () => {
   const lPathRule = { scope: "folder", from: { path: "src/" }, to: {} };
 
   it("does not match folders not in the from path of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({ name: "test/shouldnotmatch" }, {})(lPathRule),
       false,
     );
   });
   it("does match folders in the from path of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({ name: "src/shouldmatch" }, {})(lPathRule),
       true,
     );
@@ -70,13 +64,13 @@ describe("[I] validate/match-folder-dependency-rule - match from pathNot", () =>
   const lPathNotRule = { scope: "folder", from: { pathNot: "src/" }, to: {} };
 
   it("does not match folders in the from pathNot of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({ name: "src/shouldnotmatch" }, {})(lPathNotRule),
       false,
     );
   });
   it("does match folders in the from pathNot of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({ name: "test/shouldmatch" }, {})(lPathNotRule),
       true,
     );
@@ -94,13 +88,13 @@ describe("[I] validate/match-folder-dependency-rule - match to path", () => {
   };
 
   it("does not match folders not in the from path of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({}, { name: "test/shouldnotmatch" })(lPathRule),
       false,
     );
   });
   it("does not match folders not in the from path of the rule (group matching variant)", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match(
         { name: "src/components/thing" },
         { name: "test/components/other-thing" },
@@ -109,13 +103,13 @@ describe("[I] validate/match-folder-dependency-rule - match to path", () => {
     );
   });
   it("does match folders in the from path of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({}, { name: "src/shouldmatch" })(lPathRule),
       true,
     );
   });
   it("does match folders in the from path of the rule (group matching variant - matching one, not the other)", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match(
         { name: "src/components/thing" },
         { name: "src/components/thing/folder-in-thing" },
@@ -124,7 +118,7 @@ describe("[I] validate/match-folder-dependency-rule - match to path", () => {
     );
   });
   it("does not match folders in the from path of the rule (group matching  - not matching any)", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match(
         { name: "src/components/thing" },
         { name: "src/not-even-a-component" },
@@ -138,13 +132,13 @@ describe("[I] validate/match-folder-dependency-rule - match to pathNot", () => {
   const lPathNotRule = { scope: "folder", from: {}, to: { pathNot: "src/" } };
 
   it("does not match folders in the from pathNot of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({}, { name: "src/shouldnotmatch" })(lPathNotRule),
       false,
     );
   });
   it("does match folders in the from pathNot of the rule", () => {
-    strictEqual(
+    equal(
       matchFolderRule.match({}, { name: "test/shouldmatch" })(lPathNotRule),
       true,
     );

--- a/test/validate/match-module-rule.dependents.spec.mjs
+++ b/test/validate/match-module-rule.dependents.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import matchModuleRule from "../../src/validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, module: {} };
@@ -55,28 +55,25 @@ const USED_FROM_SNACKBAR_BETWEEN = {
 
 describe("[I] validate/match-module-rule - dependents", () => {
   it("rule without dependents restriction doesn't flag (implicit)", () => {
-    strictEqual(matchModuleRule.matchesDependentsRule(EMPTY_RULE, {}), false);
+    equal(matchModuleRule.matchesDependentsRule(EMPTY_RULE, {}), false);
   });
   it("rule without dependents restriction doesn't flag (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(EMPTY_RULE, { dependents: [] }),
       false,
     );
   });
   it("rule with dependents doesn't match a module with no dependents attribute", () => {
-    strictEqual(
-      matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, {}),
-      false,
-    );
+    equal(matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, {}), false);
   });
   it("rule that matches any dependents does match a module with a dependents attribute", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, { dependents: [] }),
       true,
     );
   });
   it("rule that matches any dependents does match a module with a dependents attribute (>1 dependent)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, {
         dependents: ["aap", "noot", "mies", "wim"],
       }),
@@ -85,7 +82,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) rule doesn't flag when there's 2 dependents", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         MUST_BE_SHARED_DONT_CARE_FROM_WHERE,
         {
@@ -98,7 +95,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) rule flags when there's 1 dependent", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         MUST_BE_SHARED_DONT_CARE_FROM_WHERE,
         {
@@ -111,7 +108,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) rule flags when there's 0 dependents", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         MUST_BE_SHARED_DONT_CARE_FROM_WHERE,
         {
@@ -124,7 +121,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) with a from doesn't flag when there's 2 dependents from that from", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
@@ -134,7 +131,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) with a from doesn't flag when there's 2 dependents from that from (+ some others that don't matter)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: [
@@ -149,7 +146,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) with a from path when there's only 1 dependents from that from path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: [
@@ -162,7 +159,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) with a from pathNot when there's only 1 dependents from that from pathNot", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR,
         {
@@ -178,7 +175,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must-share (>=2 dependents) with a from pathNot when there's 0 dependents from that from pathNot", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR,
         {
@@ -191,7 +188,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must not be used more than 3 times from snackbar - happy scenario", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES,
         {
@@ -204,7 +201,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("must not be used more than 3 times from snackbar - fail scenario", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(
         CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES,
         {
@@ -222,7 +219,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("combo breaker (3 < x < 5) - happy scenario", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
         source: "src/utensils/frieten.ts",
         dependents: [
@@ -237,7 +234,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
   });
 
   it("combo breaker (3 < x < 5) - fail scenario", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
         source: "src/utensils/frieten.ts",
         dependents: [

--- a/test/validate/match-module-rule.orphan.spec.mjs
+++ b/test/validate/match-module-rule.orphan.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import matchModuleRule from "../../src/validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
@@ -8,31 +8,31 @@ const ORPHAN_IN_PATH_NOT = { from: { orphan: true, pathNot: "^src" }, to: {} };
 
 describe("[I] validate/match-module-rule - orphan", () => {
   it("rule without orphan attribute doesn't non-orphans (implicit)", () => {
-    strictEqual(matchModuleRule.matchesOrphanRule(EMPTY_RULE, {}), false);
+    equal(matchModuleRule.matchesOrphanRule(EMPTY_RULE, {}), false);
   });
   it("rule without orphan attribute doesn't non-orphans (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(EMPTY_RULE, { orphan: false }),
       false,
     );
   });
   it("rule without orphan attribute doesn't match orphan module", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(EMPTY_RULE, { orphan: true }),
       false,
     );
   });
   it("orphan match rule doesn't match non-orphans", () => {
-    strictEqual(matchModuleRule.matchesOrphanRule(ANY_ORPHAN, {}), false);
+    equal(matchModuleRule.matchesOrphanRule(ANY_ORPHAN, {}), false);
   });
   it("orphan match rule matches orphans", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(ANY_ORPHAN, { orphan: true }),
       true,
     );
   });
   it("orphan match rule with path doesn't match orphans in other paths", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH, {
         orphan: true,
         source: "test/lalal.spec.ts",
@@ -41,7 +41,7 @@ describe("[I] validate/match-module-rule - orphan", () => {
     );
   });
   it("orphan match rule with path matches orphans in that path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH, {
         orphan: true,
         source: "src/lalal.ts",
@@ -50,7 +50,7 @@ describe("[I] validate/match-module-rule - orphan", () => {
     );
   });
   it("orphan match rule with path matches orphans outside that path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH_NOT, {
         orphan: true,
         source: "test/lalal.spec.ts",
@@ -59,7 +59,7 @@ describe("[I] validate/match-module-rule - orphan", () => {
     );
   });
   it("orphan match rule with pathNot doesn't match orphans in that path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH_NOT, {
         orphan: true,
         source: "src/lalal.ts",

--- a/test/validate/match-module-rule.reachable.spec.mjs
+++ b/test/validate/match-module-rule.reachable.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import matchModuleRule from "../../src/validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
@@ -25,10 +25,10 @@ const ANY_UNREACHABLE_IN_ALLOWED_SET = {
 
 describe("[I] validate/match-module-rule - reachable", () => {
   it("rule without reachable attribute doesn't match reachables (implicit)", () => {
-    strictEqual(matchModuleRule.matchesReachableRule(EMPTY_RULE, {}), false);
+    equal(matchModuleRule.matchesReachableRule(EMPTY_RULE, {}), false);
   });
   it("rule without reachable attribute doesn't match reachables (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(EMPTY_RULE, {
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
@@ -36,13 +36,10 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute doesn't match reachables (implicit)", () => {
-    strictEqual(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {}),
-      false,
-    );
+    equal(matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {}), false);
   });
   it("rule with reachable attribute doesn't match reachables (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {
         reachable: [{ value: true, asDefinedInRule: "no-unreachable" }],
       }),
@@ -50,7 +47,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute matches unreachables according to that rule name", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
@@ -58,7 +55,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute does not match unreachables according to other rule name", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {
         reachable: [{ value: false, asDefinedInRule: "other-rule-name" }],
       }),
@@ -66,7 +63,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("nameless rule with reachable attribute does not match unreachables according to other rule name", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_IN_ALLOWED_SET, {
         reachable: [{ value: false, asDefinedInRule: "other-rule-name" }],
       }),
@@ -74,7 +71,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("nameless rule with reachable attribute matchs unreachables according to not-in-allowed", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_IN_ALLOWED_SET, {
         reachable: [{ value: false, asDefinedInRule: "not-in-allowed" }],
       }),
@@ -82,7 +79,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute & path matches unreachables according to that rule name in that path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
@@ -91,7 +88,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute & path does not match unreachables according to that rule name and not in that path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_WITH_PATH, {
         source: "test/lalala.ts",
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
@@ -100,7 +97,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute & path matches reachables according to that rule name in that path", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
         reachable: [{ value: true, asDefinedInRule: "no-unreachable" }],
@@ -109,7 +106,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute & path does not match unreachables according to that rule name in that path (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
@@ -118,7 +115,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
     );
   });
   it("rule with reachable attribute & path does not match unreachables according to that rule name in that path (implicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
       }),

--- a/test/validate/match-module-rule.reaches.spec.mjs
+++ b/test/validate/match-module-rule.reaches.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import matchModuleRule from "../../src/validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
@@ -15,10 +15,10 @@ const ANY_REACHES_IN_ALLOWED = {
 
 describe("[I] validate/match-module-rule - reaches", () => {
   it("rule without reachable attribute doesn't match modules with a reaches (implicit)", () => {
-    strictEqual(matchModuleRule.matchesReachesRule(EMPTY_RULE, {}), false);
+    equal(matchModuleRule.matchesReachesRule(EMPTY_RULE, {}), false);
   });
   it("rule without reachable attribute doesn't match modules with a reaches (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachesRule(EMPTY_RULE, {
         reaches: [
           {
@@ -31,7 +31,7 @@ describe("[I] validate/match-module-rule - reaches", () => {
     );
   });
   it("rule without reachable attribute matches modules with a reaches (explicit)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachesRule(ANY_REACHABLE, {
         reaches: [
           {
@@ -44,7 +44,7 @@ describe("[I] validate/match-module-rule - reaches", () => {
     );
   });
   it("rule without reachable attribute matches modules with a reaches (explicit, nameless rule)", () => {
-    strictEqual(
+    equal(
       matchModuleRule.matchesReachesRule(ANY_REACHES_IN_ALLOWED, {
         reaches: [
           {

--- a/test/validate/match-module-rule.spec.mjs
+++ b/test/validate/match-module-rule.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import matchModuleRule from "../../src/validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
@@ -6,19 +6,19 @@ const ORPHAN_RULE = { from: { orphan: true }, to: {} };
 
 describe("[I] validate/match-module-rule - match", () => {
   it("does not match anything when passed a non-module rule", () => {
-    strictEqual(matchModuleRule.match({})(EMPTY_RULE), false);
+    equal(matchModuleRule.match({})(EMPTY_RULE), false);
   });
   it("does not match anything when passed a non-matchig module rule", () => {
-    strictEqual(matchModuleRule.match({})(ORPHAN_RULE), false);
+    equal(matchModuleRule.match({})(ORPHAN_RULE), false);
   });
   it("does not match anything when passed an orphan rule and there's an explicit non-orphan module", () => {
-    strictEqual(
+    equal(
       matchModuleRule.match({ from: { orphan: false } })(ORPHAN_RULE),
       false,
     );
   });
   it("matches when passed an orphan rule and there's an explicit non-orphan module", () => {
-    strictEqual(
+    equal(
       matchModuleRule.match({ from: { orphan: true } })(ORPHAN_RULE),
       false,
     );

--- a/test/validate/violates-required-rule.spec.mjs
+++ b/test/validate/violates-required-rule.spec.mjs
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { equal } from "node:assert/strict";
 import violatesRequiredRule from "../../src/validate/violates-required-rule.mjs";
 
 const SIMPLE_RULE = {
@@ -23,14 +23,14 @@ const GROUP_MATCHING_RULE = {
 };
 describe("[I] validate/violates-required-rule", () => {
   it("does not violate when the module does not match", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(SIMPLE_RULE, { source: "does not match" }),
       false,
     );
   });
 
   it("violates when the module matches and there's no dependencies", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(SIMPLE_RULE, {
         source: "controllers/sprockets/fred-controller.ts",
         dependencies: [],
@@ -40,7 +40,7 @@ describe("[I] validate/violates-required-rule", () => {
   });
 
   it("violates when the module matches and there's no matching dependencies", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(SIMPLE_RULE, {
         source: "controllers/sprockets/fred-controller.ts",
         dependencies: [
@@ -55,7 +55,7 @@ describe("[I] validate/violates-required-rule", () => {
   });
 
   it("passes when the module matches and there's a matching dependency", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(SIMPLE_RULE, {
         source: "controllers/sprockets/fred-controller.ts",
         dependencies: [
@@ -70,7 +70,7 @@ describe("[I] validate/violates-required-rule", () => {
   });
 
   it("violates when the module matches and there's no matching dependency (group matching)", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(GROUP_MATCHING_RULE, {
         source: "test/simsalabim.spec.js",
         dependencies: [
@@ -85,7 +85,7 @@ describe("[I] validate/violates-required-rule", () => {
   });
 
   it("violates when the module matches and there's no dependencies (group matching)", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(GROUP_MATCHING_RULE, {
         source: "test/simsalabim.spec.js",
         dependencies: [],
@@ -95,7 +95,7 @@ describe("[I] validate/violates-required-rule", () => {
   });
 
   it("passes when the module matches and there's no matching dependency (group matching)", () => {
-    strictEqual(
+    equal(
       violatesRequiredRule(GROUP_MATCHING_RULE, {
         source: "test/simsalabim.spec.js",
         dependencies: [


### PR DESCRIPTION
## Description

- in stead of using the strictEqual/  deepStrictEqual methods from  node:assert use the equal and  deepEqual methods from node:assert/strict

## Motivation and Context

... which makes tests easier to read.

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
