### PR TITLE
fix(init): adds often used suffixes to some of the initial rules

### DIFF
--- a/.dependency-cruiser.json
+++ b/.dependency-cruiser.json
@@ -3,6 +3,37 @@
   "extends": "./configs/recommended-strict",
   "forbidden": [
     {
+      "name": "no-deprecated-core",
+      "comment": "A module depends on a node core module that has been deprecated. Find an alternative - these are bound to exist - node doesn't deprecate lightly.",
+      "severity": "error",
+      "from": {},
+      "to": {
+        "dependencyTypes": ["core"],
+        "path": [
+          "^v8/tools/codemap$",
+          "^v8/tools/consarray$",
+          "^v8/tools/csvparser$",
+          "^v8/tools/logreader$",
+          "^v8/tools/profile_view$",
+          "^v8/tools/profile$",
+          "^v8/tools/SourceMap$",
+          "^v8/tools/splaytree$",
+          "^v8/tools/tickprocessor-driver$",
+          "^v8/tools/tickprocessor$",
+          "^node-inspect/lib/_inspect$",
+          "^node-inspect/lib/internal/inspect_client$",
+          "^node-inspect/lib/internal/inspect_repl$",
+          "^async_hooks$",
+          "^punycode$",
+          "^domain$",
+          "^constants$",
+          "^sys$",
+          "^_linklist$",
+          "^_stream_wrap$"
+        ]
+      }
+    },
+    {
       "name": "not-to-unresolvable",
       "comment": "This module tried to depend on something that can't be resolved to disk. Revise yer code",
       "from": {},
@@ -16,10 +47,10 @@
       "from": {
         "orphan": true,
         "pathNot": [
-          "(^|/)[.][^/]+[.](js|cjs|mjs|ts|json)$",
+          "(^|/)[.][^/]+[.](?:js|cjs|mjs|ts|json)$",
           "[.]d[.]m?ts$",
           "(^|/)tsconfig[.]json$",
-          "(^|/)(babel|webpack)[.]config[.](js|cjs|mjs|ts|json)$",
+          "(^|/)(?:babel|webpack)[.]config[.](?:js|cjs|mjs|ts|json)$",
           "-reporter-plugin[.]mjs$",
           "[.]schema[.]json$",
           "^tools/istanbul-json-summary-to-markdown[.]mjs$",

--- a/configs/rules/no-deprecated-core.cjs
+++ b/configs/rules/no-deprecated-core.cjs
@@ -7,6 +7,6 @@ module.exports = {
   from: {},
   to: {
     dependencyTypes: ["core"],
-    path: "^(punycode|domain|constants|sys|_linklist|_stream_wrap)$",
+    path: "^(?:punycode|domain|constants|sys|_linklist|_stream_wrap)$",
   },
 };

--- a/configs/rules/no-orphans.cjs
+++ b/configs/rules/no-orphans.cjs
@@ -2,7 +2,7 @@ const DOT_FILE_PATTERN = "(^|/)\\.[^/]+\\.(js|cjs|mjs|ts|json)$";
 const TS_DECLARATION_FILE_PATTERN = "\\.d\\.(c|m)?ts$";
 const TS_CONFIG_FILE_PATTERN = "(^|/)tsconfig\\.json$";
 const OTHER_CONFIG_FILES_PATTERN =
-  "(^|/)(babel|webpack)\\.config\\.(js|cjs|mjs|ts|json)$";
+  "(^|/)(?:babel|webpack)\\.config\\.(?:js|cjs|mjs|ts|json)$";
 
 const KNOWN_CONFIG_FILE_PATTERNS = [
   DOT_FILE_PATTERN,

--- a/src/cli/init-config/config-template.mjs
+++ b/src/cli/init-config/config-template.mjs
@@ -25,10 +25,10 @@ module.exports = {
       from: {
         orphan: true,
         pathNot: [
-          '(^|/)[.][^/]+[.](js|cjs|mjs|ts|json)$', // dot files
-          '[.]d[.]ts$',                            // TypeScript declaration files
-          '(^|/)tsconfig[.]json$',                 // TypeScript config
-          '(^|/)(babel|webpack)[.]config[.](js|cjs|mjs|ts|json)$' // other configs
+          '(^|/)[.][^/]+[.](?:js|cjs|mjs|ts|cts|mts|json)$',                  // dot files
+          '[.]d[.]ts$',                                                       // TypeScript declaration files
+          '(^|/)tsconfig[.]json$',                                            // TypeScript config
+          '(^|/)(?:babel|webpack)[.]config[.](?:js|cjs|mjs|ts|cts|mts|json)$' // other configs
         ]
       },
       to: {},
@@ -45,26 +45,26 @@ module.exports = {
           'core'
         ],
         path: [
-          '^(v8\/tools\/codemap)$',
-          '^(v8\/tools\/consarray)$',
-          '^(v8\/tools\/csvparser)$',
-          '^(v8\/tools\/logreader)$',
-          '^(v8\/tools\/profile_view)$',
-          '^(v8\/tools\/profile)$',
-          '^(v8\/tools\/SourceMap)$',
-          '^(v8\/tools\/splaytree)$',
-          '^(v8\/tools\/tickprocessor-driver)$',
-          '^(v8\/tools\/tickprocessor)$',
-          '^(node-inspect\/lib\/_inspect)$',
-          '^(node-inspect\/lib\/internal\/inspect_client)$',
-          '^(node-inspect\/lib\/internal\/inspect_repl)$',
-          '^(async_hooks)$',
-          '^(punycode)$',
-          '^(domain)$',
-          '^(constants)$',
-          '^(sys)$',
-          '^(_linklist)$',
-          '^(_stream_wrap)$'
+          '^v8\/tools\/codemap$',
+          '^v8\/tools\/consarray$',
+          '^v8\/tools\/csvparser$',
+          '^v8\/tools\/logreader$',
+          '^v8\/tools\/profile_view$',
+          '^v8\/tools\/profile$',
+          '^v8\/tools\/SourceMap$',
+          '^v8\/tools\/splaytree$',
+          '^v8\/tools\/tickprocessor-driver$',
+          '^v8\/tools\/tickprocessor$',
+          '^node-inspect\/lib\/_inspect$',
+          '^node-inspect\/lib\/internal\/inspect_client$',
+          '^node-inspect\/lib\/internal\/inspect_repl$',
+          '^async_hooks$',
+          '^punycode$',
+          '^domain$',
+          '^constants$',
+          '^sys$',
+          '^_linklist$',
+          '^_stream_wrap$'
         ],
       }
     },
@@ -136,7 +136,7 @@ module.exports = {
       severity: 'error',
       from: {},
       to: {
-        path: '[.](spec|test)[.](js|mjs|cjs|ts|ls|coffee|litcoffee|coffee[.]md)$'
+        path: '[.](?:spec|test)[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx|ls|coffee|litcoffee|coffee[.]md)$'
       }
     },
     {
@@ -150,7 +150,7 @@ module.exports = {
         'from.pathNot re of the not-to-dev-dep rule in the dependency-cruiser configuration',
       from: {
         path: '{{sourceLocationRE}}',
-        pathNot: '[.](spec|test)[.](js|mjs|cjs|ts|ls|coffee|litcoffee|coffee[.]md)$'
+        pathNot: '[.](?:spec|test)[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx|ls|coffee|litcoffee|coffee[.]md)$'
       },
       to: {
         dependencyTypes: [
@@ -338,7 +338,7 @@ module.exports = {
            collapses everything in node_modules to one folder deep so you see
            the external modules, but not the innards your app depends upon.
          */
-        collapsePattern: 'node_modules/(@[^/]+/[^/]+|[^/]+)',
+        collapsePattern: 'node_modules/(?:@[^/]+/[^/]+|[^/]+)',
 
         /* Options to tweak the appearance of your graph.See
            https://github.com/sverweij/dependency-cruiser/blob/main/doc/options-reference.md#reporteroptions
@@ -362,7 +362,7 @@ module.exports = {
           dependency graph reporter (\`archi\`) you probably want to tweak
           this collapsePattern to your situation.
         */
-        collapsePattern: '^(packages|src|lib|app|bin|test(s?)|spec(s?))/[^/]+|node_modules/(@[^/]+/[^/]+|[^/]+)',
+        collapsePattern: '^(?:packages|src|lib(s?)|app(s?)|bin|test(s?)|spec(s?))/[^/]+|node_modules/(?:@[^/]+/[^/]+|[^/]+)',
 
         /* Options to tweak the appearance of your graph.See
            https://github.com/sverweij/dependency-cruiser/blob/main/doc/options-reference.md#reporteroptions


### PR DESCRIPTION
## Description

- modifications to the rules & configuration `--init` generates by default when setting up dependency-cruiser in a new repository:
  - adds .jsx, .tsx, .mts and .cts extensions to some fo
  - uses _non_-capturing groups in regexes that don't need groups to be capturing
  - remove regex grouping where it isn't needed (either to group expressions or to make a regex more readable)
  - also consider `apps` and `libs` as folders to collapse to for the `archi` reporter config in addition to `app` and `lib` (and other generic folder names like `src` etc).
- apply some of these to dependency-cruiser own .dependency-cruiser.json

## Motivation and Context

- fixes #916 
- making regex groupings non-capturing where they aren't needed for capturing things should make them faster to process (not measured as I don't expect much of an _actual_ difference here).

## How Has This Been Tested?

- [x] green ci
- [x] generate a .dependency-cruiser.js and with that do a self-cruise

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:
  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
