### PR TITLE
feat(init): adds exception to not-to-dev-dep for type-only dependencies

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -134,10 +134,14 @@
       "name": "not-to-dev-dep",
       "severity": "error",
       "comment": "In production code do not depend on external ('npm') modules not declared in your package.json's dependencies - otherwise a production only install (i.e. 'npm ci') will break. If this rule triggers on something that's only used during development, adapt the 'from' of the rule in the dependency-cruiser configuration.",
-      "from": { "path": "^(bin|src)" },
+      "from": {
+        "pathNot": ["^test/", "^tools/"]
+      },
       "to": {
         "dependencyTypes": ["npm-dev"],
-        "exoticallyRequired": false
+        "exoticallyRequired": false,
+        "dependencyTypesNot": ["type-only"],
+        "pathNot": ["node_modules/@types/"]
       }
     },
     {

--- a/src/cli/init-config/config-template.mjs
+++ b/src/cli/init-config/config-template.mjs
@@ -154,7 +154,15 @@ module.exports = {
       },
       to: {
         dependencyTypes: [
-          'npm-dev'
+          'npm-dev',
+        ],
+        // type only dependencies are not a problem as they don't end up in the
+        // production code or are ignored by the runtime.
+        dependencyTypesNot: [
+          'type-only'
+        ],
+        pathNot: [
+          '@types/'
         ]
       }
     },

--- a/src/cli/init-config/config-template.mjs
+++ b/src/cli/init-config/config-template.mjs
@@ -162,7 +162,7 @@ module.exports = {
           'type-only'
         ],
         pathNot: [
-          '@types/'
+          'node_modules/@types/'
         ]
       }
     },

--- a/types/extract-ts-config.d.ts
+++ b/types/extract-ts-config.d.ts
@@ -1,4 +1,4 @@
-import { ParsedCommandLine } from "typescript";
+import type { ParsedCommandLine } from "typescript";
 
 /**
  * Reads the file with name `pTSConfigFileName` and returns its parsed


### PR DESCRIPTION
## Description

- adds an exception to the `not-to-dev-dep` for type-only dependencies to ones in `@types` folders (which are _pretty_ likely to be type only as well, even when not explicitly imported as such)
- does the same for dependency-cruiser's own configuration

## Motivation and Context

Implements the second suggestion from #873 

## How Has This Been Tested?

- [x] green ci
- [x] manually against a TS repo

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
