### PR TITLE
refactor: replaces 'glob' with 'picomatch'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+<<<<<<< HEAD
         node-version: [18.x, 20.x]
+=======
+        node-version: [16.x, 20.x]
+>>>>>>> 6a3e220e (Revert "disable all non-windows workflows & actions")
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+<<<<<<< HEAD
         if: github.event_name == 'pull_request' && matrix.node-version == env.NODE_LATEST
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
         if: github.event_name != 'pull_request' || matrix.node-version != env.NODE_LATEST
+=======
+        if: github.event_name == 'pull_request' && matrix.node-version == env.NODE_LATEST 
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 1
+        if: github.event_name != 'pull_request' || matrix.node-version != env.NODE_LATEST 
+>>>>>>> 6a3e220e (Revert "disable all non-windows workflows & actions")
       - uses: actions/cache@v3
         with:
           path: node_modules
@@ -142,3 +154,7 @@ jobs:
       #     node --version
       #     yarn --version
       #     yarn test:cover
+<<<<<<< HEAD
+=======
+
+>>>>>>> 6a3e220e (Revert "disable all non-windows workflows & actions")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,30 +27,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         node-version: [18.x, 20.x]
-=======
-        node-version: [16.x, 20.x]
->>>>>>> 6a3e220e (Revert "disable all non-windows workflows & actions")
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-<<<<<<< HEAD
         if: github.event_name == 'pull_request' && matrix.node-version == env.NODE_LATEST
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
         if: github.event_name != 'pull_request' || matrix.node-version != env.NODE_LATEST
-=======
-        if: github.event_name == 'pull_request' && matrix.node-version == env.NODE_LATEST 
-      - uses: actions/checkout@v4
-        with: 
-          fetch-depth: 1
-        if: github.event_name != 'pull_request' || matrix.node-version != env.NODE_LATEST 
->>>>>>> 6a3e220e (Revert "disable all non-windows workflows & actions")
       - uses: actions/cache@v3
         with:
           path: node_modules
@@ -154,7 +142,3 @@ jobs:
       #     node --version
       #     yarn --version
       #     yarn test:cover
-<<<<<<< HEAD
-=======
-
->>>>>>> 6a3e220e (Revert "disable all non-windows workflows & actions")

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "commander": "11.0.0",
         "enhanced-resolve": "5.15.0",
         "figures": "5.0.0",
-        "glob": "10.3.6",
         "ignore": "5.2.4",
         "indent-string": "5.0.0",
         "interpret": "^3.1.1",
