### PR TITLE
refactor: replaces lodash/has & lodash/get with native options where possible

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,7 +1,7 @@
 {
   "checkCoverage": true,
   "statements": 99.89,
-  "branches": 98.86,
+  "branches": 98.41,
   "functions": 100,
   "lines": 99.89,
   "exclude": [

--- a/src/cli/init-config/environment-helpers.mjs
+++ b/src/cli/init-config/environment-helpers.mjs
@@ -1,7 +1,5 @@
-// @ts-check
 import { readFileSync, readdirSync, accessSync, statSync, R_OK } from "node:fs";
 import { join } from "node:path";
-import has from "lodash/has.js";
 import { DEFAULT_CONFIG_FILE_NAME } from "../defaults.mjs";
 
 const LIKELY_SOURCE_FOLDERS = ["src", "lib", "app", "bin", "sources"];
@@ -47,7 +45,8 @@ function babelIsConfiguredInManifest() {
   let lReturnValue = false;
 
   try {
-    lReturnValue = has(readManifest(), "babel");
+    // @ts-expect-error defaultly tsc doesn't know about newfangled stuff like hasOwn
+    lReturnValue = Object.hasOwn(readManifest(), "babel");
   } catch (pError) {
     // silently ignore - we'll return false anyway then
   }
@@ -75,7 +74,7 @@ export function isTypeModule() {
  */
 function getFolderNames(pFolderName) {
   return readdirSync(pFolderName, "utf8").filter((pFileName) =>
-    statSync(join(pFolderName, pFileName)).isDirectory()
+    statSync(join(pFolderName, pFileName)).isDirectory(),
   );
 }
 
@@ -88,7 +87,7 @@ function getMatchingFileNames(pPattern, pFolderName = process.cwd()) {
   return readdirSync(pFolderName, "utf8").filter(
     (pFileName) =>
       statSync(join(pFolderName, pFileName)).isFile() &&
-      pFileName.match(pPattern)
+      pFileName.match(pPattern),
   );
 }
 
@@ -102,14 +101,14 @@ export function isLikelyMonoRepo(pFolderNames = getFolderNames(process.cwd())) {
 
 export function hasTestsWithinSource(pTestLocations, pSourceLocations) {
   return pTestLocations.every((pTestLocation) =>
-    pSourceLocations.includes(pTestLocation)
+    pSourceLocations.includes(pTestLocation),
   );
 }
 
 export function getFolderCandidates(pCandidateFolderArray) {
   return (pFolderNames = getFolderNames(process.cwd())) => {
     return pFolderNames.filter((pFolderName) =>
-      pCandidateFolderArray.includes(pFolderName)
+      pCandidateFolderArray.includes(pFolderName),
     );
   };
 }
@@ -134,7 +133,7 @@ function getManifestFilesWithABabelConfig() {
 
 export const getBabelConfigCandidates = () =>
   getManifestFilesWithABabelConfig().concat(
-    getMatchingFileNames(BABEL_CONFIG_CANDIDATE_PATTERN)
+    getMatchingFileNames(BABEL_CONFIG_CANDIDATE_PATTERN),
   );
 export const hasBabelConfigCandidates = () =>
   getBabelConfigCandidates().length > 0;
@@ -154,12 +153,12 @@ export const hasWebpackConfigCandidates = () =>
   getWebpackConfigCandidates().length > 0;
 
 export const getSourceFolderCandidates = getFolderCandidates(
-  LIKELY_SOURCE_FOLDERS
+  LIKELY_SOURCE_FOLDERS,
 );
 export const getTestFolderCandidates = getFolderCandidates(LIKELY_TEST_FOLDERS);
 
 export const getMonoRepoPackagesCandidates = getFolderCandidates(
-  LIKELY_PACKAGES_FOLDERS
+  LIKELY_PACKAGES_FOLDERS,
 );
 
 /**

--- a/src/cli/init-config/normalize-init-options.mjs
+++ b/src/cli/init-config/normalize-init-options.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import {
   getSourceFolderCandidates,
   getTestFolderCandidates,
@@ -72,7 +71,7 @@ function populate(pInitOptions) {
  */
 export default function normalizeInitOptions(pInitOptions) {
   let lReturnValue = populate(pInitOptions);
-  if (!has(lReturnValue, "hasTestsOutsideSource")) {
+  if (!Object.hasOwn(lReturnValue, "hasTestsOutsideSource")) {
     lReturnValue.hasTestsOutsideSource =
       !pInitOptions.isMonoRepo &&
       !hasTestsWithinSource(

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -1,8 +1,6 @@
 import { accessSync, R_OK } from "node:fs";
 import { isAbsolute } from "node:path";
 import set from "lodash/set.js";
-import get from "lodash/get.js";
-import has from "lodash/has.js";
 import {
   RULES_FILE_NAME_SEARCH_ARRAY,
   DEFAULT_BASELINE_FILE_NAME,
@@ -22,7 +20,7 @@ function getOptionValue(pDefault) {
 function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
   let lOptions = structuredClone(pCliOptions);
 
-  if (has(lOptions, pConfigWrapperName)) {
+  if (Object.hasOwn(lOptions, pConfigWrapperName)) {
     set(
       lOptions,
       `ruleSet.options.${pConfigWrapperName}.fileName`,
@@ -33,8 +31,8 @@ function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
   }
 
   if (
-    get(lOptions, `ruleSet.options.${pConfigWrapperName}`, null) &&
-    !get(lOptions, `ruleSet.options.${pConfigWrapperName}.fileName`, null)
+    (lOptions?.ruleSet?.options?.[pConfigWrapperName] ?? null) &&
+    !(lOptions?.ruleSet?.options?.[pConfigWrapperName]?.fileName ?? null)
   ) {
     set(lOptions, `ruleSet.options.${pConfigWrapperName}.fileName`, pDefault);
   }
@@ -108,7 +106,10 @@ function validateAndGetKnownViolationsFileName(pKnownViolations) {
 }
 
 function normalizeKnownViolationsOption(pCliOptions) {
-  if (!has(pCliOptions, "ignoreKnown") || pCliOptions.ignoreKnown === false) {
+  if (
+    !Object.hasOwn(pCliOptions, "ignoreKnown") ||
+    pCliOptions.ignoreKnown === false
+  ) {
     return {};
   }
   return {
@@ -135,7 +136,7 @@ async function normalizeValidationOption(pCliOptions) {
 }
 
 function normalizeProgress(pCliOptions) {
-  if (!has(pCliOptions, "progress")) {
+  if (!Object.hasOwn(pCliOptions, "progress")) {
     return {};
   }
 
@@ -147,7 +148,7 @@ function normalizeProgress(pCliOptions) {
 }
 
 function normalizeCacheStrategy(pCliOptions) {
-  if (!has(pCliOptions, "cacheStrategy")) {
+  if (!Object.hasOwn(pCliOptions, "cacheStrategy")) {
     return {};
   }
   const lStrategy =
@@ -169,7 +170,7 @@ function normalizeCacheStrategy(pCliOptions) {
 }
 
 function normalizeCache(pCliOptions) {
-  if (!has(pCliOptions, "cache")) {
+  if (!Object.hasOwn(pCliOptions, "cache")) {
     return {};
   }
 
@@ -203,13 +204,13 @@ export default async function normalizeOptions(pOptionsAsPassedFromCommander) {
     ...pOptionsAsPassedFromCommander,
   };
 
-  if (has(lOptions, "moduleSystems")) {
+  if (Object.hasOwn(lOptions, "moduleSystems")) {
     lOptions.moduleSystems = lOptions.moduleSystems
       .split(",")
       .map((pString) => pString.trim());
   }
 
-  if (has(lOptions, "config")) {
+  if (Object.hasOwn(lOptions, "config")) {
     lOptions.validate = lOptions.config;
   }
 

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -1,5 +1,4 @@
 import { dirname } from "node:path";
-import has from "lodash/has.js";
 import readConfig from "./read-config.mjs";
 import mergeConfigs from "./merge-configs.mjs";
 import normalizeResolveOptions from "#main/resolve-options/normalize.mjs";
@@ -80,7 +79,7 @@ export default async function extractDepcruiseConfig(
 
   let lReturnValue = await readConfig(lResolvedFileName);
 
-  if (has(lReturnValue, "extends")) {
+  if (lReturnValue?.extends) {
     lReturnValue = await processExtends(
       lReturnValue,
       pAlreadyVisited,

--- a/src/enrich/derive/reachable.mjs
+++ b/src/enrich/derive/reachable.mjs
@@ -1,14 +1,15 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
-import has from "lodash/has.js";
 import matchers from "#validate/matchers.mjs";
 import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
 
 function getReachableRules(pRuleSet) {
   return (pRuleSet?.forbidden ?? [])
-    .filter((pRule) => has(pRule.to, "reachable"))
+    .filter((pRule) => Object.hasOwn(pRule?.to ?? {}, "reachable"))
     .concat(
-      (pRuleSet?.allowed ?? []).filter((pRule) => has(pRule.to, "reachable")),
+      (pRuleSet?.allowed ?? []).filter((pRule) =>
+        Object.hasOwn(pRule?.to ?? {}, "reachable"),
+      ),
     );
 }
 

--- a/src/enrich/summarize/summarize-folders.mjs
+++ b/src/enrich/summarize/summarize-folders.mjs
@@ -1,12 +1,11 @@
-import has from "lodash/has.js";
 import { findRuleByName } from "#graph-utl/rule-set.mjs";
 
 function classifyViolation(pRule, pRuleSet) {
   const lRule = findRuleByName(pRuleSet, pRule.name);
-  if (has(lRule, "to.moreUnstable")) {
+  if (Object.hasOwn(lRule?.to ?? {}, "moreUnstable")) {
     return "instability";
   }
-  if (has(lRule, "to.circular")) {
+  if (Object.hasOwn(lRule?.to ?? {}, "circular")) {
     return "cycle";
   }
   return "folder";

--- a/src/enrich/summarize/summarize-modules.mjs
+++ b/src/enrich/summarize/summarize-modules.mjs
@@ -1,5 +1,4 @@
 import flattenDeep from "lodash/flattenDeep.js";
-import has from "lodash/has.js";
 import uniqWith from "lodash/uniqWith.js";
 import isSameViolation from "./is-same-violation.mjs";
 import { findRuleByName } from "#graph-utl/rule-set.mjs";
@@ -14,6 +13,7 @@ function cutNonTransgressions(pModule) {
   };
 }
 
+// eslint-disable-next-line complexity
 function toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet) {
   let lReturnValue = {
     type: "dependency",
@@ -23,7 +23,7 @@ function toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet) {
   };
 
   if (
-    has(pDependency, "cycle") &&
+    Object.hasOwn(pDependency, "cycle") &&
     findRuleByName(pRuleSet, pRule.name)?.to?.circular
   ) {
     lReturnValue = {
@@ -34,9 +34,12 @@ function toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet) {
   }
 
   if (
-    has(pModule, "instability") &&
-    has(pDependency, "instability") &&
-    has(findRuleByName(pRuleSet, pRule.name), "to.moreUnstable")
+    Object.hasOwn(pModule, "instability") &&
+    Object.hasOwn(pDependency, "instability") &&
+    Object.hasOwn(
+      findRuleByName(pRuleSet, pRule.name)?.to ?? {},
+      "moreUnstable",
+    )
   ) {
     lReturnValue = {
       ...lReturnValue,

--- a/src/enrich/summarize/summarize-options.mjs
+++ b/src/enrich/summarize/summarize-options.mjs
@@ -1,5 +1,3 @@
-import has from "lodash/has.js";
-
 const SHAREABLE_OPTIONS = [
   "babelConfig",
   "baseDir",
@@ -35,22 +33,23 @@ const SHAREABLE_OPTIONS = [
 function makeOptionsPresentable(pOptions) {
   return SHAREABLE_OPTIONS.filter(
     (pShareableOptionKey) =>
-      has(pOptions, pShareableOptionKey) && pOptions[pShareableOptionKey] !== 0
+      Object.hasOwn(pOptions, pShareableOptionKey) &&
+      pOptions?.[pShareableOptionKey] !== 0,
   )
     .filter(
       (pShareableOptionKey) =>
         pShareableOptionKey !== "doNotFollow" ||
-        Object.keys(pOptions.doNotFollow).length > 0
+        Object.keys(pOptions.doNotFollow).length > 0,
     )
     .filter(
       (pShareableOptionKey) =>
         pShareableOptionKey !== "exclude" ||
-        Object.keys(pOptions.exclude).length > 0
+        Object.keys(pOptions.exclude).length > 0,
     )
     .filter(
       (pShareableOptionKey) =>
         pShareableOptionKey !== "knownViolations" ||
-        pOptions.knownViolations.length > 0
+        pOptions.knownViolations.length > 0,
     )
     .reduce((pAll, pShareableOptionKey) => {
       pAll[pShareableOptionKey] = pOptions[pShareableOptionKey];

--- a/src/extract/index.mjs
+++ b/src/extract/index.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import getDependencies from "./get-dependencies.mjs";
 import gatherInitialSources from "./gather-initial-sources.mjs";
 import clearCaches from "./clear-caches.mjs";
@@ -123,7 +122,7 @@ function filterExcludedDynamicDependencies(pModule, pExclude) {
     ...pModule,
     dependencies: pModule.dependencies.filter(
       ({ dynamic }) =>
-        !has(pExclude, "dynamic") || pExclude.dynamic !== dynamic,
+        !Object.hasOwn(pExclude, "dynamic") || pExclude.dynamic !== dynamic,
     ),
   };
 }

--- a/src/extract/resolve/determine-dependency-types.mjs
+++ b/src/extract/resolve/determine-dependency-types.mjs
@@ -1,5 +1,4 @@
 import { join } from "node:path/posix";
-import has from "lodash/has.js";
 import {
   isRelativeModuleName,
   isExternalModule,
@@ -17,7 +16,7 @@ function dependencyKeyHasModuleName(
 ) {
   return (pKey) =>
     pKey.includes("ependencies") &&
-    has(pPackageDependencies[pKey], join(pPrefix, pModuleName));
+    Object.hasOwn(pPackageDependencies[pKey], join(pPrefix, pModuleName));
 }
 
 const NPM2DEP_TYPE = new Map([

--- a/src/extract/resolve/external-module-helpers.mjs
+++ b/src/extract/resolve/external-module-helpers.mjs
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import memoize, { memoizeClear } from "memoize";
-import has from "lodash/has.js";
 import { resolve } from "./resolve.mjs";
 import { isScoped, isRelativeModuleName } from "./module-classifiers.mjs";
 
@@ -131,7 +130,8 @@ export function dependencyIsDeprecated(
   );
 
   if (Boolean(lPackageJson)) {
-    lReturnValue = has(lPackageJson, "deprecated") && lPackageJson.deprecated;
+    lReturnValue =
+      Object.hasOwn(lPackageJson, "deprecated") && lPackageJson.deprecated;
   }
   return lReturnValue;
 }
@@ -155,7 +155,7 @@ export function getLicense(pModuleName, pFileDirectory, pResolveOptions) {
 
   if (
     Boolean(lPackageJson) &&
-    has(lPackageJson, "license") &&
+    Object.hasOwn(lPackageJson, "license") &&
     typeof lPackageJson.license === "string"
   ) {
     lReturnValue = lPackageJson.license;

--- a/src/graph-utl/add-focus.mjs
+++ b/src/graph-utl/add-focus.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import IndexedModuleGraph from "./indexed-module-graph.mjs";
 import { moduleMatchesFilter } from "./match-facade.mjs";
 
@@ -17,7 +16,7 @@ function scrub(pModuleNamesSet) {
   return (pModule) => ({
     ...pModule,
     dependencies: pModule.dependencies.filter(({ resolved }) =>
-      pModuleNamesSet.has(resolved)
+      pModuleNamesSet.has(resolved),
     ),
   });
 }
@@ -29,10 +28,10 @@ function scrub(pModuleNamesSet) {
  * @returns
  */
 export default function addFocus(pModules, pFilter) {
-  if (has(pFilter, "path")) {
+  if (pFilter?.path) {
     const lDepth = typeof pFilter.depth === "undefined" ? 1 : pFilter.depth;
     const lFocusedModuleNames = getFocusModules(pModules, pFilter).map(
-      ({ source }) => source
+      ({ source }) => source,
     );
     let lReachableModuleNamesArray = [];
     let lIndexedModules = new IndexedModuleGraph(pModules);
@@ -40,10 +39,10 @@ export default function addFocus(pModules, pFilter) {
     for (let lFocusedModule of lFocusedModuleNames) {
       lReachableModuleNamesArray = lReachableModuleNamesArray
         .concat(
-          lIndexedModules.findTransitiveDependents(lFocusedModule, lDepth)
+          lIndexedModules.findTransitiveDependents(lFocusedModule, lDepth),
         )
         .concat(
-          lIndexedModules.findTransitiveDependencies(lFocusedModule, lDepth)
+          lIndexedModules.findTransitiveDependencies(lFocusedModule, lDepth),
         );
     }
 

--- a/src/graph-utl/rule-set.mjs
+++ b/src/graph-utl/rule-set.mjs
@@ -1,5 +1,3 @@
-import has from "lodash/has.js";
-
 /**
  * Finds the first rule in the rule set that has name pName,
  * and undefined if no such rule exists/ the rule is an 'allowed'
@@ -13,7 +11,14 @@ import has from "lodash/has.js";
  */
 export function findRuleByName(pRuleSet, pName) {
   return (pRuleSet?.forbidden ?? []).find(
-    (pForbiddenRule) => pForbiddenRule.name === pName
+    (pForbiddenRule) => pForbiddenRule.name === pName,
+  );
+}
+
+function ruleHasALicenseLikeAttribute(pRule) {
+  return (
+    Object.hasOwn(pRule?.to ?? {}, "license") ||
+    Object.hasOwn(pRule?.to ?? {}, "licenseNot")
   );
 }
 
@@ -28,12 +33,8 @@ export function findRuleByName(pRuleSet, pName) {
  */
 export function ruleSetHasLicenseRule(pRuleSet) {
   return (
-    (pRuleSet?.forbidden ?? []).some(
-      (pRule) => has(pRule, "to.license") || has(pRule, "to.licenseNot")
-    ) ||
-    (pRuleSet?.allowed ?? []).some(
-      (pRule) => has(pRule, "to.license") || has(pRule, "to.licenseNot")
-    )
+    (pRuleSet?.forbidden ?? []).some(ruleHasALicenseLikeAttribute) ||
+    (pRuleSet?.allowed ?? []).some(ruleHasALicenseLikeAttribute)
   );
 }
 /**
@@ -44,10 +45,10 @@ export function ruleSetHasLicenseRule(pRuleSet) {
 export function ruleSetHasDeprecationRule(pRuleSet) {
   return (
     (pRuleSet?.forbidden ?? []).some((pRule) =>
-      (pRule?.to?.dependencyTypes ?? []).includes("deprecated")
+      (pRule?.to?.dependencyTypes ?? []).includes("deprecated"),
     ) ||
     (pRuleSet?.allowed ?? []).some((pRule) =>
-      (pRule?.to?.dependencyTypes ?? []).includes("deprecated")
+      (pRule?.to?.dependencyTypes ?? []).includes("deprecated"),
     )
   );
 }

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -19,9 +19,10 @@ export default async function cruise(
   pTranspileOptions,
 ) {
   bus.summary("parsing options", c(1));
+  const lCruiseOptionsValid = assertCruiseOptionsValid(pCruiseOptions);
   /** @type {import("../../types/strict-options.js").IStrictCruiseOptions} */
   let lCruiseOptions = normalizeCruiseOptions(
-    assertCruiseOptionsValid(pCruiseOptions),
+    lCruiseOptionsValid,
     pFileAndDirectoryArray,
   );
   let lCache = null;

--- a/src/main/helpers.mjs
+++ b/src/main/helpers.mjs
@@ -30,10 +30,13 @@ export function normalizeREProperties(
   let lPropertyContainer = structuredClone(pPropertyContainer);
 
   for (const lProperty of pREProperties) {
+    // lProperty can be nested properties, so we use lodash.has and lodash.get
+    // instead of elvis operators
     if (has(lPropertyContainer, lProperty)) {
       set(
         lPropertyContainer,
         lProperty,
+
         normalizeToREAsString(get(lPropertyContainer, lProperty)),
       );
     }

--- a/src/main/options/assert-validity.mjs
+++ b/src/main/options/assert-validity.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import merge from "lodash/merge.js";
 import safeRegex from "safe-regex";
 import report from "#report/index.mjs";
@@ -100,7 +99,7 @@ export function assertCruiseOptionsValid(pOptions) {
 
     assertFocusDepthValid(pOptions.focusDepth);
 
-    if (has(pOptions, "ruleSet.options")) {
+    if (pOptions?.ruleSet?.options) {
       lReturnValue = assertCruiseOptionsValid(pOptions.ruleSet.options);
     }
     return merge({}, lReturnValue, pOptions);

--- a/src/main/options/normalize.mjs
+++ b/src/main/options/normalize.mjs
@@ -1,5 +1,4 @@
 /* eslint-disable security/detect-object-injection */
-import has from "lodash/has.js";
 import { normalizeREProperties } from "../helpers.mjs";
 import defaults from "./defaults.mjs";
 
@@ -71,8 +70,8 @@ function normalizeCollapse(pCollapse) {
 function normalizeFocusDepth(pFormatOptions) {
   /** @type  {import("../../../types/dependency-cruiser.js").IFormatOptions}*/
   let lFormatOptions = structuredClone(pFormatOptions);
-  if (has(lFormatOptions, "focusDepth")) {
-    if (has(lFormatOptions, "focus")) {
+  if (Object.hasOwn(lFormatOptions, "focusDepth")) {
+    if (lFormatOptions?.focus) {
       lFormatOptions.focus.depth = Number.parseInt(
         lFormatOptions.focusDepth,
         10,
@@ -93,7 +92,8 @@ function hasMetricsRule(pRule) {
   //       Or is it a misuse to ensure folder derivations (like cycles) get
   //       kicked off?
   return (
-    has(pRule, "to.moreUnstable") || (pRule?.scope ?? "module") === "folder"
+    Object.hasOwn(pRule?.to ?? {}, "moreUnstable") ||
+    (pRule?.scope ?? "module") === "folder"
   );
 }
 
@@ -184,7 +184,7 @@ export function normalizeCruiseOptions(pOptions, pFileAndDirectoryArray = []) {
   // having two types/ interfaces
   lReturnValue.maxDepth = Number.parseInt(lReturnValue.maxDepth, 10);
   lReturnValue.moduleSystems = uniq(lReturnValue.moduleSystems);
-  if (has(lReturnValue, "collapse")) {
+  if (Object.hasOwn(lReturnValue, "collapse")) {
     lReturnValue.collapse = normalizeCollapse(lReturnValue.collapse);
   }
   // TODO: further down the execution path code still relies on .doNotFollow
@@ -226,7 +226,7 @@ export function normalizeCruiseOptions(pOptions, pFileAndDirectoryArray = []) {
 export function normalizeFormatOptions(pFormatOptions) {
   let lFormatOptions = structuredClone(pFormatOptions);
 
-  if (has(lFormatOptions, "collapse")) {
+  if (Object.hasOwn(lFormatOptions, "collapse")) {
     lFormatOptions.collapse = normalizeCollapse(lFormatOptions.collapse);
   }
 

--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import report from "#report/index.mjs";
 import summarize from "#enrich/summarize/index.mjs";
 import { applyFilters } from "#graph-utl/filter-bank.mjs";
@@ -15,7 +14,7 @@ import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
 function reSummarizeResults(pResult, pFormatOptions) {
   let lModules = applyFilters(pResult.modules, pFormatOptions);
 
-  if (has(pFormatOptions, "collapse")) {
+  if (Object.hasOwn(pFormatOptions, "collapse")) {
     lModules = consolidateToPattern(lModules, pFormatOptions.collapse)
       .sort(compare.modules)
       .map(stripSelfTransitions);
@@ -55,7 +54,7 @@ export default async function reportWrap(pResult, pFormatOptions) {
     reSummarizeResults(pResult, pFormatOptions),
     // passing format options here so reporters that read collapse patterns
     // from the result take the one passed in the format options instead
-    has(pFormatOptions, "collapse")
+    Object.hasOwn(pFormatOptions, "collapse")
       ? { ...lReportOptions, collapsePattern: pFormatOptions.collapse }
       : lReportOptions,
   );

--- a/src/main/rule-set/assert-validity.mjs
+++ b/src/main/rule-set/assert-validity.mjs
@@ -29,6 +29,8 @@ function assertSchemaCompliance(pSchema, pConfiguration) {
 }
 
 function hasPath(pObject, pSection, pCondition) {
+  // pCondition can be nested properties, so we use lodash.has instead
+  // of elvis operators
   return has(pObject, pSection) && has(pObject[pSection], pCondition);
 }
 
@@ -92,7 +94,7 @@ export default function assertRuleSetValid(pConfiguration) {
   assertSchemaCompliance(configurationSchema, pConfiguration);
   (pConfiguration.allowed || []).forEach(assertRuleSafety);
   (pConfiguration.forbidden || []).forEach(assertRuleSafety);
-  if (has(pConfiguration, "options")) {
+  if (pConfiguration?.options) {
     assertCruiseOptionsValid(pConfiguration.options);
   }
   return pConfiguration;

--- a/src/main/rule-set/normalize.mjs
+++ b/src/main/rule-set/normalize.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import { normalizeREProperties, normalizeToREAsString } from "../helpers.mjs";
 
 const VALID_SEVERITIES = /^(error|warn|info|ignore)$/;
@@ -42,7 +41,7 @@ function normalizeVia(pVia) {
   } else {
     lReturnValue = structuredClone(pVia);
   }
-  if (has(lReturnValue, "path")) {
+  if (lReturnValue?.path) {
     lReturnValue.path = normalizeToREAsString(lReturnValue.path);
   }
   return lReturnValue;
@@ -52,14 +51,14 @@ function normalizeVia(pVia) {
 function normalizeVias(pRuleTo) {
   const lRuleTo = structuredClone(pRuleTo);
 
-  if (has(lRuleTo, "via")) {
+  if (lRuleTo?.via) {
     lRuleTo.via = normalizeVia(lRuleTo.via);
   }
-  if (has(lRuleTo, "viaOnly")) {
+  if (lRuleTo?.viaOnly) {
     lRuleTo.viaOnly = normalizeVia(lRuleTo.viaOnly);
   }
-  if (has(lRuleTo, "viaNot")) {
-    if (!has(lRuleTo, "viaOnly.pathNot")) {
+  if (lRuleTo?.viaNot) {
+    if (!lRuleTo?.viaOnly?.pathNot) {
       lRuleTo.viaOnly = {
         ...lRuleTo.viaOnly,
         pathNot: normalizeToREAsString(lRuleTo.viaNot),
@@ -67,8 +66,8 @@ function normalizeVias(pRuleTo) {
     }
     delete lRuleTo.viaNot;
   }
-  if (has(lRuleTo, "viaSomeNot")) {
-    if (!has(lRuleTo, "via.pathNot")) {
+  if (lRuleTo?.viaSomeNot) {
+    if (!lRuleTo?.via?.pathNot) {
       lRuleTo.via = {
         ...lRuleTo.via,
         pathNot: normalizeToREAsString(lRuleTo.viaSomeNot),
@@ -108,7 +107,7 @@ function normalizeRule(pRule) {
 export default function normalizeRuleSet(pRuleSet) {
   const lRuleSet = structuredClone(pRuleSet);
 
-  if (has(lRuleSet, "allowed")) {
+  if (lRuleSet?.allowed) {
     lRuleSet.allowedSeverity = normalizeSeverity(lRuleSet.allowedSeverity);
     if (lRuleSet.allowedSeverity === "ignore") {
       Reflect.deleteProperty(lRuleSet, "allowed");
@@ -126,13 +125,13 @@ export default function normalizeRuleSet(pRuleSet) {
     }
   }
 
-  if (has(lRuleSet, "forbidden")) {
+  if (lRuleSet?.forbidden) {
     lRuleSet.forbidden = lRuleSet.forbidden
       .map(normalizeRule)
       .filter((pRule) => pRule.severity !== "ignore");
   }
 
-  if (has(lRuleSet, "required")) {
+  if (lRuleSet?.required) {
     lRuleSet.required = lRuleSet.required
       .map(normalizeRule)
       .filter((pRule) => pRule.severity !== "ignore");

--- a/src/report/anon/index.mjs
+++ b/src/report/anon/index.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import { anonymizePath, WHITELIST_RE } from "./anonymize-path.mjs";
 
 const EOL = "\n";
@@ -179,7 +178,7 @@ function sanitizeWordList(pWordList) {
 export default function reportAnonymous(pResults, pAnonymousReporterOptions) {
   /** @type {{wordlist?: String[]}} */
   let lAnonymousReporterOptions = pAnonymousReporterOptions || {};
-  if (!has(lAnonymousReporterOptions, "wordlist")) {
+  if (!lAnonymousReporterOptions.wordlist) {
     lAnonymousReporterOptions.wordlist =
       pResults?.summary?.optionsUsed?.reporterOptions?.anon?.wordlist ?? [];
   }

--- a/src/report/dot/index.mjs
+++ b/src/report/dot/index.mjs
@@ -148,11 +148,11 @@ function report(
 }
 
 function pryReporterOptionsFromResults(pGranularity, pResults) {
-  const lFallbackReporterOptions = get(
-    pResults,
-    "summary.optionsUsed.reporterOptions.dot",
-  );
+  const lFallbackReporterOptions =
+    pResults?.summary?.optionsUsed?.reporterOptions?.dot;
 
+  // using lodash.get here because the reporter options will contain nested
+  // properties, which it handles for us
   return get(
     pResults,
     GRANULARITY2REPORTER_OPTIONS.get(pGranularity),
@@ -161,26 +161,22 @@ function pryReporterOptionsFromResults(pGranularity, pResults) {
 }
 
 function pryThemeFromResults(pGranularity, pResults) {
-  const lFallbackTheme = get(
-    pResults,
-    "summary.optionsUsed.reporterOptions.dot.theme",
-  );
-  return get(
-    pryReporterOptionsFromResults(pGranularity, pResults),
-    "theme",
-    lFallbackTheme,
+  const lFallbackTheme =
+    pResults?.summary?.optionsUsed?.reporterOptions?.dot?.theme;
+
+  return (
+    pryReporterOptionsFromResults(pGranularity, pResults)?.theme ??
+    lFallbackTheme
   );
 }
 
 function pryFiltersFromResults(pGranularity, pResults) {
-  const lFallbackFilters = get(
-    pResults,
-    "summary.optionsUsed.reporterOptions.dot.filters",
-  );
-  return get(
-    pryReporterOptionsFromResults(pGranularity, pResults),
-    "filters",
-    lFallbackFilters,
+  const lFallbackFilters =
+    pResults?.summary?.optionsUsed?.reporterOptions?.dot?.filters;
+
+  return (
+    pryReporterOptionsFromResults(pGranularity, pResults)?.filters ??
+    lFallbackFilters
   );
 }
 
@@ -192,10 +188,9 @@ function getCollapseFallbackPattern(pGranularity) {
 }
 
 function pryCollapsePatternFromResults(pGranularity, pResults) {
-  return get(
-    pryReporterOptionsFromResults(pGranularity, pResults),
-    "collapsePattern",
-    getCollapseFallbackPattern(pGranularity),
+  return (
+    pryReporterOptionsFromResults(pGranularity, pResults)?.collapsePattern ??
+    getCollapseFallbackPattern(pGranularity)
   );
 }
 

--- a/src/report/dot/module-utl.mjs
+++ b/src/report/dot/module-utl.mjs
@@ -1,5 +1,4 @@
 import { basename, sep, dirname } from "node:path/posix";
-import has from "lodash/has.js";
 import { formatPercentage, getURLForModule } from "../utl/index.mjs";
 import theming from "./theming.mjs";
 
@@ -14,7 +13,7 @@ function attributizeObject(pObject) {
 
 function extractFirstTransgression(pModule) {
   return {
-    ...(has(pModule, "rules[0]")
+    ...(pModule?.rules?.[0]
       ? { ...pModule, tooltip: pModule.rules[0].name }
       : pModule),
     dependencies: pModule.dependencies.map((pDependency) =>
@@ -64,7 +63,11 @@ function aggregate(pPathSnippet, pCounter, pPathArray) {
 function makeInstabilityString(pModule, pShowMetrics = false) {
   let lInstabilityString = "";
 
-  if (pShowMetrics && has(pModule, "instability") && !pModule.consolidated) {
+  if (
+    pShowMetrics &&
+    Object.hasOwn(pModule, "instability") &&
+    !pModule.consolidated
+  ) {
     lInstabilityString = ` <FONT color="#808080" point-size="8">${formatPercentage(
       pModule.instability,
     )}</FONT>`;

--- a/src/report/error-html/utl.mjs
+++ b/src/report/error-html/utl.mjs
@@ -1,10 +1,11 @@
-import has from "lodash/has.js";
 import { formatViolation, formatPercentage } from "../utl/index.mjs";
 import meta from "#meta.cjs";
 
 function getFormattedAllowedRule(pRuleSetUsed) {
   const lAllowed = pRuleSetUsed?.allowed ?? [];
-  const lCommentedRule = lAllowed.find((pRule) => has(pRule, "comment"));
+  const lCommentedRule = lAllowed.find((pRule) =>
+    Object.hasOwn(pRule, "comment"),
+  );
   const lComment = lCommentedRule ? lCommentedRule.comment : "-";
 
   return lAllowed.length > 0

--- a/src/report/plugins.mjs
+++ b/src/report/plugins.mjs
@@ -1,5 +1,3 @@
-import has from "lodash/has.js";
-
 export function isValidPlugin(pPluginFunction) {
   let lReturnValue = false;
   /** @type {import('../../types/dependency-cruiser').ICruiseResult} */
@@ -19,8 +17,8 @@ export function isValidPlugin(pPluginFunction) {
   if (typeof pPluginFunction === "function") {
     const lTestReportOutput = pPluginFunction(lMinimalCruiseResult);
     lReturnValue =
-      has(lTestReportOutput, "output") &&
-      has(lTestReportOutput, "exitCode") &&
+      Object.hasOwn(lTestReportOutput, "output") &&
+      Object.hasOwn(lTestReportOutput, "exitCode") &&
       typeof lTestReportOutput.exitCode === "number";
   }
   return lReturnValue;
@@ -34,7 +32,7 @@ async function getPluginReporter(pOutputType) {
     lReturnValue = lModule.default;
   } catch (pError) {
     throw new Error(
-      `Could not find reporter plugin '${pOutputType}' (or it isn't valid)`
+      `Could not find reporter plugin '${pOutputType}' (or it isn't valid)`,
     );
   }
   if (!isValidPlugin(lReturnValue)) {

--- a/src/validate/index.mjs
+++ b/src/validate/index.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import matchModuleRule from "./match-module-rule.mjs";
 import matchDependencyRule from "./match-dependency-rule.mjs";
 import violatesRequiredRule from "./violates-required-rule.mjs";
@@ -19,7 +18,7 @@ function validateAgainstAllowedRules(pRuleSet, pMatchModule, pFrom, pTo) {
 
   if (pRuleSet.allowed) {
     const lInterestingAllowedRules = pRuleSet.allowed.filter(
-      pMatchModule.isInteresting
+      pMatchModule.isInteresting,
     );
 
     if (
@@ -50,7 +49,7 @@ function validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo) {
 function validateAgainstRequiredRules(pRuleSet, pModule, pMatchModule) {
   let lFoundRequiredRuleViolations = [];
 
-  if (has(pRuleSet, "required")) {
+  if (pRuleSet?.required) {
     lFoundRequiredRuleViolations = pRuleSet.required
       .filter(pMatchModule.isInteresting)
       .filter((pRule) => violatesRequiredRule(pRule, pModule))
@@ -78,7 +77,7 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
     pRuleSet,
     pMatchModule,
     pFrom,
-    pTo
+    pTo,
   )
     .concat(validateAgainstForbiddenRules(pRuleSet, pMatchModule, pFrom, pTo))
     .concat(validateAgainstRequiredRules(pRuleSet, pFrom, pMatchModule))
@@ -105,7 +104,7 @@ export default {
       pRuleSet,
       pFromFolder,
       pToFolder,
-      matchFolderRule
+      matchFolderRule,
     );
   },
 };

--- a/src/validate/match-module-rule.mjs
+++ b/src/validate/match-module-rule.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
 import matchers from "./matchers.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
@@ -13,7 +12,7 @@ import { extractGroups } from "#utl/regex-util.mjs";
  */
 function matchesOrphanRule(pRule, pModule) {
   return (
-    has(pRule, "from.orphan") &&
+    Object.hasOwn(pRule?.from ?? {}, "orphan") &&
     // @ts-expect-error the 'has' above guarantees there's a 'from.orphan' attribute
     pModule.orphan === pRule.from.orphan &&
     matchers.fromPath(pRule, pModule) &&
@@ -31,7 +30,10 @@ function matchesOrphanRule(pRule, pModule) {
  * @returns {boolean}
  */
 function matchesReachableRule(pRule, pModule) {
-  if (has(pRule, "to.reachable") && has(pModule, "reachable")) {
+  if (
+    Object.hasOwn(pRule?.to ?? {}, "reachable") &&
+    Object.hasOwn(pModule, "reachable")
+  ) {
     // @ts-expect-error the 'has' above ensures the 'reachable' exists
     const lReachableRecord = pModule.reachable.find(
       (pReachable) =>
@@ -62,8 +64,8 @@ function matchesReachableRule(pRule, pModule) {
  */
 function matchesReachesRule(pRule, pModule) {
   return (
-    has(pRule, "to.reachable") &&
-    has(pModule, "reaches") &&
+    Object.hasOwn(pRule?.to ?? {}, "reachable") &&
+    Object.hasOwn(pModule, "reaches") &&
     // @ts-expect-error the 'has' above guarantees the .reaches exists
     pModule.reaches.some(
       (pReaches) =>
@@ -102,11 +104,12 @@ function dependentsCountsMatch(pRule, pDependents) {
  * @param {import("../../types/cruise-result.mjs").IModule} pModule
  * @returns {boolean}
  */
+// eslint-disable-next-line complexity
 function matchesDependentsRule(pRule, pModule) {
   if (
-    (has(pModule, "dependents") &&
-      has(pRule, "module.numberOfDependentsLessThan")) ||
-    has(pRule, "module.numberOfDependentsMoreThan")
+    (Object.hasOwn(pModule, "dependents") &&
+      Object.hasOwn(pRule?.module ?? {}, "numberOfDependentsLessThan")) ||
+    Object.hasOwn(pRule?.module ?? {}, "numberOfDependentsMoreThan")
   ) {
     return (
       // group matching seems like a nice idea, however, the 'from' part of the

--- a/src/validate/matchers.mjs
+++ b/src/validate/matchers.mjs
@@ -1,5 +1,4 @@
 /* eslint-disable security/detect-object-injection */
-import has from "lodash/has.js";
 import { replaceGroupPlaceholders } from "#utl/regex-util.mjs";
 import { intersects } from "#utl/array-util.mjs";
 
@@ -22,7 +21,7 @@ const DEPENDENCY_TYPE_DUPLICATES_THAT_MATTER = new Set([
 
 function propertyEquals(pRule, pDependency, pProperty) {
   // The properties can be booleans, so we can't use !pRule.to[pProperty]
-  if (has(pRule.to, pProperty)) {
+  if (Object.hasOwn(pRule.to, pProperty)) {
     return pDependency[pProperty] === pRule.to[pProperty];
   }
   return true;
@@ -173,7 +172,7 @@ function toViaOnly(pRule, pDependency, pGroups) {
 }
 
 function toIsMoreUnstable(pRule, pModule, pDependency) {
-  if (has(pRule, "to.moreUnstable")) {
+  if (Object.hasOwn(pRule.to, "moreUnstable")) {
     return (
       (pRule.to.moreUnstable &&
         pModule.instability < pDependency.instability) ||
@@ -198,7 +197,7 @@ function matchesMoreThanOneDependencyType(pRule, pDependency) {
    * lNotReallyDuplicates set.
    */
 
-  if (has(pRule.to, "moreThanOneDependencyType")) {
+  if (Object.hasOwn(pRule.to, "moreThanOneDependencyType")) {
     return (
       pRule.to.moreThanOneDependencyType ===
       pDependency.dependencyTypes.filter((pDependencyType) =>

--- a/src/validate/rule-classifiers.mjs
+++ b/src/validate/rule-classifiers.mjs
@@ -1,15 +1,13 @@
-import has from "lodash/has.js";
-
 /**
  * @param {import("../../types/strict-rule-set").IStrictAnyRuleType} pRule a dependency-cruiser rule
  * @returns {boolean} whether or not the rule is 'module only'
  */
 export function isModuleOnlyRule(pRule) {
   return (
-    has(pRule, "from.orphan") ||
+    Object.hasOwn(pRule?.from ?? {}, "orphan") ||
     // note: the to might become optional for required rules
-    has(pRule, "to.reachable") ||
-    has(pRule, "module")
+    Object.hasOwn(pRule?.to ?? {}, "reachable") ||
+    Object.hasOwn(pRule, "module")
   );
 }
 /**


### PR DESCRIPTION
## Description, Motivation and Context

- replaces lodash/has & lodash/get with native options where possible
because it now often _is_ easily possible with native options

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
