### PR TITLE
refactor: introduces use of node imports aliasses in package.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,11 +11,14 @@ module.exports = {
     "@typescript-eslint/no-var-requires": "off", // we kind-of live off of those in here
     "@typescript-eslint/no-unused-vars": "off", // duplicate of the same in several other sets
     "budapestian/global-constant-pattern": "off", // currently does not work with the AST as emitted @typescript-eslint parser (FIXME)
-    "no-param-reassign": "error",
     "security/detect-non-literal-fs-filename": "off",
-    "unicorn/no-useless-fallback-in-spread": "off", // useful, probably. We'll try it later, though
     "import/exports-last": "off", // Useless remnant of the time when single pass compilers were in vogue
+    "import/no-unresolved": "off", // Does not recognize package.json #imports, which we use (in nodejs since v12.9.0), nor does it understand self-references to exports (e.g. dependency-cruiser/mermaid-reporter-plugin)
+    "no-param-reassign": "error",
+    "node/no-missing-import": "off", // Does not recognize package.json #imports, which we use (in nodejs since v12.9.0), nor does it understand self-references to exports (e.g. dependency-cruiser/mermaid-reporter-plugin)
+    "node/no-missing-require": "off", // Does not recognize package.json #imports, which we use (in nodejs since v12.9.0), nor does it understand self-references to exports (e.g. dependency-cruiser/mermaid-reporter-plugin)
     "unicorn/no-empty-file": "off", // See https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2175
+    "unicorn/no-useless-fallback-in-spread": "off", // useful, probably. We'll try it later, though
   },
   overrides: [
     {

--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { program } from "commander";
 import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
-import meta from "../src/meta.js";
 import cli from "../src/cli/index.mjs";
+import meta from "#meta";
 
 function formatError(pError) {
   process.stderr.write(pError.message);

--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { program } from "commander";
-import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
-import cli from "../src/cli/index.mjs";
+import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
+import cli from "#cli/index.mjs";
 import meta from "#meta";
 
 function formatError(pError) {

--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { program } from "commander";
-import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
-import format from "../src/cli/format.mjs";
+import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
+import format from "#cli/format.mjs";
 import meta from "#meta";
 
 function formatError(pError) {

--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -2,8 +2,8 @@
 
 import { program } from "commander";
 import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
-import meta from "../src/meta.js";
 import format from "../src/cli/format.mjs";
+import meta from "#meta";
 
 function formatError(pError) {
   process.stderr.write(pError.message);

--- a/bin/dependency-cruise.mjs
+++ b/bin/dependency-cruise.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { EOL } from "node:os";
 import { program } from "commander";
-import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
-import cli from "../src/cli/index.mjs";
+import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
+import cli from "#cli/index.mjs";
 import meta from "#meta";
 
 try {

--- a/bin/dependency-cruise.mjs
+++ b/bin/dependency-cruise.mjs
@@ -2,8 +2,8 @@
 import { EOL } from "node:os";
 import { program } from "commander";
 import assertNodeEnvironmentSuitable from "../src/cli/assert-node-environment-suitable.mjs";
-import meta from "../src/meta.js";
 import cli from "../src/cli/index.mjs";
+import meta from "#meta";
 
 try {
   assertNodeEnvironmentSuitable();

--- a/bin/wrap-stream-in-html.mjs
+++ b/bin/wrap-stream-in-html.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-import wrapStreamInHtml from "../src/cli/tools/wrap-stream-in-html.mjs";
+import wrapStreamInHtml from "#cli/tools/wrap-stream-in-html.mjs";
 
 wrapStreamInHtml(process.stdin, process.stdout);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "#extract/*": "./src/extract/*",
     "#graph-utl/*": "./src/graph-utl/*",
     "#meta": "./src/meta.js",
+    "#report/*": "./src/report/*",
     "#utl/*": "./src/utl/*"
   },
   "exports": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "#enrich/*": "./src/enrich/*",
     "#extract/*": "./src/extract/*",
     "#graph-utl/*": "./src/graph-utl/*",
+    "#main/*": "./src/main/*",
     "#meta": "./src/meta.js",
     "#report/*": "./src/report/*",
     "#utl/*": "./src/utl/*"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "main": "src/main/index.mjs",
   "imports": {
     "#cache/*": "./src/cache/*",
+    "#config-utl/*": "./src/config-utl/*",
     "#configuration-schema": "./src/schema/configuration.schema.mjs",
     "#cli/*": "./src/cli/*",
     "#cruise-result-schema": "./src/schema/cruise-result.schema.mjs",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   },
   "main": "src/main/index.mjs",
   "imports": {
+    "#enrich/*": "./src/enrich/*",
+    "#extract/*": "./src/extract/*",
     "#graph-utl/*": "./src/graph-utl/*",
     "#meta": "./src/meta.js",
     "#utl/*": "./src/utl/*"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
   },
   "main": "src/main/index.mjs",
   "imports": {
-    "#utl/*": "./src/utl/*",
-    "#meta": "./src/meta.js"
+    "#graph-utl/*": "./src/graph-utl/*",
+    "#meta": "./src/meta.js",
+    "#utl/*": "./src/utl/*"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
   "main": "src/main/index.mjs",
   "imports": {
     "#cache/*": "./src/cache/*",
+    "#configuration-schema": "./src/schema/configuration.schema.mjs",
     "#cli/*": "./src/cli/*",
+    "#cruise-result-schema": "./src/schema/cruise-result.schema.mjs",
     "#enrich/*": "./src/enrich/*",
     "#extract/*": "./src/extract/*",
     "#graph-utl/*": "./src/graph-utl/*",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "main": "src/main/index.mjs",
   "imports": {
     "#cache/*": "./src/cache/*",
+    "#cli/*": "./src/cli/*",
     "#enrich/*": "./src/enrich/*",
     "#extract/*": "./src/extract/*",
     "#graph-utl/*": "./src/graph-utl/*",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "main": "src/main/index.mjs",
   "imports": {
+    "#cache/*": "./src/cache/*",
     "#enrich/*": "./src/enrich/*",
     "#extract/*": "./src/extract/*",
     "#graph-utl/*": "./src/graph-utl/*",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "#main/*": "./src/main/*",
     "#meta": "./src/meta.js",
     "#report/*": "./src/report/*",
-    "#utl/*": "./src/utl/*"
+    "#utl/*": "./src/utl/*",
+    "#validate/*": "./src/validate/*"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs"
   },
   "main": "src/main/index.mjs",
+  "imports": {
+    "#utl/*": "./src/utl/*",
+    "#meta": "./src/meta.js"
+  },
   "exports": {
     ".": {
       "import": "./src/main/index.mjs",

--- a/src/cache/cache.mjs
+++ b/src/cache/cache.mjs
@@ -1,10 +1,11 @@
 // @ts-check
 import { readFile, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { scannableExtensions } from "../extract/transpile/meta.mjs";
 import { optionsAreCompatible } from "./options-compatible.mjs";
 import MetadataStrategy from "./metadata-strategy.mjs";
 import ContentStrategy from "./content-strategy.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import { scannableExtensions } from "#extract/transpile/meta.mjs";
 // @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
 import { bus } from "#utl/bus.mjs";
 

--- a/src/cache/cache.mjs
+++ b/src/cache/cache.mjs
@@ -2,10 +2,11 @@
 import { readFile, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { scannableExtensions } from "../extract/transpile/meta.mjs";
-import { bus } from "../utl/bus.mjs";
 import { optionsAreCompatible } from "./options-compatible.mjs";
 import MetadataStrategy from "./metadata-strategy.mjs";
 import ContentStrategy from "./content-strategy.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import { bus } from "#utl/bus.mjs";
 
 const CACHE_FILE_NAME = "cache.json";
 
@@ -36,19 +37,19 @@ export default class Cache {
         pCruiseOptions,
         {
           extensions: new Set(
-            scannableExtensions.concat(pCruiseOptions.extraExtensionsToScan)
+            scannableExtensions.concat(pCruiseOptions.extraExtensionsToScan),
           ),
-        }
+        },
       ));
     bus.debug("cache: - comparing");
     return (
       this.cacheStrategy.revisionDataEqual(
         pCachedCruiseResult.revisionData,
-        this.revisionData
+        this.revisionData,
       ) &&
       optionsAreCompatible(
         pCachedCruiseResult.summary.optionsUsed,
-        pCruiseOptions
+        pCruiseOptions,
       )
     );
   }
@@ -60,7 +61,7 @@ export default class Cache {
   async read(pCacheFolder) {
     try {
       return JSON.parse(
-        await readFile(join(pCacheFolder, CACHE_FILE_NAME), "utf8")
+        await readFile(join(pCacheFolder, CACHE_FILE_NAME), "utf8"),
       );
     } catch (pError) {
       return { modules: [], summary: {} };
@@ -81,10 +82,10 @@ export default class Cache {
       JSON.stringify(
         this.cacheStrategy.prepareRevisionDataForSaving(
           pCruiseResult,
-          lRevisionData
-        )
+          lRevisionData,
+        ),
       ),
-      "utf8"
+      "utf8",
     );
   }
 }

--- a/src/cache/find-content-changes.mjs
+++ b/src/cache/find-content-changes.mjs
@@ -1,8 +1,6 @@
 /* eslint-disable no-inline-comments */
 // @ts-check
 import { join } from "node:path/posix";
-import { bus } from "../utl/bus.mjs";
-import findAllFiles from "../utl/find-all-files.mjs";
 import {
   getFileHashSync,
   excludeFilter,
@@ -10,6 +8,10 @@ import {
   hasInterestingExtension,
   moduleIsInterestingForDiff,
 } from "./helpers.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import { bus } from "#utl/bus.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import findAllFiles from "#utl/find-all-files.mjs";
 
 /**
  * @param {Set<string>} pFileSet
@@ -19,7 +21,7 @@ import {
 function diffCachedModuleAgainstFileSet(
   pFileSet,
   pBaseDirectory,
-  pFileHashFunction = getFileHashSync
+  pFileHashFunction = getFileHashSync,
 ) {
   return (pModule) => {
     if (!moduleIsInterestingForDiff(pModule)) {
@@ -31,7 +33,7 @@ function diffCachedModuleAgainstFileSet(
     }
 
     const lNewCheckSum = pFileHashFunction(
-      join(pBaseDirectory, pModule.source)
+      join(pBaseDirectory, pModule.source),
     );
     if (lNewCheckSum !== pModule.checksum) {
       return {
@@ -72,7 +74,7 @@ function diffCachedModuleAgainstFileSet(
 export default function findContentChanges(
   pDirectory,
   pCachedCruiseResult,
-  pOptions
+  pOptions,
 ) {
   bus.debug("cache: - getting revision data");
   const lFileSet = new Set(
@@ -80,12 +82,12 @@ export default function findContentChanges(
       baseDir: pOptions.baseDir,
       excludeFilterFn: excludeFilter(pOptions.exclude),
       includeOnlyFilterFn: includeOnlyFilter(pOptions.includeOnly),
-    }).filter(hasInterestingExtension(pOptions.extensions))
+    }).filter(hasInterestingExtension(pOptions.extensions)),
   );
 
   bus.debug("cache: - getting (cached - new)");
   const lDiffCachedVsNew = pCachedCruiseResult.modules.map(
-    diffCachedModuleAgainstFileSet(lFileSet, pOptions.baseDir)
+    diffCachedModuleAgainstFileSet(lFileSet, pOptions.baseDir),
   );
 
   bus.debug("cache: - getting (new - cached)");

--- a/src/cache/helpers.mjs
+++ b/src/cache/helpers.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
 import memoize from "lodash/memoize.js";
-import { filenameMatchesPattern } from "../graph-utl/match-facade.mjs";
+import { filenameMatchesPattern } from "#graph-utl/match-facade.mjs";
 
 /**
  * @param {string} pString
@@ -101,10 +101,10 @@ export function hasInterestingExtension(pExtensions) {
 export function changeHasInterestingExtension(pExtensions) {
   return (pChange) => {
     const lNameHasInterestingExtension = hasInterestingExtension(pExtensions)(
-      pChange.name
+      pChange.name,
     );
     const lOldNameHasInterestingExtension = Boolean(
-      pChange.oldName && hasInterestingExtension(pExtensions)(pChange.oldName)
+      pChange.oldName && hasInterestingExtension(pExtensions)(pChange.oldName),
     );
     return lNameHasInterestingExtension || lOldNameHasInterestingExtension;
   };
@@ -128,7 +128,7 @@ const DEFAULT_INTERESTING_CHANGE_TYPES = new Set([
 export function isInterestingChangeType(pInterestingChangeTypes) {
   return (pChange) =>
     (pInterestingChangeTypes ?? DEFAULT_INTERESTING_CHANGE_TYPES).has(
-      pChange.changeType
+      pChange.changeType,
     );
 }
 

--- a/src/cache/metadata-strategy.mjs
+++ b/src/cache/metadata-strategy.mjs
@@ -2,7 +2,6 @@
 // @ts-check
 import { isDeepStrictEqual } from "node:util";
 import { getSHA, list } from "watskeburt";
-import { bus } from "../utl/bus.mjs";
 import {
   isInterestingChangeType,
   addCheckSumToChangeSync,
@@ -10,6 +9,8 @@ import {
   includeOnlyFilter,
   changeHasInterestingExtension,
 } from "./helpers.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import { bus } from "#utl/bus.mjs";
 
 export default class MetaDataStrategy {
   /**
@@ -27,7 +28,7 @@ export default class MetaDataStrategy {
     _pDirectory,
     _pCachedCruiseResult,
     pCruiseOptions,
-    pOptions
+    pOptions,
   ) {
     const lOptions = {
       shaRetrievalFn: getSHA,
@@ -45,7 +46,7 @@ export default class MetaDataStrategy {
       const lChanges = lDiff
         .filter(({ name }) => excludeFilter(pCruiseOptions.exclude)(name))
         .filter(({ name }) =>
-          includeOnlyFilter(pCruiseOptions.includeOnly)(name)
+          includeOnlyFilter(pCruiseOptions.includeOnly)(name),
         )
         .filter(changeHasInterestingExtension(lOptions.extensions))
         .filter(isInterestingChangeType(lOptions.interestingChangeTypes));
@@ -56,7 +57,7 @@ export default class MetaDataStrategy {
       };
     } catch (pError) {
       throw new Error(
-        `The --cache option works in concert with git - and it seems either the current folder isn't version managed or git isn't installed. Error:${`\n\n          ${pError}\n`}`
+        `The --cache option works in concert with git - and it seems either the current folder isn't version managed or git isn't installed. Error:${`\n\n          ${pError}\n`}`,
       );
     }
   }

--- a/src/cli/assert-node-environment-suitable.mjs
+++ b/src/cli/assert-node-environment-suitable.mjs
@@ -1,5 +1,5 @@
 import satisfies from "semver/functions/satisfies.js";
-import meta from "../meta.js";
+import meta from "#meta";
 
 export default function assertNodeEnvironmentSuitable(pNodeVersion) {
   // not using default parameter here because the check should run

--- a/src/cli/format-meta-info.mjs
+++ b/src/cli/format-meta-info.mjs
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import figures from "figures";
 
-import { getAvailableTranspilers, allExtensions } from "../main/index.mjs";
+import { getAvailableTranspilers, allExtensions } from "#main/index.mjs";
 
 function bool2Symbol(pBool) {
   return pBool ? chalk.green(figures.tick) : chalk.red(figures.cross);
@@ -13,7 +13,7 @@ function formatTranspilers() {
       `${pAll}    ${bool2Symbol(pThis.available)} ${pThis.name} (${
         pThis.version
       })\n`,
-    `    ${bool2Symbol(true)} javascript (>es1)\n`
+    `    ${bool2Symbol(true)} javascript (>es1)\n`,
   );
 }
 
@@ -21,7 +21,7 @@ function formatExtensions(pExtensions) {
   return pExtensions.reduce(
     (pAll, pThis) =>
       `${pAll}    ${bool2Symbol(pThis.available)} ${pThis.extension}\n`,
-    ""
+    "",
   );
 }
 
@@ -30,7 +30,7 @@ export default function formatMetaInfo() {
   Supported:
 
     If you need a supported, but not enabled transpiler ('${chalk.red(
-      figures.cross
+      figures.cross,
     )}' below), just install
     it in the same folder dependency-cruiser is installed. E.g. 'npm i livescript'
     will enable livescript support if it's installed in your project folder.

--- a/src/cli/format.mjs
+++ b/src/cli/format.mjs
@@ -1,7 +1,7 @@
-import _format from "../main/format.mjs";
 import assertFileExistence from "./utl/assert-file-existence.mjs";
 import normalizeOptions from "./normalize-cli-options.mjs";
 import { getInStream, write } from "./utl/io.mjs";
+import _format from "#main/format.mjs";
 
 /**
  *

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -4,14 +4,13 @@ import set from "lodash/set.js";
 import isInstalledGlobally from "is-installed-globally";
 import chalk from "chalk";
 
-import cruise from "../main/cruise.mjs";
-
 import assertFileExistence from "./utl/assert-file-existence.mjs";
 import normalizeCliOptions from "./normalize-cli-options.mjs";
 import { write } from "./utl/io.mjs";
 import setUpCliFeedbackListener from "./listeners/cli-feedback.mjs";
 import setUpPerformanceLogListener from "./listeners/performance-log/index.mjs";
 import setUpNDJSONListener from "./listeners/ndjson.mjs";
+import cruise from "#main/cruise.mjs";
 import { INFO, bus } from "#utl/bus.mjs";
 
 async function extractResolveOptions(pCruiseOptions) {

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -20,7 +20,7 @@ async function extractResolveOptions(pCruiseOptions) {
 
   if (lWebPackConfigFileName) {
     const { default: extractWebpackResolveConfig } = await import(
-      "../config-utl/extract-webpack-resolve-config.mjs"
+      "#config-utl/extract-webpack-resolve-config.mjs"
     );
     lResolveOptions = await extractWebpackResolveConfig(
       lWebPackConfigFileName,
@@ -34,7 +34,7 @@ async function extractResolveOptions(pCruiseOptions) {
 async function addKnownViolations(pCruiseOptions) {
   if (pCruiseOptions.knownViolationsFile) {
     const { default: extractKnownViolations } = await import(
-      "../config-utl/extract-known-violations.mjs"
+      "#config-utl/extract-known-violations.mjs"
     );
     const lKnownViolations = await extractKnownViolations(
       pCruiseOptions.knownViolationsFile,
@@ -56,7 +56,7 @@ async function extractTSConfigOptions(pCruiseOptions) {
 
   if (lTSConfigFileName) {
     const { default: extractTSConfig } = await import(
-      "../config-utl/extract-ts-config.mjs"
+      "#config-utl/extract-ts-config.mjs"
     );
     lReturnValue = extractTSConfig(lTSConfigFileName);
   }
@@ -70,7 +70,7 @@ async function extractBabelConfigOptions(pCruiseOptions) {
     pCruiseOptions?.ruleSet?.options?.babelConfig?.fileName ?? null;
   if (lBabelConfigFileName) {
     const { default: extractBabelConfig } = await import(
-      "../config-utl/extract-babel-config.mjs"
+      "#config-utl/extract-babel-config.mjs"
     );
     lReturnValue = extractBabelConfig(lBabelConfigFileName);
   }

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -5,7 +5,6 @@ import isInstalledGlobally from "is-installed-globally";
 import chalk from "chalk";
 
 import cruise from "../main/cruise.mjs";
-import { INFO, bus } from "../utl/bus.mjs";
 
 import assertFileExistence from "./utl/assert-file-existence.mjs";
 import normalizeCliOptions from "./normalize-cli-options.mjs";
@@ -13,6 +12,7 @@ import { write } from "./utl/io.mjs";
 import setUpCliFeedbackListener from "./listeners/cli-feedback.mjs";
 import setUpPerformanceLogListener from "./listeners/performance-log/index.mjs";
 import setUpNDJSONListener from "./listeners/ndjson.mjs";
+import { INFO, bus } from "#utl/bus.mjs";
 
 async function extractResolveOptions(pCruiseOptions) {
   let lResolveOptions = {};

--- a/src/cli/init-config/find-extensions.mjs
+++ b/src/cli/init-config/find-extensions.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 /* eslint-disable security/detect-object-injection */
-import { scannableExtensions } from "../../extract/transpile/meta.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import { scannableExtensions } from "#extract/transpile/meta.mjs";
 // @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
 import getExtension from "#utl/get-extension.mjs";
 // @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json

--- a/src/cli/init-config/find-extensions.mjs
+++ b/src/cli/init-config/find-extensions.mjs
@@ -1,8 +1,10 @@
 // @ts-check
 /* eslint-disable security/detect-object-injection */
-import getExtension from "../../utl/get-extension.mjs";
 import { scannableExtensions } from "../../extract/transpile/meta.mjs";
-import findAllFiles from "../../utl/find-all-files.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import getExtension from "#utl/get-extension.mjs";
+// @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
+import findAllFiles from "#utl/find-all-files.mjs";
 
 /**
  * @param {Record<string,number>} pAll
@@ -42,7 +44,7 @@ export default function findExtensions(pDirectories, pOptions) {
         ignoreFileContents: lOptions?.ignoreFileContents,
       })
         .map(getExtension)
-        .filter(Boolean)
+        .filter(Boolean),
     )
     .reduce(reduceToCounts, {});
 

--- a/src/cli/init-config/normalize-init-options.mjs
+++ b/src/cli/init-config/normalize-init-options.mjs
@@ -1,5 +1,4 @@
 import has from "lodash/has.js";
-import meta from "../../meta.js";
 import {
   getSourceFolderCandidates,
   getTestFolderCandidates,
@@ -7,6 +6,7 @@ import {
   toSourceLocationArray,
 } from "./environment-helpers.mjs";
 import findExtensions from "./find-extensions.mjs";
+import meta from "#meta";
 
 /**
  * @param {import("./types.js").IInitConfig} pInitOptions

--- a/src/cli/init-config/write-run-scripts-to-manifest.mjs
+++ b/src/cli/init-config/write-run-scripts-to-manifest.mjs
@@ -2,10 +2,10 @@
 import { writeFileSync } from "node:fs";
 import figures from "figures";
 import chalk from "chalk";
-import wrapAndIndent from "../../utl/wrap-and-indent.mjs";
 import { PACKAGE_MANIFEST as _PACKAGE_MANIFEST } from "../defaults.mjs";
 import { readManifest } from "./environment-helpers.mjs";
 import { folderNameArrayToRE } from "./utl.mjs";
+import wrapAndIndent from "#utl/wrap-and-indent.mjs";
 
 const PACKAGE_MANIFEST = `./${_PACKAGE_MANIFEST}`;
 

--- a/src/cli/listeners/cli-feedback.mjs
+++ b/src/cli/listeners/cli-feedback.mjs
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import figures from "figures";
-import { SUMMARY } from "../../utl/bus.mjs";
+import { SUMMARY } from "#utl/bus.mjs";
 
 const FULL_ON = 100;
 
@@ -19,7 +19,7 @@ function getPercentageBar(pPercentage, pParameters) {
   const lBlanks = lParameters.barSize - lBlocks;
 
   return `${chalk.green(lParameters.block.repeat(lBlocks))}${chalk.green(
-    lParameters.blank.repeat(lBlanks)
+    lParameters.blank.repeat(lBlanks),
   )} ${Math.round(FULL_ON * lPercentage)}%`;
 }
 
@@ -36,7 +36,7 @@ function getProgressMessageWriter(pStream, pState, pMaxLogLevel) {
     if (pStream.isTTY && lOptions.level <= pMaxLogLevel) {
       pStream.clearLine(1);
       pStream.write(
-        `  ${getPercentageBar(lOptions.complete)} ${pMessage} ...\n`
+        `  ${getPercentageBar(lOptions.complete)} ${pMessage} ...\n`,
       );
       pStream.moveCursor(0, -1);
     }
@@ -57,14 +57,14 @@ function getStartWriter(pStream) {
 export default function setUpCliFeedbackListener(
   pEventEmitter,
   pMaxLogLevel = SUMMARY,
-  pStream = process.stderr
+  pStream = process.stderr,
 ) {
   const lState = {
     complete: 0,
   };
   pEventEmitter.on(
     "progress",
-    getProgressMessageWriter(pStream, lState, pMaxLogLevel)
+    getProgressMessageWriter(pStream, lState, pMaxLogLevel),
   );
 
   pEventEmitter.on("write-start", getStartWriter(pStream));

--- a/src/cli/listeners/ndjson.mjs
+++ b/src/cli/listeners/ndjson.mjs
@@ -1,5 +1,5 @@
 import { EOL } from "node:os";
-import { INFO, SUMMARY } from "../../utl/bus.mjs";
+import { INFO, SUMMARY } from "#utl/bus.mjs";
 
 const MICRO_SECONDS_PER_SECOND = 1000000;
 
@@ -72,7 +72,7 @@ function getProgressWriter(pStream, pState, pMaxLevel) {
 export default function setUpNDJSONListener(
   pEventEmitter,
   pMaxLevel = INFO,
-  pStream = process.stderr
+  pStream = process.stderr,
 ) {
   let lState = {
     runStartTime: new Date(Date.now()).toISOString(),

--- a/src/cli/listeners/performance-log/format-helpers.mjs
+++ b/src/cli/listeners/performance-log/format-helpers.mjs
@@ -1,6 +1,5 @@
- 
 import chalk from "chalk";
-import { INFO } from "../../../utl/bus.mjs";
+import { INFO } from "#utl/bus.mjs";
 
 const MS_PER_SECOND = 1000;
 const MS_PER_MICRO_SECOND = 0.001;
@@ -39,7 +38,7 @@ export function formatDividerLine() {
   const lMessageColumnHDivider = "-".repeat(MAX_EXPECTED_MESSAGE_LENGTH);
 
   return `${`${lNumberColumnDivider} `.repeat(
-    NUMBER_OF_COLUMNS - 1
+    NUMBER_OF_COLUMNS - 1,
   )}${lMessageColumnHDivider}\n`;
 }
 
@@ -54,7 +53,7 @@ export function formatHeader() {
         pad("⏱  system") +
         pad("⏱  user") +
         pad("⏱  real")
-      }after step...\n`
+      }after step...\n`,
     )
     .concat(formatDividerLine());
 }
@@ -66,24 +65,24 @@ function formatMessage(pMessage, pLevel) {
 export function formatTime(
   pNumber,
   pConversionMultiplier = MS_PER_SECOND,
-  pLevel
+  pLevel,
 ) {
   return formatMessage(
     gTimeFormat(pConversionMultiplier * pNumber)
       .padStart(MAX_EXPECTED_METRIC_LENGTH)
       .concat(" "),
-    pLevel
+    pLevel,
   );
 }
 
 export function formatMemory(pBytes, pLevel) {
   const lReturnValue = gSizeFormat(pBytes / K).padStart(
-    MAX_EXPECTED_METRIC_LENGTH
+    MAX_EXPECTED_METRIC_LENGTH,
   );
 
   return formatMessage(
     (pBytes < 0 ? chalk.blue(lReturnValue) : lReturnValue).concat(" "),
-    pLevel
+    pLevel,
   );
 }
 

--- a/src/cli/listeners/performance-log/index.mjs
+++ b/src/cli/listeners/performance-log/index.mjs
@@ -1,5 +1,5 @@
-import { INFO, SUMMARY } from "../../../utl/bus.mjs";
 import { getHeader, getProgressLine, getEndText } from "./handlers.mjs";
+import { INFO, SUMMARY } from "#utl/bus.mjs";
 
 function getHeaderWriter(pStream, pMaxLevel) {
   return (_pMessage, pOptions) => {
@@ -16,7 +16,7 @@ function getProgressWriter(pStream, pState, pMaxLevel) {
       pMessage,
       pState,
       lOptions.level,
-      pMaxLevel
+      pMaxLevel,
     );
     pStream.write(lProgressLine);
   };
@@ -32,7 +32,7 @@ function getEndWriter(pStream, pState, pMaxLevel) {
 export default function setUpPerformanceLogListener(
   pEventEmitter,
   pMaxLevel = INFO,
-  pStream = process.stderr
+  pStream = process.stderr,
 ) {
   let lState = {
     previousMessage: "nodejs starting",

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -3,7 +3,6 @@ import { isAbsolute } from "node:path";
 import set from "lodash/set.js";
 import get from "lodash/get.js";
 import has from "lodash/has.js";
-import loadConfig from "../config-utl/extract-depcruise-config/index.mjs";
 import {
   RULES_FILE_NAME_SEARCH_ARRAY,
   DEFAULT_BASELINE_FILE_NAME,
@@ -14,6 +13,7 @@ import {
   BABEL_CONFIG,
   OLD_DEFAULT_RULES_FILE_NAME,
 } from "./defaults.mjs";
+import loadConfig from "#config-utl/extract-depcruise-config/index.mjs";
 
 function getOptionValue(pDefault) {
   return (pValue) => (typeof pValue === "string" ? pValue : pDefault);

--- a/src/config-utl/extract-babel-config.mjs
+++ b/src/config-utl/extract-babel-config.mjs
@@ -3,8 +3,8 @@ import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
 import json5 from "json5";
 import tryImport from "semver-try-require";
-import meta from "../meta.js";
 import makeAbsolute from "./make-absolute.mjs";
+import meta from "#meta";
 
 async function getJSConfig(pBabelConfigFileName) {
   let lReturnValue = {};
@@ -19,7 +19,7 @@ async function getJSConfig(pBabelConfigFileName) {
       `${
         `Encountered an error while parsing babel config '${pBabelConfigFileName}':` +
         `\n\n          ${pError}`
-      }\n\n         At this time dependency-cruiser only supports babel configurations\n         in either commonjs or json5.\n`
+      }\n\n         At this time dependency-cruiser only supports babel configurations\n         in either commonjs or json5.\n`,
     );
   }
 
@@ -28,7 +28,7 @@ async function getJSConfig(pBabelConfigFileName) {
     // function with a bunch of params (lReturnValue = lReturnValue(APIPAPI))
     throw new TypeError(
       `The babel config '${pBabelConfigFileName}' returns a function. At this time\n` +
-        `         dependency-cruiser doesn't support that yet.`
+        `         dependency-cruiser doesn't support that yet.`,
     );
   }
   return lReturnValue;
@@ -42,7 +42,7 @@ async function getJSON5Config(pBabelConfigFileName) {
   } catch (pError) {
     throw new Error(
       `Encountered an error while parsing the babel config '${pBabelConfigFileName}':` +
-        `\n\n          ${pError}\n`
+        `\n\n          ${pError}\n`,
     );
   }
 
@@ -65,7 +65,7 @@ async function getConfig(pBabelConfigFileName) {
 
   if (!lExtensionToParseFunction.has(lExtension)) {
     throw new Error(
-      `${`The babel config '${pBabelConfigFileName}' is in a format ('${lExtension}')\n`}         dependency-cruiser doesn't support yet.\n`
+      `${`The babel config '${pBabelConfigFileName}' is in a format ('${lExtension}')\n`}         dependency-cruiser doesn't support yet.\n`,
     );
   }
   // eslint-disable-next-line no-return-await

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -1,9 +1,9 @@
 import { dirname } from "node:path";
 import has from "lodash/has.js";
-import { resolve } from "../../extract/resolve/resolve.mjs";
 import normalizeResolveOptions from "../../main/resolve-options/normalize.mjs";
 import readConfig from "./read-config.mjs";
 import mergeConfigs from "./merge-configs.mjs";
+import { resolve } from "#extract/resolve/resolve.mjs";
 
 /* eslint no-use-before-define: 0 */
 async function processExtends(pReturnValue, pAlreadyVisited, pBaseDirectory) {

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -1,8 +1,8 @@
 import { dirname } from "node:path";
 import has from "lodash/has.js";
-import normalizeResolveOptions from "../../main/resolve-options/normalize.mjs";
 import readConfig from "./read-config.mjs";
 import mergeConfigs from "./merge-configs.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import { resolve } from "#extract/resolve/resolve.mjs";
 
 /* eslint no-use-before-define: 0 */

--- a/src/config-utl/extract-ts-config.mjs
+++ b/src/config-utl/extract-ts-config.mjs
@@ -1,10 +1,10 @@
 import { dirname, resolve } from "node:path";
 import tryImport from "semver-try-require";
-import meta from "../meta.js";
+import meta from "#meta";
 
 const typescript = await tryImport(
   "typescript",
-  meta.supportedTranspilers.typescript
+  meta.supportedTranspilers.typescript,
 );
 
 const FORMAT_DIAGNOSTICS_HOST = {
@@ -44,12 +44,12 @@ export default function extractTSConfig(pTSConfigFileName) {
   if (typescript) {
     const lConfig = typescript.readConfigFile(
       pTSConfigFileName,
-      typescript.sys.readFile
+      typescript.sys.readFile,
     );
 
     if (typeof lConfig.error !== "undefined") {
       throw new TypeError(
-        typescript.formatDiagnostics([lConfig.error], FORMAT_DIAGNOSTICS_HOST)
+        typescript.formatDiagnostics([lConfig.error], FORMAT_DIAGNOSTICS_HOST),
       );
     }
     lReturnValue = typescript.parseJsonConfigFileContent(
@@ -57,15 +57,15 @@ export default function extractTSConfig(pTSConfigFileName) {
       typescript.sys,
       dirname(resolve(pTSConfigFileName)),
       {},
-      pTSConfigFileName
+      pTSConfigFileName,
     );
 
     if (lReturnValue.errors.length > 0) {
       throw new Error(
         typescript.formatDiagnostics(
           lReturnValue.errors,
-          FORMAT_DIAGNOSTICS_HOST
-        )
+          FORMAT_DIAGNOSTICS_HOST,
+        ),
       );
     }
     // lRetval.fileNames; // all files included in the project

--- a/src/enrich/add-validations.mjs
+++ b/src/enrich/add-validations.mjs
@@ -1,4 +1,4 @@
-import validate from "../validate/index.mjs";
+import validate from "#validate/index.mjs";
 
 function addDependencyViolations(pModule, pDependency, pRuleSet, pValidate) {
   return {
@@ -26,7 +26,7 @@ export default function addValidations(pModules, pRuleSet, pValidate) {
     ...pModule,
     ...(pValidate ? validate.module(pRuleSet, pModule) : { valid: true }),
     dependencies: pModule.dependencies.map((pDependency) =>
-      addDependencyViolations(pModule, pDependency, pRuleSet, pValidate)
+      addDependencyViolations(pModule, pDependency, pRuleSet, pValidate),
     ),
   }));
 }

--- a/src/enrich/derive/folders/aggregate-to-folders.mjs
+++ b/src/enrich/derive/folders/aggregate-to-folders.mjs
@@ -2,7 +2,6 @@
 import { dirname } from "node:path/posix";
 import { calculateInstability, metricsAreCalculable } from "../module-utl.mjs";
 import detectCycles from "../circular.mjs";
-import IndexedModuleGraph from "../../../graph-utl/indexed-module-graph.mjs";
 import {
   findFolderByName,
   getAfferentCouplings,
@@ -10,6 +9,7 @@ import {
   getParentFolders,
   object2Array,
 } from "./utl.mjs";
+import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 
 function upsertCouplings(pAllDependents, pNewDependents) {
   pNewDependents.forEach((pNewDependent) => {
@@ -29,13 +29,13 @@ function upsertFolderAttributes(pAllMetrics, pModule, pDirname) {
 
   upsertCouplings(
     pAllMetrics[pDirname].dependents,
-    getAfferentCouplings(pModule, pDirname)
+    getAfferentCouplings(pModule, pDirname),
   );
   upsertCouplings(
     pAllMetrics[pDirname].dependencies,
     getEfferentCouplings(pModule, pDirname).map(
-      (pDependency) => pDependency.resolved
-    )
+      (pDependency) => pDependency.resolved,
+    ),
   );
   pAllMetrics[pDirname].moduleCount += 1;
   return pAllMetrics;
@@ -43,7 +43,7 @@ function upsertFolderAttributes(pAllMetrics, pModule, pDirname) {
 
 function aggregateToFolder(pAllFolders, pModule) {
   getParentFolders(dirname(pModule.source)).forEach((pParentDirectory) =>
-    upsertFolderAttributes(pAllFolders, pModule, pParentDirectory)
+    upsertFolderAttributes(pAllFolders, pModule, pParentDirectory),
   );
   return pAllFolders;
 }
@@ -58,9 +58,9 @@ function getFolderLevelCouplings(pCouplingArray) {
       pCouplingArray.map((pCoupling) =>
         dirname(pCoupling.name) === "."
           ? pCoupling.name
-          : dirname(pCoupling.name)
-      )
-    )
+          : dirname(pCoupling.name),
+      ),
+    ),
   ).map((pCoupling) => ({ name: pCoupling }));
 }
 
@@ -101,7 +101,9 @@ function uniq(pArray) {
 function getSinks(pFolders) {
   const lKnownFolders = new Set(pFolders.map(({ name }) => name));
   const lAllFolders = uniq(
-    pFolders.flatMap(({ dependencies }) => dependencies.map(({ name }) => name))
+    pFolders.flatMap(({ dependencies }) =>
+      dependencies.map(({ name }) => name),
+    ),
   );
   const lReturnValue = lAllFolders
     .filter((pFolder) => !lKnownFolders.has(pFolder))
@@ -116,7 +118,7 @@ function getSinks(pFolders) {
 
 export default function aggregateToFolders(pModules) {
   let lFolders = object2Array(
-    pModules.filter(metricsAreCalculable).reduce(aggregateToFolder, {})
+    pModules.filter(metricsAreCalculable).reduce(aggregateToFolder, {}),
   )
     .map(calculateFolderMetrics)
     .map(deNormalizeInstability);

--- a/src/enrich/derive/folders/index.mjs
+++ b/src/enrich/derive/folders/index.mjs
@@ -1,5 +1,5 @@
-import validate from "../../../validate/index.mjs";
 import aggregateToFolders from "./aggregate-to-folders.mjs";
+import validate from "#validate/index.mjs";
 
 /**
  * @param {import("../../../../types/dependency-cruiser.js").IFolder} pFolder
@@ -18,7 +18,7 @@ function addFolderDependencyViolations(pOptions) {
     ...pFolder,
 
     dependencies: pFolder.dependencies.map(
-      validateFolderDependency(pFolder, pOptions)
+      validateFolderDependency(pFolder, pOptions),
     ),
   });
 }
@@ -34,7 +34,7 @@ export default function deriveFolderMetrics(pModules, pOptions) {
   if (pOptions.metrics) {
     lReturnValue = {
       folders: aggregateToFolders(pModules).map(
-        addFolderDependencyViolations(pOptions)
+        addFolderDependencyViolations(pOptions),
       ),
     };
   }

--- a/src/enrich/derive/metrics/get-module-metrics.mjs
+++ b/src/enrich/derive/metrics/get-module-metrics.mjs
@@ -1,5 +1,5 @@
-import IndexedModuleGraph from "../../../graph-utl/indexed-module-graph.mjs";
 import { calculateInstability, metricsAreCalculable } from "../module-utl.mjs";
+import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 
 export function addInstabilityMetric(pModule) {
   return {
@@ -8,7 +8,7 @@ export function addInstabilityMetric(pModule) {
       ? {
           instability: calculateInstability(
             pModule.dependencies.length,
-            pModule.dependents.length
+            pModule.dependents.length,
           ),
         }
       : {}),
@@ -28,12 +28,12 @@ function addInstabilityToDependency(pAllModules) {
 export function deNormalizeInstabilityMetricsToDependencies(
   pModule,
   _,
-  pAllModules
+  pAllModules,
 ) {
   return {
     ...pModule,
     dependencies: pModule.dependencies.map(
-      addInstabilityToDependency(pAllModules)
+      addInstabilityToDependency(pAllModules),
     ),
   };
 }

--- a/src/enrich/derive/reachable.mjs
+++ b/src/enrich/derive/reachable.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
 import has from "lodash/has.js";
-import matchers from "../../validate/matchers.mjs";
+import matchers from "#validate/matchers.mjs";
 import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
 

--- a/src/enrich/derive/reachable.mjs
+++ b/src/enrich/derive/reachable.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
 import has from "lodash/has.js";
 import matchers from "../../validate/matchers.mjs";
-import { extractGroups } from "../../utl/regex-util.mjs";
 import IndexedModuleGraph from "../../graph-utl/indexed-module-graph.mjs";
+import { extractGroups } from "#utl/regex-util.mjs";
 
 function getReachableRules(pRuleSet) {
   return (pRuleSet?.forbidden ?? [])

--- a/src/enrich/derive/reachable.mjs
+++ b/src/enrich/derive/reachable.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
 import has from "lodash/has.js";
 import matchers from "../../validate/matchers.mjs";
-import IndexedModuleGraph from "../../graph-utl/indexed-module-graph.mjs";
+import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
 
 function getReachableRules(pRuleSet) {

--- a/src/enrich/enrich-modules.mjs
+++ b/src/enrich/enrich-modules.mjs
@@ -1,5 +1,3 @@
-import addFocus from "../graph-utl/add-focus.mjs";
-import IndexedModuleGraph from "../graph-utl/indexed-module-graph.mjs";
 import deriveCycles from "./derive/circular.mjs";
 import deriveOrphans from "./derive/orphan/index.mjs";
 import addDependents from "./derive/dependents/index.mjs";
@@ -7,6 +5,8 @@ import deriveReachable from "./derive/reachable.mjs";
 import addValidations from "./add-validations.mjs";
 import softenKnownViolations from "./soften-known-violations.mjs";
 import deriveModuleMetrics from "./derive/metrics/index.mjs";
+import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
+import addFocus from "#graph-utl/add-focus.mjs";
 import { bus } from "#utl/bus.mjs";
 
 export default function enrichModules(pModules, pOptions) {

--- a/src/enrich/enrich-modules.mjs
+++ b/src/enrich/enrich-modules.mjs
@@ -1,4 +1,3 @@
-import { bus } from "../utl/bus.mjs";
 import addFocus from "../graph-utl/add-focus.mjs";
 import IndexedModuleGraph from "../graph-utl/indexed-module-graph.mjs";
 import deriveCycles from "./derive/circular.mjs";
@@ -8,6 +7,7 @@ import deriveReachable from "./derive/reachable.mjs";
 import addValidations from "./add-validations.mjs";
 import softenKnownViolations from "./soften-known-violations.mjs";
 import deriveModuleMetrics from "./derive/metrics/index.mjs";
+import { bus } from "#utl/bus.mjs";
 
 export default function enrichModules(pModules, pOptions) {
   bus.info("analyzing: cycles");

--- a/src/enrich/soften-known-violations.mjs
+++ b/src/enrich/soften-known-violations.mjs
@@ -1,18 +1,18 @@
-import { bus } from "../utl/bus.mjs";
 import isSameViolation from "./summarize/is-same-violation.mjs";
+import { bus } from "#utl/bus.mjs";
 
 function softenModuleViolation(
   pRule,
   pModuleSource,
   pKnownModuleViolations,
-  pSoftenedSeverity
+  pSoftenedSeverity,
 ) {
   return {
     ...pRule,
     severity: pKnownModuleViolations.some(
       (pKnownError) =>
         pKnownError.from === pModuleSource &&
-        pKnownError.rule.name === pRule.name
+        pKnownError.rule.name === pRule.name,
     )
       ? pSoftenedSeverity
       : pRule.severity,
@@ -22,12 +22,12 @@ function softenModuleViolation(
 function softenDependencyViolation(
   pViolationKey,
   pKnownDependencyViolations,
-  pSoftenedSeverity
+  pSoftenedSeverity,
 ) {
   return {
     ...pViolationKey.rule,
     severity: pKnownDependencyViolations.some((pKnownError) =>
-      isSameViolation(pKnownError, pViolationKey)
+      isSameViolation(pKnownError, pViolationKey),
     )
       ? pSoftenedSeverity
       : pViolationKey.rule.severity,
@@ -38,7 +38,7 @@ function softenDependencyViolations(
   pDependency,
   pModuleSource,
   pKnownDependencyViolations,
-  pSoftenedSeverity
+  pSoftenedSeverity,
 ) {
   if (!pDependency.valid) {
     return {
@@ -52,8 +52,8 @@ function softenDependencyViolations(
             cycle: pDependency.cycle,
           },
           pKnownDependencyViolations,
-          pSoftenedSeverity
-        )
+          pSoftenedSeverity,
+        ),
       ),
     };
   }
@@ -78,10 +78,10 @@ function softenKnownViolation(pModule, pKnownViolations, pSoftenedSeverity) {
           pModule.source,
           pKnownViolations.filter(
             (pKnownError) =>
-              pKnownError.from === pKnownError.to && !pKnownError.cycle
+              pKnownError.from === pKnownError.to && !pKnownError.cycle,
           ),
-          pSoftenedSeverity
-        )
+          pSoftenedSeverity,
+        ),
       ),
     };
   }
@@ -94,10 +94,10 @@ function softenKnownViolation(pModule, pKnownViolations, pSoftenedSeverity) {
         pModule.source,
         pKnownViolations.filter(
           (pKnownError) =>
-            pKnownError.from !== pKnownError.to || pKnownError.cycle
+            pKnownError.from !== pKnownError.to || pKnownError.cycle,
         ),
-        pSoftenedSeverity
-      )
+        pSoftenedSeverity,
+      ),
     ),
   };
 
@@ -114,12 +114,12 @@ function softenKnownViolation(pModule, pKnownViolations, pSoftenedSeverity) {
 export default function softenKnownViolations(
   pModules,
   pKnownViolations,
-  pSoftenedSeverity = "ignore"
+  pSoftenedSeverity = "ignore",
 ) {
   if (Boolean(pKnownViolations)) {
     bus.info("analyzing: comparing against known errors");
     return pModules.map((pModule) =>
-      softenKnownViolation(pModule, pKnownViolations, pSoftenedSeverity)
+      softenKnownViolation(pModule, pKnownViolations, pSoftenedSeverity),
     );
   }
   return pModules;

--- a/src/enrich/summarize/index.mjs
+++ b/src/enrich/summarize/index.mjs
@@ -1,4 +1,3 @@
-import compare from "../../graph-utl/compare.mjs";
 import addRuleSetUsed from "./add-rule-set-used.mjs";
 import summarizeModules from "./summarize-modules.mjs";
 import summarizeFolders from "./summarize-folders.mjs";
@@ -8,6 +7,7 @@ import {
   getModulesCruised,
   getDependenciesCruised,
 } from "./get-stats.mjs";
+import compare from "#graph-utl/compare.mjs";
 
 /**
  *
@@ -27,7 +27,7 @@ export default function summarize(
   pModules,
   pOptions,
   pFileDirectoryArray,
-  pFolders
+  pFolders,
 ) {
   const lViolations = summarizeModules(pModules, pOptions.ruleSet)
     .concat(summarizeFolders(pFolders || [], pOptions.ruleSet))

--- a/src/enrich/summarize/summarize-folders.mjs
+++ b/src/enrich/summarize/summarize-folders.mjs
@@ -1,5 +1,5 @@
 import has from "lodash/has.js";
-import { findRuleByName } from "../../graph-utl/rule-set.mjs";
+import { findRuleByName } from "#graph-utl/rule-set.mjs";
 
 function classifyViolation(pRule, pRuleSet) {
   const lRule = findRuleByName(pRuleSet, pRule.name);
@@ -38,7 +38,7 @@ function getViolations(pFolder, pRuleSet) {
               }
             : {}),
         };
-      })
+      }),
     );
 }
 

--- a/src/enrich/summarize/summarize-modules.mjs
+++ b/src/enrich/summarize/summarize-modules.mjs
@@ -1,15 +1,15 @@
 import flattenDeep from "lodash/flattenDeep.js";
 import has from "lodash/has.js";
 import uniqWith from "lodash/uniqWith.js";
-import { findRuleByName } from "../../graph-utl/rule-set.mjs";
-import compare from "../../graph-utl/compare.mjs";
 import isSameViolation from "./is-same-violation.mjs";
+import { findRuleByName } from "#graph-utl/rule-set.mjs";
+import compare from "#graph-utl/compare.mjs";
 
 function cutNonTransgressions(pModule) {
   return {
     ...pModule,
     dependencies: pModule.dependencies.filter(
-      (pDependency) => pDependency.valid === false
+      (pDependency) => pDependency.valid === false,
     ),
   };
 }
@@ -76,10 +76,10 @@ function extractDependencyViolations(pModules, pRuleSet) {
       .map((pModule) =>
         pModule.dependencies.map((pDependency) =>
           pDependency.rules.map((pRule) =>
-            toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet)
-          )
-        )
-      )
+            toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet),
+          ),
+        ),
+      ),
   );
 }
 
@@ -96,9 +96,9 @@ function toModuleViolationSummary(pRule, pModule, pRuleSet) {
             pReachable.modules.map((pReachableModule) => ({
               to: pReachableModule.source,
               via: pReachableModule.via,
-            }))
+            })),
           ),
-        []
+        [],
       )
       .map((pToModule) => ({
         type: "reachability",
@@ -121,12 +121,12 @@ function extractModuleViolations(pModules, pRuleSet) {
           pModule.rules.reduce(
             (pAllRules, pRule) =>
               pAllRules.concat(
-                toModuleViolationSummary(pRule, pModule, pRuleSet)
+                toModuleViolationSummary(pRule, pModule, pRuleSet),
               ),
-            []
-          )
+            [],
+          ),
         ),
-      []
+      [],
     );
 }
 
@@ -135,6 +135,6 @@ export default function summarizeModules(pModules, pRuleSet) {
     extractDependencyViolations(pModules, pRuleSet)
       .concat(extractModuleViolations(pModules, pRuleSet))
       .sort(compare.violations),
-    isSameViolation
+    isSameViolation,
   );
 }

--- a/src/extract/ast-extractors/extract-typescript-deps.mjs
+++ b/src/extract/ast-extractors/extract-typescript-deps.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable no-inline-comments */
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 /** @type {import("typescript")} */
 const typescript = await tryImport(
   "typescript",
-  meta.supportedTranspilers.typescript
+  meta.supportedTranspilers.typescript,
 );
 
 function isTypeOnly(pStatement) {
@@ -41,7 +41,7 @@ function extractImportsAndExports(pAST) {
       (pStatement) =>
         (typescript.SyntaxKind[pStatement.kind] === "ImportDeclaration" ||
           typescript.SyntaxKind[pStatement.kind] === "ExportDeclaration") &&
-        Boolean(pStatement.moduleSpecifier)
+        Boolean(pStatement.moduleSpecifier),
     )
     .map((pStatement) => ({
       module: pStatement.moduleSpecifier.text,
@@ -69,7 +69,7 @@ function extractImportEquals(pAST) {
         typescript.SyntaxKind[pStatement.kind] === "ImportEqualsDeclaration" &&
         pStatement.moduleReference &&
         pStatement.moduleReference.expression &&
-        pStatement.moduleReference.expression.text
+        pStatement.moduleReference.expression.text,
     )
     .map((pStatement) => ({
       module: pStatement.moduleReference.expression.text,
@@ -97,14 +97,14 @@ function extractTripleSlashDirectives(pAST) {
         module: pReference.fileName,
         moduleSystem: "tsd",
         exoticallyRequired: false,
-      }))
+      })),
     )
     .concat(
       pAST.amdDependencies.map((pReference) => ({
         module: pReference.path,
         moduleSystem: "tsd",
         exoticallyRequired: false,
-      }))
+      })),
     );
 }
 
@@ -267,14 +267,14 @@ function extractNestedDependencies(pAST, pExoticRequireStrings) {
  */
 export default function extractTypeScriptDependencies(
   pTypeScriptAST,
-  pExoticRequireStrings
+  pExoticRequireStrings,
 ) {
   return Boolean(typescript)
     ? extractImportsAndExports(pTypeScriptAST)
         .concat(extractImportEquals(pTypeScriptAST))
         .concat(extractTripleSlashDirectives(pTypeScriptAST))
         .concat(
-          extractNestedDependencies(pTypeScriptAST, pExoticRequireStrings)
+          extractNestedDependencies(pTypeScriptAST, pExoticRequireStrings),
         )
         .map((pModule) => ({ dynamic: false, ...pModule }))
     : /* c8 ignore next */ [];

--- a/src/extract/ast-extractors/swc-dependency-visitor.mjs
+++ b/src/extract/ast-extractors/swc-dependency-visitor.mjs
@@ -1,12 +1,12 @@
 /* eslint-disable no-inline-comments */
 /* eslint-disable max-classes-per-file */
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 /** @type {import('@swc/core/Visitor')} */
 const { Visitor } = await tryImport(
   "@swc/core/Visitor.js",
-  meta.supportedTranspilers.swc
+  meta.supportedTranspilers.swc,
 );
 
 function pryStringsFromArguments(pArguments) {
@@ -39,7 +39,7 @@ function argumentsAreUsable(pArguments) {
   return (
     pArguments.length > 0 &&
     ["StringLiteral", "TemplateLiteral"].includes(
-      pArguments[0].expression.type
+      pArguments[0].expression.type,
     ) &&
     (!(pArguments[0].expression.type === "TemplateLiteral") ||
       isPlaceholderlessTemplateLiteral(pArguments[0]))
@@ -209,7 +209,7 @@ export default Visitor
 
         // using "window.require" as an exotic require string...
         this.lResult = this.lResult.concat(
-          extractExoticMemberCallExpression(pNode, this.lExoticRequireStrings)
+          extractExoticMemberCallExpression(pNode, this.lExoticRequireStrings),
         );
 
         return super.visitCallExpression(pNode);

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -1,8 +1,8 @@
 import { readdirSync, statSync } from "node:fs";
 import { join, normalize } from "node:path";
 import picomatch from "picomatch";
-import { filenameMatchesPattern } from "../graph-utl/match-facade.mjs";
 import { scannableExtensions } from "./transpile/meta.mjs";
+import { filenameMatchesPattern } from "#graph-utl/match-facade.mjs";
 import getExtension from "#utl/get-extension.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 

--- a/src/extract/gather-initial-sources.mjs
+++ b/src/extract/gather-initial-sources.mjs
@@ -2,9 +2,9 @@ import { readdirSync, statSync } from "node:fs";
 import { join, normalize } from "node:path";
 import picomatch from "picomatch";
 import { filenameMatchesPattern } from "../graph-utl/match-facade.mjs";
-import getExtension from "../utl/get-extension.mjs";
-import pathToPosix from "../utl/path-to-posix.mjs";
 import { scannableExtensions } from "./transpile/meta.mjs";
+import getExtension from "#utl/get-extension.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 /**
  *

--- a/src/extract/index.mjs
+++ b/src/extract/index.mjs
@@ -1,8 +1,8 @@
 import has from "lodash/has.js";
-import { bus } from "../utl/bus.mjs";
 import getDependencies from "./get-dependencies.mjs";
 import gatherInitialSources from "./gather-initial-sources.mjs";
 import clearCaches from "./clear-caches.mjs";
+import { bus } from "#utl/bus.mjs";
 
 /* eslint max-params:0 */
 function extractRecursive(
@@ -11,7 +11,7 @@ function extractRecursive(
   pVisited,
   pDepth,
   pResolveOptions,
-  pTranspileOptions
+  pTranspileOptions,
 ) {
   pVisited.add(pFileName);
   const lDependencies =
@@ -20,13 +20,13 @@ function extractRecursive(
           pFileName,
           pCruiseOptions,
           pResolveOptions,
-          pTranspileOptions
+          pTranspileOptions,
         )
       : [];
 
   return lDependencies
     .filter(
-      ({ followable, matchesDoNotFollow }) => followable && !matchesDoNotFollow
+      ({ followable, matchesDoNotFollow }) => followable && !matchesDoNotFollow,
     )
     .reduce(
       (pAll, { resolved }) => {
@@ -38,8 +38,8 @@ function extractRecursive(
               pVisited,
               pDepth + 1,
               pResolveOptions,
-              pTranspileOptions
-            )
+              pTranspileOptions,
+            ),
           );
         }
         return pAll;
@@ -49,7 +49,7 @@ function extractRecursive(
           source: pFileName,
           dependencies: lDependencies,
         },
-      ]
+      ],
     );
 }
 
@@ -57,14 +57,14 @@ function extractFileDirectoryArray(
   pFileDirectoryArray,
   pCruiseOptions,
   pResolveOptions,
-  pTranspileOptions
+  pTranspileOptions,
 ) {
   let lVisited = new Set();
 
   bus.info("reading files: gathering initial sources");
   const lInitialSources = gatherInitialSources(
     pFileDirectoryArray,
-    pCruiseOptions
+    pCruiseOptions,
   );
 
   bus.info("reading files: visiting dependencies");
@@ -78,8 +78,8 @@ function extractFileDirectoryArray(
           lVisited,
           0,
           pResolveOptions,
-          pTranspileOptions
-        )
+          pTranspileOptions,
+        ),
       );
     }
     return pDependencies;
@@ -113,7 +113,7 @@ function complete(pAll, pFromListItem) {
       pFromListItem.dependencies
         .filter(isNotFollowable)
         .filter(notInFromListAlready(pAll))
-        .map(toDependencyToSource)
+        .map(toDependencyToSource),
     );
 }
 
@@ -122,7 +122,8 @@ function filterExcludedDynamicDependencies(pModule, pExclude) {
   return {
     ...pModule,
     dependencies: pModule.dependencies.filter(
-      ({ dynamic }) => !has(pExclude, "dynamic") || pExclude.dynamic !== dynamic
+      ({ dynamic }) =>
+        !has(pExclude, "dynamic") || pExclude.dynamic !== dynamic,
     ),
   };
 }
@@ -141,7 +142,7 @@ export default function extract(
   pFileDirectoryArray,
   pCruiseOptions,
   pResolveOptions,
-  pTranspileOptions
+  pTranspileOptions,
 ) {
   clearCaches();
 
@@ -149,11 +150,11 @@ export default function extract(
     pFileDirectoryArray,
     pCruiseOptions,
     pResolveOptions,
-    pTranspileOptions
+    pTranspileOptions,
   )
     .reduce(complete, [])
     .map((pModule) =>
-      filterExcludedDynamicDependencies(pModule, pCruiseOptions.exclude)
+      filterExcludedDynamicDependencies(pModule, pCruiseOptions.exclude),
     );
   pResolveOptions.fileSystem.purge();
   clearCaches();

--- a/src/extract/parse/to-javascript-ast.mjs
+++ b/src/extract/parse/to-javascript-ast.mjs
@@ -4,7 +4,7 @@ import { parse as acornLooseParse } from "acorn-loose";
 import acornJsx from "acorn-jsx";
 import memoize from "lodash/memoize.js";
 import transpile from "../transpile/index.mjs";
-import getExtension from "../../utl/get-extension.mjs";
+import getExtension from "#utl/get-extension.mjs";
 
 /** @type acorn.Options */
 const ACORN_OPTIONS = {
@@ -69,7 +69,7 @@ function getAST(pFileName, pTranspileOptions) {
       extension: getExtension(pFileName),
       filename: pFileName,
     },
-    pTranspileOptions
+    pTranspileOptions,
   );
 }
 
@@ -84,7 +84,7 @@ function getAST(pFileName, pTranspileOptions) {
  */
 export const getASTCached = memoize(
   getAST,
-  (pFileName, pTranspileOptions) => `${pFileName}|${pTranspileOptions}`
+  (pFileName, pTranspileOptions) => `${pFileName}|${pTranspileOptions}`,
 );
 
 export function clearCache() {

--- a/src/extract/parse/to-swc-ast.mjs
+++ b/src/extract/parse/to-swc-ast.mjs
@@ -1,6 +1,6 @@
 import tryImport from "semver-try-require";
 import memoize from "lodash/memoize.js";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 /** @type {import('@swc/core')} */
 const swc = await tryImport("@swc/core", meta.supportedTranspilers.swc);

--- a/src/extract/parse/to-typescript-ast.mjs
+++ b/src/extract/parse/to-typescript-ast.mjs
@@ -1,14 +1,14 @@
 import { readFileSync } from "node:fs";
 import tryImport from "semver-try-require";
 import memoize from "lodash/memoize.js";
-import meta from "../../meta.js";
 import transpile from "../transpile/index.mjs";
-import getExtension from "../../utl/get-extension.mjs";
+import meta from "#meta";
+import getExtension from "#utl/get-extension.mjs";
 
 /** @type {import('typescript')} */
 const typescript = await tryImport(
   "typescript",
-  meta.supportedTranspilers.typescript
+  meta.supportedTranspilers.typescript,
 );
 
 /**
@@ -29,7 +29,7 @@ export function getASTFromSource(pFileRecord, pTranspileOptions) {
     pFileRecord.filename || "$internal-file-name",
     lSource,
     typescript.ScriptTarget.Latest,
-    false
+    false,
   );
 }
 
@@ -49,7 +49,7 @@ function getAST(pFileName, pTranspileOptions) {
       extension: getExtension(pFileName),
       filename: pFileName,
     },
-    pTranspileOptions
+    pTranspileOptions,
   );
 }
 

--- a/src/extract/resolve/index.mjs
+++ b/src/extract/resolve/index.mjs
@@ -1,13 +1,13 @@
 import { realpathSync } from "node:fs";
 import { extname, resolve as path_resolve, relative } from "node:path";
 import monkeyPatchedModule from "node:module";
-import pathToPosix from "../../utl/path-to-posix.mjs";
 import { isRelativeModuleName } from "./module-classifiers.mjs";
 import { resolveAMD } from "./resolve-amd.mjs";
 import resolveCommonJS from "./resolve-cjs.mjs";
 import { stripToModuleName, addLicenseAttribute } from "./resolve-helpers.mjs";
 import determineDependencyTypes from "./determine-dependency-types.mjs";
 import { getManifest } from "./get-manifest.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 /**
  *

--- a/src/extract/resolve/module-classifiers.mjs
+++ b/src/extract/resolve/module-classifiers.mjs
@@ -1,5 +1,5 @@
 import { isAbsolute, resolve as path_resolve } from "node:path";
-import getExtension from "../../utl/get-extension.mjs";
+import getExtension from "#utl/get-extension.mjs";
 
 let gFollowableExtensionsCache = new Set();
 let gFollowableExtensionsCacheInitialized = false;
@@ -21,7 +21,7 @@ export function isRelativeModuleName(pModuleName) {
 export function isExternalModule(
   pResolvedModuleName,
   pModuleFolderNames = ["node_modules"],
-  pBaseDirectory = "."
+  pBaseDirectory = ".",
 ) {
   return (
     Boolean(pResolvedModuleName) &&
@@ -37,11 +37,11 @@ export function isExternalModule(
       (pModuleFolderName) => {
         if (isAbsolute(pModuleFolderName)) {
           return path_resolve(pBaseDirectory, pResolvedModuleName).startsWith(
-            pModuleFolderName
+            pModuleFolderName,
           );
         }
         return pResolvedModuleName.includes(pModuleFolderName);
-      }
+      },
     )
   );
 }
@@ -85,13 +85,13 @@ function getFollowableExtensions(pResolveOptions) {
 
 export function isFollowable(pResolvedFilename, pResolveOptions) {
   return getFollowableExtensions(pResolveOptions).has(
-    getExtension(pResolvedFilename)
+    getExtension(pResolvedFilename),
   );
 }
 
 function isWebPackAliased(pModuleName, pAliasObject) {
   return Object.keys(pAliasObject || {}).some((pAliasLHS) =>
-    pModuleName.startsWith(pAliasLHS)
+    pModuleName.startsWith(pAliasLHS),
   );
 }
 
@@ -99,7 +99,7 @@ function isLikelyTSAliased(
   pModuleName,
   pResolvedModuleName,
   pResolveOptions,
-  pBaseDirectory
+  pBaseDirectory,
 ) {
   return (
     pResolveOptions.tsConfig &&

--- a/src/extract/resolve/resolve-amd.mjs
+++ b/src/extract/resolve/resolve-amd.mjs
@@ -1,8 +1,8 @@
 import { accessSync, R_OK } from "node:fs";
 import { relative, join } from "node:path";
 import memoize from "lodash/memoize.js";
-import pathToPosix from "../../utl/path-to-posix.mjs";
 import { isBuiltin } from "./is-built-in.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 const fileExists = memoize((pFile) => {
   try {

--- a/src/extract/resolve/resolve-cjs.mjs
+++ b/src/extract/resolve/resolve-cjs.mjs
@@ -1,8 +1,8 @@
 import { relative } from "node:path";
-import pathToPosix from "../../utl/path-to-posix.mjs";
 import { isFollowable } from "./module-classifiers.mjs";
 import { resolve } from "./resolve.mjs";
 import { isBuiltin } from "./is-built-in.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 function addResolutionAttributes(
   pBaseDirectory,

--- a/src/extract/resolve/resolve.mjs
+++ b/src/extract/resolve/resolve.mjs
@@ -1,6 +1,6 @@
 import enhancedResolve from "enhanced-resolve";
-import pathToPosix from "../../utl/path-to-posix.mjs";
 import { stripQueryParameters } from "../helpers.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 let gResolvers = {};
 let gInitialized = {};
@@ -38,7 +38,7 @@ export function resolve(
   pModuleName,
   pFileDirectory,
   pResolveOptions,
-  pCachingContext = "cruise"
+  pCachingContext = "cruise",
 ) {
   init(pResolveOptions, pCachingContext);
 
@@ -48,8 +48,8 @@ export function resolve(
       // lookupStartPath
       pathToPosix(pFileDirectory),
       // request
-      pModuleName
-    )
+      pModuleName,
+    ),
   );
 }
 

--- a/src/extract/transpile/babel-wrap.mjs
+++ b/src/extract/transpile/babel-wrap.mjs
@@ -1,5 +1,5 @@
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 const babel = await tryImport("@babel/core", meta.supportedTranspilers.babel);
 

--- a/src/extract/transpile/coffeescript-wrap.mjs
+++ b/src/extract/transpile/coffeescript-wrap.mjs
@@ -1,5 +1,5 @@
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 /*
  * coffeescript's npm repo was renamed from coffee-script to coffeescript
@@ -9,14 +9,14 @@ import meta from "../../meta.js";
 async function getCoffeeScriptModule() {
   let lReturnValue = await tryImport(
     "coffeescript",
-    meta.supportedTranspilers.coffeescript
+    meta.supportedTranspilers.coffeescript,
   );
 
   /* c8 ignore start */
   if (lReturnValue === false) {
     lReturnValue = await tryImport(
       "coffee-script",
-      meta.supportedTranspilers["coffee-script"]
+      meta.supportedTranspilers["coffee-script"],
     );
   }
   /* c8 ignore stop */

--- a/src/extract/transpile/livescript-wrap.mjs
+++ b/src/extract/transpile/livescript-wrap.mjs
@@ -1,9 +1,9 @@
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 const livescript = await tryImport(
   "livescript",
-  meta.supportedTranspilers.livescript
+  meta.supportedTranspilers.livescript,
 );
 
 /* c8 ignore start */

--- a/src/extract/transpile/meta.mjs
+++ b/src/extract/transpile/meta.mjs
@@ -1,6 +1,6 @@
 /* eslint security/detect-object-injection : 0*/
-import meta from "../../meta.js";
 import tryAvailable from "./try-import-available.mjs";
+import meta from "#meta";
 
 function gotCoffee() {
   return (
@@ -20,11 +20,11 @@ const TRANSPILER2AVAILABLE = {
   typescript: tryAvailable("typescript", meta.supportedTranspilers.typescript),
   "vue-template-compiler": tryAvailable(
     "vue-template-compiler",
-    meta.supportedTranspilers["vue-template-compiler"]
+    meta.supportedTranspilers["vue-template-compiler"],
   ),
   "@vue/compiler-sfc": tryAvailable(
     "@vue/compiler-sfc",
-    meta.supportedTranspilers["@vue/compiler-sfc"]
+    meta.supportedTranspilers["@vue/compiler-sfc"],
   ),
 };
 
@@ -78,7 +78,7 @@ export const allExtensions = Array.from(EXTENSION2AVAILABLE.keys()).map(
   (pExtension) => ({
     extension: pExtension,
     available: extensionIsAvailable(pExtension),
-  })
+  }),
 );
 
 /**
@@ -88,7 +88,7 @@ export const allExtensions = Array.from(EXTENSION2AVAILABLE.keys()).map(
  * @type {string[]}
  */
 export const scannableExtensions = Array.from(
-  EXTENSION2AVAILABLE.keys()
+  EXTENSION2AVAILABLE.keys(),
 ).filter(extensionIsAvailable);
 
 /**

--- a/src/extract/transpile/svelte-wrap.mjs
+++ b/src/extract/transpile/svelte-wrap.mjs
@@ -1,10 +1,10 @@
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
 import preProcess from "./svelte-preprocess.mjs";
+import meta from "#meta";
 
 const { compile } = await tryImport(
   "svelte/compiler",
-  meta.supportedTranspilers.svelte
+  meta.supportedTranspilers.svelte,
 );
 
 function getTranspiler(pTranspilerWrapper) {
@@ -12,7 +12,7 @@ function getTranspiler(pTranspilerWrapper) {
     const lPreProcessedSource = preProcess(
       pSource,
       pTranspilerWrapper,
-      pTranspilerOptions
+      pTranspilerOptions,
     );
     return compile(lPreProcessedSource).js.code;
   };

--- a/src/extract/transpile/typescript-wrap.mjs
+++ b/src/extract/transpile/typescript-wrap.mjs
@@ -1,9 +1,9 @@
 import tryImport from "semver-try-require";
-import meta from "../../meta.js";
+import meta from "#meta";
 
 const typescript = await tryImport(
   "typescript",
-  meta.supportedTranspilers.typescript
+  meta.supportedTranspilers.typescript,
 );
 
 function getCompilerOptions(pFlavor, pTSConfig) {
@@ -41,7 +41,7 @@ export default function typescriptWrap(pFlavor) {
         ...(pTranspileOptions.tsConfig || {}),
         compilerOptions: getCompilerOptions(
           pFlavor,
-          pTranspileOptions.tsConfig || {}
+          pTranspileOptions.tsConfig || {},
         ),
       }).outputText,
   };

--- a/src/extract/transpile/vue-template-wrap.cjs
+++ b/src/extract/transpile/vue-template-wrap.cjs
@@ -1,7 +1,7 @@
 const { EOL } = require("node:os");
 const isEmpty = require("lodash/isEmpty");
 const tryRequire = require("semver-try-require");
-const meta = require("../../meta.js");
+const meta = require("#meta");
 
 /*
  * vue-template-compiler was replaced by @vue/compiler-sfc for Vue3.
@@ -15,13 +15,13 @@ function getVueTemplateCompiler() {
 
   let lCompiler = tryRequire(
     "vue-template-compiler",
-    meta.supportedTranspilers["vue-template-compiler"]
+    meta.supportedTranspilers["vue-template-compiler"],
   );
 
   if (lCompiler === false) {
     lCompiler = tryRequire(
       "@vue/compiler-sfc",
-      meta.supportedTranspilers["@vue/compiler-sfc"]
+      meta.supportedTranspilers["@vue/compiler-sfc"],
     );
     lIsVue3 = true;
   }

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -58,7 +58,7 @@ export default async function cruise(
     import("./files-and-dirs/normalize.mjs"),
     import("./resolve-options/normalize.mjs"),
     import("#extract/index.mjs"),
-    import("../enrich/index.mjs"),
+    import("#enrich/index.mjs"),
   ]);
 
   if (Boolean(lCruiseOptions.ruleSet)) {

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -32,7 +32,7 @@ export default async function cruise(
       c(2),
     );
 
-    const { default: Cache } = await import("../cache/cache.mjs");
+    const { default: Cache } = await import("#cache/cache.mjs");
     lCache = new Cache(lCruiseOptions.cache.strategy);
     const lCachedResults = await lCache.read(lCruiseOptions.cache.folder);
 

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -57,7 +57,7 @@ export default async function cruise(
     import("./rule-set/assert-validity.mjs"),
     import("./files-and-dirs/normalize.mjs"),
     import("./resolve-options/normalize.mjs"),
-    import("../extract/index.mjs"),
+    import("#extract/index.mjs"),
     import("../enrich/index.mjs"),
   ]);
 

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -1,9 +1,8 @@
-/* eslint-disable no-return-await */
-/* eslint-disable no-magic-numbers */
-import { bus } from "../utl/bus.mjs";
+/* eslint-disable no-return-await, no-magic-numbers */
 import { assertCruiseOptionsValid } from "./options/assert-validity.mjs";
 import { normalizeCruiseOptions } from "./options/normalize.mjs";
 import reportWrap from "./report-wrap.mjs";
+import { bus } from "#utl/bus.mjs";
 
 const TOTAL_STEPS = 10;
 

--- a/src/main/format.mjs
+++ b/src/main/format.mjs
@@ -1,9 +1,9 @@
 import Ajv from "ajv";
 
-import cruiseResultSchema from "../schema/cruise-result.schema.mjs";
 import { assertFormatOptionsValid } from "./options/assert-validity.mjs";
 import { normalizeFormatOptions } from "./options/normalize.mjs";
 import reportWrap from "./report-wrap.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 
 function validateResultAgainstSchema(pResult) {
   const ajv = new Ajv();

--- a/src/main/index.d.ts
+++ b/src/main/index.d.ts
@@ -1,4 +1,4 @@
 // workaround to nodenext shenanigans with the TypeScript compiler
 // see https://github.com/sverweij/dependency-cruiser/issues/754
-// eslint-disable-next-line import/no-unresolved, node/no-missing-import, node/no-unpublished-import
+// eslint-disable-next-line node/no-unpublished-import
 export * from "../../types/dependency-cruiser";

--- a/src/main/index.mjs
+++ b/src/main/index.mjs
@@ -1,14 +1,14 @@
+import format from "./format.mjs";
+import cruise from "./cruise.mjs";
 import {
   allExtensions,
   getAvailableTranspilers,
-} from "../extract/transpile/meta.mjs";
-import format from "./format.mjs";
-import cruise from "./cruise.mjs";
+} from "#extract/transpile/meta.mjs";
 
 export {
   allExtensions,
   getAvailableTranspilers,
-} from "../extract/transpile/meta.mjs";
+} from "#extract/transpile/meta.mjs";
 export { default as cruise } from "./cruise.mjs";
 export { default as format } from "./format.mjs";
 

--- a/src/main/options/assert-validity.mjs
+++ b/src/main/options/assert-validity.mjs
@@ -1,7 +1,7 @@
 import has from "lodash/has.js";
 import merge from "lodash/merge.js";
 import safeRegex from "safe-regex";
-import report from "../../report/index.mjs";
+import report from "#report/index.mjs";
 
 const MODULE_SYSTEM_LIST_RE = /^((cjs|amd|es6|tsd)(,|$))+$/gi;
 const VALID_DEPTH_RE = /^\d{1,2}$/g;

--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -1,5 +1,5 @@
 import has from "lodash/has.js";
-import report from "../report/index.mjs";
+import report from "#report/index.mjs";
 import summarize from "#enrich/summarize/index.mjs";
 import { applyFilters } from "#graph-utl/filter-bank.mjs";
 import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";

--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -1,6 +1,6 @@
 import has from "lodash/has.js";
-import summarize from "../enrich/summarize/index.mjs";
 import report from "../report/index.mjs";
+import summarize from "#enrich/summarize/index.mjs";
 import { applyFilters } from "#graph-utl/filter-bank.mjs";
 import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
 import compare from "#graph-utl/compare.mjs";

--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -1,10 +1,10 @@
 import has from "lodash/has.js";
-import { applyFilters } from "../graph-utl/filter-bank.mjs";
 import summarize from "../enrich/summarize/index.mjs";
-import consolidateToPattern from "../graph-utl/consolidate-to-pattern.mjs";
-import compare from "../graph-utl/compare.mjs";
-import stripSelfTransitions from "../graph-utl/strip-self-transitions.mjs";
 import report from "../report/index.mjs";
+import { applyFilters } from "#graph-utl/filter-bank.mjs";
+import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
+import compare from "#graph-utl/compare.mjs";
+import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
 
 /**
  *
@@ -32,7 +32,7 @@ function reSummarizeResults(pResult, pFormatOptions) {
         },
         (pResult.summary.optionsUsed.args || "").split(" "),
         // TODO: apply filters to the folders too
-        pResult.folders
+        pResult.folders,
       ),
     },
     modules: lModules,
@@ -57,6 +57,6 @@ export default async function reportWrap(pResult, pFormatOptions) {
     // from the result take the one passed in the format options instead
     has(pFormatOptions, "collapse")
       ? { ...lReportOptions, collapsePattern: pFormatOptions.collapse }
-      : lReportOptions
+      : lReportOptions,
   );
 }

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import enhancedResolve from "enhanced-resolve";
 import omit from "lodash/omit.js";
-import { scannableExtensions } from "../../extract/transpile/meta.mjs";
+import { scannableExtensions } from "#extract/transpile/meta.mjs";
 import {
   ruleSetHasDeprecationRule,
   ruleSetHasLicenseRule,

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -5,7 +5,7 @@ import { scannableExtensions } from "../../extract/transpile/meta.mjs";
 import {
   ruleSetHasDeprecationRule,
   ruleSetHasLicenseRule,
-} from "../../graph-utl/rule-set.mjs";
+} from "#graph-utl/rule-set.mjs";
 
 const DEFAULT_CACHE_DURATION = 4000;
 /** @type {Partial<import("../../../types/dependency-cruiser").IResolveOptions>} */

--- a/src/main/rule-set/assert-validity.mjs
+++ b/src/main/rule-set/assert-validity.mjs
@@ -2,8 +2,8 @@ import Ajv from "ajv";
 import safeRegex from "safe-regex";
 import has from "lodash/has.js";
 import { assertCruiseOptionsValid } from "../options/assert-validity.mjs";
-import configurationSchema from "../../schema/configuration.schema.mjs";
 import { normalizeToREAsString } from "../helpers.mjs";
+import configurationSchema from "#configuration-schema";
 
 const ajv = new Ajv();
 // the default for this is 25 - as noted in the safe-regex source code already,

--- a/src/report/dot/index.mjs
+++ b/src/report/dot/index.mjs
@@ -1,11 +1,11 @@
 /* eslint-disable prefer-template */
 import get from "lodash/get.js";
-import { applyFilters } from "../../graph-utl/filter-bank.mjs";
 import theming from "./theming.mjs";
 import moduleUtl from "./module-utl.mjs";
 import prepareFolderLevel from "./prepare-folder-level.mjs";
 import prepareCustomLevel from "./prepare-custom-level.mjs";
 import prepareFlatLevel from "./prepare-flat-level.mjs";
+import { applyFilters } from "#graph-utl/filter-bank.mjs";
 
 // not importing EOL from "node:os" so output is the same on windows and unices
 const EOL = "\n";

--- a/src/report/dot/prepare-custom-level.mjs
+++ b/src/report/dot/prepare-custom-level.mjs
@@ -1,13 +1,13 @@
-import consolidateToPattern from "../../graph-utl/consolidate-to-pattern.mjs";
-import compare from "../../graph-utl/compare.mjs";
-import stripSelfTransitions from "../../graph-utl/strip-self-transitions.mjs";
 import moduleUtl from "./module-utl.mjs";
+import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
+import compare from "#graph-utl/compare.mjs";
+import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
 
 export default function prepareCustomLevel(
   pResults,
   pTheme,
   pCollapsePattern,
-  pShowMetrics
+  pShowMetrics,
 ) {
   return (
     pCollapsePattern

--- a/src/report/dot/prepare-flat-level.mjs
+++ b/src/report/dot/prepare-flat-level.mjs
@@ -1,5 +1,5 @@
-import compare from "../../graph-utl/compare.mjs";
 import moduleUtl from "./module-utl.mjs";
+import compare from "#graph-utl/compare.mjs";
 
 export default function prepareFlatLevel(pResults, pTheme, _, pShowMetrics) {
   return pResults.modules

--- a/src/report/dot/prepare-folder-level.mjs
+++ b/src/report/dot/prepare-folder-level.mjs
@@ -1,7 +1,7 @@
-import consolidateToFolder from "../../graph-utl/consolidate-to-folder.mjs";
-import compare from "../../graph-utl/compare.mjs";
-import stripSelfTransitions from "../../graph-utl/strip-self-transitions.mjs";
 import moduleUtl from "./module-utl.mjs";
+import consolidateToFolder from "#graph-utl/consolidate-to-folder.mjs";
+import compare from "#graph-utl/compare.mjs";
+import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
 
 export default function prepareFolderLevel(pResults, pTheme, _, pShowMetrics) {
   return consolidateToFolder(pResults.modules)

--- a/src/report/error-html/index.mjs
+++ b/src/report/error-html/index.mjs
@@ -1,10 +1,10 @@
-import meta from "../../meta.js";
 import {
   determineFromExtras,
   aggregateViolations,
   determineTo,
 } from "./utl.mjs";
 import template from "./error-html-template.mjs";
+import meta from "#meta";
 
 function getViolatedRuleRowClass(pViolatedRule) {
   return pViolatedRule.unviolated ? ' class="unviolated"' : "";

--- a/src/report/error-html/utl.mjs
+++ b/src/report/error-html/utl.mjs
@@ -1,6 +1,6 @@
 import has from "lodash/has.js";
-import meta from "../../meta.js";
 import { formatViolation, formatPercentage } from "../utl/index.mjs";
+import meta from "#meta";
 
 function getFormattedAllowedRule(pRuleSetUsed) {
   const lAllowed = pRuleSetUsed?.allowed ?? [];

--- a/src/report/error.mjs
+++ b/src/report/error.mjs
@@ -2,11 +2,11 @@ import { EOL } from "node:os";
 import chalk from "chalk";
 import figures from "figures";
 import { findRuleByName } from "../graph-utl/rule-set.mjs";
-import wrapAndIndent from "../utl/wrap-and-indent.mjs";
 import {
   formatPercentage,
   formatViolation as _formatViolation,
 } from "./utl/index.mjs";
+import wrapAndIndent from "#utl/wrap-and-indent.mjs";
 
 const SEVERITY2CHALK = new Map([
   ["error", chalk.red],
@@ -21,8 +21,8 @@ function formatExtraPathInformation(pExtra) {
   return EOL.concat(
     wrapAndIndent(
       pExtra.join(` ${figures.arrowRight} ${EOL}`),
-      EXTRA_PATH_INFORMATION_INDENT
-    )
+      EXTRA_PATH_INFORMATION_INDENT,
+    ),
   );
 }
 
@@ -32,7 +32,7 @@ function formatModuleViolation(pViolation) {
 
 function formatDependencyViolation(pViolation) {
   return `${chalk.bold(pViolation.from)} ${figures.arrowRight} ${chalk.bold(
-    pViolation.to
+    pViolation.to,
   )}`;
 }
 
@@ -44,7 +44,7 @@ function formatCycleViolation(pViolation) {
 
 function formatReachabilityViolation(pViolation) {
   return `${chalk.bold(pViolation.from)} ${figures.arrowRight} ${chalk.bold(
-    pViolation.to
+    pViolation.to,
   )}${formatExtraPathInformation(pViolation.via)}`;
 }
 
@@ -53,9 +53,9 @@ function formatInstabilityViolation(pViolation) {
     chalk.dim(
       `instability: ${formatPercentage(pViolation.metrics.from.instability)} ${
         figures.arrowRight
-      } ${formatPercentage(pViolation.metrics.to.instability)}`
+      } ${formatPercentage(pViolation.metrics.to.instability)}`,
     ),
-    EXTRA_PATH_INFORMATION_INDENT
+    EXTRA_PATH_INFORMATION_INDENT,
   )}`;
 }
 
@@ -70,12 +70,12 @@ function formatViolation(pViolation) {
   const lFormattedViolators = _formatViolation(
     pViolation,
     lViolationType2Formatter,
-    formatDependencyViolation
+    formatDependencyViolation,
   );
 
   return (
     `${SEVERITY2CHALK.get(pViolation.rule.severity)(
-      pViolation.rule.severity
+      pViolation.rule.severity,
     )} ${pViolation.rule.name}: ${lFormattedViolators}` +
     `${
       pViolation.comment
@@ -95,7 +95,7 @@ function sumMeta(pMeta) {
 
 function formatSummary(pSummary) {
   let lMessage = `${EOL}${figures.cross} ${sumMeta(
-    pSummary
+    pSummary,
   )} dependency violations (${formatMeta(pSummary)}). ${
     pSummary.totalCruised
   } modules, ${pSummary.totalDependenciesCruised} dependencies cruised.${EOL}`;
@@ -115,7 +115,7 @@ function addExplanation(pRuleSet, pLong) {
 function formatIgnoreWarning(pNumberOfIgnoredViolations) {
   if (pNumberOfIgnoredViolations > 0) {
     return chalk.yellow(
-      `${figures.warning} ${pNumberOfIgnoredViolations} known violations ignored. Run with --no-ignore-known to see them.${EOL}`
+      `${figures.warning} ${pNumberOfIgnoredViolations} known violations ignored. Run with --no-ignore-known to see them.${EOL}`,
     );
   }
   return "";
@@ -123,18 +123,18 @@ function formatIgnoreWarning(pNumberOfIgnoredViolations) {
 
 function report(pResults, pLong) {
   const lNonIgnorableViolations = pResults.summary.violations.filter(
-    (pViolation) => pViolation.rule.severity !== "ignore"
+    (pViolation) => pViolation.rule.severity !== "ignore",
   );
 
   if (lNonIgnorableViolations.length === 0) {
     return `${EOL}${chalk.green(
-      figures.tick
+      figures.tick,
     )} no dependency violations found (${
       pResults.summary.totalCruised
     } modules, ${
       pResults.summary.totalDependenciesCruised
     } dependencies cruised)${EOL}${formatIgnoreWarning(
-      pResults.summary.ignore
+      pResults.summary.ignore,
     )}${EOL}`;
   }
 

--- a/src/report/error.mjs
+++ b/src/report/error.mjs
@@ -1,11 +1,11 @@
 import { EOL } from "node:os";
 import chalk from "chalk";
 import figures from "figures";
-import { findRuleByName } from "../graph-utl/rule-set.mjs";
 import {
   formatPercentage,
   formatViolation as _formatViolation,
 } from "./utl/index.mjs";
+import { findRuleByName } from "#graph-utl/rule-set.mjs";
 import wrapAndIndent from "#utl/wrap-and-indent.mjs";
 
 const SEVERITY2CHALK = new Map([

--- a/src/report/markdown.mjs
+++ b/src/report/markdown.mjs
@@ -1,5 +1,5 @@
-import meta from "../meta.js";
 import errorHtmlUtl from "./error-html/utl.mjs";
+import meta from "#meta";
 
 const { aggregateViolations, determineTo, determineFromExtras } = errorHtmlUtl;
 
@@ -64,18 +64,18 @@ function formatRulesSummary(pCruiseResult, pIncludeIgnoredInSummary) {
 
   return aggregateViolations(
     pCruiseResult.summary.violations,
-    pCruiseResult.summary.ruleSetUsed
+    pCruiseResult.summary.ruleSetUsed,
   )
     .filter(
       (pRule) =>
-        pRule.count > 0 || (pIncludeIgnoredInSummary && pRule.ignoredCount > 0)
+        pRule.count > 0 || (pIncludeIgnoredInSummary && pRule.ignoredCount > 0),
     )
     .reduce(
       (pAll, pRule) =>
         `${pAll}|${severity2Icon(pRule.severity)}&nbsp;_${pRule.name}_|**${
           pRule.count
         }**|**${pRule.ignoredCount}**|${pRule.comment}|\n`,
-      lTableHead
+      lTableHead,
     );
 }
 
@@ -91,7 +91,7 @@ function formatViolations(pViolations, pIncludeIgnoredInDetails) {
   return pViolations
     .filter(
       (pViolation) =>
-        pViolation.rule.severity !== "ignore" || pIncludeIgnoredInDetails
+        pViolation.rule.severity !== "ignore" || pIncludeIgnoredInDetails,
     )
     .reduce((pAll, pViolation) => {
       const lFromExtras = determineFromExtras(pViolation);
@@ -127,7 +127,7 @@ function report(pResults, pOptions) {
     if (pResults.summary.violations.length > 0 && lOptions.showRulesSummary) {
       lReturnValue += `${formatRulesSummary(
         pResults,
-        lOptions.includeIgnoredInSummary
+        lOptions.includeIgnoredInSummary,
       )}\n\n`;
     }
   }
@@ -142,7 +142,7 @@ function report(pResults, pOptions) {
       }
       lReturnValue += `${formatViolations(
         pResults.summary.violations,
-        lOptions.includeIgnoredInDetails
+        lOptions.includeIgnoredInDetails,
       )}\n\n`;
       if (lOptions.collapseDetails) {
         lReturnValue += "</details>\n\n";

--- a/src/validate/index.d.ts
+++ b/src/validate/index.d.ts
@@ -1,6 +1,4 @@
 /* eslint-disable node/no-unpublished-import */
-/* eslint-disable node/no-missing-import */
-/* eslint-disable import/no-unresolved */
 import {
   IDependency,
   IFolder,

--- a/src/validate/match-dependency-rule.mjs
+++ b/src/validate/match-dependency-rule.mjs
@@ -1,6 +1,6 @@
-import { extractGroups } from "../utl/regex-util.mjs";
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
 import matchers from "./matchers.mjs";
+import { extractGroups } from "#utl/regex-util.mjs";
 
 /**
  *
@@ -37,7 +37,7 @@ function match(pFrom, pTo) {
         pRule,
         pTo,
         "exoticRequireNot",
-        "exoticRequire"
+        "exoticRequire",
       ) &&
       matchers.toVia(pRule, pTo, lGroups) &&
       matchers.toViaOnly(pRule, pTo, lGroups) &&

--- a/src/validate/match-folder-dependency-rule.mjs
+++ b/src/validate/match-folder-dependency-rule.mjs
@@ -1,6 +1,6 @@
-import { extractGroups, replaceGroupPlaceholders } from "../utl/regex-util.mjs";
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
 import matchers from "./matchers.mjs";
+import { extractGroups, replaceGroupPlaceholders } from "#utl/regex-util.mjs";
 
 function fromFolderPath(pRule, pFromFolder) {
   return Boolean(!pRule.from.path || pFromFolder.name.match(pRule.from.path));
@@ -8,21 +8,23 @@ function fromFolderPath(pRule, pFromFolder) {
 
 function fromFolderPathNot(pRule, pFromFolder) {
   return Boolean(
-    !pRule.from.pathNot || !pFromFolder.name.match(pRule.from.pathNot)
+    !pRule.from.pathNot || !pFromFolder.name.match(pRule.from.pathNot),
   );
 }
 
 function toFolderPath(pRule, pToFolder, pGroups) {
   return Boolean(
     !pRule.to.path ||
-      pToFolder.name.match(replaceGroupPlaceholders(pRule.to.path, pGroups))
+      pToFolder.name.match(replaceGroupPlaceholders(pRule.to.path, pGroups)),
   );
 }
 
 function toFolderPathNot(pRule, pToFolder, pGroups) {
   return Boolean(
     !pRule.to.pathNot ||
-      !pToFolder.name.match(replaceGroupPlaceholders(pRule.to.pathNot, pGroups))
+      !pToFolder.name.match(
+        replaceGroupPlaceholders(pRule.to.pathNot, pGroups),
+      ),
   );
 }
 

--- a/src/validate/match-module-rule.mjs
+++ b/src/validate/match-module-rule.mjs
@@ -1,7 +1,7 @@
 import has from "lodash/has.js";
-import { extractGroups } from "../utl/regex-util.mjs";
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
 import matchers from "./matchers.mjs";
+import { extractGroups } from "#utl/regex-util.mjs";
 
 /**
  * Returns true if pRule is an orphan rule and pModule is an orphan.
@@ -37,7 +37,7 @@ function matchesReachableRule(pRule, pModule) {
       (pReachable) =>
         pReachable.asDefinedInRule === pRule.name &&
         // @ts-expect-error the 'has' above ensures the 'to.reachable' exists
-        pReachable.value === pRule.to.reachable
+        pReachable.value === pRule.to.reachable,
     );
     if (lReachableRecord) {
       const lGroups = extractGroups(pRule.from, lReachableRecord.matchedFrom);
@@ -71,8 +71,8 @@ function matchesReachesRule(pRule, pModule) {
         pReaches.modules.some(
           (pReachesModule) =>
             matchers.toModulePath(pRule, pReachesModule) &&
-            matchers.toModulePathNot(pRule, pReachesModule)
-        )
+            matchers.toModulePathNot(pRule, pReachesModule),
+        ),
     )
   );
 }
@@ -86,7 +86,7 @@ function dependentsCountsMatch(pRule, pDependents) {
   const lMatchingDependentsCount = pDependents.filter(
     (pDependent) =>
       Boolean(!pRule.from.path || pDependent.match(pRule.from.path)) &&
-      Boolean(!pRule.from.pathNot || !pDependent.match(pRule.from.pathNot))
+      Boolean(!pRule.from.pathNot || !pDependent.match(pRule.from.pathNot)),
   ).length;
   return (
     (!pRule.module.numberOfDependentsLessThan ||

--- a/src/validate/matchers.mjs
+++ b/src/validate/matchers.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable security/detect-object-injection */
 import has from "lodash/has.js";
-import { replaceGroupPlaceholders } from "../utl/regex-util.mjs";
-import { intersects } from "../utl/array-util.mjs";
+import { replaceGroupPlaceholders } from "#utl/regex-util.mjs";
+import { intersects } from "#utl/array-util.mjs";
 
 function propertyEquals(pRule, pDependency, pProperty) {
   // The properties can be booleans, so we can't use !pRule.to[pProperty]
@@ -15,7 +15,7 @@ function propertyMatches(pRule, pDependency, pRuleProperty, pProperty) {
   return Boolean(
     !pRule.to[pRuleProperty] ||
       (pDependency[pProperty] &&
-        pDependency[pProperty].match(pRule.to[pRuleProperty]))
+        pDependency[pProperty].match(pRule.to[pRuleProperty])),
   );
 }
 
@@ -23,7 +23,7 @@ function propertyMatchesNot(pRule, pDependency, pRuleProperty, pProperty) {
   return Boolean(
     !pRule.to[pRuleProperty] ||
       (pDependency[pProperty] &&
-        !pDependency[pProperty].match(pRule.to[pRuleProperty]))
+        !pDependency[pProperty].match(pRule.to[pRuleProperty])),
   );
 }
 
@@ -33,7 +33,7 @@ function fromPath(pRule, pModule) {
 
 function fromPathNot(pRule, pModule) {
   return Boolean(
-    !pRule.from.pathNot || !pModule.source.match(pRule.from.pathNot)
+    !pRule.from.pathNot || !pModule.source.match(pRule.from.pathNot),
   );
 }
 
@@ -43,14 +43,14 @@ function modulePath(pRule, pModule) {
 
 function modulePathNot(pRule, pModule) {
   return Boolean(
-    !pRule.module.pathNot || !pModule.source.match(pRule.module.pathNot)
+    !pRule.module.pathNot || !pModule.source.match(pRule.module.pathNot),
   );
 }
 
 function _toPath(pRule, pString, pGroups = []) {
   return Boolean(
     !pRule.to.path ||
-      pString.match(replaceGroupPlaceholders(pRule.to.path, pGroups))
+      pString.match(replaceGroupPlaceholders(pRule.to.path, pGroups)),
   );
 }
 
@@ -80,14 +80,14 @@ function toModulePathNot(pRule, pModule, pGroups) {
 function toDependencyTypes(pRule, pDependency) {
   return Boolean(
     !pRule.to.dependencyTypes ||
-      intersects(pDependency.dependencyTypes, pRule.to.dependencyTypes)
+      intersects(pDependency.dependencyTypes, pRule.to.dependencyTypes),
   );
 }
 
 function toDependencyTypesNot(pRule, pDependency) {
   return Boolean(
     !pRule.to.dependencyTypesNot ||
-      !intersects(pDependency.dependencyTypes, pRule.to.dependencyTypesNot)
+      !intersects(pDependency.dependencyTypes, pRule.to.dependencyTypesNot),
   );
 }
 
@@ -96,8 +96,8 @@ function toVia(pRule, pDependency, pGroups) {
     !pRule.to.via ||
       (pDependency.cycle &&
         pDependency.cycle.some((pVia) =>
-          pVia.match(replaceGroupPlaceholders(pRule.to.via, pGroups))
-        ))
+          pVia.match(replaceGroupPlaceholders(pRule.to.via, pGroups)),
+        )),
   );
 }
 
@@ -106,8 +106,8 @@ function toViaOnly(pRule, pDependency, pGroups) {
     !pRule.to.viaOnly ||
       (pDependency.cycle &&
         pDependency.cycle.every((pVia) =>
-          pVia.match(replaceGroupPlaceholders(pRule.to.viaOnly, pGroups))
-        ))
+          pVia.match(replaceGroupPlaceholders(pRule.to.viaOnly, pGroups)),
+        )),
   );
 }
 
@@ -116,8 +116,8 @@ function toViaNot(pRule, pDependency, pGroups) {
     !pRule.to.viaNot ||
       (pDependency.cycle &&
         !pDependency.cycle.some((pVia) =>
-          pVia.match(replaceGroupPlaceholders(pRule.to.viaNot, pGroups))
-        ))
+          pVia.match(replaceGroupPlaceholders(pRule.to.viaNot, pGroups)),
+        )),
   );
 }
 
@@ -126,8 +126,8 @@ function toviaSomeNot(pRule, pDependency, pGroups) {
     !pRule.to.viaSomeNot ||
       (pDependency.cycle &&
         !pDependency.cycle.every((pVia) =>
-          pVia.match(replaceGroupPlaceholders(pRule.to.viaSomeNot, pGroups))
-        ))
+          pVia.match(replaceGroupPlaceholders(pRule.to.viaSomeNot, pGroups)),
+        )),
   );
 }
 

--- a/src/validate/violates-required-rule.mjs
+++ b/src/validate/violates-required-rule.mjs
@@ -1,5 +1,5 @@
-import { extractGroups } from "../utl/regex-util.mjs";
 import matchers from "./matchers.mjs";
+import { extractGroups } from "#utl/regex-util.mjs";
 
 /**
  * Returns true if the module violates the rule.
@@ -19,7 +19,7 @@ export default function violatesRequiredRule(pRule, pModule) {
     const lGroups = extractGroups(pRule.module, pModule.source);
 
     lReturnValue = !pModule.dependencies.some((pDependency) =>
-      matchers.toPath(pRule, pDependency, lGroups)
+      matchers.toPath(pRule, pDependency, lGroups),
     );
   }
   return lReturnValue;

--- a/test/api.spec.mjs
+++ b/test/api.spec.mjs
@@ -1,6 +1,3 @@
-// eslint disable because import/no-unresolved,node/no-missing-import don't
-// know about (local) module imports yet
-/* eslint-disable import/no-unresolved,node/no-missing-import */
 import { equal } from "node:assert/strict";
 import satisfies from "semver/functions/satisfies.js";
 import dependencyCruiser from "dependency-cruiser";

--- a/test/cache/cache.spec.mjs
+++ b/test/cache/cache.spec.mjs
@@ -3,7 +3,7 @@ import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { describe } from "mocha";
-import Cache from "../../src/cache/cache.mjs";
+import Cache from "#cache/cache.mjs";
 
 const OUTPUTS_FOLDER = "test/cache/__outputs__/";
 

--- a/test/cache/content-strategy.spec.mjs
+++ b/test/cache/content-strategy.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, equal } from "node:assert/strict";
-import ContentStrategy from "../../src/cache/content-strategy.mjs";
+import ContentStrategy from "#cache/content-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
 const INTERESTING_CHANGE_TYPES = new Set([

--- a/test/cache/find-content-changes.spec.mjs
+++ b/test/cache/find-content-changes.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import findContentChanges from "../../src/cache/find-content-changes.mjs";
+import findContentChanges from "#cache/find-content-changes.mjs";
 
 describe("[U] cache/find-content-changes - cached vs new", () => {
   it("returns files not in directory but in cache as 'ignored' when they're not interesting for diffing", () => {

--- a/test/cache/metadata-strategy.spec.mjs
+++ b/test/cache/metadata-strategy.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, equal, match } from "node:assert/strict";
-import MetaDataStrategy from "../../src/cache/metadata-strategy.mjs";
+import MetaDataStrategy from "#cache/metadata-strategy.mjs";
 
 const INTERESTING_EXTENSIONS = new Set([".aap", ".noot", ".mies"]);
 const INTERESTING_CHANGE_TYPES = new Set([

--- a/test/cache/options-compatible.spec.mjs
+++ b/test/cache/options-compatible.spec.mjs
@@ -8,7 +8,7 @@ import {
   metricsIsCompatible,
   cacheOptionIsCompatible,
   optionsAreCompatible,
-} from "../../src/cache/options-compatible.mjs";
+} from "#cache/options-compatible.mjs";
 
 describe("[U] cache/options-compatible - optionIsCompatible", () => {
   it("if neither filter exists they're compatible", () => {

--- a/test/cli/format-meta-info.spec.mjs
+++ b/test/cli/format-meta-info.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import meta from "../../src/cli/format-meta-info.mjs";
+import meta from "#cli/format-meta-info.mjs";
 
 describe("[U] cli/formatMetaInfo - transpiler formatted meta information", () => {
   it("tells which extensions can be scanned", () => {

--- a/test/cli/format.spec.mjs
+++ b/test/cli/format.spec.mjs
@@ -2,8 +2,8 @@
 import { readFileSync } from "node:fs";
 import { equal } from "node:assert/strict";
 import { fileURLToPath } from "node:url";
-import format from "../../src/cli/format.mjs";
 import deleteDammit from "./delete-dammit.utl.cjs";
+import format from "#cli/format.mjs";
 
 function relative(pFileName) {
   return fileURLToPath(new URL(pFileName, import.meta.url));

--- a/test/cli/index.spec.mjs
+++ b/test/cli/index.spec.mjs
@@ -5,9 +5,9 @@ import { doesNotThrow, equal, throws } from "node:assert/strict";
 import { join, posix as path } from "node:path";
 import chalk from "chalk";
 import intercept from "intercept-stdout";
-import cli from "../../src/cli/index.mjs";
 import { assertFileEqual, assertJSONFileEqual } from "./asserthelpers.utl.mjs";
 import deleteDammit from "./delete-dammit.utl.cjs";
+import cli from "#cli/index.mjs";
 
 const OUT_DIR = "./test/cli/__output__";
 const FIX_DIR = "./test/cli/__fixtures__";

--- a/test/cli/init-config/build-config.spec.mjs
+++ b/test/cli/init-config/build-config.spec.mjs
@@ -3,10 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path/posix";
 import { deepEqual, ok, equal } from "node:assert/strict";
 import Ajv from "ajv";
-import buildConfig from "../../../src/cli/init-config/build-config.mjs";
-import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";
 import configurationSchema from "../../../src/schema/configuration.schema.mjs";
 import deleteDammit from "../delete-dammit.utl.cjs";
+import buildConfig from "#cli/init-config/build-config.mjs";
+import normalizeInitOptions from "#cli/init-config/normalize-init-options.mjs";
 
 const ajv = new Ajv();
 

--- a/test/cli/init-config/build-config.spec.mjs
+++ b/test/cli/init-config/build-config.spec.mjs
@@ -3,8 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path/posix";
 import { deepEqual, ok, equal } from "node:assert/strict";
 import Ajv from "ajv";
-import configurationSchema from "../../../src/schema/configuration.schema.mjs";
 import deleteDammit from "../delete-dammit.utl.cjs";
+import configurationSchema from "#configuration-schema";
 import buildConfig from "#cli/init-config/build-config.mjs";
 import normalizeInitOptions from "#cli/init-config/normalize-init-options.mjs";
 

--- a/test/cli/init-config/environment-helpers-matching-filenames.spec.mjs
+++ b/test/cli/init-config/environment-helpers-matching-filenames.spec.mjs
@@ -9,7 +9,7 @@ import {
   getWebpackConfigCandidates,
   getDefaultConfigFileName,
   isTypeModule,
-} from "../../../src/cli/init-config/environment-helpers.mjs";
+} from "#cli/init-config/environment-helpers.mjs";
 
 describe("[U] cli/init-config/environment-helpers - getBabelConfigCandidates", () => {
   const WORKINGDIR = process.cwd();

--- a/test/cli/init-config/environment-helpers.spec.mjs
+++ b/test/cli/init-config/environment-helpers.spec.mjs
@@ -3,7 +3,7 @@ import {
   isLikelyMonoRepo,
   hasTestsWithinSource,
   getFolderCandidates,
-} from "../../../src/cli/init-config/environment-helpers.mjs";
+} from "#cli/init-config/environment-helpers.mjs";
 
 describe("[U] cli/init-config/environment-helpers - isLikelyMonoRepo", () => {
   it("declares the current folder to be not a mono repo", () => {

--- a/test/cli/init-config/find-extensions.spec.mjs
+++ b/test/cli/init-config/find-extensions.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, throws } from "node:assert/strict";
-import findExtensions from "../../../src/cli/init-config/find-extensions.mjs";
+import findExtensions from "#cli/init-config/find-extensions.mjs";
 
 describe("[U] cli/init-config/find-extensions", () => {
   it("returns an empty array of extensions when passed no directories", () => {

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { deepEqual, equal } from "node:assert/strict";
 import Ajv from "ajv";
 import deleteDammit from "../delete-dammit.utl.cjs";
-import configurationSchema from "../../../src/schema/configuration.schema.mjs";
+import configurationSchema from "#configuration-schema";
 import initConfig from "#cli/init-config/index.mjs";
 
 const ajv = new Ajv();

--- a/test/cli/init-config/index.spec.mjs
+++ b/test/cli/init-config/index.spec.mjs
@@ -3,8 +3,8 @@ import { join } from "node:path";
 import { deepEqual, equal } from "node:assert/strict";
 import Ajv from "ajv";
 import deleteDammit from "../delete-dammit.utl.cjs";
-import initConfig from "../../../src/cli/init-config/index.mjs";
 import configurationSchema from "../../../src/schema/configuration.schema.mjs";
+import initConfig from "#cli/init-config/index.mjs";
 
 const ajv = new Ajv();
 

--- a/test/cli/init-config/normalize-init-options.spec.mjs
+++ b/test/cli/init-config/normalize-init-options.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, equal } from "node:assert/strict";
-import normalizeInitOptions from "../../../src/cli/init-config/normalize-init-options.mjs";
+import normalizeInitOptions from "#cli/init-config/normalize-init-options.mjs";
 
 describe("[U] cli/init-config/normalize-init-options", () => {
   let lSavedWorkingDirectory = process.cwd();

--- a/test/cli/init-config/utl.spec.mjs
+++ b/test/cli/init-config/utl.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { folderNameArrayToRE } from "../../../src/cli/init-config/utl.mjs";
+import { folderNameArrayToRE } from "#cli/init-config/utl.mjs";
 
 describe("[U] cli/init-config/utl - folderNameArrayToRE", () => {
   it("transforms an array of folder names into a regex string - empty", () => {

--- a/test/cli/init-config/validators.spec.mjs
+++ b/test/cli/init-config/validators.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { validateLocation } from "../../../src/cli/init-config/validators.mjs";
+import { validateLocation } from "#cli/init-config/validators.mjs";
 
 describe("[U] cli/init-config/inquirer-validators - validateLocation", () => {
   const WORKING_DIR = process.cwd();

--- a/test/cli/init-config/write-config.spec.mjs
+++ b/test/cli/init-config/write-config.spec.mjs
@@ -2,7 +2,7 @@ import { ok, equal } from "node:assert/strict";
 import { writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import deleteDammit from "../delete-dammit.utl.cjs";
-import writeConfig from "../../../src/cli/init-config/write-config.mjs";
+import writeConfig from "#cli/init-config/write-config.mjs";
 
 const RULES_FILE_JS = ".dependency-cruiser.js";
 

--- a/test/cli/init-config/write-run-scripts-to-manifest.spec.mjs
+++ b/test/cli/init-config/write-run-scripts-to-manifest.spec.mjs
@@ -2,7 +2,7 @@ import { deepEqual } from "node:assert/strict";
 import {
   addRunScriptsToManifest,
   compileRunScripts,
-} from "../../../src/cli/init-config/write-run-scripts-to-manifest.mjs";
+} from "#cli/init-config/write-run-scripts-to-manifest.mjs";
 
 describe("[U] cli/init-config/write-run-scripts-to-manifest - logic", () => {
   it("no manifest and no scripts retain the empty manifest with a scripts section", () => {

--- a/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/format-helpers.spec.mjs
@@ -5,7 +5,7 @@ import {
   formatTime,
   formatMemory,
   formatPerfLine,
-} from "../../../../src/cli/listeners/performance-log/format-helpers.mjs";
+} from "#cli/listeners/performance-log/format-helpers.mjs";
 
 /*
  * as the formatHelpers use the Intl API, it's necessary to set the locale

--- a/test/cli/listeners/performance-log-listener/handlers.spec.mjs
+++ b/test/cli/listeners/performance-log-listener/handlers.spec.mjs
@@ -4,7 +4,7 @@ import {
   getHeader,
   getEndText,
   getProgressLine,
-} from "../../../../src/cli/listeners/performance-log/handlers.mjs";
+} from "#cli/listeners/performance-log/handlers.mjs";
 
 const MAX_LEVEL = 20;
 

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -2,7 +2,7 @@ import { fileURLToPath } from "node:url";
 import { deepEqual, equal } from "node:assert/strict";
 import normalizeCliOptions, {
   determineRulesFileName,
-} from "../../src/cli/normalize-cli-options.mjs";
+} from "#cli/normalize-cli-options.mjs";
 
 // eslint-disable-next-line max-statements
 describe("[I] cli/normalizeCliOptions - regular normalizations", () => {

--- a/test/cli/tools/wrap-stream-in-html.spec.mjs
+++ b/test/cli/tools/wrap-stream-in-html.spec.mjs
@@ -1,7 +1,7 @@
 import { createReadStream } from "node:fs";
 import { Writable } from "node:stream";
 import { equal } from "node:assert/strict";
-import wrapStreamInHTML from "../../../src/cli/tools/wrap-stream-in-html.mjs";
+import wrapStreamInHTML from "#cli/tools/wrap-stream-in-html.mjs";
 
 class WriteableExpectStream extends Writable {
   _write(pThing) {

--- a/test/cli/utl/assert-file-existence.spec.mjs
+++ b/test/cli/utl/assert-file-existence.spec.mjs
@@ -1,5 +1,5 @@
 import { doesNotThrow, throws } from "node:assert/strict";
-import validateFileExistence from "../../../src/cli/utl/assert-file-existence.mjs";
+import validateFileExistence from "#cli/utl/assert-file-existence.mjs";
 
 describe("[U] cli/utl/validateFileExistence", () => {
   it("throws when the file or dir passed does not exists", () => {

--- a/test/cli/utl/io.spec.mjs
+++ b/test/cli/utl/io.spec.mjs
@@ -2,7 +2,7 @@ import { ReadStream } from "node:fs";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { deepEqual, notDeepStrictEqual, equal } from "node:assert/strict";
-import { getInStream } from "../../../src/cli/utl/io.mjs";
+import { getInStream } from "#cli/utl/io.mjs";
 
 describe("[U] cli/utl/io", () => {
   const OUTFILE = fileURLToPath(

--- a/test/cli/validate-node-environment.spec.mjs
+++ b/test/cli/validate-node-environment.spec.mjs
@@ -1,5 +1,5 @@
 import { doesNotThrow, throws } from "node:assert/strict";
-import assertNodeEnvironmentSuitable from "../../src/cli/assert-node-environment-suitable.mjs";
+import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
 
 describe("[U] cli/validateNodeEnv", () => {
   it("throws when an older and unsupported node version is passed", () => {

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -2,7 +2,7 @@ import { deepEqual, ok, equal } from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import omit from "lodash/omit.js";
 import extractBabelConfig from "../../src/config-utl/extract-babel-config.mjs";
-import pathToPosix from "../../src/utl/path-to-posix.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 function getFullPath(pRelativePath) {
   return fileURLToPath(new URL(pRelativePath, import.meta.url));

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual, ok, equal } from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import omit from "lodash/omit.js";
-import extractBabelConfig from "../../src/config-utl/extract-babel-config.mjs";
+import extractBabelConfig from "#config-utl/extract-babel-config.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 
 function getFullPath(pRelativePath) {

--- a/test/config-utl/extract-depcruise-config/index.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/index.spec.mjs
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { ok, deepEqual } from "node:assert/strict";
-import loadConfig from "../../../src/config-utl/extract-depcruise-config/index.mjs";
+import loadConfig from "#config-utl/extract-depcruise-config/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const mockDirectory = join(__dirname, "__mocks__");

--- a/test/config-utl/extract-depcruise-config/merge-rule-sets.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/merge-rule-sets.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import merge from "../../../src/config-utl/extract-depcruise-config/merge-configs.mjs";
+import merge from "#config-utl/extract-depcruise-config/merge-configs.mjs";
 
 describe("[U] config-utl/mergeRuleSets - general", () => {
   it("two empty rule sets yield an empty rule set with named attributes", () => {

--- a/test/config-utl/extract-depcruise-config/read-config.spec.mjs
+++ b/test/config-utl/extract-depcruise-config/read-config.spec.mjs
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-import readConfig from "../../../src/config-utl/extract-depcruise-config/read-config.mjs";
+import readConfig from "#config-utl/extract-depcruise-config/read-config.mjs";
 
 function getFullPath(pRelativePath) {
   return fileURLToPath(new URL(pRelativePath, import.meta.url));

--- a/test/config-utl/extract-known-violations.spec.mjs
+++ b/test/config-utl/extract-known-violations.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, ok } from "node:assert/strict";
-import extractKnownViolations from "../../src/config-utl/extract-known-violations.mjs";
+import extractKnownViolations from "#config-utl/extract-known-violations.mjs";
 
 describe("[I] config-utl/extractKnownViolations", () => {
   const WORKINGDIR = process.cwd();

--- a/test/config-utl/extract-ts-config.spec.mjs
+++ b/test/config-utl/extract-ts-config.spec.mjs
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { deepEqual, throws } from "node:assert/strict";
-import loadTSConfig from "../../src/config-utl/extract-ts-config.mjs";
+import loadTSConfig from "#config-utl/extract-ts-config.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 
 function getFullPath(pRelativePath) {

--- a/test/config-utl/extract-ts-config.spec.mjs
+++ b/test/config-utl/extract-ts-config.spec.mjs
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { deepEqual, throws } from "node:assert/strict";
 import loadTSConfig from "../../src/config-utl/extract-ts-config.mjs";
-import pathToPosix from "../../src/utl/path-to-posix.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 function getFullPath(pRelativePath) {
   return fileURLToPath(new URL(pRelativePath, import.meta.url));

--- a/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-native.spec.mjs
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { deepEqual, equal } from "node:assert/strict";
 
-import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
+import loadResolveConfig from "#config-utl/extract-webpack-resolve-config.mjs";
 
 function getFullPath(pRelativePath) {
   return fileURLToPath(new URL(pRelativePath, import.meta.url));

--- a/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
+++ b/test/config-utl/extract-webpack-resolve-config-non-native.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual, match, equal } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import loadResolveConfig from "../../src/config-utl/extract-webpack-resolve-config.mjs";
+import loadResolveConfig from "#config-utl/extract-webpack-resolve-config.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/config-utl/make-absolute.spec.mjs
+++ b/test/config-utl/make-absolute.spec.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { equal } from "node:assert/strict";
-import makeAbsolute from "../../src/config-utl/make-absolute.mjs";
+import makeAbsolute from "#config-utl/make-absolute.mjs";
 
 describe("[U] cli/utl/makeAbsolute", () => {
   it("leaves absolute path names alone", () => {

--- a/test/configs/no-orphans.spec.mjs
+++ b/test/configs/no-orphans.spec.mjs
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import noOrphansRule from "../../configs/rules/no-orphans.js";
-import matchModuleRule from "../../src/validate/match-module-rule.mjs";
+import matchModuleRule from "#validate/match-module-rule.mjs";
 
 describe("[I] configs/rules/no-orphans", () => {
   it("flags non-excepted orphans as orphan rule transgression", () => {

--- a/test/enrich/de-duplicate-violations.spec.mjs
+++ b/test/enrich/de-duplicate-violations.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import uniqWith from "lodash/uniqWith.js";
-import isSameViolation from "../../src/enrich/summarize/is-same-violation.mjs";
+import isSameViolation from "#enrich/summarize/is-same-violation.mjs";
 
 const deDuplicateViolations = (pViolations) =>
   uniqWith(pViolations, isSameViolation);

--- a/test/enrich/derive/dependents/get-dependents.spec.mjs
+++ b/test/enrich/derive/dependents/get-dependents.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 
-import getDependents from "../../../../src/enrich/derive/dependents/get-dependents.mjs";
+import getDependents from "#enrich/derive/dependents/get-dependents.mjs";
 
 describe("[U] enrich/derive/dependents/get-dependents", () => {
   it("empty module without a source name & no modules yield no modules", () => {

--- a/test/enrich/derive/folders/aggregate-to-folders.spec.mjs
+++ b/test/enrich/derive/folders/aggregate-to-folders.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 
-import aggregateToFolders from "../../../../src/enrich/derive/folders/aggregate-to-folders.mjs";
+import aggregateToFolders from "#enrich/derive/folders/aggregate-to-folders.mjs";
 
 function compareFolders(pLeftFolder, pRightFolder) {
   return pLeftFolder.name.localeCompare(pRightFolder.name);

--- a/test/enrich/derive/folders/index.spec.mjs
+++ b/test/enrich/derive/folders/index.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 
-import deriveFolders from "../../../../src/enrich/derive/folders/index.mjs";
+import deriveFolders from "#enrich/derive/folders/index.mjs";
 
 describe("[U] enrich/derive/folders - folder stability metrics derivation", () => {
   it("doesn't do anything when we're not asking for metrics (metrics nor outputType)", () => {

--- a/test/enrich/derive/folders/utl.spec.mjs
+++ b/test/enrich/derive/folders/utl.spec.mjs
@@ -5,7 +5,7 @@ import {
   getEfferentCouplings,
   getParentFolders,
   object2Array,
-} from "../../../../src/enrich/derive/folders/utl.mjs";
+} from "#enrich/derive/folders/utl.mjs";
 
 describe("[U] enrich/derive/folders/utl - getAfferentCouplings", () => {
   it("no dependents => 0", () => {

--- a/test/enrich/derive/metrics/module.spec.mjs
+++ b/test/enrich/derive/metrics/module.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual, equal } from "node:assert/strict";
 
-import deriveModuleMetrics from "../../../../src/enrich/derive/metrics/index.mjs";
+import deriveModuleMetrics from "#enrich/derive/metrics/index.mjs";
 
 describe("[U] enrich/derive/metrics/module - module stability metrics derivation", () => {
   it("doesn't do anything when we're not asking for metrics (metrics nor outputType)", () => {

--- a/test/enrich/derive/orphan/index.spec.mjs
+++ b/test/enrich/derive/orphan/index.spec.mjs
@@ -1,10 +1,10 @@
 import { deepEqual } from "node:assert/strict";
 
-import orphan from "../../../../src/enrich/derive/orphan/index.mjs";
 import ONE_MODULE_FIXTURE from "./__mocks__/one-module.mjs";
 import ONE_MODULE_AFTER_PROCESSING from "./__mocks__/one-module.afterprocessing.mjs";
 import TWO_MODULES_FIXTURE from "./__mocks__/two-module.mjs";
 import TWO_MODULES_AFTER_PROCESSING from "./__mocks__/two-module.afterprocessing.mjs";
+import orphan from "#enrich/derive/orphan/index.mjs";
 
 describe("[U] enrich/derive/orphan/index - orphan detection", () => {
   it('attaches the "orphan" boolean to orphan modules by default', () => {

--- a/test/enrich/derive/orphan/is-orphan.spec.mjs
+++ b/test/enrich/derive/orphan/is-orphan.spec.mjs
@@ -1,8 +1,8 @@
 import { equal } from "node:assert/strict";
 
-import isOrphan from "../../../../src/enrich/derive/orphan/is-orphan.mjs";
 import ONE_MODULE_FIXTURE from "./__mocks__/one-module.mjs";
 import TWO_MODULES_FIXTURE from "./__mocks__/two-module.mjs";
+import isOrphan from "#enrich/derive/orphan/is-orphan.mjs";
 
 describe("[U] enrich/derive/orphan/isOrphan", () => {
   it("flags a single module dependency graph as orphan", () => {

--- a/test/enrich/derive/reachable.spec.mjs
+++ b/test/enrich/derive/reachable.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import normalize from "../../../src/main/rule-set/normalize.mjs";
 import addReachability from "../../../src/enrich/derive/reachable.mjs";
-import clearExtractCaches from "../../../src/extract/clear-caches.mjs";
+import clearExtractCaches from "#extract/clear-caches.mjs";
 
 const GRAPH = [
   {

--- a/test/enrich/derive/reachable.spec.mjs
+++ b/test/enrich/derive/reachable.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import normalize from "../../../src/main/rule-set/normalize.mjs";
-import addReachability from "../../../src/enrich/derive/reachable.mjs";
+import addReachability from "#enrich/derive/reachable.mjs";
 import clearExtractCaches from "#extract/clear-caches.mjs";
 
 const GRAPH = [

--- a/test/enrich/derive/reachable.spec.mjs
+++ b/test/enrich/derive/reachable.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import normalize from "../../../src/main/rule-set/normalize.mjs";
+import normalize from "#main/rule-set/normalize.mjs";
 import addReachability from "#enrich/derive/reachable.mjs";
 import clearExtractCaches from "#extract/clear-caches.mjs";
 

--- a/test/enrich/soften-known-violations.spec.mjs
+++ b/test/enrich/soften-known-violations.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import softenKnownViolations from "../../src/enrich/soften-known-violations.mjs";
+import softenKnownViolations from "#enrich/soften-known-violations.mjs";
 
 describe("[U] enrich/soften-known-violations - modules violations", () => {
   /** @type import("../../types/baseline-violations").IBaselineViolations */

--- a/test/enrich/summarize-folders.spec.mjs
+++ b/test/enrich/summarize-folders.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import summarizeFolders from "../../src/enrich/summarize/summarize-folders.mjs";
+import summarizeFolders from "#enrich/summarize/summarize-folders.mjs";
 
 const FIXTURE_WITHOUT_VIOLATIONS = [
   {

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,10 +1,10 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import summarize from "../../src/enrich/summarize/index.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cycleStartsOnOne from "./__mocks__/cycle-starts-on-one.mjs";
 import cycleStartsOnTwo from "./__mocks__/cycle-starts-on-two.mjs";
 import cycleFest from "./__mocks__/cycle-fest.mjs";
+import summarize from "#enrich/summarize/index.mjs";
 
 const ajv = new Ajv();
 

--- a/test/enrich/summarize.spec.mjs
+++ b/test/enrich/summarize.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cycleStartsOnOne from "./__mocks__/cycle-starts-on-one.mjs";
 import cycleStartsOnTwo from "./__mocks__/cycle-starts-on-two.mjs";
 import cycleFest from "./__mocks__/cycle-fest.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import summarize from "#enrich/summarize/index.mjs";
 
 const ajv = new Ajv();

--- a/test/extract/ast-extractors/extract-amd-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-amd-deps.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import extractAMDDeps from "../../../src/extract/ast-extractors/extract-amd-deps.mjs";
-import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
+import extractAMDDeps from "#extract/ast-extractors/extract-amd-deps.mjs";
+import { getASTFromSource } from "#extract/parse/to-javascript-ast.mjs";
 
 const extractAMD = (
   pJavaScriptSource,

--- a/test/extract/ast-extractors/extract-cjs-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-cjs-deps.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import extractcommonJSDeps from "../../../src/extract/ast-extractors/extract-cjs-deps.mjs";
-import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
+import extractcommonJSDeps from "#extract/ast-extractors/extract-cjs-deps.mjs";
+import { getASTFromSource } from "#extract/parse/to-javascript-ast.mjs";
 
 const extractcommonJS = (
   pJavaScriptSource,

--- a/test/extract/ast-extractors/extract-es6-deps.spec.mjs
+++ b/test/extract/ast-extractors/extract-es6-deps.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import extractES6Deps from "../../../src/extract/ast-extractors/extract-es6-deps.mjs";
-import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
+import extractES6Deps from "#extract/ast-extractors/extract-es6-deps.mjs";
+import { getASTFromSource } from "#extract/parse/to-javascript-ast.mjs";
 
 const extractES6 = (pJavaScriptSource, pDependencies, pExtension = ".js") =>
   extractES6Deps(

--- a/test/extract/ast-extractors/extract-typescript-others.spec.mjs
+++ b/test/extract/ast-extractors/extract-typescript-others.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import extractTypescriptFromAST from "../../../src/extract/ast-extractors/extract-typescript-deps.mjs";
+import extractTypescriptFromAST from "#extract/ast-extractors/extract-typescript-deps.mjs";
 
 describe("[U] ast-extractors/extract-typescript - others", () => {
   // see issue #167 - union types on tsc 2.8 and before don't deliver/

--- a/test/extract/ast-extractors/extract-typescript.utl.mjs
+++ b/test/extract/ast-extractors/extract-typescript.utl.mjs
@@ -1,5 +1,5 @@
-import extractTypescript from "../../../src/extract/ast-extractors/extract-typescript-deps.mjs";
-import { getASTFromSource } from "../../../src/extract/parse/to-typescript-ast.mjs";
+import extractTypescript from "#extract/ast-extractors/extract-typescript-deps.mjs";
+import { getASTFromSource } from "#extract/parse/to-typescript-ast.mjs";
 
 export default (pTypesScriptSource, pExoticRequireStrings = []) =>
   extractTypescript(

--- a/test/extract/ast-extractors/extract-with-swc.utl.mjs
+++ b/test/extract/ast-extractors/extract-with-swc.utl.mjs
@@ -1,5 +1,5 @@
-import extractSwcDependencies from "../../../src/extract/ast-extractors/extract-swc-deps.mjs";
-import { getASTFromSource } from "../../../src/extract/parse/to-swc-ast.mjs";
+import extractSwcDependencies from "#extract/ast-extractors/extract-swc-deps.mjs";
+import { getASTFromSource } from "#extract/parse/to-swc-ast.mjs";
 
 export default (pTypesScriptSource, pExoticRequireStrings = []) =>
   extractSwcDependencies(

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { lstatSync } from "node:fs";
-import gatherInitialSources from "../../src/extract/gather-initial-sources.mjs";
 import p2p from "../../src/utl/path-to-posix.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
+import gatherInitialSources from "#extract/gather-initial-sources.mjs";
 
 // make the import pathToPosix the correct function profile
 // (1 parameter exactly) for use in map

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { lstatSync } from "node:fs";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
 import p2p from "#utl/path-to-posix.mjs";
 import gatherInitialSources from "#extract/gather-initial-sources.mjs";
 

--- a/test/extract/gather-initial-sources.spec.mjs
+++ b/test/extract/gather-initial-sources.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual, equal } from "node:assert/strict";
 import { lstatSync } from "node:fs";
-import p2p from "../../src/utl/path-to-posix.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
+import p2p from "#utl/path-to-posix.mjs";
 import gatherInitialSources from "#extract/gather-initial-sources.mjs";
 
 // make the import pathToPosix the correct function profile

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -6,8 +6,8 @@ import symlinkDir from "symlink-dir";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
-import getDependencies from "../../src/extract/get-dependencies.mjs";
 import { runFixture } from "./run-get-dependencies-fixture.utl.mjs";
+import getDependencies from "#extract/get-dependencies.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -3,10 +3,10 @@ import { join } from "node:path";
 import { unlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import symlinkDir from "symlink-dir";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import { runFixture } from "./run-get-dependencies-fixture.utl.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
 import getDependencies from "#extract/get-dependencies.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -3,9 +3,9 @@ import { join } from "node:path";
 import { unlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import symlinkDir from "symlink-dir";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
 import getDependencies from "#extract/get-dependencies.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -6,7 +6,7 @@ import symlinkDir from "symlink-dir";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
-import getDependencies from "../../src/extract/get-dependencies.mjs";
+import getDependencies from "#extract/get-dependencies.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/get-dependencies.odds-and-ends.spec.mjs
+++ b/test/extract/get-dependencies.odds-and-ends.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual, doesNotThrow, equal, throws } from "node:assert/strict";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import { runFixture } from "./run-get-dependencies-fixture.utl.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
 import getDependencies from "#extract/get-dependencies.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/get-dependencies.odds-and-ends.spec.mjs
+++ b/test/extract/get-dependencies.odds-and-ends.spec.mjs
@@ -2,8 +2,8 @@ import { deepEqual, doesNotThrow, equal, throws } from "node:assert/strict";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
-import getDependencies from "../../src/extract/get-dependencies.mjs";
 import { runFixture } from "./run-get-dependencies-fixture.utl.mjs";
+import getDependencies from "#extract/get-dependencies.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/helpers-dependencies-equal.spec.mjs
+++ b/test/extract/helpers-dependencies-equal.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { dependenciesEqual } from "../../src/extract/helpers.mjs";
+import { dependenciesEqual } from "#extract/helpers.mjs";
 
 describe("[U] extract/helpers - dependencyEqual", () => {
   it("two empty dependencies are equal", () => {

--- a/test/extract/helpers-detect-pre-compilation-ness.spec.mjs
+++ b/test/extract/helpers-detect-pre-compilation-ness.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import { detectPreCompilationNess } from "../../src/extract/helpers.mjs";
+import { detectPreCompilationNess } from "#extract/helpers.mjs";
 
 describe("[U] extract/helpers - detectPreCompilationNess", () => {
   it("empty dependency lists yield an empty one", () => {

--- a/test/extract/helpers-extract-module-attributes.spec.mjs
+++ b/test/extract/helpers-extract-module-attributes.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import { extractModuleAttributes } from "../../src/extract/helpers.mjs";
+import { extractModuleAttributes } from "#extract/helpers.mjs";
 
 describe("[U] extract/helpers - extractModuleAttributes", () => {
   it("leaves regular module specifications alone", () => {

--- a/test/extract/helpers-strip-query-parameters.spec.mjs
+++ b/test/extract/helpers-strip-query-parameters.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { stripQueryParameters } from "../../src/extract/helpers.mjs";
+import { stripQueryParameters } from "#extract/helpers.mjs";
 
 describe("[U] extract/helpers - stripQueryParams", () => {
   it("leaves the empty string alone", () => {

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -1,9 +1,9 @@
 import { renameSync } from "node:fs";
 import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
-import extract from "../../src/extract/index.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
+import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -1,8 +1,8 @@
 import { renameSync } from "node:fs";
 import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
 import { createRequireJSON } from "../backwards.utl.mjs";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
-import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
-import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
-import extract from "../../src/extract/index.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import extract from "#extract/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/extract/parse/to-javascript-ast.spec.mjs
+++ b/test/extract/parse/to-javascript-ast.spec.mjs
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import get from "lodash/get.js";
-import { getASTFromSource } from "../../../src/extract/parse/to-javascript-ast.mjs";
+import { getASTFromSource } from "#extract/parse/to-javascript-ast.mjs";
 
 const TSCONFIG_CONSTANTS = {
   ESNEXT: 99,

--- a/test/extract/resolve/classify.is-external-module.spec.mjs
+++ b/test/extract/resolve/classify.is-external-module.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { isExternalModule } from "../../../src/extract/resolve/module-classifiers.mjs";
+import { isExternalModule } from "#extract/resolve/module-classifiers.mjs";
 
 describe("[U] extract/resolve/module-classifiers - isExternalModule", () => {
   it("returns false when passed nothing", () => {

--- a/test/extract/resolve/classify.is-relative-module-name.spec.mjs
+++ b/test/extract/resolve/classify.is-relative-module-name.spec.mjs
@@ -1,5 +1,5 @@
 import { throws, equal } from "node:assert/strict";
-import { isRelativeModuleName } from "../../../src/extract/resolve/module-classifiers.mjs";
+import { isRelativeModuleName } from "#extract/resolve/module-classifiers.mjs";
 
 describe("[U] extract/resolve/module-classifiers - isRelativeModuleName", () => {
   it("throws an error when passed nothing", () => {

--- a/test/extract/resolve/determine-dependency-types.spec.mjs
+++ b/test/extract/resolve/determine-dependency-types.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import determineDependencyTypes from "../../../src/extract/resolve/determine-dependency-types.mjs";
+import determineDependencyTypes from "#extract/resolve/determine-dependency-types.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/extract/resolve/external-module-helpers.spec.mjs
+++ b/test/extract/resolve/external-module-helpers.spec.mjs
@@ -1,6 +1,6 @@
 import { ok, equal } from "node:assert/strict";
-import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
-import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
 import clearCaches from "#extract/clear-caches.mjs";
 import {
   getPackageJson,

--- a/test/extract/resolve/external-module-helpers.spec.mjs
+++ b/test/extract/resolve/external-module-helpers.spec.mjs
@@ -1,13 +1,13 @@
 import { ok, equal } from "node:assert/strict";
-import clearCaches from "../../../src/extract/clear-caches.mjs";
+import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
+import clearCaches from "#extract/clear-caches.mjs";
 import {
   getPackageJson,
   getPackageRoot,
   getLicense,
   dependencyIsDeprecated,
-} from "../../../src/extract/resolve/external-module-helpers.mjs";
-import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
-import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
+} from "#extract/resolve/external-module-helpers.mjs";
 
 const BASIC_RESOLVE_OPTIONS = await normalizeResolveOptions(
   {},

--- a/test/extract/resolve/get-manifest.spec.mjs
+++ b/test/extract/resolve/get-manifest.spec.mjs
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { parse, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual, equal, throws } from "node:assert/strict";
-import { getManifest } from "../../../src/extract/resolve/get-manifest.mjs";
+import { getManifest } from "#extract/resolve/get-manifest.mjs";
 
 const rootPackageJson = JSON.parse(
   readFileSync(

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -2,8 +2,8 @@
 import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import resolve from "#extract/resolve/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -2,7 +2,7 @@
 import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import resolve from "#extract/resolve/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-import extractTSConfig from "../../../src/config-utl/extract-ts-config.mjs";
+import extractTSConfig from "#config-utl/extract-ts-config.mjs";
 import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import resolve from "#extract/resolve/index.mjs";
 

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -2,8 +2,8 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
 import extractTSConfig from "../../../src/config-utl/extract-ts-config.mjs";
-import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import resolve from "#extract/resolve/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
 import extractTSConfig from "../../../src/config-utl/extract-ts-config.mjs";
-import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import resolve from "#extract/resolve/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/extract/resolve/index.typescript.spec.mjs
+++ b/test/extract/resolve/index.typescript.spec.mjs
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import resolve from "#extract/resolve/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/extract/resolve/index.typescript.spec.mjs
+++ b/test/extract/resolve/index.typescript.spec.mjs
@@ -1,8 +1,8 @@
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-import resolve from "../../../src/extract/resolve/index.mjs";
 import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import resolve from "#extract/resolve/index.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/extract/resolve/is-built-in.spec.mjs
+++ b/test/extract/resolve/is-built-in.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { isBuiltin } from "../../../src/extract/resolve/is-built-in.mjs";
+import { isBuiltin } from "#extract/resolve/is-built-in.mjs";
 
 describe("[U] extract/resolve/is-built-in - isBuiltIn", () => {
   it("should return true for built-in modules", () => {

--- a/test/extract/resolve/merge-manifests.spec.mjs
+++ b/test/extract/resolve/merge-manifests.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import mergePackages from "../../../src/extract/resolve/merge-manifests.mjs";
+import mergePackages from "#extract/resolve/merge-manifests.mjs";
 
 const INPUT = {
   description: "testington",

--- a/test/extract/resolve/resolve-helpers.spec.mjs
+++ b/test/extract/resolve/resolve-helpers.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { stripToModuleName } from "../../../src/extract/resolve/resolve-helpers.mjs";
+import { stripToModuleName } from "#extract/resolve/resolve-helpers.mjs";
 
 describe("[U] extract/resolve/resolveHelpers - stripToModuleName", () => {
   it("yields the empty string when stripping the empty string", () => {

--- a/test/extract/run-get-dependencies-fixture.utl.mjs
+++ b/test/extract/run-get-dependencies-fixture.utl.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
-import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 import getDependencies from "#extract/get-dependencies.mjs";
 
 /* eslint-disable mocha/no-exports */

--- a/test/extract/run-get-dependencies-fixture.utl.mjs
+++ b/test/extract/run-get-dependencies-fixture.utl.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
-import getDependencies from "../../src/extract/get-dependencies.mjs";
 import { normalizeCruiseOptions } from "../../src/main/options/normalize.mjs";
 import normalizeResolveOptions from "../../src/main/resolve-options/normalize.mjs";
+import getDependencies from "#extract/get-dependencies.mjs";
 
 /* eslint-disable mocha/no-exports */
 export function runFixture(pFixture, pParser = "acorn") {

--- a/test/extract/transpile/babel-wrap.spec.mjs
+++ b/test/extract/transpile/babel-wrap.spec.mjs
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import normalizeSource from "../normalize-source.utl.mjs";
-import wrap from "../../../src/extract/transpile/babel-wrap.mjs";
+import wrap from "#extract/transpile/babel-wrap.mjs";
 
 describe("[I] extract/transpile/babel-wrap", () => {
   it("tells the babel transpiler is available", () => {

--- a/test/extract/transpile/coffeescript-wrap.spec.mjs
+++ b/test/extract/transpile/coffeescript-wrap.spec.mjs
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import normalizeNewline from "normalize-newline";
-import coffeescriptWrap from "../../../src/extract/transpile/coffeescript-wrap.mjs";
+import coffeescriptWrap from "#extract/transpile/coffeescript-wrap.mjs";
 
 const wrap = coffeescriptWrap();
 const litWrap = coffeescriptWrap(true);

--- a/test/extract/transpile/index.spec.mjs
+++ b/test/extract/transpile/index.spec.mjs
@@ -2,15 +2,13 @@ import { deepEqual, ok, equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import transpile, {
-  getWrapper,
-} from "../../../src/extract/transpile/index.mjs";
 import normalizeSource from "../normalize-source.utl.mjs";
+import transpile, { getWrapper } from "#extract/transpile/index.mjs";
 
-import jsWrap from "../../../src/extract/transpile/javascript-wrap.mjs";
-import lsWrap from "../../../src/extract/transpile/livescript-wrap.mjs";
-import babelWrap from "../../../src/extract/transpile/babel-wrap.mjs";
-import vueTemplateWrap from "../../../src/extract/transpile/vue-template-wrap.cjs";
+import jsWrap from "#extract/transpile/javascript-wrap.mjs";
+import lsWrap from "#extract/transpile/livescript-wrap.mjs";
+import babelWrap from "#extract/transpile/babel-wrap.mjs";
+import vueTemplateWrap from "#extract/transpile/vue-template-wrap.cjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/extract/transpile/javascript-wrap.spec.mjs
+++ b/test/extract/transpile/javascript-wrap.spec.mjs
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import wrap from "../../../src/extract/transpile/javascript-wrap.mjs";
+import wrap from "#extract/transpile/javascript-wrap.mjs";
 
 describe("[I] javascript transpiler", () => {
   it("tells the jsx transpiler is available", () => {

--- a/test/extract/transpile/livescript-wrap.spec.mjs
+++ b/test/extract/transpile/livescript-wrap.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import wrap from "../../../src/extract/transpile/livescript-wrap.mjs";
+import wrap from "#extract/transpile/livescript-wrap.mjs";
 
 describe("[I] livescript transpiler", () => {
   it("tells the livescript transpiler is not available", () => {

--- a/test/extract/transpile/meta.spec.mjs
+++ b/test/extract/transpile/meta.spec.mjs
@@ -2,7 +2,7 @@ import { deepEqual } from "node:assert/strict";
 import {
   getAvailableTranspilers,
   scannableExtensions,
-} from "../../../src/extract/transpile/meta.mjs";
+} from "#extract/transpile/meta.mjs";
 
 describe("[U] extract/transpile/meta", () => {
   it("tells which extensions can be scanned", () => {

--- a/test/extract/transpile/svelte-preprocess.spec.mjs
+++ b/test/extract/transpile/svelte-preprocess.spec.mjs
@@ -2,8 +2,8 @@ import { equal } from "node:assert/strict";
 // eslint-disable-next-line node/file-extension-in-import
 import * as svelteCompiler from "svelte/compiler";
 import normalizeNewline from "normalize-newline";
-import thing from "../../../src/extract/transpile/typescript-wrap.mjs";
-import sveltePreProcess from "../../../src/extract/transpile/svelte-preprocess.mjs";
+import thing from "#extract/transpile/typescript-wrap.mjs";
+import sveltePreProcess from "#extract/transpile/svelte-preprocess.mjs";
 
 const typeScriptWrap = thing(false);
 

--- a/test/extract/transpile/svelte-wrap.spec.mjs
+++ b/test/extract/transpile/svelte-wrap.spec.mjs
@@ -1,8 +1,8 @@
 import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import svelteWrap from "../../../src/extract/transpile/svelte-wrap.mjs";
 import normalizeSource from "../normalize-source.utl.mjs";
-import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.mjs";
+import svelteWrap from "#extract/transpile/svelte-wrap.mjs";
+import typescriptWrap from "#extract/transpile/typescript-wrap.mjs";
 
 const wrap = svelteWrap(typescriptWrap(true));
 

--- a/test/extract/transpile/try-import-available.spec.mjs
+++ b/test/extract/transpile/try-import-available.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import tryImportAvailable from "../../../src/extract/transpile/try-import-available.mjs";
+import tryImportAvailable from "#extract/transpile/try-import-available.mjs";
 
 describe("[U] extract/transpile/try-import-available", () => {
   it("returns true when the module can be resolved", () => {

--- a/test/extract/transpile/typescript-wrap.spec.mjs
+++ b/test/extract/transpile/typescript-wrap.spec.mjs
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import normalizeSource from "../normalize-source.utl.mjs";
-import typescriptWrap from "../../../src/extract/transpile/typescript-wrap.mjs";
+import typescriptWrap from "#extract/transpile/typescript-wrap.mjs";
 
 const typeScriptRegularWrap = typescriptWrap();
 const typeScriptTsxWrap = typescriptWrap("tsx");

--- a/test/extract/transpile/vue-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue-template-wrap.spec.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import normalizeNewline from "normalize-newline";
-import wrap from "../../../src/extract/transpile/vue-template-wrap.cjs";
+import wrap from "#extract/transpile/vue-template-wrap.cjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/extract/transpile/vue3-template-wrap.spec.mjs
+++ b/test/extract/transpile/vue3-template-wrap.spec.mjs
@@ -13,17 +13,14 @@ const proxyquire = require("proxyquire").noPreserveCache();
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 // instead of requiring the module under test, proxyquire it
-const wrap = proxyquire.load(
-  "../../../src/extract/transpile/vue-template-wrap.cjs",
-  {
-    // Force the tryRequire on "vue-template-compiler" to fail
-    // so that we ensure we are using Vue 3 for this test
-    "semver-try-require": (pModuleName) =>
-      pModuleName === "vue-template-compiler"
-        ? false
-        : require("@vue/compiler-sfc"),
-  },
-);
+const wrap = proxyquire.load("#extract/transpile/vue-template-wrap.cjs", {
+  // Force the tryRequire on "vue-template-compiler" to fail
+  // so that we ensure we are using Vue 3 for this test
+  "semver-try-require": (pModuleName) =>
+    pModuleName === "vue-template-compiler"
+      ? false
+      : require("@vue/compiler-sfc"),
+});
 
 describe("[I] vue transpiler", () => {
   it("extracts the script content from a vue SFC", () => {

--- a/test/graph-utl/__fixtures__/focus/dependency-cruiser-focus-on-main-depth-2.mjs
+++ b/test/graph-utl/__fixtures__/focus/dependency-cruiser-focus-on-main-depth-2.mjs
@@ -310,7 +310,7 @@ export default [
     source: "src/enrich/enrich-modules.js",
     dependencies: [
       {
-        module: "../../src/graph-utl/add-focus",
+        module: "#graph-utl/add-focus",
         moduleSystem: "cjs",
         dynamic: false,
         exoticallyRequired: false,

--- a/test/graph-utl/__fixtures__/focus/dependency-cruiser-only-src.mjs
+++ b/test/graph-utl/__fixtures__/focus/dependency-cruiser-only-src.mjs
@@ -832,7 +832,7 @@ export default [
     source: "src/enrich/enrich-modules.js",
     dependencies: [
       {
-        module: "../../src/graph-utl/add-focus",
+        module: "#graph-utl/add-focus",
         moduleSystem: "cjs",
         dynamic: false,
         exoticallyRequired: false,

--- a/test/graph-utl/add-focus.spec.mjs
+++ b/test/graph-utl/add-focus.spec.mjs
@@ -1,9 +1,9 @@
 /* eslint-disable unicorn/no-useless-undefined */
 import { deepEqual } from "node:assert/strict";
-import addFocus from "../../src/graph-utl/add-focus.mjs";
 import $input from "./__fixtures__/focus/dependency-cruiser-only-src.mjs";
 import focusOnMainDepthOne from "./__fixtures__/focus/dependency-cruiser-focus-on-main.mjs";
 import focusOnMainDepthTwo from "./__fixtures__/focus/dependency-cruiser-focus-on-main-depth-2.mjs";
+import addFocus from "#graph-utl/add-focus.mjs";
 
 describe("[U] graph-utl/add-focus", () => {
   it("returns the input modules when there's no pattern", () => {

--- a/test/graph-utl/compare.rules.spec.mjs
+++ b/test/graph-utl/compare.rules.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { rules } from "../../src/graph-utl/compare.mjs";
+import { rules } from "#graph-utl/compare.mjs";
 
 describe("[U] graph-utl/compare - rules", () => {
   it("samesies yield 0", () => {

--- a/test/graph-utl/compare.severities.spec.mjs
+++ b/test/graph-utl/compare.severities.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { severities } from "../../src/graph-utl/compare.mjs";
+import { severities } from "#graph-utl/compare.mjs";
 
 describe("[U] graph-utl/compare - severities", () => {
   it("returns 0 for identical severities", () => {

--- a/test/graph-utl/compare.violations.spec.mjs
+++ b/test/graph-utl/compare.violations.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { violations } from "../../src/graph-utl/compare.mjs";
+import { violations } from "#graph-utl/compare.mjs";
 
 describe("[U] graph-utl/compare - violations", () => {
   const lViolation = {

--- a/test/graph-utl/consolidate-to-folder.spec.mjs
+++ b/test/graph-utl/consolidate-to-folder.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import consolidateToFolder from "../../src/graph-utl/consolidate-to-folder.mjs";
+import consolidateToFolder from "#graph-utl/consolidate-to-folder.mjs";
 
 describe("[U] graph-utl/consolidateToFolder", () => {
   it("source gets squashed to its folder", () => {

--- a/test/graph-utl/consolidate-to-pattern.spec.mjs
+++ b/test/graph-utl/consolidate-to-pattern.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import consolidateToPattern from "../../src/graph-utl/consolidate-to-pattern.mjs";
+import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
 
 describe("[U] graph-utl/consolidateToPattern", () => {
   it("no pattern => no squashing", () => {

--- a/test/graph-utl/filter-bank.spec.mjs
+++ b/test/graph-utl/filter-bank.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
-import { applyFilters } from "../../src/graph-utl/filter-bank.mjs";
 import reportModules from "./__mocks__/report-modules.mjs";
 import reportIndexModule from "./__fixtures__/reaches/report-index-module.mjs";
 import multiModuleRegexResult from "./__fixtures__/reaches/multi-module-regex-result.mjs";
 import highlightResult from "./__fixtures__/highlight/highlight-result.mjs";
+import { applyFilters } from "#graph-utl/filter-bank.mjs";
 
 const MODULES = [
   {

--- a/test/graph-utl/indexed-module-graph.spec.mjs
+++ b/test/graph-utl/indexed-module-graph.spec.mjs
@@ -1,9 +1,9 @@
 /* eslint-disable no-magic-numbers, no-undefined */
 import { deepEqual, equal } from "node:assert/strict";
-import IndexedModuleGraph from "../../src/graph-utl/indexed-module-graph.mjs";
 import unIndexedModules from "./__mocks__/un-indexed-modules.mjs";
 import unIndexedModulesWithoutDependents from "./__mocks__/un-indexed-modules-without-dependents.mjs";
 import cycleInputGraphs from "./__mocks__/cycle-input-graphs.mjs";
+import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 
 describe("[U] graph-utl/indexed-module-graph - findModuleByName", () => {
   it("searching any module in an empty graph yields undefined", () => {

--- a/test/graph-utl/rule-set.spec.mjs
+++ b/test/graph-utl/rule-set.spec.mjs
@@ -4,7 +4,7 @@ import {
   findRuleByName,
   ruleSetHasLicenseRule,
   ruleSetHasDeprecationRule,
-} from "../../src/graph-utl/rule-set.mjs";
+} from "#graph-utl/rule-set.mjs";
 
 describe("[U] graph-utl/rule-set - findRuleByName", () => {
   const lRuleSet = {

--- a/test/main/files-and-dirs/normalize.spec.mjs
+++ b/test/main/files-and-dirs/normalize.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import { win32, posix } from "node:path";
 import { fileURLToPath } from "node:url";
-import normalizeFilesAndDirectories from "../../../src/main/files-and-dirs/normalize.mjs";
+import normalizeFilesAndDirectories from "#main/files-and-dirs/normalize.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/main/helpers.spec.mjs
+++ b/test/main/helpers.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import { normalizeREProperties } from "../../src/main/helpers.mjs";
+import { normalizeREProperties } from "#main/helpers.mjs";
 
 const POTENTIAL_ARRAY_PROPERTIES = ["aap", "noot", "mies", "wim"];
 const ARRAYED_OBJECT = {

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/main/main.cruise-reporterless.spec.mjs
+++ b/test/main/main.cruise-reporterless.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -2,8 +2,8 @@ import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
 import { rmSync } from "node:fs";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import cruise from "../../src/main/cruise.mjs";
 import Cache from "../../src/cache/cache.mjs";
+import cruise from "#main/cruise.mjs";
 
 const ajv = new Ajv();
 

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
 import { rmSync } from "node:fs";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import Cache from "#cache/cache.mjs";
 import cruise from "#main/cruise.mjs";
 

--- a/test/main/main.cruise.cache.spec.mjs
+++ b/test/main/main.cruise.cache.spec.mjs
@@ -2,7 +2,7 @@ import { deepEqual, notDeepStrictEqual } from "node:assert/strict";
 import { rmSync } from "node:fs";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import Cache from "../../src/cache/cache.mjs";
+import Cache from "#cache/cache.mjs";
 import cruise from "#main/cruise.mjs";
 
 const ajv = new Ajv();

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/main/main.cruise.dynamic-imports.spec.mjs
+++ b/test/main/main.cruise.dynamic-imports.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import Ajv from "ajv";
-import normalizeOptions from "../../src/cli/normalize-cli-options.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
+import normalizeOptions from "#cli/normalize-cli-options.mjs";
 import cruise from "#main/cruise.mjs";
 
 const ajv = new Ajv();

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import Ajv from "ajv";
-import cruise from "../../src/main/cruise.mjs";
 import normalizeOptions from "../../src/cli/normalize-cli-options.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
+import cruise from "#main/cruise.mjs";
 
 const ajv = new Ajv();
 

--- a/test/main/main.cruise.reachable-integration.spec.mjs
+++ b/test/main/main.cruise.reachable-integration.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import normalizeOptions from "#cli/normalize-cli-options.mjs";
 import cruise from "#main/cruise.mjs";
 

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -4,9 +4,9 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruise from "#main/cruise.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -3,11 +3,11 @@ import { posix as path } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
-import pathToPosix from "../../src/utl/path-to-posix.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/main/main.cruise.spec.mjs
+++ b/test/main/main.cruise.spec.mjs
@@ -3,9 +3,9 @@ import { posix as path } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import cruise from "#main/cruise.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
+++ b/test/main/main.cruise.ts-pre-compilation-deps.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
-import cruise from "../../src/main/cruise.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/main/main.cruise.type-only-imports.spec.mjs
+++ b/test/main/main.cruise.type-only-imports.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/main/main.cruise.type-only-module-references.spec.mjs
+++ b/test/main/main.cruise.type-only-module-references.spec.mjs
@@ -1,9 +1,9 @@
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruise from "../../src/main/cruise.mjs";
 import cruiseResultSchema from "../../src/schema/cruise-result.schema.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
 import normBaseDirectory from "./norm-base-directory.utl.mjs";
+import cruise from "#main/cruise.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/main/main.format.spec.mjs
+++ b/test/main/main.format.spec.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import { deepEqual, ok, equal } from "node:assert/strict";
-import format from "../../src/main/format.mjs";
 import { createRequireJSON } from "../backwards.utl.mjs";
+import format from "#main/format.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 const cruiseResult = requireJSON(

--- a/test/main/options/assert-validity.spec.mjs
+++ b/test/main/options/assert-validity.spec.mjs
@@ -1,5 +1,5 @@
 import { doesNotThrow, equal, throws } from "node:assert/strict";
-import { assertCruiseOptionsValid } from "../../../src/main/options/assert-validity.mjs";
+import { assertCruiseOptionsValid } from "#main/options/assert-validity.mjs";
 
 describe("[U] main/options/validate - module systems", () => {
   it("throws when a invalid module system is passed ", () => {

--- a/test/main/options/normalize.cruise-options.spec.mjs
+++ b/test/main/options/normalize.cruise-options.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, ok, equal } from "node:assert/strict";
-import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
 
 describe("[U] main/options/normalize - cruise options", () => {
   it("ensures maxDepth is an int when passed an int", () => {

--- a/test/main/options/normalize.format-options.spec.mjs
+++ b/test/main/options/normalize.format-options.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import { normalizeFormatOptions } from "../../../src/main/options/normalize.mjs";
+import { normalizeFormatOptions } from "#main/options/normalize.mjs";
 
 describe("[U] main/options/normalize - format options", () => {
   it("makes focus strings into an object", () => {

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -1,8 +1,8 @@
 import { ok, equal, deepEqual } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { normalizeCruiseOptions } from "../../../src/main/options/normalize.mjs";
-import normalizeResolveOptions from "../../../src/main/resolve-options/normalize.mjs";
+import { normalizeCruiseOptions } from "#main/options/normalize.mjs";
+import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/test/main/rule-set/assert-validity.spec.mjs
+++ b/test/main/rule-set/assert-validity.spec.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { deepEqual, throws } from "node:assert/strict";
-import assertRuleSetValid from "../../../src/main/rule-set/assert-validity.mjs";
+import assertRuleSetValid from "#main/rule-set/assert-validity.mjs";
 
 function shouldBarfWithMessage(pRulesFile, pMessage) {
   throws(

--- a/test/main/rule-set/normalize.spec.mjs
+++ b/test/main/rule-set/normalize.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import normalize from "../../../src/main/rule-set/normalize.mjs";
+import normalize from "#main/rule-set/normalize.mjs";
 
 describe("[U] main/rule-set/normalize", () => {
   it("leaves the empty ruleset alone", () => {

--- a/test/report/anon/anonymize-path-element.spec.mjs
+++ b/test/report/anon/anonymize-path-element.spec.mjs
@@ -1,5 +1,5 @@
 import { match, notDeepStrictEqual, equal } from "node:assert/strict";
-import { anonymizePathElement } from "../../../src/report/anon/anonymize-path-element.mjs";
+import { anonymizePathElement } from "#report/anon/anonymize-path-element.mjs";
 
 describe("[U] report/anon/anonymizePathElement - uncached", () => {
   it("'' => ''", () => {

--- a/test/report/anon/anonymize-path.spec.mjs
+++ b/test/report/anon/anonymize-path.spec.mjs
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
-import { anonymizePath } from "../../../src/report/anon/anonymize-path.mjs";
-import { clearCache } from "../../../src/report/anon/anonymize-path-element.mjs";
+import { anonymizePath } from "#report/anon/anonymize-path.mjs";
+import { clearCache } from "#report/anon/anonymize-path-element.mjs";
 
 describe("[U] report/anon/anonymizePath", () => {
   beforeEach(() => {

--- a/test/report/anon/anonymize.spec.mjs
+++ b/test/report/anon/anonymize.spec.mjs
@@ -1,8 +1,6 @@
 import { equal, deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
 import cruiseResultSchema from "../../../src/schema/cruise-result.schema.mjs";
-import { clearCache } from "../../../src/report/anon/anonymize-path-element.mjs";
-import anonymize from "../../../src/report/anon/index.mjs";
 import sourceReport from "./__mocks__/src-report.mjs";
 import fixtureReport from "./__fixtures__/src-report.mjs";
 import sourceReportWithWordlist from "./__mocks__/src-report-wordlist.mjs";
@@ -17,6 +15,8 @@ import sourceFolders from "./__mocks__/folders.mjs";
 import fixtureFolders from "./__fixtures__/folders.mjs";
 import sourceFolderCycles from "./__mocks__/folder-cycles.mjs";
 import fixtureFolderCycles from "./__fixtures__/folder-cycles.mjs";
+import anonymize from "#report/anon/index.mjs";
+import { clearCache } from "#report/anon/anonymize-path-element.mjs";
 
 const ajv = new Ajv();
 

--- a/test/report/anon/anonymize.spec.mjs
+++ b/test/report/anon/anonymize.spec.mjs
@@ -1,6 +1,5 @@
 import { equal, deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import cruiseResultSchema from "../../../src/schema/cruise-result.schema.mjs";
 import sourceReport from "./__mocks__/src-report.mjs";
 import fixtureReport from "./__fixtures__/src-report.mjs";
 import sourceReportWithWordlist from "./__mocks__/src-report-wordlist.mjs";
@@ -15,6 +14,7 @@ import sourceFolders from "./__mocks__/folders.mjs";
 import fixtureFolders from "./__fixtures__/folders.mjs";
 import sourceFolderCycles from "./__mocks__/folder-cycles.mjs";
 import fixtureFolderCycles from "./__fixtures__/folder-cycles.mjs";
+import cruiseResultSchema from "#cruise-result-schema";
 import anonymize from "#report/anon/index.mjs";
 import { clearCache } from "#report/anon/anonymize-path-element.mjs";
 

--- a/test/report/anon/random-string.spec.mjs
+++ b/test/report/anon/random-string.spec.mjs
@@ -1,5 +1,5 @@
 import { match, equal } from "node:assert/strict";
-import randomString from "../../../src/report/anon/random-string.mjs";
+import randomString from "#report/anon/random-string.mjs";
 
 describe("[U] report/anon/random-string", () => {
   it("returns the empty string when passed the empty string", () => {

--- a/test/report/azure-devops/__mocks__/errors-and-known-violations.mjs
+++ b/test/report/azure-devops/__mocks__/errors-and-known-violations.mjs
@@ -1538,7 +1538,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/add-focus",
+          module: "#graph-utl/add-focus",
           moduleSystem: "cjs",
           exoticallyRequired: false,
           resolved: "src/graph-utl/add-focus.js",
@@ -18183,7 +18183,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/add-focus.js",
+          module: "#graph-utl/add-focus.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/add-focus.js",
@@ -18220,7 +18220,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18257,7 +18257,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18294,7 +18294,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18331,7 +18331,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/consolidate-to-folder.js",
+          module: "#graph-utl/consolidate-to-folder.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/consolidate-to-folder.js",
@@ -18368,7 +18368,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/consolidate-to-pattern.js",
+          module: "#graph-utl/consolidate-to-pattern.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/consolidate-to-pattern.js",
@@ -18405,7 +18405,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/filterbank.js",
+          module: "#graph-utl/filterbank.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/filterbank.js",
@@ -18442,7 +18442,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/rule-set.js",
+          module: "#graph-utl/rule-set.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/rule-set.js",

--- a/test/report/azure-devops/__mocks__/known-violations.mjs
+++ b/test/report/azure-devops/__mocks__/known-violations.mjs
@@ -1538,7 +1538,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/add-focus",
+          module: "#graph-utl/add-focus",
           moduleSystem: "cjs",
           exoticallyRequired: false,
           resolved: "src/graph-utl/add-focus.js",
@@ -18183,7 +18183,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/add-focus.js",
+          module: "#graph-utl/add-focus.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/add-focus.js",
@@ -18220,7 +18220,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18257,7 +18257,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18294,7 +18294,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18331,7 +18331,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/consolidate-to-folder.js",
+          module: "#graph-utl/consolidate-to-folder.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/consolidate-to-folder.js",
@@ -18368,7 +18368,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/consolidate-to-pattern.js",
+          module: "#graph-utl/consolidate-to-pattern.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/consolidate-to-pattern.js",
@@ -18405,7 +18405,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/filterbank.js",
+          module: "#graph-utl/filterbank.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/filterbank.js",
@@ -18442,7 +18442,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/rule-set.js",
+          module: "#graph-utl/rule-set.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/rule-set.js",

--- a/test/report/azure-devops/azure-devops.spec.mjs
+++ b/test/report/azure-devops/azure-devops.spec.mjs
@@ -2,7 +2,6 @@ import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import normalizeNewline from "normalize-newline";
-import render from "../../../src/report/azure-devops.mjs";
 import okdeps from "./__mocks__/everything-fine.mjs";
 import warndeps from "./__mocks__/there-are-warnings.mjs";
 import errdeps from "./__mocks__/there-are-errors.mjs";
@@ -14,6 +13,7 @@ import unsupportedErrorLevels from "./__mocks__/unsupported-severity.mjs";
 import knownViolations from "./__mocks__/known-violations.mjs";
 import errorsAndKnownViolations from "./__mocks__/errors-and-known-violations.mjs";
 import instabilities from "./__mocks__/instabilities.mjs";
+import render from "#report/azure-devops.mjs";
 
 function readFixture(pRelativePath) {
   return readFileSync(

--- a/test/report/baseline/baseline.spec.mjs
+++ b/test/report/baseline/baseline.spec.mjs
@@ -1,8 +1,8 @@
 import { deepEqual, equal } from "node:assert/strict";
 import Ajv from "ajv";
-import baseline from "../../../src/report/baseline.mjs";
 import { createRequireJSON } from "../../backwards.utl.mjs";
 import baselineSchema from "../../../src/schema/baseline-violations.schema.mjs";
+import baseline from "#report/baseline.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 const ajv = new Ajv();

--- a/test/report/csv/csv.spec.mjs
+++ b/test/report/csv/csv.spec.mjs
@@ -2,8 +2,8 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { deepEqual, equal } from "node:assert/strict";
 import normalizeNewline from "normalize-newline";
-import render from "../../../src/report/csv.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
+import render from "#report/csv.mjs";
 
 const elementFixture = normalizeNewline(
   readFileSync(

--- a/test/report/dot/custom-level/index.spec.mjs
+++ b/test/report/dot/custom-level/index.spec.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
-import dot from "../../../../src/report/dot/index.mjs";
+import dot from "#report/dot/index.mjs";
 
 const render = dot("custom");
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/report/dot/flat-level/index.spec.mjs
+++ b/test/report/dot/flat-level/index.spec.mjs
@@ -2,8 +2,8 @@ import { deepEqual, equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import dot from "../../../../src/report/dot/index.mjs";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
+import dot from "#report/dot/index.mjs";
 
 const render = dot("flat");
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/report/dot/folder-level/folder-level.spec.mjs
+++ b/test/report/dot/folder-level/folder-level.spec.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
-import dot from "../../../../src/report/dot/index.mjs";
+import dot from "#report/dot/index.mjs";
 
 const render = dot("folder");
 const requireJSON = createRequireJSON(import.meta.url);

--- a/test/report/dot/module-level/index.spec.mjs
+++ b/test/report/dot/module-level/index.spec.mjs
@@ -2,9 +2,9 @@ import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import defaultTheme from "../../../../src/report/dot/default-theme.mjs";
-import dot from "../../../../src/report/dot/index.mjs";
 import { createRequireJSON } from "../../../backwards.utl.mjs";
+import defaultTheme from "#report/dot/default-theme.mjs";
+import dot from "#report/dot/index.mjs";
 
 const defaultRender = dot();
 const render = dot("module");

--- a/test/report/dot/module-utl.spec.mjs
+++ b/test/report/dot/module-utl.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import moduleUtl from "../../../src/report/dot/module-utl.mjs";
+import moduleUtl from "#report/dot/module-utl.mjs";
 
 describe("[U] report/dot/module-utl", () => {
   it("extractFirstTransgression - keeps as is when there's no transgressions", () => {

--- a/test/report/dot/theming.spec.mjs
+++ b/test/report/dot/theming.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import _cloneDeep from "lodash/cloneDeep.js";
-import theming from "../../../src/report/dot/theming.mjs";
+import theming from "#report/dot/theming.mjs";
 
 describe("[U] report/dot/theming - determineModuleColors - default theme", () => {
   it("empty module => no colors", () => {

--- a/test/report/error-html/error-html.spec.mjs
+++ b/test/report/error-html/error-html.spec.mjs
@@ -1,9 +1,9 @@
 import { match, equal, doesNotMatch } from "node:assert/strict";
-import errorHTML from "../../../src/report/error-html/index.mjs";
 import everythingFineResult from "./__mocks__/everything-fine.mjs";
 import validationMoreThanOnce from "./__mocks__/violation-more-than-once.mjs";
 import validationMoreThanOnceWithAnIgnore from "./__mocks__/violation-more-than-once-with-an-ignore.mjs";
 import orphansCyclesMetrics from "./__mocks__/orphans-cycles-metrics.mjs";
+import errorHTML from "#report/error-html/index.mjs";
 
 describe("[I] report/error-html", () => {
   const lOkeliDokelyKey = "gummy bears";

--- a/test/report/error-html/utl.spec.mjs
+++ b/test/report/error-html/utl.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual, equal } from "node:assert/strict";
-import utl from "../../../src/report/error-html/utl.mjs";
+import utl from "#report/error-html/utl.mjs";
 
 function summaryHasMinimalAttributes(pResult) {
   equal(pResult.hasOwnProperty("depcruiseVersion"), true);

--- a/test/report/error/error-long.spec.mjs
+++ b/test/report/error/error-long.spec.mjs
@@ -3,12 +3,12 @@
 import { equal, match } from "node:assert/strict";
 import { EOL } from "node:os";
 import chalk from "chalk";
-import render from "../../../src/report/error-long.mjs";
 import okDeps from "./__mocks__/everything-fine.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
 import warnDeps from "./__mocks__/err-only-warnings.mjs";
 import errorsAdditionalInfo from "./__mocks__/err-with-additional-information.mjs";
 import orphanErrs from "./__mocks__/orphan-deps.mjs";
+import render from "#report/error-long.mjs";
 
 describe("[I] report/error-long", () => {
   let chalkLevel = chalk.level;

--- a/test/report/error/error.spec.mjs
+++ b/test/report/error/error.spec.mjs
@@ -3,7 +3,6 @@
 import { doesNotMatch, match, equal } from "node:assert/strict";
 import { EOL } from "node:os";
 import chalk from "chalk";
-import render from "../../../src/report/error.mjs";
 import okdeps from "./__mocks__/everything-fine.mjs";
 import dependencies from "./__mocks__/cjs-no-dependency-valid.mjs";
 import onlyWarningDependencies from "./__mocks__/err-only-warnings.mjs";
@@ -15,6 +14,7 @@ import ignoredViolations from "./__mocks__/ignored-violations.mjs";
 import ignoredAndRealViolations from "./__mocks__/ignored-and-real-violations.mjs";
 import missingViolationType from "./__mocks__/missing-violation-type.mjs";
 import unknownViolationType from "./__mocks__/unknown-violation-type.mjs";
+import render from "#report/error.mjs";
 
 describe("[I] report/error", () => {
   let chalkLevel = chalk.level;

--- a/test/report/html/html.spec.mjs
+++ b/test/report/html/html.spec.mjs
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { deepEqual, equal } from "node:assert/strict";
-import render from "../../../src/report/html/index.mjs";
 import deps from "./__mocks__/cjs-no-dependency-valid.mjs";
+import render from "#report/html/index.mjs";
 
 const elementFixture = readFileSync(
   fileURLToPath(

--- a/test/report/markdown/markdown.spec.mjs
+++ b/test/report/markdown/markdown.spec.mjs
@@ -1,10 +1,10 @@
 /* eslint-disable prefer-regex-literals */
 import { match, doesNotMatch, equal } from "node:assert/strict";
-import markdown from "../../../src/report/markdown.mjs";
 import everythingFineResult from "./__mocks__/everything-fine.mjs";
 import validationMoreThanOnce from "./__mocks__/violation-more-than-once.mjs";
 import validationMoreThanOnceWithAnIgnore from "./__mocks__/violation-more-than-once-with-an-ignore.mjs";
 import orphansCyclesMetrics from "./__mocks__/orphans-cycles-metrics.mjs";
+import markdown from "#report/markdown.mjs";
 
 describe("[I] report/markdown", () => {
   const lOkeliDokelyKey = "gummy bears";

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -2,8 +2,6 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-// eslint-plugins import and node don't yet understand these 'self references'
-// eslint-disable-next-line import/no-unresolved, node/no-missing-import
 import mermaidReporterPlugin from "dependency-cruiser/mermaid-reporter-plugin";
 import mermaid from "../../../src/report/mermaid.mjs";
 import { createRequireJSON } from "../../backwards.utl.mjs";

--- a/test/report/mermaid/mermaid.spec.mjs
+++ b/test/report/mermaid/mermaid.spec.mjs
@@ -3,8 +3,8 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
 import mermaidReporterPlugin from "dependency-cruiser/mermaid-reporter-plugin";
-import mermaid from "../../../src/report/mermaid.mjs";
 import { createRequireJSON } from "../../backwards.utl.mjs";
+import mermaid from "#report/mermaid.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 const __dirname = fileURLToPath(new URL(".", import.meta.url));

--- a/test/report/metrics/metrics.spec.mjs
+++ b/test/report/metrics/metrics.spec.mjs
@@ -2,8 +2,8 @@
 /* eslint-disable no-regex-spaces */
 import { EOL } from "node:os";
 import { doesNotMatch, match, equal } from "node:assert/strict";
-import metrics from "../../../src/report/metrics.mjs";
 import cruiseResultWithMetricsForModulesAndFolders from "./__mocks/cruise-result-with-metrics-for-modules-and-folders.mjs";
+import metrics from "#report/metrics.mjs";
 
 describe("[I] report/metrics", () => {
   it("errors when the input doesn't contain a 'folders' section", () => {

--- a/test/report/null/null.spec.mjs
+++ b/test/report/null/null.spec.mjs
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import nullReporter from "../../../src/report/null.mjs";
+import nullReporter from "#report/null.mjs";
 
 const gSmallOKResult = {
   modules: [

--- a/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
+++ b/test/report/plugins/index.get-external-plugin-reporter.spec.mjs
@@ -1,7 +1,7 @@
 import { match, equal } from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { getExternalPluginReporter } from "../../../src/report/plugins.mjs";
+import { getExternalPluginReporter } from "#report/plugins.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const FIXTURE_DIRECTORY = join(__dirname, "__fixtures__");

--- a/test/report/plugins/index.is-valid-plugin.spec.mjs
+++ b/test/report/plugins/index.is-valid-plugin.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { isValidPlugin } from "../../../src/report/plugins.mjs";
+import { isValidPlugin } from "#report/plugins.mjs";
 
 describe("[U] report/plugins - isValidPlugin", () => {
   it("returns false when the plugin's function doesn't return an exit code attribute", async () => {

--- a/test/report/teamcity/__mocks__/known-violations.mjs
+++ b/test/report/teamcity/__mocks__/known-violations.mjs
@@ -1538,7 +1538,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/add-focus",
+          module: "#graph-utl/add-focus",
           moduleSystem: "cjs",
           exoticallyRequired: false,
           resolved: "src/graph-utl/add-focus.js",
@@ -18183,7 +18183,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/add-focus.js",
+          module: "#graph-utl/add-focus.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/add-focus.js",
@@ -18220,7 +18220,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18257,7 +18257,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18294,7 +18294,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/compare.js",
+          module: "#graph-utl/compare.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/compare.js",
@@ -18331,7 +18331,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/consolidate-to-folder.js",
+          module: "#graph-utl/consolidate-to-folder.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/consolidate-to-folder.js",
@@ -18368,7 +18368,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/consolidate-to-pattern.js",
+          module: "#graph-utl/consolidate-to-pattern.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/consolidate-to-pattern.js",
@@ -18405,7 +18405,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/filterbank.js",
+          module: "#graph-utl/filterbank.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/filterbank.js",
@@ -18442,7 +18442,7 @@ export default {
       dependencies: [
         {
           dynamic: false,
-          module: "../../src/graph-utl/rule-set.js",
+          module: "#graph-utl/rule-set.js",
           moduleSystem: "es6",
           exoticallyRequired: false,
           resolved: "src/graph-utl/rule-set.js",

--- a/test/report/teamcity/teamcity.spec.mjs
+++ b/test/report/teamcity/teamcity.spec.mjs
@@ -1,7 +1,6 @@
 import { equal } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import render from "../../../src/report/teamcity.mjs";
 import okdeps from "./__mocks__/everything-fine.mjs";
 import moduleErrs from "./__mocks__/module-errors.mjs";
 import requiredErrs from "./__mocks__/required-errors.mjs";
@@ -10,6 +9,7 @@ import vias from "./__mocks__/via-deps.mjs";
 import unsupportedErrorLevels from "./__mocks__/unsupported-severity.mjs";
 import knownViolations from "./__mocks__/known-violations.mjs";
 import instabilities from "./__mocks__/instabilities.mjs";
+import render from "#report/teamcity.mjs";
 
 function removePerSessionAttributes(pString) {
   return pString.replace(/ flowId='[^']+' timestamp='[^']+'/g, "");

--- a/test/report/text/text.spec.mjs
+++ b/test/report/text/text.spec.mjs
@@ -3,9 +3,9 @@ import { fileURLToPath } from "node:url";
 import { equal } from "node:assert/strict";
 import chalk from "chalk";
 import normalizeNewline from "normalize-newline";
-import renderText from "../../../src/report/text.mjs";
 import dependencies from "./__mocks__/dependencies.mjs";
 import cruiseResultWithFocus from "./__mocks__/cruise-result-with-focus.mjs";
+import renderText from "#report/text.mjs";
 
 describe("[I] report/text", () => {
   let lOldChalkLevel = 0;

--- a/test/report/utl/dependency-to-incidence-transformer.spec.mjs
+++ b/test/report/utl/dependency-to-incidence-transformer.spec.mjs
@@ -1,10 +1,10 @@
 import { deepEqual } from "node:assert/strict";
-import transform from "../../../src/report/utl/dependency-to-incidence-transformer.mjs";
 
 import oneViolation from "./__mocks__/one-violation.mjs";
 import ONE_VIOLATION_DEPS_FIXTURE from "./__mocks__/one-violation-incidences.mjs";
 import moreViolations from "./__mocks__/more-violations.mjs";
 import MORE_VIOLATIONS_DEPS_FIXTURE from "./__mocks__/more-violations-incidences.mjs";
+import transform from "#report/utl/dependency-to-incidence-transformer.mjs";
 
 const ONE_VIOLATION_DEPS_INPUT = oneViolation.modules;
 const MORE_VIOLATIONS_DEPS_INPUT = moreViolations.modules;

--- a/test/utl/get-extension.spec.mjs
+++ b/test/utl/get-extension.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import getExtension from "../../src/utl/get-extension.mjs";
+import getExtension from "#utl/get-extension.mjs";
 
 describe("[U] utl/getExtension", () => {
   it(".coffee.md classifies as .coffee.md", () => {

--- a/test/utl/regex-util.spec.mjs
+++ b/test/utl/regex-util.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { replaceGroupPlaceholders } from "../../src/utl/regex-util.mjs";
+import { replaceGroupPlaceholders } from "#utl/regex-util.mjs";
 
 describe("[U] utl/regex-util", () => {
   it("replaceGroupPlaceholders - leaves re alone if passed empty match result", () => {

--- a/test/validate/index.core.spec.mjs
+++ b/test/validate/index.core.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - core", () => {
   const lNotToCoreRuleSet = parseRuleSet({

--- a/test/validate/index.could-not-resolve.spec.mjs
+++ b/test/validate/index.could-not-resolve.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - couldNotResolve", () => {
   const lNotToUnresolvableRuleSet = parseRuleSet({

--- a/test/validate/index.cycle-via-not.spec.mjs
+++ b/test/validate/index.cycle-via-not.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index dependency - cycle viaNot", () => {
   const lCycleViaNotRuleSet = parseRuleSet({

--- a/test/validate/index.cycle-via-some-not.spec.mjs
+++ b/test/validate/index.cycle-via-some-not.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index dependency - cycle viaSomeNot - with group matching", () => {
   const lCycleButNotViaGroupMatchRuleSet = {

--- a/test/validate/index.cycle-via.spec.mjs
+++ b/test/validate/index.cycle-via.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index dependency - cycle via", () => {
   const lCycleViaRuleSet = parseRuleSet({

--- a/test/validate/index.exotic-require.spec.mjs
+++ b/test/validate/index.exotic-require.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - exoticallyRequired", () => {
   const lExoticallyRequiredRuleSet = parseRuleSet({

--- a/test/validate/index.groupmatching.spec.mjs
+++ b/test/validate/index.groupmatching.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index group matching - path group matched in a pathnot", () => {
   const lGroupToPathNotRuleSet = {

--- a/test/validate/index.license.spec.mjs
+++ b/test/validate/index.license.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - license", () => {
   const lLicenseRuleSet = parseRuleSet({

--- a/test/validate/index.more-than-one-dependency-type.spec.mjs
+++ b/test/validate/index.more-than-one-dependency-type.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] index/validate - moreThanOneDependencyType", () => {
   it(`no relations with modules of > 1 dep type (e.g. specified 2x in package.json)`, () => {

--- a/test/validate/index.more-unstable.spec.mjs
+++ b/test/validate/index.more-unstable.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - stability checks", () => {
   const lForbiddenRuleSet = parseRuleSet({

--- a/test/validate/index.orphans.spec.mjs
+++ b/test/validate/index.orphans.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - orphans", () => {
   const lOrphanRuleSet = parseRuleSet({

--- a/test/validate/index.pre-compilation-only.spec.mjs
+++ b/test/validate/index.pre-compilation-only.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - preCompilationOnly", () => {
   const lPreCompilationOnlyRuleSet = parseRuleSet({

--- a/test/validate/index.reachable.spec.mjs
+++ b/test/validate/index.reachable.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - reachable (in forbidden set)", () => {
   const lReachableFalseRuleSet = parseRuleSet({

--- a/test/validate/index.required-rules.spec.mjs
+++ b/test/validate/index.required-rules.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index - required rules", () => {
   const lRequiredRuleSet = parseRuleSet({

--- a/test/validate/index.spec.mjs
+++ b/test/validate/index.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] validate/index dependency - generic tests", () => {
   it("is ok with the empty validation", () => {

--- a/test/validate/index.type-only.spec.mjs
+++ b/test/validate/index.type-only.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import validate from "../../src/validate/index.mjs";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
+import validate from "#validate/index.mjs";
 
 describe("[I] [I] validate/index - type-only", () => {
   const lTypeOnlyRuleSet = parseRuleSet({

--- a/test/validate/match-folder-dependency-rule.spec.mjs
+++ b/test/validate/match-folder-dependency-rule.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchFolderRule from "../../src/validate/match-folder-dependency-rule.mjs";
+import matchFolderRule from "#validate/match-folder-dependency-rule.mjs";
 
 describe("[I] validate/match-folder-dependency-rule - match generic", () => {
   const lEmptyRule = { scope: "folder", from: {}, to: {} };

--- a/test/validate/match-module-rule.dependents.spec.mjs
+++ b/test/validate/match-module-rule.dependents.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "../../src/validate/match-module-rule.mjs";
+import matchModuleRule from "#validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, module: {} };
 const ANY_DEPENDENTS = {

--- a/test/validate/match-module-rule.orphan.spec.mjs
+++ b/test/validate/match-module-rule.orphan.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "../../src/validate/match-module-rule.mjs";
+import matchModuleRule from "#validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ANY_ORPHAN = { from: { orphan: true }, to: {} };

--- a/test/validate/match-module-rule.reachable.spec.mjs
+++ b/test/validate/match-module-rule.reachable.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "../../src/validate/match-module-rule.mjs";
+import matchModuleRule from "#validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ANY_UNREACHABLE = {

--- a/test/validate/match-module-rule.reaches.spec.mjs
+++ b/test/validate/match-module-rule.reaches.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "../../src/validate/match-module-rule.mjs";
+import matchModuleRule from "#validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ANY_REACHABLE = {

--- a/test/validate/match-module-rule.spec.mjs
+++ b/test/validate/match-module-rule.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "../../src/validate/match-module-rule.mjs";
+import matchModuleRule from "#validate/match-module-rule.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ORPHAN_RULE = { from: { orphan: true }, to: {} };

--- a/test/validate/parse-ruleset.utl.mjs
+++ b/test/validate/parse-ruleset.utl.mjs
@@ -1,4 +1,4 @@
-import normalizeRuleSet from "../../src/main/rule-set/normalize.mjs";
-import assertRuleSetValid from "../../src/main/rule-set/assert-validity.mjs";
+import normalizeRuleSet from "#main/rule-set/normalize.mjs";
+import assertRuleSetValid from "#main/rule-set/assert-validity.mjs";
 
 export default (pRuleSet) => normalizeRuleSet(assertRuleSetValid(pRuleSet));

--- a/test/validate/violates-required-rule.spec.mjs
+++ b/test/validate/violates-required-rule.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import violatesRequiredRule from "../../src/validate/violates-required-rule.mjs";
+import violatesRequiredRule from "#validate/violates-required-rule.mjs";
 
 const SIMPLE_RULE = {
   module: {


### PR DESCRIPTION
## Description

Use import aliases in package.json for ...
- [x] `utl/*`
- [x] `meta.js`
- [x] `graph-utl/*`
- [x] `extract/*`
- [x] `enrich/*`
- [x] `report/*`
- [x] `main/*`
- [x] `cache/*`
- [x] `cli/*`
- [x] the json schemas
- [x] `validate/*`
- [x] `config-utl/*`

## Motivation and Context

- Makes code easier to read (and move around, might it come to that)
- Dog fooding a feature I've not used in any other project


## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
