### PR TITLE
refactor: replaces lodash' flattenDeep, isEmpty, reject, omit, merge with native alternatives

### DIFF
--- a/src/enrich/summarize/summarize-modules.mjs
+++ b/src/enrich/summarize/summarize-modules.mjs
@@ -1,4 +1,3 @@
-import flattenDeep from "lodash/flattenDeep.js";
 import uniqWith from "lodash/uniqWith.js";
 import isSameViolation from "./is-same-violation.mjs";
 import { findRuleByName } from "#graph-utl/rule-set.mjs";
@@ -72,18 +71,17 @@ function toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet) {
  * @return {any} an array of violations
  */
 function extractDependencyViolations(pModules, pRuleSet) {
-  return flattenDeep(
-    pModules
-      .map(cutNonTransgressions)
-      .filter((pModule) => pModule.dependencies.length > 0)
-      .map((pModule) =>
-        pModule.dependencies.map((pDependency) =>
-          pDependency.rules.map((pRule) =>
-            toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet),
-          ),
+  return pModules
+    .map(cutNonTransgressions)
+    .filter((pModule) => pModule.dependencies.length > 0)
+    .map((pModule) =>
+      pModule.dependencies.map((pDependency) =>
+        pDependency.rules.map((pRule) =>
+          toDependencyViolationSummary(pRule, pModule, pDependency, pRuleSet),
         ),
       ),
-  );
+    )
+    .flat(Infinity);
 }
 
 function toModuleViolationSummary(pRule, pModule, pRuleSet) {

--- a/src/extract/transpile/vue-template-wrap.cjs
+++ b/src/extract/transpile/vue-template-wrap.cjs
@@ -1,5 +1,4 @@
 const { EOL } = require("node:os");
-const isEmpty = require("lodash/isEmpty");
 const tryRequire = require("#utl/try-require.cjs");
 const meta = require("#meta.cjs");
 
@@ -27,6 +26,12 @@ function getVueTemplateCompiler() {
   }
 
   return { lCompiler, lIsVue3 };
+}
+
+function isEmpty(pObject) {
+  return (
+    Object.entries(pObject).length === 0 && !pObject?.length && !pObject?.size
+  );
 }
 
 const { lCompiler: vueTemplateCompiler, lIsVue3: isVue3 } =

--- a/src/graph-utl/consolidate-module-dependencies.mjs
+++ b/src/graph-utl/consolidate-module-dependencies.mjs
@@ -1,4 +1,3 @@
-import reject from "lodash/reject.js";
 import compare from "./compare.mjs";
 import { uniq } from "#utl/array-util.mjs";
 
@@ -42,9 +41,10 @@ function consolidateDependencies(pDependencies) {
     lReturnValue.push(
       mergeDependencies(lDependencies[0].resolved, lDependencies),
     );
-    lDependencies = reject(lDependencies, {
-      resolved: lDependencies[0].resolved,
-    });
+    lDependencies = lDependencies.filter(
+      // eslint-disable-next-line no-loop-func
+      (pDependency) => pDependency.resolved !== lDependencies[0].resolved,
+    );
   }
 
   return lReturnValue;

--- a/src/graph-utl/consolidate-modules.mjs
+++ b/src/graph-utl/consolidate-modules.mjs
@@ -1,4 +1,3 @@
-import _reject from "lodash/reject.js";
 import uniqBy from "lodash/uniqBy.js";
 import compare from "./compare.mjs";
 
@@ -39,7 +38,10 @@ export default function consolidateModules(pModules) {
 
   while (lModules.length > 0) {
     lReturnValue.push(mergeModules(lModules[0].source, lModules));
-    lModules = _reject(lModules, { source: lModules[0].source });
+    lModules = lModules.filter(
+      // eslint-disable-next-line no-loop-func
+      (pModule) => pModule.source !== lModules[0].source,
+    );
   }
   return lReturnValue;
 }

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import enhancedResolve from "enhanced-resolve";
-import omit from "lodash/omit.js";
 import { scannableExtensions } from "#extract/transpile/meta.mjs";
 import {
   ruleSetHasDeprecationRule,
@@ -31,6 +30,13 @@ const DEFAULT_RESOLVE_OPTIONS = {
   // Also see https://github.com/sverweij/dependency-cruiser/issues/338
   exportsFields: [],
 };
+
+function omit(pObject, pProperty) {
+  const lObject = structuredClone(pObject);
+  // eslint-disable-next-line security/detect-object-injection
+  delete lObject[pProperty];
+  return lObject;
+}
 
 /**
  *

--- a/test/main/options/assert-validity.spec.mjs
+++ b/test/main/options/assert-validity.spec.mjs
@@ -1,4 +1,5 @@
 import { doesNotThrow, equal, throws } from "node:assert/strict";
+import { deepEqual } from "node:assert";
 import { assertCruiseOptionsValid } from "#main/options/assert-validity.mjs";
 
 describe("[U] main/options/validate - module systems", () => {
@@ -183,5 +184,31 @@ describe("[U] main/options/validate - exclude", () => {
 
     equal(lOptions.exclude, "from the ruleset");
     equal(lOptions.doNotFollow, "from the commandline");
+  });
+});
+
+describe("[U] main/options/validate - enhancedResolveOptions", () => {
+  it("options passed in --validate rule-set drip down to the proper options (objects edition)", () => {
+    const lOptions = assertCruiseOptionsValid({
+      enhancedResolveOptions: {
+        exportsFields: ["exports"],
+        conditionNames: ["import", "require"],
+        extensions: [".cjs", ".mjs"],
+      },
+      ruleSet: {
+        options: {
+          enhancedResolveOptions: {
+            exportsFields: ["exports"],
+            conditionNames: ["import"],
+          },
+        },
+      },
+    });
+
+    deepEqual(lOptions.enhancedResolveOptions, {
+      exportsFields: ["exports"],
+      conditionNames: ["import", "require"],
+      extensions: [".cjs", ".mjs"],
+    });
   });
 });


### PR DESCRIPTION
## Description

- replaces lodash' flattenDeep, isEmpty, reject, omit, merge with native alternatives

## Motivation and Context

Part of a series of PR's to phase out lodash (which is not maintained anymore) as a production dependency.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
