### PR TITLE
refactor: replaces lodash/memoize with memoize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "is-installed-globally": "1.0.0",
         "json5": "2.2.3",
         "lodash": "4.17.21",
+        "memoize": "10.0.0",
         "picomatch": "4.0.1",
         "prompts": "2.4.2",
         "rechoir": "^0.8.0",
@@ -4640,6 +4641,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.0.0.tgz",
+      "integrity": "sha512-H6cBLgsi6vMWOcCpvVCdFFnl3kerEXbrYh9q+lY6VXvQSmM6CkmV08VOwT+WE2tzIEqRPFfAq3fm4v/UIW6mSA==",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "dev": true,
@@ -4698,6 +4713,17 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "is-installed-globally": "1.0.0",
     "json5": "2.2.3",
     "lodash": "4.17.21",
+    "memoize": "10.0.0",
     "picomatch": "4.0.1",
     "prompts": "2.4.2",
     "rechoir": "^0.8.0",

--- a/src/cache/helpers.mjs
+++ b/src/cache/helpers.mjs
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { extname } from "node:path";
-import memoize from "lodash/memoize.js";
+import memoize from "memoize";
 // @ts-expect-error ts(2307) - the ts compiler is not privy to the existence of #imports in package.json
 import { filenameMatchesPattern } from "#graph-utl/match-facade.mjs";
 

--- a/src/extract/parse/to-javascript-ast.mjs
+++ b/src/extract/parse/to-javascript-ast.mjs
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { Parser as acornParser, parse as acornParse } from "acorn";
 import { parse as acornLooseParse } from "acorn-loose";
 import acornJsx from "acorn-jsx";
-import memoize from "lodash/memoize.js";
+import memoize, { memoizeClear } from "memoize";
 import transpile from "../transpile/index.mjs";
 import getExtension from "#utl/get-extension.mjs";
 
