### PR TITLE
feat(reporter/dot): only considers rule severity for coloring invalid modules/ dependencies

### DIFF
--- a/src/report/dot/default-theme.mjs
+++ b/src/report/dot/default-theme.mjs
@@ -47,14 +47,6 @@ export default {
       attributes: { fontcolor: "blue", color: "blue" },
     },
     {
-      criteria: { valid: false },
-      attributes: { fontcolor: "red", color: "red" },
-    },
-    {
-      criteria: { couldNotResolve: true },
-      attributes: { color: "red", fontcolor: "red" },
-    },
-    {
       criteria: { coreModule: true },
       attributes: { color: "grey", fontcolor: "grey" },
     },
@@ -130,10 +122,6 @@ export default {
     {
       criteria: { dynamic: true },
       attributes: { style: "dashed" },
-    },
-    {
-      criteria: { valid: false },
-      attributes: { fontcolor: "red", color: "red" },
     },
     {
       criteria: { circular: true },

--- a/test/report/dot/theming.spec.mjs
+++ b/test/report/dot/theming.spec.mjs
@@ -25,7 +25,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
         { couldNotResolve: true },
         theming.normalizeTheme({}).modules,
       ),
-      { color: "red", fontcolor: "red" },
+      {},
     );
   });
 


### PR DESCRIPTION
## Description, Motivation and Context

- _only_ color modules & dependencies in one of the severity level colors when there's a severity set on the associated rule

The default `dot` configuration built into dependency-cruiser made that things that were invalid, but for which the rule was _ignored_ showed up with a red color. This is obviously not helpful (why otherwise ignore the rule).

## How Has This Been Tested?

- [x] green ci
- [x] adjusted automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
