### PR TITLE
refactor: renames functions that assert things so they reflect that

### DIFF
--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { program } from "commander";
-import validateNodeEnvironment from "../src/cli/validate-node-environment.mjs";
+import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
 import meta from "../src/meta.js";
 import cli from "../src/cli/index.mjs";
 
@@ -10,7 +10,7 @@ function formatError(pError) {
 }
 
 try {
-  validateNodeEnvironment();
+  assertNodeEnvironmentSuitable();
 
   program
     .description(

--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { program } from "commander";
-import validateNodeEnvironment from "../src/cli/validate-node-environment.mjs";
+import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
 import meta from "../src/meta.js";
 import format from "../src/cli/format.mjs";
 
@@ -11,7 +11,7 @@ function formatError(pError) {
 }
 
 try {
-  validateNodeEnvironment();
+  assertNodeEnvironmentSuitable();
 
   program
     .description(

--- a/bin/dependency-cruise.mjs
+++ b/bin/dependency-cruise.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import { EOL } from "node:os";
 import { program } from "commander";
-import validateNodeEnvironment from "../src/cli/validate-node-environment.mjs";
+import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
 import meta from "../src/meta.js";
 import cli from "../src/cli/index.mjs";
 
 try {
-  validateNodeEnvironment();
+  assertNodeEnvironmentSuitable();
 
   program
     .description(

--- a/src/cli/assert-node-environment-suitable.mjs
+++ b/src/cli/assert-node-environment-suitable.mjs
@@ -1,7 +1,7 @@
 import satisfies from "semver/functions/satisfies.js";
 import meta from "../meta.js";
 
-export default function validateNodeEnvironment(pNodeVersion) {
+export default function assertNodeEnvironmentSuitable(pNodeVersion) {
   // not using default parameter here because the check should run
   // run on node 4 as well
   const lNodeVersion = pNodeVersion || process.versions.node;

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-return-await */
 /* eslint-disable no-magic-numbers */
 import { bus } from "../utl/bus.mjs";
-import { validateCruiseOptions } from "./options/validate.mjs";
+import { assertCruiseOptionsValid } from "./options/assert-validity.mjs";
 import { normalizeCruiseOptions } from "./options/normalize.mjs";
 import reportWrap from "./report-wrap.mjs";
 
@@ -22,7 +22,7 @@ export default async function cruise(
   bus.summary("parsing options", c(1));
   /** @type {import("../../types/strict-options.js").IStrictCruiseOptions} */
   let lCruiseOptions = normalizeCruiseOptions(
-    validateCruiseOptions(pCruiseOptions),
+    assertCruiseOptionsValid(pCruiseOptions),
     pFileAndDirectoryArray,
   );
   let lCache = null;

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -17,20 +17,20 @@ export default async function cruise(
   pFileAndDirectoryArray,
   pCruiseOptions,
   pResolveOptions,
-  pTranspileOptions
+  pTranspileOptions,
 ) {
   bus.summary("parsing options", c(1));
   /** @type {import("../../types/strict-options.js").IStrictCruiseOptions} */
   let lCruiseOptions = normalizeCruiseOptions(
     validateCruiseOptions(pCruiseOptions),
-    pFileAndDirectoryArray
+    pFileAndDirectoryArray,
   );
   let lCache = null;
 
   if (lCruiseOptions.cache) {
     bus.summary(
       `cache: checking freshness with ${lCruiseOptions.cache.strategy}`,
-      c(2)
+      c(2),
     );
 
     const { default: Cache } = await import("../cache/cache.mjs");
@@ -46,7 +46,7 @@ export default async function cruise(
   bus.summary("importing analytical modules", c(3));
   const [
     { default: normalizeRuleSet },
-    { default: validateRuleSet },
+    { default: assertRuleSetValid },
     { default: normalizeFilesAndDirectories },
     { default: normalizeResolveOptions },
     { default: extract },
@@ -55,7 +55,7 @@ export default async function cruise(
     // despite rule set parsing being behind an if, it's the 'normal' use case
     // for dependency-cruiser, so import it unconditionally nonetheless
     import("./rule-set/normalize.mjs"),
-    import("./rule-set/validate.mjs"),
+    import("./rule-set/assert-validity.mjs"),
     import("./files-and-dirs/normalize.mjs"),
     import("./resolve-options/normalize.mjs"),
     import("../extract/index.mjs"),
@@ -65,19 +65,19 @@ export default async function cruise(
   if (Boolean(lCruiseOptions.ruleSet)) {
     bus.summary("parsing rule set", c(4));
     lCruiseOptions.ruleSet = normalizeRuleSet(
-      validateRuleSet(lCruiseOptions.ruleSet)
+      assertRuleSetValid(lCruiseOptions.ruleSet),
     );
   }
 
   const lNormalizedFileAndDirectoryArray = normalizeFilesAndDirectories(
-    pFileAndDirectoryArray
+    pFileAndDirectoryArray,
   );
 
   bus.summary("determining how to resolve", c(5));
   const lNormalizedResolveOptions = await normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
-    pTranspileOptions?.tsConfig
+    pTranspileOptions?.tsConfig,
   );
 
   bus.summary("reading files", c(6));
@@ -85,14 +85,14 @@ export default async function cruise(
     lNormalizedFileAndDirectoryArray,
     lCruiseOptions,
     lNormalizedResolveOptions,
-    pTranspileOptions
+    pTranspileOptions,
   );
 
   bus.summary("analyzing", c(7));
   const lCruiseResult = enrich(
     lExtractionResult,
     lCruiseOptions,
-    lNormalizedFileAndDirectoryArray
+    lNormalizedFileAndDirectoryArray,
   );
 
   if (lCruiseOptions.cache) {

--- a/src/main/format.mjs
+++ b/src/main/format.mjs
@@ -1,7 +1,7 @@
 import Ajv from "ajv";
 
 import cruiseResultSchema from "../schema/cruise-result.schema.mjs";
-import { validateFormatOptions } from "./options/validate.mjs";
+import { assertFormatOptionsValid } from "./options/assert-validity.mjs";
 import { normalizeFormatOptions } from "./options/normalize.mjs";
 import reportWrap from "./report-wrap.mjs";
 
@@ -10,14 +10,14 @@ function validateResultAgainstSchema(pResult) {
 
   if (!ajv.validate(cruiseResultSchema, pResult)) {
     throw new Error(
-      `The supplied dependency-cruiser result is not valid: ${ajv.errorsText()}.\n`
+      `The supplied dependency-cruiser result is not valid: ${ajv.errorsText()}.\n`,
     );
   }
 }
 /** @type {import("../../types/dependency-cruiser.js").format} */
 export default async function format(pResult, pFormatOptions = {}) {
   const lFormatOptions = normalizeFormatOptions(pFormatOptions);
-  validateFormatOptions(lFormatOptions);
+  assertFormatOptionsValid(lFormatOptions);
 
   validateResultAgainstSchema(pResult);
 

--- a/src/main/options/assert-validity.mjs
+++ b/src/main/options/assert-validity.mjs
@@ -6,29 +6,29 @@ import report from "../../report/index.mjs";
 const MODULE_SYSTEM_LIST_RE = /^((cjs|amd|es6|tsd)(,|$))+$/gi;
 const VALID_DEPTH_RE = /^\d{1,2}$/g;
 
-function validateSystems(pModuleSystems) {
+function assertModuleSystemsValid(pModuleSystems) {
   if (
     Boolean(pModuleSystems) &&
     Array.isArray(pModuleSystems) &&
     !pModuleSystems.every((pModuleSystem) =>
-      Boolean(pModuleSystem.match(MODULE_SYSTEM_LIST_RE))
+      Boolean(pModuleSystem.match(MODULE_SYSTEM_LIST_RE)),
     )
   ) {
     throw new Error(
-      `Invalid module system list: '${pModuleSystems.join(", ")}'\n`
+      `Invalid module system list: '${pModuleSystems.join(", ")}'\n`,
     );
   }
 }
 
-function validateRegExpSafety(pPattern) {
+function assertRegExpSafety(pPattern) {
   if (Boolean(pPattern) && !safeRegex(pPattern)) {
     throw new Error(
-      `The pattern '${pPattern}' will probably run very slowly - cowardly refusing to run.\n`
+      `The pattern '${pPattern}' will probably run very slowly - cowardly refusing to run.\n`,
     );
   }
 }
 
-function validateOutputType(pOutputType) {
+function assertOutputTypeValid(pOutputType) {
   if (
     Boolean(pOutputType) &&
     !report.getAvailableReporters().includes(pOutputType) &&
@@ -38,15 +38,15 @@ function validateOutputType(pOutputType) {
   }
 }
 
-function validateMaxDepth(pDepth) {
+function assertMaxDepthValid(pDepth) {
   if (Boolean(pDepth) && !pDepth.toString().match(VALID_DEPTH_RE)) {
     throw new Error(
-      `'${pDepth}' is not a valid depth - use an integer between 0 and 99`
+      `'${pDepth}' is not a valid depth - use an integer between 0 and 99`,
     );
   }
 }
 
-function validateFocusDepth(pFocusDepth) {
+function assertFocusDepthValid(pFocusDepth) {
   const lFocusDepth = Number.parseInt(pFocusDepth, 10);
   const lMaxFocusDepth = 99;
 
@@ -57,18 +57,18 @@ function validateFocusDepth(pFocusDepth) {
       lFocusDepth > lMaxFocusDepth)
   ) {
     throw new Error(
-      `'${pFocusDepth}' is not a valid focus depth - use an integer between 0 and ${lMaxFocusDepth}`
+      `'${pFocusDepth}' is not a valid focus depth - use an integer between 0 and ${lMaxFocusDepth}`,
     );
   }
 }
 
-function validatePathsSafety(pFilterOption) {
+function assertPathsSafety(pFilterOption) {
   if (typeof pFilterOption === "string") {
-    validateRegExpSafety(pFilterOption);
+    assertRegExpSafety(pFilterOption);
   }
 
-  validateRegExpSafety(pFilterOption?.path ?? "");
-  validateRegExpSafety(pFilterOption?.pathNot ?? "");
+  assertRegExpSafety(pFilterOption?.path ?? "");
+  assertRegExpSafety(pFilterOption?.pathNot ?? "");
 }
 
 /**
@@ -76,32 +76,32 @@ function validatePathsSafety(pFilterOption) {
  * @throws {Error}
  * @returns {import("../../../types/dependency-cruiser.js").ICruiseOptions}
  */
-export function validateCruiseOptions(pOptions) {
+export function assertCruiseOptionsValid(pOptions) {
   let lReturnValue = {};
 
   if (Boolean(pOptions)) {
     // necessary because can slip through the cracks when passed as a cli parameter
-    validateSystems(pOptions.moduleSystems);
+    assertModuleSystemsValid(pOptions.moduleSystems);
 
     // necessary because this safety check can't be done in json schema (a.f.a.i.k.)
-    validatePathsSafety(pOptions.doNotFollow);
-    validatePathsSafety(pOptions.exclude);
-    validateRegExpSafety(pOptions.includeOnly);
-    validateRegExpSafety(pOptions.focus);
-    validateRegExpSafety(pOptions.reaches);
-    validateRegExpSafety(pOptions.highlight);
-    validateRegExpSafety(pOptions.collapse);
+    assertPathsSafety(pOptions.doNotFollow);
+    assertPathsSafety(pOptions.exclude);
+    assertRegExpSafety(pOptions.includeOnly);
+    assertRegExpSafety(pOptions.focus);
+    assertRegExpSafety(pOptions.reaches);
+    assertRegExpSafety(pOptions.highlight);
+    assertRegExpSafety(pOptions.collapse);
 
     // necessary because not in the config schema
-    validateOutputType(pOptions.outputType);
+    assertOutputTypeValid(pOptions.outputType);
 
     // necessary because not found a way to do this properly in JSON schema
-    validateMaxDepth(pOptions.maxDepth);
+    assertMaxDepthValid(pOptions.maxDepth);
 
-    validateFocusDepth(pOptions.focusDepth);
+    assertFocusDepthValid(pOptions.focusDepth);
 
     if (has(pOptions, "ruleSet.options")) {
-      lReturnValue = validateCruiseOptions(pOptions.ruleSet.options);
+      lReturnValue = assertCruiseOptionsValid(pOptions.ruleSet.options);
     }
     return merge({}, lReturnValue, pOptions);
   }
@@ -113,12 +113,12 @@ export function validateCruiseOptions(pOptions) {
  * @param {import("../../../types/dependency-cruiser.js").IFormatOptions} pFormatOptions
  * @throws {Error}
  */
-export function validateFormatOptions(pFormatOptions) {
-  validatePathsSafety(pFormatOptions.exclude);
-  validatePathsSafety(pFormatOptions.focus);
-  validatePathsSafety(pFormatOptions.reaches);
-  validatePathsSafety(pFormatOptions.includeOnly);
-  validateRegExpSafety(pFormatOptions.collapse);
-  validateOutputType(pFormatOptions.outputType);
-  validateFocusDepth(pFormatOptions.focusDepth);
+export function assertFormatOptionsValid(pFormatOptions) {
+  assertPathsSafety(pFormatOptions.exclude);
+  assertPathsSafety(pFormatOptions.focus);
+  assertPathsSafety(pFormatOptions.reaches);
+  assertPathsSafety(pFormatOptions.includeOnly);
+  assertRegExpSafety(pFormatOptions.collapse);
+  assertOutputTypeValid(pFormatOptions.outputType);
+  assertFocusDepthValid(pFormatOptions.focusDepth);
 }

--- a/src/main/rule-set/assert-validity.mjs
+++ b/src/main/rule-set/assert-validity.mjs
@@ -1,7 +1,7 @@
 import Ajv from "ajv";
 import safeRegex from "safe-regex";
 import has from "lodash/has.js";
-import { validateCruiseOptions } from "../options/validate.mjs";
+import { assertCruiseOptionsValid } from "../options/assert-validity.mjs";
 import configurationSchema from "../../schema/configuration.schema.mjs";
 import { normalizeToREAsString } from "../helpers.mjs";
 
@@ -88,7 +88,7 @@ export default function assertRuleSetValid(pConfiguration) {
   (pConfiguration.allowed || []).forEach(assertRuleSafety);
   (pConfiguration.forbidden || []).forEach(assertRuleSafety);
   if (has(pConfiguration, "options")) {
-    validateCruiseOptions(pConfiguration.options);
+    assertCruiseOptionsValid(pConfiguration.options);
   }
   return pConfiguration;
 }

--- a/src/main/rule-set/assert-validity.mjs
+++ b/src/main/rule-set/assert-validity.mjs
@@ -19,10 +19,10 @@ const ajv = new Ajv();
 // of the safe-regex package.
 const MAX_SAFE_REGEX_STAR_REPEAT_LIMIT = 10000;
 
-function validateAgainstSchema(pSchema, pConfiguration) {
+function assertSchemaCompliance(pSchema, pConfiguration) {
   if (!ajv.validate(pSchema, pConfiguration)) {
     throw new Error(
-      `The supplied configuration is not valid: ${ajv.errorsText()}.\n`
+      `The supplied configuration is not valid: ${ajv.errorsText()}.\n`,
     );
   }
 }
@@ -40,7 +40,7 @@ function safeRule(pRule, pSection, pCondition) {
   );
 }
 
-function checkRuleSafety(pRule) {
+function assertRuleSafety(pRule) {
   const lRegexConditions = [
     { section: "from", condition: "path" },
     { section: "to", condition: "path" },
@@ -56,15 +56,16 @@ function checkRuleSafety(pRule) {
 
   if (
     lRegexConditions.some(
-      (pCondition) => !safeRule(pRule, pCondition.section, pCondition.condition)
+      (pCondition) =>
+        !safeRule(pRule, pCondition.section, pCondition.condition),
     )
   ) {
     throw new Error(
       `rule ${JSON.stringify(
         pRule,
         null,
-        ""
-      )} has an unsafe regular expression. Bailing out.\n`
+        "",
+      )} has an unsafe regular expression. Bailing out.\n`,
     );
   }
 }
@@ -74,7 +75,7 @@ function checkRuleSafety(pRule) {
  * Throws an Error in all other cases.
  *
  * Validations:
- * - the ruleset adheres to the [config json schema](../../schema/configuration.schema.json)
+ * - the rule set adheres to the [config json schema](../../schema/configuration.schema.json)
  * - any regular expression in the rule set is 'safe' (~= won't be too slow)
  *
  * @param  {import("../../../types/configuration.js").IConfiguration} pConfiguration The configuration to validate
@@ -82,10 +83,10 @@ function checkRuleSafety(pRule) {
  * @throws {Error}                 An error with the reason for the error as
  *                                 a message
  */
-export default function validateConfiguration(pConfiguration) {
-  validateAgainstSchema(configurationSchema, pConfiguration);
-  (pConfiguration.allowed || []).forEach(checkRuleSafety);
-  (pConfiguration.forbidden || []).forEach(checkRuleSafety);
+export default function assertRuleSetValid(pConfiguration) {
+  assertSchemaCompliance(configurationSchema, pConfiguration);
+  (pConfiguration.allowed || []).forEach(assertRuleSafety);
+  (pConfiguration.forbidden || []).forEach(assertRuleSafety);
   if (has(pConfiguration, "options")) {
     validateCruiseOptions(pConfiguration.options);
   }

--- a/test/cli/validate-node-environment.spec.mjs
+++ b/test/cli/validate-node-environment.spec.mjs
@@ -1,46 +1,46 @@
 import { doesNotThrow, throws } from "node:assert/strict";
-import validateNodeEnvironment from "../../src/cli/validate-node-environment.mjs";
+import assertNodeEnvironmentSuitable from "../../src/cli/assert-node-environment-suitable.mjs";
 
 describe("[U] cli/validateNodeEnv", () => {
   it("throws when an older and unsupported node version is passed", () => {
     throws(() => {
-      validateNodeEnvironment("6.0.0");
+      assertNodeEnvironmentSuitable("6.0.0");
     });
   });
 
   it("throws when a newer but unsupported node version is passed", () => {
     throws(() => {
-      validateNodeEnvironment("9.0.0");
+      assertNodeEnvironmentSuitable("9.0.0");
     });
   });
 
   it("doesn't throw when an empty node version is passed (assuming test is run on a supported platform)", () => {
     doesNotThrow(() => {
-      validateNodeEnvironment("");
+      assertNodeEnvironmentSuitable("");
     });
   });
 
   it("doesn't throw when a null node version is passed (assuming test is run on a supported platform)", () => {
     doesNotThrow(() => {
-      validateNodeEnvironment(null);
+      assertNodeEnvironmentSuitable(null);
     });
   });
 
   it("doesn't throw when an undefined node version is passed (assuming test is run on a supported platform)", () => {
     doesNotThrow(() => {
-      validateNodeEnvironment();
+      assertNodeEnvironmentSuitable();
     });
   });
 
   it("doesn't throw when no node version is passed (assuming this test is run on a supported platform ...)", () => {
     doesNotThrow(() => {
-      validateNodeEnvironment();
+      assertNodeEnvironmentSuitable();
     });
   });
 
   it("doesn't throw when a supported node version is passed", () => {
     doesNotThrow(() => {
-      validateNodeEnvironment("20.0.0");
+      assertNodeEnvironmentSuitable("20.0.0");
     });
   });
 });

--- a/test/main/options/assert-validity.spec.mjs
+++ b/test/main/options/assert-validity.spec.mjs
@@ -1,10 +1,10 @@
 import { doesNotThrow, equal, throws } from "node:assert/strict";
-import { validateCruiseOptions } from "../../../src/main/options/validate.mjs";
+import { assertCruiseOptionsValid } from "../../../src/main/options/assert-validity.mjs";
 
 describe("[U] main/options/validate - module systems", () => {
   it("throws when a invalid module system is passed ", () => {
     throws(() => {
-      validateCruiseOptions({
+      assertCruiseOptionsValid({
         moduleSystems: ["notavalidmodulesystem"],
       });
     }, /Invalid module system list: 'notavalidmodulesystem'/);
@@ -12,7 +12,7 @@ describe("[U] main/options/validate - module systems", () => {
 
   it("passes when a valid module system is passed", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ moduleSystems: ["cjs"] });
+      assertCruiseOptionsValid({ moduleSystems: ["cjs"] });
     });
   });
 });
@@ -20,13 +20,13 @@ describe("[U] main/options/validate - module systems", () => {
 describe("[U] main/options/validate - output types", () => {
   it("throws when a invalid output type is passed ", () => {
     throws(() => {
-      validateCruiseOptions({ outputType: "notAValidOutputType" });
+      assertCruiseOptionsValid({ outputType: "notAValidOutputType" });
     }, /'notAValidOutputType' is not a valid output type\./);
   });
 
   it("passes when a valid output type is passed", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ outputType: "err" });
+      assertCruiseOptionsValid({ outputType: "err" });
     });
   });
 });
@@ -34,43 +34,43 @@ describe("[U] main/options/validate - output types", () => {
 describe("[U] main/options/validate - maxDepth", () => {
   it("throws when a non-integer is passed as maxDepth", () => {
     throws(() => {
-      validateCruiseOptions({ maxDepth: "not an integer" });
+      assertCruiseOptionsValid({ maxDepth: "not an integer" });
     }, /'not an integer' is not a valid depth - use an integer between 0 and 99/);
   });
 
   it("throws when > 99 is passed as maxDepth (string)", () => {
     throws(() => {
-      validateCruiseOptions({ maxDepth: "101" });
+      assertCruiseOptionsValid({ maxDepth: "101" });
     }, /'101' is not a valid depth - use an integer between 0 and 99/);
   });
 
   it("throws when > 99 is passed as maxDepth (number)", () => {
     throws(() => {
-      validateCruiseOptions({ maxDepth: 101 });
+      assertCruiseOptionsValid({ maxDepth: 101 });
     }, /'101' is not a valid depth - use an integer between 0 and 99/);
   });
 
   it("throws when < 0 is passed as maxDepth (string)", () => {
     throws(() => {
-      validateCruiseOptions({ maxDepth: "-1" });
+      assertCruiseOptionsValid({ maxDepth: "-1" });
     }, /'-1' is not a valid depth - use an integer between 0 and 99/);
   });
 
   it("throws when < 0 is passed as maxDepth (number)", () => {
     throws(() => {
-      validateCruiseOptions({ maxDepth: -1 });
+      assertCruiseOptionsValid({ maxDepth: -1 });
     }, /'-1' is not a valid depth - use an integer between 0 and 99/);
   });
 
   it("passes when a valid depth is passed as maxDepth (string)", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ maxDepth: "42" });
+      assertCruiseOptionsValid({ maxDepth: "42" });
     });
   });
 
   it("passes when a valid depth is passed as maxDepth (number)", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ maxDepth: 42 });
+      assertCruiseOptionsValid({ maxDepth: 42 });
     });
   });
 });
@@ -78,43 +78,43 @@ describe("[U] main/options/validate - maxDepth", () => {
 describe("[U] main/options/validate - focusDepth", () => {
   it("throws when a non-integer is passed", () => {
     throws(() => {
-      validateCruiseOptions({ focusDepth: "not an integer" });
+      assertCruiseOptionsValid({ focusDepth: "not an integer" });
     }, /'not an integer' is not a valid focus depth - use an integer between 0 and 99/);
   });
 
   it("throws when > 99 is passed (string)", () => {
     throws(() => {
-      validateCruiseOptions({ focusDepth: "101" });
+      assertCruiseOptionsValid({ focusDepth: "101" });
     }, /'101' is not a valid focus depth - use an integer between 0 and 99/);
   });
 
   it("throws when > 99 is passed as maxDepth (number)", () => {
     throws(() => {
-      validateCruiseOptions({ focusDepth: 101 });
+      assertCruiseOptionsValid({ focusDepth: 101 });
     }, /'101' is not a valid focus depth - use an integer between 0 and 99/);
   });
 
   it("throws when < 0 is passed (string)", () => {
     throws(() => {
-      validateCruiseOptions({ focusDepth: "-1" });
+      assertCruiseOptionsValid({ focusDepth: "-1" });
     }, /'-1' is not a valid focus depth - use an integer between 0 and 99/);
   });
 
   it("throws when < 0 is passed (number)", () => {
     throws(() => {
-      validateCruiseOptions({ focusDepth: -1 });
+      assertCruiseOptionsValid({ focusDepth: -1 });
     }, /'-1' is not a valid focus depth - use an integer between 0 and 99/);
   });
 
   it("passes when a valid depth is passed (string)", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ focusDepth: "42" });
+      assertCruiseOptionsValid({ focusDepth: "42" });
     });
   });
 
   it("passes when a valid depth is passed (number)", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ focusDepth: 42 });
+      assertCruiseOptionsValid({ focusDepth: 42 });
     });
   });
 });
@@ -122,37 +122,37 @@ describe("[U] main/options/validate - focusDepth", () => {
 describe("[U] main/options/validate - exclude", () => {
   it("throws when --exclude is passed an unsafe regex", () => {
     throws(() => {
-      validateCruiseOptions({ exclude: "([A-Za-z]+)*" });
+      assertCruiseOptionsValid({ exclude: "([A-Za-z]+)*" });
     }, /The pattern '\(\[A-Za-z\]\+\)\*' will probably run very slowly - cowardly refusing to run\./);
   });
 
   it("throws when exclude.path is passed an unsafe regex", () => {
     throws(() => {
-      validateCruiseOptions({ exclude: "([A-Za-z]+)*" });
+      assertCruiseOptionsValid({ exclude: "([A-Za-z]+)*" });
     }, /The pattern '\(\[A-Za-z\]\+\)\*' will probably run very slowly - cowardly refusing to run\./);
   });
 
   it("throws when exclude.pathNot is passed an unsafe regex", () => {
     throws(() => {
-      validateCruiseOptions({ exclude: "([A-Za-z]+)*" });
+      assertCruiseOptionsValid({ exclude: "([A-Za-z]+)*" });
     }, /The pattern '\(\[A-Za-z\]\+\)\*' will probably run very slowly - cowardly refusing to run\./);
   });
 
   it("throws when doNotFollow.pathNot is passed an unsafe regex", () => {
     throws(() => {
-      validateCruiseOptions({ doNotFollow: "([A-Za-z]+)*" });
+      assertCruiseOptionsValid({ doNotFollow: "([A-Za-z]+)*" });
     }, /The pattern '\(\[A-Za-z\]\+\)\*' will probably run very slowly - cowardly refusing to run\./);
   });
 
   it("passes when --exclude is passed a safe regex", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({ exclude: "([A-Za-z]+)" });
+      assertCruiseOptionsValid({ exclude: "([A-Za-z]+)" });
     });
   });
 
   it("passes when --validate is passed a safe regex in rule-set.exclude", () => {
     doesNotThrow(() => {
-      validateCruiseOptions({
+      assertCruiseOptionsValid({
         ruleSet: { options: { exclude: "([A-Za-z]+)" } },
       });
     });
@@ -160,14 +160,14 @@ describe("[U] main/options/validate - exclude", () => {
 
   it("throws when --validate is passed an unsafe regex in rule-set.exclude", () => {
     throws(() => {
-      validateCruiseOptions({
+      assertCruiseOptionsValid({
         ruleSet: { options: { exclude: "(.*)+" } },
       });
     }, /The pattern '\(\.\*\)\+' will probably run very slowly - cowardly refusing to run\./);
   });
 
   it("command line options trump those passed in --validate rule-set", () => {
-    const lOptions = validateCruiseOptions({
+    const lOptions = assertCruiseOptionsValid({
       exclude: "from the commandline",
       ruleSet: { options: { exclude: "from the ruleset" } },
     });
@@ -176,7 +176,7 @@ describe("[U] main/options/validate - exclude", () => {
   });
 
   it("options passed in --validate rule-set drip down to the proper options", () => {
-    const lOptions = validateCruiseOptions({
+    const lOptions = assertCruiseOptionsValid({
       doNotFollow: "from the commandline",
       ruleSet: { options: { exclude: "from the ruleset" } },
     });

--- a/test/main/rule-set/assert-validity.spec.mjs
+++ b/test/main/rule-set/assert-validity.spec.mjs
@@ -1,11 +1,11 @@
 import { readFileSync } from "node:fs";
 import { deepEqual, throws } from "node:assert/strict";
-import validate from "../../../src/main/rule-set/validate.mjs";
+import assertRuleSetValid from "../../../src/main/rule-set/assert-validity.mjs";
 
 function shouldBarfWithMessage(pRulesFile, pMessage) {
   throws(
     () => {
-      validate(JSON.parse(readFileSync(pRulesFile, "utf8")));
+      assertRuleSetValid(JSON.parse(readFileSync(pRulesFile, "utf8")));
     },
     { message: pMessage },
   );
@@ -14,7 +14,7 @@ function shouldBarfWithMessage(pRulesFile, pMessage) {
 function shouldBeOK(pRulesFile) {
   const lRulesObject = JSON.parse(readFileSync(pRulesFile, "utf8"));
 
-  deepEqual(validate(lRulesObject), lRulesObject);
+  deepEqual(assertRuleSetValid(lRulesObject), lRulesObject);
 }
 
 describe("[I] main/rule-set/validate - regular", () => {

--- a/test/validate/parse-ruleset.utl.mjs
+++ b/test/validate/parse-ruleset.utl.mjs
@@ -1,4 +1,4 @@
 import normalizeRuleSet from "../../src/main/rule-set/normalize.mjs";
-import validateRuleSet from "../../src/main/rule-set/validate.mjs";
+import assertRuleSetValid from "../../src/main/rule-set/assert-validity.mjs";
 
-export default (pRuleSet) => normalizeRuleSet(validateRuleSet(pRuleSet));
+export default (pRuleSet) => normalizeRuleSet(assertRuleSetValid(pRuleSet));


### PR DESCRIPTION
## Description

* in the cli renames assertion that checks whether the node environment is suitable
* in the main 'option' check renames functions that assert whether the options are valid
* in the main 'rule-set' renames functions that assert whether the rule set is valid

## Motivation and Context

A lot of the assertions dependency-cruiser makes before starting were called 'validate' - which is not as clear/ descriptive of the actual functionality of the functions as 'assert' is. Renaming 

## How Has This Been Tested?

- [x] green ci
- [x] updated automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
