### PR TITLE
refactor(graph-utl): normalizes name attribute of dependencies on construction to simplify processing

### DIFF
--- a/src/enrich/derive/circular.mjs
+++ b/src/enrich/derive/circular.mjs
@@ -4,17 +4,13 @@ function addCircularityCheckToDependency(
   pIndexedGraph,
   pFrom,
   pToDep,
-  pDependencyName
+  pDependencyName,
 ) {
   let lReturnValue = {
     ...pToDep,
     circular: false,
   };
-  const lCycle = pIndexedGraph.getCycle(
-    pFrom,
-    pToDep[pDependencyName],
-    pDependencyName
-  );
+  const lCycle = pIndexedGraph.getCycle(pFrom, pToDep[pDependencyName]);
 
   if (lCycle.length > 0) {
     lReturnValue = {
@@ -35,7 +31,7 @@ function addCircularityCheckToDependency(
 export default function detectAndAddCycles(
   pNodes,
   pIndexedNodes,
-  { pSourceAttribute, pDependencyName }
+  { pSourceAttribute, pDependencyName },
 ) {
   return pNodes.map((pModule) => ({
     ...pModule,
@@ -44,8 +40,8 @@ export default function detectAndAddCycles(
         pIndexedNodes,
         pModule[pSourceAttribute],
         pToDep,
-        pDependencyName
-      )
+        pDependencyName,
+      ),
     ),
   }));
 }

--- a/src/enrich/derive/metrics/get-module-metrics.mjs
+++ b/src/enrich/derive/metrics/get-module-metrics.mjs
@@ -20,7 +20,7 @@ function addInstabilityToDependency(pAllModules) {
   return (pDependency) => ({
     ...pDependency,
     instability:
-      (lIndexedModules.findModuleByName(pDependency.resolved) || {})
+      (lIndexedModules.findVertexByName(pDependency.resolved) || {})
         .instability || 0,
   });
 }

--- a/test/graph-utl/__mocks__/cycle-input-graphs.mjs
+++ b/test/graph-utl/__mocks__/cycle-input-graphs.mjs
@@ -28,7 +28,8 @@ export default {
       source: "d",
       dependencies: [
         {
-          resolved: "d",
+          resolved: "e",
+          dependencyTypes: ["aliased", "aliased-subpath-import", "local"],
         },
       ],
     },

--- a/test/graph-utl/indexed-module-graph.spec.mjs
+++ b/test/graph-utl/indexed-module-graph.spec.mjs
@@ -5,22 +5,22 @@ import unIndexedModulesWithoutDependents from "./__mocks__/un-indexed-modules-wi
 import cycleInputGraphs from "./__mocks__/cycle-input-graphs.mjs";
 import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 
-describe("[U] graph-utl/indexed-module-graph - findModuleByName", () => {
+describe("[U] graph-utl/indexed-module-graph - findVertexByName", () => {
   it("searching any module in an empty graph yields undefined", () => {
     const graph = new IndexedModuleGraph([]);
 
-    equal(graph.findModuleByName("any-name"), undefined);
+    equal(graph.findVertexByName("any-name"), undefined);
   });
 
   it("searching a non-exiting module in a real graph yields undefined", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
 
-    equal(graph.findModuleByName("any-name"), undefined);
+    equal(graph.findVertexByName("any-name"), undefined);
   });
 
   it("searching for an existing module yields that module", () => {
     const graph = new IndexedModuleGraph(unIndexedModules);
-    deepEqual(graph.findModuleByName("src/report/dot/default-theme.js"), {
+    deepEqual(graph.findVertexByName("src/report/dot/default-theme.js"), {
       source: "src/report/dot/default-theme.js",
       dependencies: [],
       dependents: ["src/report/dot/theming.js"],
@@ -408,7 +408,7 @@ describe("[U] graph-utl/indexed-module-graph - getPath", () => {
 
 function getCycle(pGraph, pFrom, pToDep) {
   const lIndexedGraph = new IndexedModuleGraph(pGraph);
-  return lIndexedGraph.getCycle(pFrom, pToDep, "resolved");
+  return lIndexedGraph.getCycle(pFrom, pToDep);
 }
 
 describe("[U] graph-utl/indexed-module-graph - getCycle", () => {
@@ -416,7 +416,7 @@ describe("[U] graph-utl/indexed-module-graph - getCycle", () => {
     deepEqual(getCycle(cycleInputGraphs.A_B, "a", "b"), []);
   });
   it("detects self circular (c <-> c)", () => {
-    deepEqual(getCycle(cycleInputGraphs.C_C, "c", "c"), ["c", "c"]);
+    deepEqual(getCycle(cycleInputGraphs.C_C, "c", "c"), ["c"]);
   });
   it("detects 1 step circular (d <-> e)", () => {
     deepEqual(getCycle(cycleInputGraphs.D_E_D, "d", "e"), ["e", "d"]);


### PR DESCRIPTION
## Description

- normalizes name attribute on construction to simplify processing. Before you had to specify whether you'd use _resolved_ (for regular modules) or _name_ (for folders) when invoking any method that needed these (e.g. getCycle).
- refactors the getCycle attribute a bit so it emits the correct output for self-referencing modules
- makes some methods that were meant to be private really private
- renames some things to be a bit closer to default graph theory nomenclature

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
