### PR TITLE
refactor(depcruise-baseline|depcruise-fmt): replaces commander with parseArgs from node:util

### DIFF
--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -6,7 +6,8 @@ import cli from "#cli/index.mjs";
 import meta from "#meta.cjs";
 
 const ARGUMENTS_OFFSET = 2;
-const HELP_MESSAGE = `Usage: depcruise-baseline [options] <files-or-directories>
+const HELP_MESSAGE = `
+Usage: depcruise-baseline [options] <files-or-directories>
 
 Writes all known violations of rules in a .dependency-cruiser.js to a file.
 Details: https://github.com/sverweij/dependency-cruiser

--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -1,82 +1,124 @@
 #!/usr/bin/env node
-
-import { program } from "commander";
+import { parseArgs } from "node:util";
+import { EOL } from "node:os";
 import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
 import format from "#cli/format.mjs";
 import meta from "#meta.cjs";
 
-function formatError(pError) {
-  process.stderr.write(pError.message);
-  process.exitCode = 1;
+const ARGUMENTS_OFFSET = 2;
+const HELP_MESSAGE = `Usage: depcruise-fmt [options] <dependency-cruiser-json>
+
+Format dependency-cruiser output json.
+Details: https://github.com/sverweij/dependency-cruiser
+
+Options:
+  -f, --output-to <file>      file to write output to; - for stdout (default:
+                              "-")
+  -T, --output-type <type>    output type; e.g. err, err-html, dot, ddot,
+                              archi, flat, d2, mermaid or json (default: "err")
+  -I, --include-only <regex>  only include modules matching the regex
+  -F, --focus <regex>         only include modules matching the regex + their
+                              direct neighbours
+  --focus-depth <number>      the depth to focus on - only applied when --focus
+                              is passed too. 1= direct neighbors, 2=neighbours
+                              of neighbours etc. (default: 1)
+  -R, --reaches <regex>       only include modules matching the regex + all
+                              modules that can reach it
+  -H, --highlight <regex>     mark modules matching the regex as 'highlighted'
+  -x, --exclude <regex>       exclude all modules matching the regex
+  -S, --collapse <regex>      collapse a to a folder depth by passing a single
+                              digit (e.g. 2). Or pass a regex to collapse to a
+                              pattern E.g. ^packages/[^/]+/ would collapse to
+                              modules/ folders directly under your packages
+                              folder.
+  -P, --prefix <prefix>       prefix to use for links in the dot and err-html
+                              reporters
+  -e, --exit-code             exit with a non-zero exit code when the input
+                              json contains error level dependency violations.
+                              Works for err, err-long and teamcity output types
+  -V, --version               output the version number
+  -h, --help                  display help`;
+
+function formatError(pError, pErrorStream) {
+  pErrorStream.write(`${pError.message}${EOL}`);
 }
 
-try {
-  assertNodeEnvironmentSuitable();
+function normalizeValues(pValues) {
+  const lReturnValue = {
+    ...pValues,
+    outputTo: pValues["output-to"],
+    outputType: pValues["output-type"],
+    focusDepth: Number.parseInt(pValues["focus-depth"], 10),
+  };
+  delete lReturnValue["output-to"];
+  delete lReturnValue["output-type"];
+  delete lReturnValue["focus-depth"];
 
-  program
-    .description(
-      "Format dependency-cruiser output json.\nDetails: https://github.com/sverweij/dependency-cruiser",
-    )
-    .option(
-      "-f, --output-to <file>",
-      "file to write output to; - for stdout",
-      "-",
-    )
-    .option(
-      "-T, --output-type <type>",
-      "output type; e.g. err, err-html, dot, ddot, archi, flat, d2, mermaid or json",
-      "err",
-    )
-    .option(
-      "-I, --include-only <regex>",
-      "only include modules matching the regex",
-    )
-    .option(
-      "-F, --focus <regex>",
-      "only include modules matching the regex + their direct neighbours",
-    )
-    .option(
-      "--focus-depth <number>",
-      "the depth to focus on - only applied when --focus is passed too. " +
-        "1= direct neighbors, 2=neighbours of neighbours etc.",
-      1,
-    )
-    .option(
-      "-R, --reaches <regex>",
-      "only include modules matching the regex + all modules that can reach it",
-    )
-    .option(
-      "-H, --highlight <regex>",
-      "mark modules matching the regex as 'highlighted'",
-    )
-    .option("-x, --exclude <regex>", "exclude all modules matching the regex")
-    .option(
-      "-S, --collapse <regex>",
-      "collapse a to a folder depth by passing a single digit (e.g. 2). Or pass a " +
-        "regex to collapse to a pattern E.g. ^packages/[^/]+/ would collapse to " +
-        "modules/ folders directly under your packages folder. ",
-    )
-    .option(
-      "-P, --prefix <prefix>",
-      "prefix to use for links in the dot and err-html reporters",
-    )
-    .option(
-      "-e, --exit-code",
-      "exit with a non-zero exit code when the input json contains error level " +
-        "dependency violations. Works for err, err-long and teamcity output types",
-    )
-    .version(meta.version)
-    .arguments("<dependency-cruiser-json>")
-    .parse(process.argv);
+  if (pValues["include-only"]) {
+    lReturnValue.includeOnly = pValues["include-only"];
+    delete lReturnValue["include-only"];
+  }
+  if (pValues["exit-code"]) {
+    lReturnValue.exitCode = pValues["exit-code"];
+    delete lReturnValue["exit-code"];
+  }
+  return lReturnValue;
+}
 
-  if (program.args[0]) {
-    const lExitCode = await format(program.args[0], program.opts());
-    if (program.opts().exitCode) {
+function getOptions(pArguments) {
+  return parseArgs({
+    args: pArguments,
+    options: {
+      "output-to": { type: "string", short: "f", default: "-" },
+      "output-type": { type: "string", short: "T", default: "err" },
+      "include-only": { type: "string", short: "I" },
+      focus: { type: "string", short: "F" },
+      "focus-depth": { type: "string", default: "1" },
+      reaches: { type: "string", short: "R" },
+      highlight: { type: "string", short: "H" },
+      exclude: { type: "string", short: "x" },
+      collapse: { type: "string", short: "S" },
+      prefix: { type: "string", short: "P" },
+      "exit-code": { type: "boolean", short: "e" },
+      version: { type: "boolean", short: "V" },
+      help: { type: "boolean", short: "h" },
+    },
+    strict: true,
+    allowPositionals: true,
+    tokens: false,
+  });
+}
+
+export async function commandLineInterface(
+  pArguments = process.argv.slice(ARGUMENTS_OFFSET),
+  pOutStream = process.stdout,
+  pErrorStream = process.stderr,
+  pErrorExitCode = 1,
+) {
+  try {
+    assertNodeEnvironmentSuitable();
+    const { values, positionals } = getOptions(pArguments);
+    const normalizedValues = normalizeValues(values);
+
+    if (normalizedValues.version) {
+      pOutStream.write(`${meta.version}${EOL}`);
+      return;
+    }
+    if (normalizedValues.help || positionals.length === 0) {
+      pOutStream.write(`${HELP_MESSAGE}${EOL}`);
+      return;
+    }
+
+    const lExitCode = await format(positionals[0], normalizedValues);
+    if (normalizedValues.exitCode) {
+      // eslint-disable-next-line require-atomic-updates
       process.exitCode = lExitCode;
     }
-  } else {
-    program.help();
+  } catch (pError) {
+    formatError(pError, pErrorStream);
+    // eslint-disable-next-line require-atomic-updates
+    process.exitCode = pErrorExitCode;
   }
-} catch (pError) {
-  formatError(pError);
 }
+
+await commandLineInterface();

--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -6,7 +6,8 @@ import format from "#cli/format.mjs";
 import meta from "#meta.cjs";
 
 const ARGUMENTS_OFFSET = 2;
-const HELP_MESSAGE = `Usage: depcruise-fmt [options] <dependency-cruiser-json>
+const HELP_MESSAGE = `
+Usage: depcruise-fmt [options] <dependency-cruiser-json>
 
 Format dependency-cruiser output json.
 Details: https://github.com/sverweij/dependency-cruiser


### PR DESCRIPTION
This seems like a neat idea, but especially the dependency-cruise cli uses quite a lot of the functionality in commander (defaults, validation, negation, kebab-to-camel, help formatting), part of which we'd have to re-implement locally, which wouldn't add to the reliability or maintainability of our code.

Hence: closed without merging.


## Description

uses parseArgs instead of commander for
- [x] depcruise-baseline
- [x] depcruise-fmt
- [ ] dependency-cruise

## Motivation and Context

- Reduce dependencies on third party packages & reduce installed footprint.
- Reduces the start-up time with ~10ms (on my admittedly slow machine) because the ~100kb of commander modules don't have to be loaded anymore.

B.t.w. 
- we can only get away with this replacement because dependency-cruiser's command line interface is relatively straightforward (just options & arguments, no sub-commands).
- commander is _still_ an excellent and easy to use command line parser

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
