### PR TITLE
refactor: replaces lodash's clone & cloneDeep with native structuredClone

### DIFF
--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -1,6 +1,5 @@
 import { join } from "node:path";
 import picomatch from "picomatch";
-import cloneDeep from "lodash/cloneDeep.js";
 import set from "lodash/set.js";
 import isInstalledGlobally from "is-installed-globally";
 import chalk from "chalk";
@@ -44,7 +43,7 @@ async function addKnownViolations(pCruiseOptions) {
 
     // Check against json schema is already done in src/main/options/validate
     // so here we can just concentrate on the io
-    let lCruiseOptions = cloneDeep(pCruiseOptions);
+    let lCruiseOptions = structuredClone(pCruiseOptions);
     set(lCruiseOptions, "ruleSet.options.knownViolations", lKnownViolations);
     return lCruiseOptions;
   }

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -3,7 +3,6 @@ import { isAbsolute } from "node:path";
 import set from "lodash/set.js";
 import get from "lodash/get.js";
 import has from "lodash/has.js";
-import clone from "lodash/clone.js";
 import loadConfig from "../config-utl/extract-depcruise-config/index.mjs";
 import {
   RULES_FILE_NAME_SEARCH_ARRAY,
@@ -21,13 +20,13 @@ function getOptionValue(pDefault) {
 }
 
 function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
-  let lOptions = clone(pCliOptions);
+  let lOptions = structuredClone(pCliOptions);
 
   if (has(lOptions, pConfigWrapperName)) {
     set(
       lOptions,
       `ruleSet.options.${pConfigWrapperName}.fileName`,
-      getOptionValue(pDefault)(lOptions[pConfigWrapperName])
+      getOptionValue(pDefault)(lOptions[pConfigWrapperName]),
       /* eslint security/detect-object-injection: 0 */
     );
     Reflect.deleteProperty(lOptions, pConfigWrapperName);
@@ -61,7 +60,7 @@ function validateAndGetCustomRulesFileName(pValidate) {
     throw new Error(
       `Can't open config file '${pValidate}' for reading. Does it exist?\n` +
         `         - You can create a config file by running 'npx dependency-cruiser --init'\n` +
-        `         - If you intended to run without a config file use --no-config\n`
+        `         - If you intended to run without a config file use --no-config\n`,
     );
   }
   return lReturnValue;
@@ -74,7 +73,7 @@ function validateAndGetDefaultRulesFileName() {
     throw new TypeError(
       `Can't open a config file (.dependency-cruiser.(c)js) at the default location. Does it exist?\n` +
         `         - You can create one by running 'npx dependency-cruiser --init'\n` +
-        `         - Want to run a without a config file? Use --no-config\n`
+        `         - Want to run a without a config file? Use --no-config\n`,
     );
   }
   return lReturnValue;
@@ -103,7 +102,7 @@ function validateAndGetKnownViolationsFileName(pKnownViolations) {
   } else {
     throw new Error(
       `Can't open '${lKnownViolationsFileName}' for reading. Does it exist?\n` +
-        `         (You can create a .dependency-cruiser-known-violations.json with --output-type baseline)\n`
+        `         (You can create a .dependency-cruiser-known-violations.json with --output-type baseline)\n`,
     );
   }
 }
@@ -114,7 +113,7 @@ function normalizeKnownViolationsOption(pCliOptions) {
   }
   return {
     knownViolationsFile: validateAndGetKnownViolationsFileName(
-      pCliOptions.ignoreKnown
+      pCliOptions.ignoreKnown,
     ),
   };
 }
