### PR TITLE
fix(report): also show metrics in the x-dot-webpage reporter output

### DIFF
--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -38,6 +38,10 @@ function reSummarizeResults(pResult, pFormatOptions) {
   };
 }
 
+function getReporterSection(pOutputType) {
+  return pOutputType === "x-dot-webpage" ? "dot" : pOutputType;
+}
+
 /**
  *
  * @param {import("../..).ICruiseResult} pResult result of a previous run of dependency-cruiser
@@ -47,8 +51,9 @@ function reSummarizeResults(pResult, pFormatOptions) {
 export default async function reportWrap(pResult, pFormatOptions) {
   const lReportFunction = await report.getReporter(pFormatOptions.outputType);
   const lReportOptions =
-    pResult.summary.optionsUsed?.reporterOptions?.[pFormatOptions.outputType] ??
-    {};
+    pResult.summary.optionsUsed?.reporterOptions?.[
+      getReporterSection(pFormatOptions.outputType)
+    ] ?? {};
 
   return lReportFunction(
     reSummarizeResults(pResult, pFormatOptions),

--- a/src/report/dot-webpage/dot-module.mjs
+++ b/src/report/dot-webpage/dot-module.mjs
@@ -24,7 +24,7 @@ function convert(pDot, pOptions) {
     },
   );
   if (status === 0) {
-    return stdout.toString("binary");
+    return stdout.toString("utf8");
   } else if (error) {
     throw error;
   } else {
@@ -61,8 +61,6 @@ function isAvailable(pOptions) {
  * @returns {IReporterOutput}
  */
 export default function dotWebpage(pResults, pDotWebpageReporterOptions) {
-  const { output } = dotModuleReporter(pResults, pDotWebpageReporterOptions);
-
   if (!isAvailable(pDotWebpageReporterOptions)) {
     throw new Error(
       "GraphViz dot, which is required for the 'x-dot-webpage' reporter doesn't " +
@@ -70,6 +68,7 @@ export default function dotWebpage(pResults, pDotWebpageReporterOptions) {
         "instruction on how to get it on your system: https://www.graphviz.org/download/",
     );
   }
+  const { output } = dotModuleReporter(pResults, pDotWebpageReporterOptions);
   return {
     output: wrapInHTML(convert(output, pDotWebpageReporterOptions)),
     exitCode: 0,


### PR DESCRIPTION
## Description

- also show metrics in the x-dot-webpage reporter output
- fixes a problem where some non-ascii characters showed up wrong in the output

## Motivation and Context

It didn't and that's a bug

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
