### PR TITLE
refactor: removes 3rd party dependency 'indent-string'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "enhanced-resolve": "5.17.0",
         "figures": "6.1.0",
         "ignore": "5.3.1",
-        "indent-string": "5.0.0",
         "interpret": "^3.1.1",
         "is-installed-globally": "1.0.0",
         "json5": "2.2.3",
@@ -3942,16 +3941,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "enhanced-resolve": "5.17.0",
     "figures": "6.1.0",
     "ignore": "5.3.1",
-    "indent-string": "5.0.0",
     "interpret": "^3.1.1",
     "is-installed-globally": "1.0.0",
     "json5": "2.2.3",

--- a/src/utl/wrap-and-indent.mjs
+++ b/src/utl/wrap-and-indent.mjs
@@ -1,11 +1,16 @@
-import indentString from "indent-string";
 import wrapAnsi from "wrap-ansi";
 
 const DEFAULT_INDENT = 4;
 
-export default function wrapAndIndent(pString, pIndent = DEFAULT_INDENT) {
-  const lDogmaticMaxConsoleWidth = 78;
-  const lMaxWidth = lDogmaticMaxConsoleWidth - pIndent;
+function indentString(pString, pCount) {
+  const lRegex = /^(?!\s*$)/gm;
 
-  return indentString(wrapAnsi(pString, lMaxWidth), pIndent);
+  return pString.replace(lRegex, " ".repeat(pCount));
+}
+
+export default function wrapAndIndent(pString, pCount = DEFAULT_INDENT) {
+  const lDogmaticMaxConsoleWidth = 78;
+  const lMaxWidth = lDogmaticMaxConsoleWidth - pCount;
+
+  return indentString(wrapAnsi(pString, lMaxWidth), pCount);
 }


### PR DESCRIPTION
## Description

- removes 3rd party dependency 'indent-string'
- replaces it with the simple string replace it ultimately comes down to (regex shamelessly copied from the indent-string package).

## Motivation and Context

Less dependencies => less maintenance overhead. Moreover, the part of  indent-string we actually use is _so_ trivial it's simpler to pull it in.


## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