@@ -82,13 +82,15 @@ function getAST(pFileName, pTranspileOptions) {
  * @param {any} pTranspileOptions - options for the transpiler(s) - typically a tsconfig or a babel config
  * @return {acorn.Node} - a (javascript) AST
  */
-export const getASTCached = memoize(
-  getAST,
-  (pFileName, pTranspileOptions) => `${pFileName}|${pTranspileOptions}`,
-);
+// taking the transpile options into account of the memoize cache key seems like
+// a good idea. However, previously we use `${pTranspileOptions}` which always
+// serializes to [object Object], which doesn't help. So for now we're not
+// taking the transpile options into account. If we ever need to, it'll be
+// a JSON.stringify away (which _will_ be significantly slower)
+export const getASTCached = memoize(getAST);
 
 export function clearCache() {
-  getASTCached.cache.clear();
+  memoizeClear(getASTCached);
 }
 
 export default {

--- a/src/extract/parse/to-swc-ast.mjs
+++ b/src/extract/parse/to-swc-ast.mjs
@@ -1,5 +1,5 @@
 import tryImport from "semver-try-require";
-import memoize from "lodash/memoize.js";
+import memoize, { memoizeClear } from "memoize";
 import meta from "#meta.cjs";
 
 /** @type {import('@swc/core')} */
@@ -29,7 +29,7 @@ function getAST(pFileName) {
 export const getASTCached = memoize(getAST);
 
 export function clearCache() {
-  getASTCached.cache.clear();
+  memoizeClear(getASTCached);
 }
 
 export default {

--- a/src/extract/parse/to-typescript-ast.mjs
+++ b/src/extract/parse/to-typescript-ast.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import tryImport from "semver-try-require";
-import memoize from "lodash/memoize.js";
+import memoize, { memoizeClear } from "memoize";
 import transpile from "../transpile/index.mjs";
 import meta from "#meta.cjs";
 import getExtension from "#utl/get-extension.mjs";
@@ -56,7 +56,7 @@ function getAST(pFileName, pTranspileOptions) {
 export const getASTCached = memoize(getAST);
 
 export function clearCache() {
-  getASTCached.cache.clear();
+  memoizeClear(getASTCached);
 }
 
 export default {

--- a/src/extract/resolve/resolve-amd.mjs
+++ b/src/extract/resolve/resolve-amd.mjs
@@ -1,6 +1,6 @@
 import { accessSync, R_OK } from "node:fs";
 import { relative, join } from "node:path";
-import memoize from "lodash/memoize.js";
+import memoize, { memoizeClear } from "memoize";
 import { isBuiltin } from "./is-built-in.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 
@@ -63,5 +63,5 @@ export function resolveAMD(
 }
 
 export function clearCache() {
-  fileExists.cache.clear();
+  memoizeClear(fileExists);
 }

--- a/src/report/anon/anonymize-path-element.mjs
+++ b/src/report/anon/anonymize-path-element.mjs
@@ -1,4 +1,4 @@
-import memoize from "lodash/memoize.js";
+import memoize, { memoizeClear } from "memoize";
 import randomString from "./random-string.mjs";
 
 function replace(pElement, pIndex, pWordList) {
@@ -13,7 +13,7 @@ function replaceFromWordList(pPathElement, pWordList, pCached) {
     .map((pElement, pIndex) =>
       pCached
         ? replaceCached(pElement, pIndex, pWordList)
-        : replace(pElement, pIndex, pWordList)
+        : replace(pElement, pIndex, pWordList),
     )
     .join(".");
 }
@@ -49,7 +49,7 @@ export function anonymizePathElement(
   pPathElement,
   pWordList = [],
   pWhiteListRE = /^$/g,
-  pCached = true
+  pCached = true,
 ) {
   return pWhiteListRE.test(pPathElement)
     ? pPathElement
@@ -63,5 +63,5 @@ export function anonymizePathElement(
  * @returns {void}
  */
 export function clearCache() {
-  replaceCached.cache.clear();
+  memoizeClear(replaceCached);
 }


### PR DESCRIPTION
## Description

- replaces `lodash/memoize` with `memoize`

## Motivation and Context

We should slowly be starting to replace lodash functions everywhere as lodash isn't really maintained anymore. Additionally `lodash/memoize` isn't the fastest memoization function around, it looks like. 

The chosen alternative (`memoize`, formerly known as `mem`) isn't the fastest either, but
- seems to be reliably maintained
- has recent updates
- is decently fast (see benchmarks below)
- is not too large (& doesn't ship unnecessary stuff to npm like tests, sources, bundles, benchmarks, ...)
- performs decently and reliably
- takes a custom resolver function (which it calls 'cacheKey'), which is a thing we regrettably need.

Other candidates either have fallen out of maintenance (e.g. 10y without updates, ...), or miss features we need.

<details>
<summary>Speed benchmarks adopted from `memize` (who adopted from them in turn from `moize`):</summary>

- run on MacOS 12.7.4 on an 2,6Ghz Quad-Core Intel Core i7 with 16Gb RAM
- See https://github.com/aduth/memize/tree/master/benchmark for details
- The benchmark this ran was (1) adapted to run as ESM (2) adds lodash/memoize


#### Single parameter

```text
┌────────────────────┬─────────────┬──────────────────────────┬─────────────┐
│ Name               │ Ops / sec   │ Relative margin of error │ Sample size │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ fast-memoize       │ 127,482,919 │ ± 0.28%                  │ 94          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ moize              │ 101,448,279 │ ± 0.16%                  │ 94          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ memoize            │ 89,864,460  │ ± 0.15%                  │ 96          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ memize             │ 75,527,611  │ ± 1.16%                  │ 93          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ lodash             │ 50,176,290  │ ± 0.24%                  │ 95          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ ramda              │ 48,060,225  │ ± 0.54%                  │ 94          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ underscore         │ 30,460,634  │ ± 0.42%                  │ 93          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ memoizee           │ 18,648,393  │ ± 0.51%                  │ 93          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ moize (serialized) │ 16,516,070  │ ± 0.25%                  │ 92          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ memoizerific       │ 9,432,079   │ ± 0.97%                  │ 92          │
├────────────────────┼─────────────┼──────────────────────────┼─────────────┤
│ memoizejs          │ 1,610,735   │ ± 0.28%                  │ 94          │
└────────────────────┴─────────────┴──────────────────────────┴─────────────┘
```
#### Multiple parameters, only primitives
```text
┌────────────────────┬────────────┬──────────────────────────┬─────────────┐
│ Name               │ Ops / sec  │ Relative margin of error │ Sample size │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ moize              │ 32,944,874 │ ± 3.55%                  │ 79          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memize             │ 32,530,910 │ ± 2.19%                  │ 65          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoizee           │ 11,358,939 │ ± 2.89%                  │ 90          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoize            │ 9,380,007  │ ± 1.55%                  │ 88          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ moize (serialized) │ 8,536,549  │ ± 0.47%                  │ 90          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoizerific       │ 5,622,282  │ ± 1.19%                  │ 91          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ lodash             │ 5,393,388  │ ± 0.73%                  │ 92          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoizejs          │ 1,101,890  │ ± 1.10%                  │ 92          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ fast-memoize       │ 929,638    │ ± 0.22%                  │ 95          │
└────────────────────┴────────────┴──────────────────────────┴─────────────┘
```

#### Multiple parameters, some parameters contain objects

```plaintext
┌────────────────────┬────────────┬──────────────────────────┬─────────────┐
│ Name               │ Ops / sec  │ Relative margin of error │ Sample size │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memize             │ 30,529,321 │ ± 0.97%                  │ 89          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ moize              │ 28,842,916 │ ± 0.77%                  │ 91          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoizee           │ 10,445,895 │ ± 1.02%                  │ 92          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoize            │ 9,349,388  │ ± 0.50%                  │ 93          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoizerific       │ 6,107,483  │ ± 1.29%                  │ 92          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ lodash             │ 5,029,315  │ ± 0.36%                  │ 92          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ memoizejs          │ 808,879    │ ± 2.71%                  │ 94          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ moize (serialized) │ 796,306    │ ± 1.73%                  │ 88          │
├────────────────────┼────────────┼──────────────────────────┼─────────────┤
│ fast-memoize       │ 650,625    │ ± 3.18%                  │ 88          │
└────────────────────┴────────────┴──────────────────────────┴─────────────┘
```


</details>





## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
