### PR TITLE
fix(resolve): makes dependency classifier handle more flavours of the 'workspaces' type alias field

### DIFF
--- a/src/extract/resolve/module-classifiers.mjs
+++ b/src/extract/resolve/module-classifiers.mjs
@@ -131,7 +131,10 @@ function isWebPackAliased(pModuleName, pAliasObject) {
 // eslint-disable-next-line max-lines-per-function
 function isWorkspaceAliased(pModuleName, pResolvedModuleName, pManifest) {
   // reference: https://docs.npmjs.com/cli/v10/using-npm/workspaces
-  if (pManifest?.workspaces) {
+  // for pnpm the workspaces field is used for something else and actually
+  // an object. To prevent the code from borking we check whether it's an array
+  // see https://github.com/sverweij/dependency-cruiser/issues/919
+  if (pManifest?.workspaces && Array.isArray(pManifest.workspaces)) {
     // workspaces are an array of globs that match the (sub) workspace
     // folder itself only.
     //

--- a/src/extract/resolve/module-classifiers.mjs
+++ b/src/extract/resolve/module-classifiers.mjs
@@ -122,6 +122,16 @@ function isWebPackAliased(pModuleName, pAliasObject) {
   );
 }
 
+function getWorkspacesArray(pManifestWorkspacesField) {
+  if (Array.isArray(pManifestWorkspacesField)) {
+    return pManifestWorkspacesField;
+  }
+  if (pManifestWorkspacesField?.packages) {
+    return pManifestWorkspacesField.packages;
+  }
+  return [];
+}
+
 /**
  * @param {string} pModuleName
  * @param {string} pResolvedModuleName
@@ -131,10 +141,11 @@ function isWebPackAliased(pModuleName, pAliasObject) {
 // eslint-disable-next-line max-lines-per-function
 function isWorkspaceAliased(pModuleName, pResolvedModuleName, pManifest) {
   // reference: https://docs.npmjs.com/cli/v10/using-npm/workspaces
-  // for pnpm the workspaces field is used for something else and actually
+  // for yarn the workspaces field might be either an array or
   // an object. To prevent the code from borking we check whether it's an array
   // see https://github.com/sverweij/dependency-cruiser/issues/919
-  if (pManifest?.workspaces && Array.isArray(pManifest.workspaces)) {
+  const lWorkspaces = getWorkspacesArray(pManifest?.workspaces);
+  if (lWorkspaces.length >= 0) {
     // workspaces are an array of globs that match the (sub) workspace
     // folder itself only.
     //
@@ -157,9 +168,8 @@ function isWorkspaceAliased(pModuleName, pResolvedModuleName, pManifest) {
     // oh and: ```picomatch.isMatch('asdf', 'asdf/**') === true``` so
     // in case it's only 'asdf' that's in the resolved module name for some reason
     // we're good as well.
-    const lModuleFriendlyWorkspaceGlobs = pManifest.workspaces.map(
-      (pWorkspace) =>
-        pWorkspace.endsWith("/") ? `${pWorkspace}**` : `${pWorkspace}/**`,
+    const lModuleFriendlyWorkspaceGlobs = lWorkspaces.map((pWorkspace) =>
+      pWorkspace.endsWith("/") ? `${pWorkspace}**` : `${pWorkspace}/**`,
     );
     if (picomatch.isMatch(pResolvedModuleName, lModuleFriendlyWorkspaceGlobs)) {
       return true;

--- a/test/extract/resolve/module-classifiers.get-alias-types.spec.mjs
+++ b/test/extract/resolve/module-classifiers.get-alias-types.spec.mjs
@@ -219,6 +219,33 @@ describe("[I] extract/resolve/module-classifiers - getAliasTypes", () => {
     );
   });
 
+  it("ignores workspaces in package.json if it's not an array", () => {
+    const lManifest = {
+      name: "test",
+      version: "1.0.0",
+      dependencies: {},
+      workspaces: {
+        // apparently in use in pnpm for #things
+        nohoist: ["packages/", "foo", "bar"],
+      },
+    };
+    const lResolveOptions = {
+      baseDirectory: "over/the/rainbow",
+      alias: {
+        "@": "./src",
+      },
+    };
+    deepEqual(
+      getAliasTypes(
+        "some-workspaced-local-package",
+        "packages/a-package/index.js",
+        lResolveOptions,
+        lManifest,
+      ),
+      [],
+    );
+  });
+
   it("doesn't run aliased and aliased-workspace for when resolved matches a workspace, but module requested is relative", () => {
     const lManifest = {
       name: "test",

--- a/test/extract/resolve/module-classifiers.get-alias-types.spec.mjs
+++ b/test/extract/resolve/module-classifiers.get-alias-types.spec.mjs
@@ -219,13 +219,13 @@ describe("[I] extract/resolve/module-classifiers - getAliasTypes", () => {
     );
   });
 
-  it("ignores workspaces in package.json if it's not an array", () => {
+  it("ignores workspaces in package.json if it's not an array and the object doesn't contain a packages field", () => {
     const lManifest = {
       name: "test",
       version: "1.0.0",
       dependencies: {},
       workspaces: {
-        // apparently in use in pnpm for #things
+        // yarn(1) specific
         nohoist: ["packages/", "foo", "bar"],
       },
     };
@@ -243,6 +243,34 @@ describe("[I] extract/resolve/module-classifiers - getAliasTypes", () => {
         lManifest,
       ),
       [],
+    );
+  });
+
+  it("returns aliased and aliased-workspace for workspace alias (for yarn 1 workspaces.packages)", () => {
+    const lManifest = {
+      name: "test",
+      version: "1.0.0",
+      dependencies: {},
+      workspaces: {
+        // yarn(1) specific notation
+        packages: ["packages/"],
+        nohoist: ["foo", "bar"],
+      },
+    };
+    const lResolveOptions = {
+      baseDirectory: "over/the/rainbow",
+      alias: {
+        "@": "./src",
+      },
+    };
+    deepEqual(
+      getAliasTypes(
+        "some-workspaced-local-package",
+        "packages/a-package/index.js",
+        lResolveOptions,
+        lManifest,
+      ),
+      ["aliased", "aliased-workspace"],
     );
   });
 


### PR DESCRIPTION
## Description

- ignores 'workspaces' field when it isn't an array _and_  it doesn't contain a yarn1 workspaces.packages field
- also classifies dependencies resolving via yarn1 workspaces.packages fields  as _aliased_, _aliased-workspace_

## Motivation and Context

fixes #919 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression test

Note: a version with this fix has been published as `dependency-cruiser@16.2.4-beta-1` - once the PR is merged it'll be part of dependency-cruiser@16.2.4.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
