### PR TITLE
feat(extract): adds "pre-compilation-only" to the dependencyTypes as well, when detected

### DIFF
--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -963,6 +963,7 @@ dependency which resolves to a base url in a tsconfig.json you'll see `import`, 
 | triple-slash-file-reference | with a triple slash directive, specifically importing another module                                                   | `/// <reference path="./ts-thing" />`                                       |
 | triple-slash-type-reference | with a triple slash directive, specifically importing types                                                            | `/// <reference types="./ts-thing-types" />`                                |
 | triple-slash-amd-dependency | with a triple slash directive, specifically declaring an AMD dependency                                                | `/// <amd-dependency path="./ts-thing-types" />`                            |
+| pre-compilation-only        | but the dependency will disappear at runtime. See [preCompilationOnly](#preCompilationOnly)                            | `import { thing } from "./things"` // and continue to not use `thing`       |
 
 ### `dynamic`
 

--- a/src/extract/helpers.mjs
+++ b/src/extract/helpers.mjs
@@ -16,7 +16,13 @@ export function detectPreCompilationNess(pTSDependencies, pJSDependencies) {
   return pTSDependencies.map((pTSDependency) =>
     pJSDependencies.some(dependenciesEqual(pTSDependency))
       ? { ...pTSDependency, preCompilationOnly: false }
-      : { ...pTSDependency, preCompilationOnly: true },
+      : {
+          ...pTSDependency,
+          preCompilationOnly: true,
+          dependencyTypes: (pTSDependency.dependencyTypes || []).concat(
+            "pre-compilation-only",
+          ),
+        },
   );
 }
 

--- a/src/report/dot/default-theme.mjs
+++ b/src/report/dot/default-theme.mjs
@@ -136,7 +136,7 @@ export default {
       attributes: { style: "dashed", penwidth: "1.0" },
     },
     {
-      criteria: { "dependencyTypes[0]": "npm" },
+      criteria: { dependencyTypes: "npm" },
       attributes: { penwidth: "1.0" },
     },
   ],

--- a/src/report/dot/default-theme.mjs
+++ b/src/report/dot/default-theme.mjs
@@ -128,11 +128,18 @@ export default {
       attributes: { arrowhead: "normalnoneodot" },
     },
     {
-      criteria: { preCompilationOnly: true },
+      criteria: {
+        dependencyTypes: [
+          "pre-compilation-only",
+          "triple-slash-type-reference",
+          "type-import",
+          "type-only",
+        ],
+      },
       attributes: { arrowhead: "onormal", penwidth: "1.0" },
     },
     {
-      criteria: { coreModule: true },
+      criteria: { dependencyTypes: "core" },
       attributes: { style: "dashed", penwidth: "1.0" },
     },
     {

--- a/test/extract/get-dependencies.odds-and-ends.spec.mjs
+++ b/test/extract/get-dependencies.odds-and-ends.spec.mjs
@@ -250,7 +250,7 @@ describe("[I] extract/getDependencies - include", () => {
         {
           coreModule: false,
           couldNotResolve: false,
-          dependencyTypes: ["local", "import"],
+          dependencyTypes: ["local", "import", "pre-compilation-only"],
           dynamic: false,
           followable: true,
           exoticallyRequired: false,

--- a/test/extract/helpers-detect-pre-compilation-ness.spec.mjs
+++ b/test/extract/helpers-detect-pre-compilation-ness.spec.mjs
@@ -9,7 +9,14 @@ describe("[U] extract/helpers - detectPreCompilationNess", () => {
   it("deps in the first not in the second get the isPreCompilationOnly attribute", () => {
     deepEqual(
       detectPreCompilationNess([{ module: "foo", moduleSystem: "es6" }], []),
-      [{ module: "foo", moduleSystem: "es6", preCompilationOnly: true }],
+      [
+        {
+          module: "foo",
+          moduleSystem: "es6",
+          preCompilationOnly: true,
+          dependencyTypes: ["pre-compilation-only"],
+        },
+      ],
     );
   });
 

--- a/tools/schema/dependency-type.mjs
+++ b/tools/schema/dependency-type.mjs
@@ -29,6 +29,7 @@ export default {
         "npm-peer",
         "npm-unknown",
         "npm",
+        "pre-compilation-only",
         "require",
         "triple-slash-amd-dependency",
         "triple-slash-directive",

--- a/types/shared-types.d.mts
+++ b/types/shared-types.d.mts
@@ -61,6 +61,7 @@ export type DependencyType =
   | "npm-peer"
   | "npm-unknown"
   | "npm"
+  | "pre-compilation-only"
   | "require"
   | "triple-slash-amd-dependency"
   | "triple-slash-directive"


### PR DESCRIPTION
## Description

- when a dependency classifies as `preCompilationOnly: true` also add `"pre-compilation-only"` to the `dependencyTypes` array for that dependency
- in the default theme of the `dot` reporter 
  - use the `dependencyTypes` array instead of the loose boolean attributes
  - also use the 'thin line' representation for things we can with high likelihood
    classify as pre-compilation only (type-only, type-import, tsd type import)

## Motivation and Context

Consistency with other similar (derived or not) dependency types

## How Has This Been Tested?

- [x] green ci
- [x] updated automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