@@ -129,7 +128,7 @@ async function normalizeValidationOption(pCliOptions) {
   return {
     rulesFile,
     ruleSet: await loadConfig(
-      isAbsolute(rulesFile) ? rulesFile : `./${rulesFile}`
+      isAbsolute(rulesFile) ? rulesFile : `./${rulesFile}`,
     ),
     validate: true,
   };
@@ -157,7 +156,7 @@ function normalizeCacheStrategy(pCliOptions) {
   let lReturnValue = {};
 
   if (pCliOptions.cache && typeof pCliOptions.cache === "object") {
-    lReturnValue.cache = clone(pCliOptions.cache);
+    lReturnValue.cache = structuredClone(pCliOptions.cache);
     lReturnValue.cache.strategy = lStrategy;
   } else {
     lReturnValue = {
@@ -227,5 +226,5 @@ export default async function normalizeOptions(pOptionsAsPassedFromCommander) {
 }
 
 export const determineRulesFileName = getOptionValue(
-  OLD_DEFAULT_RULES_FILE_NAME
+  OLD_DEFAULT_RULES_FILE_NAME,
 );

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -1,5 +1,4 @@
 import { dirname } from "node:path";
-import cloneDeep from "lodash/cloneDeep.js";
 import has from "lodash/has.js";
 import { resolve } from "../../extract/resolve/resolve.mjs";
 import normalizeResolveOptions from "../../main/resolve-options/normalize.mjs";
@@ -8,7 +7,7 @@ import mergeConfigs from "./merge-configs.mjs";
 
 /* eslint no-use-before-define: 0 */
 async function processExtends(pReturnValue, pAlreadyVisited, pBaseDirectory) {
-  let lReturnValue = cloneDeep(pReturnValue);
+  let lReturnValue = structuredClone(pReturnValue);
 
   if (typeof lReturnValue.extends === "string") {
     lReturnValue = mergeConfigs(
@@ -16,8 +15,8 @@ async function processExtends(pReturnValue, pAlreadyVisited, pBaseDirectory) {
       await extractDepcruiseConfig(
         lReturnValue.extends,
         pAlreadyVisited,
-        pBaseDirectory
-      )
+        pBaseDirectory,
+      ),
     );
   }
 
@@ -26,7 +25,7 @@ async function processExtends(pReturnValue, pAlreadyVisited, pBaseDirectory) {
       lReturnValue = mergeConfigs(
         lReturnValue,
         // eslint-disable-next-line no-await-in-loop
-        await extractDepcruiseConfig(lExtends, pAlreadyVisited, pBaseDirectory)
+        await extractDepcruiseConfig(lExtends, pAlreadyVisited, pBaseDirectory),
       );
     }
   }
@@ -54,7 +53,7 @@ async function processExtends(pReturnValue, pAlreadyVisited, pBaseDirectory) {
 export default async function extractDepcruiseConfig(
   pConfigFileName,
   pAlreadyVisited = new Set(),
-  pBaseDirectory = process.cwd()
+  pBaseDirectory = process.cwd(),
 ) {
   const lResolvedFileName = resolve(
     pConfigFileName,
@@ -63,17 +62,17 @@ export default async function extractDepcruiseConfig(
       {
         extensions: [".js", ".json", ".cjs", ".mjs"],
       },
-      {}
+      {},
     ),
-    "cli"
+    "cli",
   );
   const lBaseDirectory = dirname(lResolvedFileName);
 
   if (pAlreadyVisited.has(lResolvedFileName)) {
     throw new Error(
       `config is circular - ${[...pAlreadyVisited].join(
-        " -> "
-      )} -> ${lResolvedFileName}.\n`
+        " -> ",
+      )} -> ${lResolvedFileName}.\n`,
     );
   }
   pAlreadyVisited.add(lResolvedFileName);
@@ -84,7 +83,7 @@ export default async function extractDepcruiseConfig(
     lReturnValue = await processExtends(
       lReturnValue,
       pAlreadyVisited,
-      lBaseDirectory
+      lBaseDirectory,
     );
   }
 

--- a/src/enrich/derive/reachable.mjs
+++ b/src/enrich/derive/reachable.mjs
@@ -1,5 +1,4 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
-import cloneDeep from "lodash/cloneDeep.js";
 import has from "lodash/has.js";
 import matchers from "../../validate/matchers.mjs";
 import { extractGroups } from "../../utl/regex-util.mjs";
@@ -9,7 +8,7 @@ function getReachableRules(pRuleSet) {
   return (pRuleSet?.forbidden ?? [])
     .filter((pRule) => has(pRule.to, "reachable"))
     .concat(
-      (pRuleSet?.allowed ?? []).filter((pRule) => has(pRule.to, "reachable"))
+      (pRuleSet?.allowed ?? []).filter((pRule) => has(pRule.to, "reachable")),
     );
 }
 
@@ -33,7 +32,7 @@ function isModuleInRuleTo(pRule, pModuleTo, pModuleFrom) {
 function mergeReachableProperties(pModule, pRule, pPath, pModuleFrom) {
   const lReachables = pModule.reachable || [];
   const lIndexExistingReachable = lReachables.findIndex(
-    (pReachable) => pReachable.asDefinedInRule === pRule.name
+    (pReachable) => pReachable.asDefinedInRule === pRule.name,
   );
   const lIsReachable = pPath.length > 1;
 
@@ -53,7 +52,7 @@ function mergeReachableProperties(pModule, pRule, pPath, pModuleFrom) {
 function mergeReachesProperties(pFromModule, pToModule, pRule, pPath) {
   const lReaches = pFromModule.reaches || [];
   const lIndexExistingReachable = lReaches.findIndex(
-    (pReachable) => pReachable.asDefinedInRule === pRule.name
+    (pReachable) => pReachable.asDefinedInRule === pRule.name,
   );
 
   if (lIndexExistingReachable > -1) {
@@ -84,7 +83,7 @@ function hasCapturingGroups(pRule) {
 
   return Boolean(
     (pRule?.to?.path ?? "").match(lCapturingGroupPlaceholderRe) ||
-      (pRule?.to?.pathNot ?? "").match(lCapturingGroupPlaceholderRe)
+      (pRule?.to?.pathNot ?? "").match(lCapturingGroupPlaceholderRe),
   );
 }
 function shouldAddReachable(pRule, pModuleTo, pGraph) {
@@ -95,7 +94,7 @@ function shouldAddReachable(pRule, pModuleTo, pGraph) {
       const lModulesFrom = pGraph.filter(isModuleInRuleFrom(pRule));
 
       lReturnValue = lModulesFrom.some((pModuleFrom) =>
-        isModuleInRuleTo(pRule, pModuleTo, pModuleFrom)
+        isModuleInRuleTo(pRule, pModuleTo, pModuleFrom),
       );
     } else {
       lReturnValue = isModuleInRuleTo(pRule, pModuleTo);
@@ -106,7 +105,7 @@ function shouldAddReachable(pRule, pModuleTo, pGraph) {
 
 function addReachesToModule(pModule, pGraph, pIndexedGraph, pReachableRule) {
   const lToModules = pGraph.filter((pToModule) =>
-    isModuleInRuleTo(pReachableRule, pToModule, pModule)
+    isModuleInRuleTo(pReachableRule, pToModule, pModule),
   );
 
   for (let lToModule of lToModules) {
@@ -118,7 +117,7 @@ function addReachesToModule(pModule, pGraph, pIndexedGraph, pReachableRule) {
           pModule,
           lToModule,
           pReachableRule,
-          lPath
+          lPath,
         );
       }
     }
@@ -143,7 +142,7 @@ function addReachableToModule(pModule, pGraph, pIndexedGraph, pReachableRule) {
         pModule,
         pReachableRule,
         lPath,
-        lFromModule.source
+        lFromModule.source,
       );
     }
   }
@@ -152,14 +151,14 @@ function addReachableToModule(pModule, pGraph, pIndexedGraph, pReachableRule) {
 
 function addReachabilityToGraph(pGraph, pIndexedGraph, pReachableRule) {
   return pGraph.map((pModule) => {
-    let lClonedModule = cloneDeep(pModule);
+    let lClonedModule = structuredClone(pModule);
 
     if (shouldAddReaches(pReachableRule, lClonedModule)) {
       lClonedModule = addReachesToModule(
         lClonedModule,
         pGraph,
         pIndexedGraph,
-        pReachableRule
+        pReachableRule,
       );
     }
     if (shouldAddReachable(pReachableRule, lClonedModule, pGraph)) {
@@ -167,7 +166,7 @@ function addReachabilityToGraph(pGraph, pIndexedGraph, pReachableRule) {
         lClonedModule,
         pGraph,
         pIndexedGraph,
-        pReachableRule
+        pReachableRule,
       );
     }
     return lClonedModule;
@@ -182,6 +181,6 @@ export default function deriveReachables(pGraph, pRuleSet) {
   return lReachableRules.reduce(
     (pReturnGraph, pRule) =>
       addReachabilityToGraph(pReturnGraph, lIndexedGraph, pRule),
-    cloneDeep(pGraph)
+    structuredClone(pGraph),
   );
 }

--- a/src/enrich/summarize/add-rule-set-used.mjs
+++ b/src/enrich/summarize/add-rule-set-used.mjs
@@ -1,9 +1,7 @@
-import clone from "lodash/clone.js";
-
 // the fixed name for allowed rules served a purpose during the extraction
 // process - but it's not necessary to reflect it in the output.
 function removeNames(pRule) {
-  const lReturnValue = clone(pRule);
+  const lReturnValue = structuredClone(pRule);
 
   Reflect.deleteProperty(lReturnValue, "name");
   return lReturnValue;
@@ -19,6 +17,6 @@ export default function addRuleSetUsed(pOptions) {
     lForbidden ? { forbidden: lForbidden } : {},
     lAllowed ? { allowed: lAllowed.map(removeNames) } : {},
     lAllowedSeverity ? { allowedSeverity: lAllowedSeverity } : {},
-    lRequired ? { required: lRequired } : {}
+    lRequired ? { required: lRequired } : {},
   );
 }

--- a/src/extract/resolve/merge-manifests.mjs
+++ b/src/extract/resolve/merge-manifests.mjs
@@ -1,12 +1,13 @@
 /* eslint-disable security/detect-object-injection */
 import uniq from "lodash/uniq.js";
-import clone from "lodash/clone.js";
 
 function normalizeManifestKeys(pManifest) {
   let lReturnValue = pManifest;
 
   if (pManifest.bundleDependencies) {
-    pManifest.bundledDependencies = clone(pManifest.bundleDependencies);
+    pManifest.bundledDependencies = structuredClone(
+      pManifest.bundleDependencies,
+    );
     Reflect.deleteProperty(pManifest, "bundleDependencies");
   }
   return lReturnValue;
@@ -34,8 +35,8 @@ function getDependencyKeys(pPackage) {
 function getJointUniqueDependencyKeys(pClosestPackage, pFurtherPackage) {
   return uniq(
     getDependencyKeys(pClosestPackage).concat(
-      getDependencyKeys(pFurtherPackage)
-    )
+      getDependencyKeys(pFurtherPackage),
+    ),
   );
 }
 
@@ -58,18 +59,18 @@ function getJointUniqueDependencyKeys(pClosestPackage, pFurtherPackage) {
 export default function mergeManifests(pClosestManifest, pFurtherManifest) {
   return getJointUniqueDependencyKeys(
     normalizeManifestKeys(pClosestManifest),
-    normalizeManifestKeys(pFurtherManifest)
+    normalizeManifestKeys(pFurtherManifest),
   )
     .map((pKey) => ({
       key: pKey,
       value: pKey.startsWith("bundle")
         ? mergeDependencyArray(
             pClosestManifest?.[pKey] ?? [],
-            pFurtherManifest?.[pKey] ?? []
+            pFurtherManifest?.[pKey] ?? [],
           )
         : mergeDependencyKey(
             pClosestManifest?.[pKey] ?? {},
-            pFurtherManifest?.[pKey] ?? {}
+            pFurtherManifest?.[pKey] ?? {},
           ),
     }))
     .reduce((pJoinedObject, pJoinedKey) => {

--- a/src/graph-utl/consolidate-module-dependencies.mjs
+++ b/src/graph-utl/consolidate-module-dependencies.mjs
@@ -1,4 +1,3 @@
-import clone from "lodash/clone.js";
 import _reject from "lodash/reject.js";
 import uniq from "lodash/uniq.js";
 import compare from "./compare.mjs";
@@ -8,7 +7,7 @@ function mergeDependency(pLeftDependency, pRightDependency) {
     ...pLeftDependency,
     ...pRightDependency,
     dependencyTypes: uniq(
-      pLeftDependency.dependencyTypes.concat(pRightDependency.dependencyTypes)
+      pLeftDependency.dependencyTypes.concat(pRightDependency.dependencyTypes),
     ),
     rules: pLeftDependency.rules
       .concat(pRightDependency?.rules ?? [])
@@ -27,17 +26,17 @@ function mergeDependencies(pResolvedName, pDependencies) {
         dependencyTypes: [],
         rules: [],
         valid: true,
-      }
+      },
     );
 }
 
 function consolidateDependencies(pDependencies) {
-  let lDependencies = clone(pDependencies);
+  let lDependencies = structuredClone(pDependencies);
   let lReturnValue = [];
 
   while (lDependencies.length > 0) {
     lReturnValue.push(
-      mergeDependencies(lDependencies[0].resolved, lDependencies)
+      mergeDependencies(lDependencies[0].resolved, lDependencies),
     );
     lDependencies = _reject(lDependencies, {
       resolved: lDependencies[0].resolved,

--- a/src/graph-utl/consolidate-modules.mjs
+++ b/src/graph-utl/consolidate-modules.mjs
@@ -1,4 +1,3 @@
-import clone from "lodash/clone.js";
 import _reject from "lodash/reject.js";
 import uniqBy from "lodash/uniqBy.js";
 import compare from "./compare.mjs";
@@ -9,7 +8,7 @@ function mergeModule(pLeftModule, pRightModule) {
     ...pRightModule,
     dependencies: uniqBy(
       pLeftModule.dependencies.concat(pRightModule.dependencies),
-      (pDependency) => pDependency.resolved
+      (pDependency) => pDependency.resolved,
     ),
     rules: pLeftModule.rules
       .concat(pRightModule?.rules ?? [])
@@ -30,12 +29,12 @@ function mergeModules(pSourceString, pModules) {
         dependencies: [],
         rules: [],
         valid: true,
-      }
+      },
     );
 }
 
 export default function consolidateModules(pModules) {
-  let lModules = clone(pModules);
+  let lModules = structuredClone(pModules);
   let lReturnValue = [];
 
   while (lModules.length > 0) {

--- a/src/graph-utl/filter-bank.mjs
+++ b/src/graph-utl/filter-bank.mjs
@@ -1,4 +1,3 @@
-import clone from "lodash/clone.js";
 import addFocus from "./add-focus.mjs";
 import IndexedModuleGraph from "./indexed-module-graph.mjs";
 import {
@@ -13,7 +12,7 @@ function includeOnly(pModules, pIncludeFilter) {
         .map((pModule) => ({
           ...pModule,
           dependencies: pModule.dependencies.filter((pDependency) =>
-            dependencyMatchesFilter(pDependency, pIncludeFilter)
+            dependencyMatchesFilter(pDependency, pIncludeFilter),
           ),
         }))
     : pModules;
@@ -27,7 +26,7 @@ function exclude(pModules, pExcludeFilter) {
           ...pModule,
           dependencies: pModule.dependencies.filter(
             (pDependency) =>
-              !dependencyMatchesFilter(pDependency, pExcludeFilter)
+              !dependencyMatchesFilter(pDependency, pExcludeFilter),
           ),
         }))
     : pModules;
@@ -49,7 +48,7 @@ function filterReaches(pModules, pReachesFilter) {
 
   for (let lModuleToReach of lModuleNamesToReach) {
     lReachingModules = lReachingModules.concat(
-      lIndexedModules.findTransitiveDependents(lModuleToReach)
+      lIndexedModules.findTransitiveDependents(lModuleToReach),
     );
   }
   return pModules
@@ -58,7 +57,7 @@ function filterReaches(pModules, pReachesFilter) {
       ...pModule,
       matchesReaches: lModuleNamesToReach.includes(pModule.source),
       dependencies: pModule.dependencies.filter(({ resolved }) =>
-        lReachingModules.includes(resolved)
+        lReachingModules.includes(resolved),
       ),
     }));
 }
@@ -73,7 +72,7 @@ function tagHighlight(pModules, pHighlightFilter) {
 // eslint-disable-next-line complexity
 export function applyFilters(pModules, pFilters) {
   if (pFilters) {
-    let lReturnValue = clone(pModules);
+    let lReturnValue = structuredClone(pModules);
 
     if (pFilters.exclude) {
       lReturnValue = exclude(lReturnValue, pFilters.exclude);

--- a/src/main/helpers.mjs
+++ b/src/main/helpers.mjs
@@ -1,7 +1,6 @@
 import get from "lodash/get.js";
 import has from "lodash/has.js";
 import set from "lodash/set.js";
-import cloneDeep from "lodash/cloneDeep.js";
 
 const RE_PROPERTIES = [
   "path",
@@ -30,16 +29,16 @@ export function normalizeToREAsString(pStringish) {
 
 export function normalizeREProperties(
   pPropertyContainer,
-  pREProperties = RE_PROPERTIES
+  pREProperties = RE_PROPERTIES,
 ) {
-  let lPropertyContainer = cloneDeep(pPropertyContainer);
+  let lPropertyContainer = structuredClone(pPropertyContainer);
 
   for (const lProperty of pREProperties) {
     if (has(lPropertyContainer, lProperty)) {
       set(
         lPropertyContainer,
         lProperty,
-        normalizeToREAsString(get(lPropertyContainer, lProperty))
+        normalizeToREAsString(get(lPropertyContainer, lProperty)),
       );
     }
   }

--- a/src/main/options/normalize.mjs
+++ b/src/main/options/normalize.mjs
@@ -1,5 +1,4 @@
 /* eslint-disable security/detect-object-injection */
-import clone from "lodash/clone.js";
 import has from "lodash/has.js";
 import { normalizeREProperties } from "../helpers.mjs";
 import defaults from "./defaults.mjs";
@@ -47,7 +46,7 @@ function normalizeFilterOptions(pOptions, pFilterOptionKeys) {
   for (let lFilterOptionKey of pFilterOptionKeys) {
     if (pOptions[lFilterOptionKey]) {
       lReturnValue[lFilterOptionKey] = normalizeFilterOption(
-        lReturnValue[lFilterOptionKey]
+        lReturnValue[lFilterOptionKey],
       );
     }
   }
@@ -63,7 +62,7 @@ function normalizeCollapse(pCollapse) {
 
   if (typeof pCollapse === "number" || pCollapse.match(lSingleDigitRe)) {
     lReturnValue = `${lFolderBelowNodeModules}|^${lFolderPattern.repeat(
-      Number.parseInt(pCollapse, 10)
+      Number.parseInt(pCollapse, 10),
     )}`;
   }
   return lReturnValue;
@@ -71,12 +70,12 @@ function normalizeCollapse(pCollapse) {
 
 function normalizeFocusDepth(pFormatOptions) {
   /** @type  {import("../../../types/dependency-cruiser.js").IFormatOptions}*/
-  let lFormatOptions = clone(pFormatOptions);
+  let lFormatOptions = structuredClone(pFormatOptions);
   if (has(lFormatOptions, "focusDepth")) {
     if (has(lFormatOptions, "focus")) {
       lFormatOptions.focus.depth = Number.parseInt(
         lFormatOptions.focusDepth,
-        10
+        10,
       );
     }
     delete lFormatOptions.focusDepth;
@@ -205,7 +204,7 @@ export function normalizeCruiseOptions(pOptions, pFileAndDirectoryArray = []) {
   lReturnValue.exoticRequireStrings = uniq(lReturnValue.exoticRequireStrings);
   if (lReturnValue.reporterOptions) {
     lReturnValue.reporterOptions = normalizeReporterOptions(
-      lReturnValue.reporterOptions
+      lReturnValue.reporterOptions,
     );
   }
   lReturnValue.metrics = shouldCalculateMetrics(pOptions);
@@ -225,7 +224,7 @@ export function normalizeCruiseOptions(pOptions, pFileAndDirectoryArray = []) {
  * @returns {import("../../../types/strict-options.js").IStrictFormatOptions}
  */
 export function normalizeFormatOptions(pFormatOptions) {
-  let lFormatOptions = clone(pFormatOptions);
+  let lFormatOptions = structuredClone(pFormatOptions);
 
   if (has(lFormatOptions, "collapse")) {
     lFormatOptions.collapse = normalizeCollapse(lFormatOptions.collapse);

--- a/src/main/rule-set/normalize.mjs
+++ b/src/main/rule-set/normalize.mjs
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash/cloneDeep.js";
 import has from "lodash/has.js";
 import { normalizeREProperties } from "../helpers.mjs";
 
@@ -59,7 +58,7 @@ function normalizeRule(pRule) {
  * @return {import("../../../types/strict-rule-set.js").IStrictRuleSet}
  */
 export default function normalizeRuleSet(pRuleSet) {
-  const lRuleSet = cloneDeep(pRuleSet);
+  const lRuleSet = structuredClone(pRuleSet);
 
   if (has(lRuleSet, "allowed")) {
     lRuleSet.allowedSeverity = normalizeSeverity(lRuleSet.allowedSeverity);

--- a/src/report/anon/index.mjs
+++ b/src/report/anon/index.mjs
@@ -1,4 +1,3 @@
-import clone from "lodash/clone.js";
 import has from "lodash/has.js";
 import { anonymizePath, WHITELIST_RE } from "./anonymize-path.mjs";
 
@@ -46,7 +45,7 @@ function anonymizeModules(pModules, pWordList) {
     if (pModule.dependents) {
       lReturnValue.dependents = anonymizePathArray(
         pModule.dependents,
-        pWordList
+        pWordList,
       );
     }
     if (pModule.reaches) {
@@ -77,7 +76,7 @@ function anonymizeFolders(pFolders, pWordList) {
         if (lReturnDependencies.cycle) {
           lReturnDependencies.cycle = anonymizePathArray(
             pDependency.cycle,
-            pWordList
+            pWordList,
           );
         }
         return lReturnDependencies;
@@ -114,7 +113,7 @@ function anonymizeViolations(pViolations, pWordList) {
  * @returns {import("../../../types/cruise-result.js").ICruiseResult}
  */
 function anonymize(pResults, pWordList) {
-  const lResults = clone(pResults);
+  const lResults = structuredClone(pResults);
 
   lResults.modules = anonymizeModules(lResults.modules, pWordList);
   if (lResults.folders) {
@@ -122,7 +121,7 @@ function anonymize(pResults, pWordList) {
   }
   lResults.summary.violations = anonymizeViolations(
     lResults.summary.violations,
-    pWordList
+    pWordList,
   );
 
   return lResults;
@@ -168,7 +167,7 @@ export default function reportAnonymous(pResults, pAnonymousReporterOptions) {
     output: JSON.stringify(
       anonymize(pResults, sanitizeWordList(lAnonymousReporterOptions.wordlist)),
       null,
-      "  "
+      "  ",
     ),
     exitCode: 0,
   };

--- a/src/report/dot/theming.mjs
+++ b/src/report/dot/theming.mjs
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash/cloneDeep.js";
 import get from "lodash/get.js";
 import has from "lodash/has.js";
 import DEFAULT_THEME from "./default-theme.mjs";
@@ -14,21 +13,21 @@ function moduleOrDependencyMatchesCriteria(pSchemeEntry, pModule) {
     (pKey) =>
       (get(pModule, pKey) || has(pModule, pKey)) &&
       (get(pModule, pKey) === get(pSchemeEntry.criteria, pKey) ||
-        matchesRE(get(pModule, pKey), get(pSchemeEntry.criteria, pKey)))
+        matchesRE(get(pModule, pKey), get(pSchemeEntry.criteria, pKey))),
   );
 }
 
 function determineAttributes(pModuleOrDependency, pAttributeCriteria) {
   return (pAttributeCriteria || [])
     .filter((pSchemeEntry) =>
-      moduleOrDependencyMatchesCriteria(pSchemeEntry, pModuleOrDependency)
+      moduleOrDependencyMatchesCriteria(pSchemeEntry, pModuleOrDependency),
     )
     .map((pSchemeEntry) => pSchemeEntry.attributes)
     .reduce((pAll, pCurrent) => ({ ...pCurrent, ...pAll }), {});
 }
 
 function normalizeTheme(pTheme) {
-  let lReturnValue = cloneDeep(DEFAULT_THEME);
+  let lReturnValue = structuredClone(DEFAULT_THEME);
 
   if (pTheme) {
     if (pTheme.replace) {
@@ -38,10 +37,10 @@ function normalizeTheme(pTheme) {
       lReturnValue.node = { ...DEFAULT_THEME.node, ...pTheme.node };
       lReturnValue.edge = { ...DEFAULT_THEME.edge, ...pTheme.edge };
       lReturnValue.modules = (pTheme.modules || []).concat(
-        DEFAULT_THEME.modules
+        DEFAULT_THEME.modules,
       );
       lReturnValue.dependencies = (pTheme.dependencies || []).concat(
-        DEFAULT_THEME.dependencies
+        DEFAULT_THEME.dependencies,
       );
     }
   }

--- a/test/main/norm-base-directory.utl.mjs
+++ b/test/main/norm-base-directory.utl.mjs
@@ -1,11 +1,10 @@
 import { join } from "node:path";
-import cloneDeep from "lodash/cloneDeep.js";
 
 export default function normBaseDirectory(
   pUnprocessedJSON,
   pBaseDirectory = process.cwd(),
 ) {
-  let lReturnValue = cloneDeep(pUnprocessedJSON);
+  let lReturnValue = structuredClone(pUnprocessedJSON);
   lReturnValue.summary.optionsUsed.baseDir = join(
     pBaseDirectory,
     lReturnValue.summary.optionsUsed?.baseDir ?? "",

--- a/test/report/anon/anonymize.spec.mjs
+++ b/test/report/anon/anonymize.spec.mjs
@@ -1,5 +1,4 @@
 import { equal, deepEqual } from "node:assert/strict";
-import _clone from "lodash/clone.js";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../../src/schema/cruise-result.schema.mjs";
 import { clearCache } from "../../../src/report/anon/anonymize-path-element.mjs";
@@ -49,7 +48,7 @@ describe("[I] report/anon", () => {
 
   it("anonymizes a result tree with the passed word list", () => {
     const lResult = anonymize(sourceReport, {
-      wordlist: _clone(META_SYNTACTIC_VARIABLES),
+      wordlist: structuredClone(META_SYNTACTIC_VARIABLES),
     });
     const lOutput = JSON.parse(lResult.output);
 
@@ -69,7 +68,7 @@ describe("[I] report/anon", () => {
 
   it("anonymizes a result tree with (violated) rules", () => {
     const lResult = anonymize(sourceCycle, {
-      wordlist: _clone(META_SYNTACTIC_VARIABLES),
+      wordlist: structuredClone(META_SYNTACTIC_VARIABLES),
     });
     const lOutput = JSON.parse(lResult.output);
 
@@ -79,7 +78,7 @@ describe("[I] report/anon", () => {
   });
   it("anonymizes a result tree with (violated) reaches rules", () => {
     const lResult = anonymize(reachesReport, {
-      wordlist: _clone(META_SYNTACTIC_VARIABLES),
+      wordlist: structuredClone(META_SYNTACTIC_VARIABLES),
     });
     const lOutput = JSON.parse(lResult.output);
 
@@ -89,7 +88,7 @@ describe("[I] report/anon", () => {
   });
   it("anonymizes a result tree with dependents", () => {
     const lResult = anonymize(sourceDependents, {
-      wordlist: _clone(META_SYNTACTIC_VARIABLES),
+      wordlist: structuredClone(META_SYNTACTIC_VARIABLES),
     });
     const lOutput = JSON.parse(lResult.output);
 
@@ -99,7 +98,7 @@ describe("[I] report/anon", () => {
   });
   it("anonymizes a result tree with folders", () => {
     const lResult = anonymize(sourceFolders, {
-      wordlist: _clone(META_SYNTACTIC_VARIABLES),
+      wordlist: structuredClone(META_SYNTACTIC_VARIABLES),
     });
     const lOutput = JSON.parse(lResult.output);
 
@@ -110,7 +109,7 @@ describe("[I] report/anon", () => {
 
   it("anonymizes a result tree with folders that contain folder cycles", () => {
     const lResult = anonymize(sourceFolderCycles, {
-      wordlist: _clone(META_SYNTACTIC_VARIABLES),
+      wordlist: structuredClone(META_SYNTACTIC_VARIABLES),
     });
     const lOutput = JSON.parse(lResult.output);
 


### PR DESCRIPTION
## Description

- replaces lodash/cloneDeep with native structuredClone
- replaces lodash/clone with native structuredClone

## Motivation and Context

Ongoing effort to reduce # of 3rd party dependencies (including that of lodash)

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
