### PR TITLE
chore(cache): migrates to watskeburt 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "semver-try-require": "6.2.3",
         "teamcity-service-messages": "0.1.14",
         "tsconfig-paths-webpack-plugin": "4.1.0",
-        "watskeburt": "2.0.5",
+        "watskeburt": "3.0.0",
         "wrap-ansi": "9.0.0"
       },
       "bin": {
@@ -6715,9 +6715,9 @@
       }
     },
     "node_modules/watskeburt": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-2.0.5.tgz",
-      "integrity": "sha512-mCxVT4o/U+nNxmYJ+Oei3qre4F28IBWR9c7RGS8aeAR7a7UY1y4ikTWcv+kaaybf1QXUANmB7XBHawHBcmg+kw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-3.0.0.tgz",
+      "integrity": "sha512-1sGPjgiMgO2zR4LbbP/GYWx7ZyYs3DFYXGa3hlnE0JQZKyS/v4mznJK8eLCIqrRbxKpx04WVKrT2jXZabIglug==",
       "bin": {
         "watskeburt": "dist/run-cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "semver-try-require": "6.2.3",
     "teamcity-service-messages": "0.1.14",
     "tsconfig-paths-webpack-plugin": "4.1.0",
-    "watskeburt": "2.0.5",
+    "watskeburt": "3.0.0",
     "wrap-ansi": "9.0.0"
   },
   "devDependencies": {

--- a/src/cache/metadata-strategy.mjs
+++ b/src/cache/metadata-strategy.mjs
@@ -49,7 +49,7 @@ export default class MetaDataStrategy {
       const lSHA = await lOptions.shaRetrievalFn();
       bus.debug("cache: - getting diff");
       const lDiff = /** @type {import("watskeburt").IChange[]} */ (
-        await lOptions.diffListFn(lSHA)
+        await lOptions.diffListFn({ oldRevision: lSHA })
       );
       const lChanges = lDiff
         .filter(({ name }) => excludeFilter(pCruiseOptions.exclude)(name))


### PR DESCRIPTION
## Description

- migrates to watskeburt 3

## Motivation and Context

Keep up with  the  times

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
