### PR TITLE
fix(graph-utl): lets findRuleByName also search in 'required' rules

### DIFF
--- a/src/graph-utl/rule-set.mjs
+++ b/src/graph-utl/rule-set.mjs
@@ -10,9 +10,10 @@
  * @return {import("../../types/rule-set").IForbiddenRuleType|undefined} - a rule (or 'undefined' if nothing found)
  */
 export function findRuleByName(pRuleSet, pName) {
-  return (pRuleSet?.forbidden ?? []).find(
-    (pForbiddenRule) => pForbiddenRule.name === pName,
+  const lNamedRules = (pRuleSet?.forbidden ?? []).concat(
+    pRuleSet?.required ?? [],
   );
+  return lNamedRules.find((pRule) => pRule.name === pName);
 }
 
 function ruleHasALicenseLikeAttribute(pRule) {

--- a/test/graph-utl/rule-set.spec.mjs
+++ b/test/graph-utl/rule-set.spec.mjs
@@ -34,6 +34,27 @@ describe("[U] graph-utl/rule-set - findRuleByName", () => {
       to: {},
     });
   });
+  it("also finds 'required' types rules, provided they're named", () => {
+    const lRuleSetWithRequiredRule = {
+      ...lRuleSet,
+      required: [
+        {
+          name: "some-required-rule",
+          comment: "heide does hok schapen",
+          severity: "warn",
+          from: {},
+          to: {},
+        },
+      ],
+    };
+    deepEqual(findRuleByName(lRuleSetWithRequiredRule, "some-required-rule"), {
+      name: "some-required-rule",
+      comment: "heide does hok schapen",
+      severity: "warn",
+      from: {},
+      to: {},
+    });
+  });
 });
 
 describe("[U] graph-utl/rule-set - ruleSetHasLicenseRule", () => {


### PR DESCRIPTION
## Description

- lets findRuleByName also search in 'required' rules

## Motivation and Context

fixes #930 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression test

## Screenshots

With this rule added to dependency-cruiser's own config
```javascript
// ...
  "required": [
    {
      "name": "something-required",
      "comment": "Foo bar baz quux garply waldo fred plugh xyzzy thud",
      "severity": "warn",
      "module": {
        "path": "^src/meta.cjs$"
      },
      "to": {
        "path": "^test/kannie"
      }
    }
  ],
// ...
```

... `npx depcruise --progress -T err-long` shows this:


```
  warn something-required: src/meta.cjs
    Foo bar baz quux garply waldo fred plugh xyzzy thud


✘ 1 dependency violations (0 errors, 1 warnings). 545 modules, 1325 dependencies cruised.
⚠ 7 known violations ignored. Run with --no-ignore-known to see them.
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