@@ -804,44 +803,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "dev": true,
@@ -928,14 +889,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@swc/core": {
@@ -1513,6 +1466,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1651,6 +1605,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/better-path-resolve": {
@@ -2181,6 +2136,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3305,27 +3261,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.6.tgz",
-      "integrity": "sha512-mEfImdc/fiYHEcF6pHFfD2b/KrdFB1qH9mRe5vI5HROF8G51SWxQJ2V56Ezl6ZL9y86gsxQ1Lgo2S746KGUPSQ==",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -3335,50 +3270,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/signal-exit": {
-      "version": "4.0.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-dirs": {
@@ -3982,6 +3873,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4018,22 +3910,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "2.2.1",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-tokens": {
@@ -4571,13 +4447,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.0.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/mocha": {
       "version": "10.2.0",
       "dev": true,
@@ -5113,6 +4982,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5121,27 +4991,6 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5786,6 +5635,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5796,6 +5646,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5995,30 +5846,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.0.1",
       "license": "MIT",
@@ -6102,17 +5929,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6540,6 +6357,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6603,72 +6421,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "is-installed-globally": "0.4.0",
         "json5": "2.2.3",
         "lodash": "4.17.21",
+        "picomatch": "2.3.1",
         "prompts": "2.4.2",
         "rechoir": "^0.8.0",
         "safe-regex": "2.1.1",
@@ -5158,8 +5159,8 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "commander": "11.0.0",
     "enhanced-resolve": "5.15.0",
     "figures": "5.0.0",
-    "glob": "10.3.6",
     "ignore": "5.2.4",
     "indent-string": "5.0.0",
     "interpret": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "is-installed-globally": "0.4.0",
     "json5": "2.2.3",
     "lodash": "4.17.21",
+    "picomatch": "2.3.1",
     "prompts": "2.4.2",
     "rechoir": "^0.8.0",
     "safe-regex": "2.1.1",

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { glob } from "glob";
+import picomatch from "picomatch";
 import cloneDeep from "lodash/cloneDeep.js";
 import set from "lodash/set.js";
 import isInstalledGlobally from "is-installed-globally";
@@ -106,7 +106,7 @@ async function runCruise(pFileDirectoryArray, pCruiseOptions) {
   );
 
   pFileDirectoryArray
-    .filter((pFileOrDirectory) => !glob.hasMagic(pFileOrDirectory))
+    .filter((pFileOrDirectory) => !picomatch.scan(pFileOrDirectory).isGlob)
     .map((pFileOrDirectory) =>
       lCruiseOptions?.ruleSet?.options?.baseDir
         ? join(lCruiseOptions.ruleSet.options.baseDir, pFileOrDirectory)

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { readdirSync, statSync } from "node:fs";
 import { join, normalize, relative } from "node:path";
 import picomatch from "picomatch";
@@ -46,7 +47,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
   return readdirSync(join(pOptions.baseDir, pDirectoryName))
     .map((pFileName) => join(pDirectoryName, pFileName))
     .filter((pFullPathToFile) =>
-      shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions)
+      shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions),
     )
     .reduce((pSum, pFullPathToFile) => {
       let lStat = statSync(join(pOptions.baseDir, pFullPathToFile), {
@@ -56,7 +57,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
       if (lStat) {
         if (lStat.isDirectory()) {
           return pSum.concat(
-            gatherScannableFilesFromDirectory(pFullPathToFile, pOptions)
+            gatherScannableFilesFromDirectory(pFullPathToFile, pOptions),
           );
         }
         if (fileIsScannable(pOptions, pFullPathToFile)) {
@@ -90,24 +91,26 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
  */
 export default function gatherInitialSources(
   pFileDirectoryAndGlobArray,
-  pOptions
+  pOptions,
 ) {
   const lOptions = { baseDir: process.cwd(), ...pOptions };
 
   return pFileDirectoryAndGlobArray
     .flatMap((pFileDirectoryOrGlob) => {
       if (picomatch.scan(pFileDirectoryOrGlob).isGlob) {
-        // eslint-disable-next-line no-console
         console.log("it's a glob:", pFileDirectoryOrGlob);
+        console.log(
+          "joined it looks like so:",
+          join(lOptions.baseDir, pFileDirectoryOrGlob),
+        );
         return glob
           .sync(join(lOptions.baseDir, pFileDirectoryOrGlob))
           .map((pFileOrDirectory) => {
-            // eslint-disable-next-line no-console
             console.log(
               "de-globbed:",
               pFileOrDirectory,
               "->",
-              pathToPosix(relative(lOptions.baseDir, pFileOrDirectory))
+              pathToPosix(relative(lOptions.baseDir, pFileOrDirectory)),
             );
             return pathToPosix(relative(lOptions.baseDir, pFileOrDirectory));
           });

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -99,10 +99,11 @@ export default function gatherInitialSources(pFileAndDirectoryArray, pOptions) {
             join(pathToPosix(lOptions.baseDir), pathToPosix(pFileOrDirectory)),
           )
           .map((pExpanded) =>
-            relative(pathToPosix(lOptions.baseDir), pExpanded),
+            pathToPosix(relative(lOptions.baseDir, pExpanded)),
           );
       }
-      return normalize(pFileOrDirectory);
+
+      return pathToPosix(normalize(pFileOrDirectory));
     })
     .flatMap((pGlobLess) => {
       if (statSync(join(lOptions.baseDir, pGlobLess)).isDirectory()) {

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -46,7 +46,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
   return readdirSync(join(pOptions.baseDir, pDirectoryName))
     .map((pFileName) => join(pDirectoryName, pFileName))
     .filter((pFullPathToFile) =>
-      shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions),
+      shouldNotBeExcluded(pathToPosix(pFullPathToFile), pOptions)
     )
     .reduce((pSum, pFullPathToFile) => {
       let lStat = statSync(join(pOptions.baseDir, pFullPathToFile), {
@@ -56,7 +56,7 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
       if (lStat) {
         if (lStat.isDirectory()) {
           return pSum.concat(
-            gatherScannableFilesFromDirectory(pFullPathToFile, pOptions),
+            gatherScannableFilesFromDirectory(pFullPathToFile, pOptions)
           );
         }
         if (fileIsScannable(pOptions, pFullPathToFile)) {
@@ -90,13 +90,15 @@ function gatherScannableFilesFromDirectory(pDirectoryName, pOptions) {
  */
 export default function gatherInitialSources(
   pFileDirectoryAndGlobArray,
-  pOptions,
+  pOptions
 ) {
   const lOptions = { baseDir: process.cwd(), ...pOptions };
 
   return pFileDirectoryAndGlobArray
     .flatMap((pFileDirectoryOrGlob) => {
       if (picomatch.scan(pFileDirectoryOrGlob).isGlob) {
+        // eslint-disable-next-line no-console
+        console.log("it's a glob:", pFileDirectoryOrGlob);
         return glob
           .sync(join(lOptions.baseDir, pFileDirectoryOrGlob))
           .map((pFileOrDirectory) => {
@@ -105,7 +107,7 @@ export default function gatherInitialSources(
               "de-globbed:",
               pFileOrDirectory,
               "->",
-              pathToPosix(relative(lOptions.baseDir, pFileOrDirectory)),
+              pathToPosix(relative(lOptions.baseDir, pFileOrDirectory))
             );
             return pathToPosix(relative(lOptions.baseDir, pFileOrDirectory));
           });

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -101,10 +101,21 @@ export default function gatherInitialSources(
         console.log("it's a glob:", pFileDirectoryOrGlob);
         console.log(
           "joined it looks like so:",
-          join(lOptions.baseDir, pFileDirectoryOrGlob),
+          join(
+            pathToPosix(lOptions.baseDir),
+            pathToPosix(pFileDirectoryOrGlob),
+          ),
         );
         return glob
-          .sync(join(lOptions.baseDir, pFileDirectoryOrGlob))
+          .sync(
+            join(
+              // needs to be "pathToPosix'ed" because glob.sync only works with
+              // posix paths on windows (\ / \\ are not treated as path separators
+              // but as escaped characters)
+              pathToPosix(lOptions.baseDir),
+              pathToPosix(pFileDirectoryOrGlob),
+            ),
+          )
           .map((pFileOrDirectory) => {
             console.log(
               "de-globbed:",

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -95,18 +95,21 @@ export default function gatherInitialSources(pFileAndDirectoryArray, pOptions) {
     .flatMap((pFileOrDirectory) => {
       if (picomatch.scan(pFileOrDirectory).isGlob) {
         return glob
-          .sync(join(lOptions.baseDir, pFileOrDirectory))
-          .map((pExpanded) => relative(lOptions.baseDir, pExpanded));
+          .sync(
+            join(pathToPosix(lOptions.baseDir), pathToPosix(pFileOrDirectory)),
+          )
+          .map((pExpanded) =>
+            relative(pathToPosix(lOptions.baseDir), pExpanded),
+          );
       }
       return normalize(pFileOrDirectory);
     })
     .flatMap((pGlobLess) => {
       if (statSync(join(lOptions.baseDir, pGlobLess)).isDirectory()) {
         return gatherScannableFilesFromDirectory(pGlobLess, lOptions);
-      } else {
-        // it's a file
-        return pathToPosix(pGlobLess);
       }
+      // Not a glob anymore, and not a directory => it's a file
+      return pathToPosix(pGlobLess);
     })
     .sort();
 }

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { readdirSync, statSync } from "node:fs";
 import { join, normalize, relative } from "node:path";
 import picomatch from "picomatch";
@@ -98,27 +97,15 @@ export default function gatherInitialSources(
   return pFileDirectoryAndGlobArray
     .flatMap((pFileDirectoryOrGlob) => {
       if (picomatch.scan(pFileDirectoryOrGlob).isGlob) {
-        console.log("it's a glob:", pFileDirectoryOrGlob);
-        console.log(
-          "joined it looks like so:",
-          pathToPosix(join(lOptions.baseDir, pFileDirectoryOrGlob)),
-        );
         return glob
           .sync(
             // needs to be "pathToPosix'ed" because glob.sync only works with
-            // posix paths on windows (\ / \\ are not treated as path separators
-            // but as escaped characters)
+            // posix paths on windows - \ and \\ are treated as character escapes
             pathToPosix(join(lOptions.baseDir, pFileDirectoryOrGlob)),
           )
-          .map((pFileOrDirectory) => {
-            console.log(
-              "de-globbed:",
-              pFileOrDirectory,
-              "->",
-              pathToPosix(relative(lOptions.baseDir, pFileOrDirectory)),
-            );
-            return pathToPosix(relative(lOptions.baseDir, pFileOrDirectory));
-          });
+          .map((pFileOrDirectory) =>
+            pathToPosix(relative(lOptions.baseDir, pFileOrDirectory)),
+          );
       }
       return pathToPosix(normalize(pFileDirectoryOrGlob));
     })

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -101,20 +101,14 @@ export default function gatherInitialSources(
         console.log("it's a glob:", pFileDirectoryOrGlob);
         console.log(
           "joined it looks like so:",
-          join(
-            pathToPosix(lOptions.baseDir),
-            pathToPosix(pFileDirectoryOrGlob),
-          ),
+          pathToPosix(join(lOptions.baseDir, pFileDirectoryOrGlob)),
         );
         return glob
           .sync(
-            join(
-              // needs to be "pathToPosix'ed" because glob.sync only works with
-              // posix paths on windows (\ / \\ are not treated as path separators
-              // but as escaped characters)
-              pathToPosix(lOptions.baseDir),
-              pathToPosix(pFileDirectoryOrGlob),
-            ),
+            // needs to be "pathToPosix'ed" because glob.sync only works with
+            // posix paths on windows (\ / \\ are not treated as path separators
+            // but as escaped characters)
+            pathToPosix(join(lOptions.baseDir, pFileDirectoryOrGlob)),
           )
           .map((pFileOrDirectory) => {
             console.log(

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -245,7 +245,33 @@ describe("[I] extract/gatherInitialSources", () => {
     );
   });
 
-  it("heeds the baseDir", () => {
+  it("heeds the baseDir for regular folder paths", () => {
+    deepEqual(
+      gatherInitialSources(
+        ["ly/"],
+        normalizeCruiseOptions({
+          baseDir:
+            "test/extract/__mocks__/gather-globbing/packages/odin/src/deep",
+        }),
+      ).map(pathToPosix),
+      ["ly/index.js", "ly/nested.js"],
+    );
+  });
+
+  it("heeds the baseDir for regular files", () => {
+    deepEqual(
+      gatherInitialSources(
+        ["ly.js", "ly.spec.js"],
+        normalizeCruiseOptions({
+          baseDir:
+            "test/extract/__mocks__/gather-globbing/packages/odin/src/deep",
+        }),
+      ).map(pathToPosix),
+      ["ly.js", "ly.spec.js"],
+    );
+  });
+
+  it("heeds the baseDir for globs", () => {
     deepEqual(
       gatherInitialSources(
         ["**/src/**/*.js"],

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -79,7 +79,7 @@ describe("[E] main.cruise - cache", () => {
     deepEqual(lResult.output, lOldCache);
 
     const lResultTwo = await cruise(
-      ["test/main/__mocks__/cache test/main/__mocks__/cache-too "],
+      ["test/main/__mocks__/cache", "test/main/__mocks__/cache-too"],
       {
         cache: CACHE_FOLDER,
       },


### PR DESCRIPTION
## Description

- replaces `glob` with `picomatch`

This PR makes use of the fact that dependency-cruiser just dropped support for node 16 and 19, using nodejs >=18.17 feature - `readdirSync`'s `recursive` option.

## Motivation and Context

See #839; reduces number of external dependencies, which reduces both security risks, maintenance effort and install size.

Not the goal of this exercise, but it also reduces the start-up time and the execution speed of the gatherInitialSources step:

|test|glob|picomatch|
|--    |-- |--
| `npm test -f "[I] extract/gatherInitialSources"` as measured by mocha | 70ms | 43ms
| gatherInitialSources step in `node ./bin/dependency-cruise.mjs  --no-cache -Tnull  'src/**'` ('real' time)| 39ms  | 24ms
| gatherInitialSources step in `node ./bin/dependency-cruise.mjs  --no-cache -Tnull  src` ('real' time)| 14ms  | 8ms
| nodejs starting step ('loading external modules') in `node ./bin/dependency-cruise.mjs  --no-cache -Tnull  'src/**'` ('real' time)| 340ms  | 326ms

> all averages over ~5 runs, on a quiet old mac (2,6 GHz Quad-Core Intel Core i7)

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
