### PR TITLE
refactor: removes 3rd party dependency 'wrap-ansi'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "semver": "^7.6.2",
         "teamcity-service-messages": "0.1.14",
         "tsconfig-paths-webpack-plugin": "4.1.0",
-        "watskeburt": "4.1.0",
-        "wrap-ansi": "9.0.0"
+        "watskeburt": "4.1.0"
       },
       "bin": {
         "depcruise": "bin/dependency-cruise.mjs",
@@ -2481,7 +2480,8 @@
     "node_modules/emoji-regex": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.0",
@@ -3626,6 +3626,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.0.0.tgz",
       "integrity": "sha512-7estWZOk4GUviMbLupPCsHePNHS7fCt6yLzBv43f8Z64xRBgoOsfdDaRuT+BU6Hq2jWsKNmvxCbxo664fxEPcA==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -6386,6 +6387,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz",
       "integrity": "sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -6432,6 +6434,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -6443,6 +6446,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -7096,6 +7100,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -7190,6 +7195,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7200,6 +7206,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7210,6 +7217,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -226,8 +226,7 @@
     "semver": "^7.6.2",
     "teamcity-service-messages": "0.1.14",
     "tsconfig-paths-webpack-plugin": "4.1.0",
-    "watskeburt": "4.1.0",
-    "wrap-ansi": "9.0.0"
+    "watskeburt": "4.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.24.7",

--- a/src/report/error.mjs
+++ b/src/report/error.mjs
@@ -44,11 +44,11 @@ function formatReachabilityViolation(pViolation) {
 }
 
 function formatInstabilityViolation(pViolation) {
-  return `${formatDependencyViolation(pViolation)}${EOL}${wrapAndIndent(
-    pc.dim(
+  return `${formatDependencyViolation(pViolation)}${EOL}${pc.dim(
+    wrapAndIndent(
       `instability: ${formatPercentage(pViolation.metrics.from.instability)} → ${formatPercentage(pViolation.metrics.to.instability)}`,
+      EXTRA_PATH_INFORMATION_INDENT,
     ),
-    EXTRA_PATH_INFORMATION_INDENT,
   )}`;
 }
 
@@ -72,7 +72,7 @@ function formatViolation(pViolation) {
     )} ${pViolation.rule.name}: ${lFormattedViolators}` +
     `${
       pViolation.comment
-        ? `${EOL}${wrapAndIndent(pc.dim(pViolation.comment))}${EOL}`
+        ? `${EOL}${pc.dim(wrapAndIndent(pViolation.comment))}${EOL}`
         : ""
     }`
   );

--- a/src/utl/wrap-and-indent.mjs
+++ b/src/utl/wrap-and-indent.mjs
@@ -7,40 +7,44 @@ function indentString(pString, pCount) {
 }
 
 /**
- *
+ * @param {string} pLine
+ * @param {number} pMaxWidth
+ */
+function splitLine(pLine, pMaxWidth) {
+  const lWords = pLine.split(" ");
+  const lWrappedLines = [];
+  let lCurrentLine = "";
+  let lCurrentWidth = 0;
+
+  for (const lWord of lWords) {
+    if (lCurrentWidth + lWord.length > pMaxWidth) {
+      lWrappedLines.push(lCurrentLine.trimEnd());
+      lCurrentLine = "";
+      lCurrentWidth = 0;
+    }
+
+    if (lCurrentLine) {
+      lCurrentLine += " ";
+      lCurrentWidth += 1;
+    }
+
+    lCurrentLine += lWord;
+    lCurrentWidth += lWord.length;
+  }
+
+  lWrappedLines.push(lCurrentLine.trimEnd());
+
+  return lWrappedLines.join("\n");
+}
+
+/**
  * @param {string} pString - the string to wrap
  * @param {number} pMaxWidth - the maximum width of the wrapped string
  */
 function wrapString(pString, pMaxWidth) {
-  const lLines = pString.split(/\r?\n/);
-
-  return lLines
-    .map((pLine) => {
-      const lWords = pLine.split(" ");
-      const lWrappedLines = [];
-      let lCurrentLine = "";
-      let lCurrentWidth = 0;
-
-      for (const lWord of lWords) {
-        if (lCurrentWidth + lWord.length > pMaxWidth) {
-          lWrappedLines.push(lCurrentLine.trimEnd());
-          lCurrentLine = "";
-          lCurrentWidth = 0;
-        }
-
-        if (lCurrentLine) {
-          lCurrentLine += " ";
-          lCurrentWidth += 1;
-        }
-
-        lCurrentLine += lWord;
-        lCurrentWidth += lWord.length;
-      }
-
-      lWrappedLines.push(lCurrentLine.trimEnd());
-
-      return lWrappedLines.join("\n");
-    })
+  return pString
+    .split(/\r?\n/)
+    .map((pLine) => splitLine(pLine, pMaxWidth))
     .join("\n");
 }
 

--- a/src/utl/wrap-and-indent.mjs
+++ b/src/utl/wrap-and-indent.mjs
@@ -1,5 +1,3 @@
-import { EOL } from "node:os";
-
 const DEFAULT_INDENT = 4;
 
 function indentString(pString, pCount) {
@@ -41,9 +39,9 @@ function wrapString(pString, pMaxWidth) {
 
       lWrappedLines.push(lCurrentLine.trimEnd());
 
-      return lWrappedLines.join(EOL);
+      return lWrappedLines.join("\n");
     })
-    .join(EOL);
+    .join("\n");
 }
 
 export default function wrapAndIndent(pString, pCount = DEFAULT_INDENT) {

--- a/src/utl/wrap-and-indent.mjs
+++ b/src/utl/wrap-and-indent.mjs
@@ -1,4 +1,4 @@
-import wrapAnsi from "wrap-ansi";
+import { EOL } from "node:os";
 
 const DEFAULT_INDENT = 4;
 
@@ -8,9 +8,47 @@ function indentString(pString, pCount) {
   return pString.replace(lRegex, " ".repeat(pCount));
 }
 
+/**
+ *
+ * @param {string} pString - the string to wrap
+ * @param {number} pMaxWidth - the maximum width of the wrapped string
+ */
+function wrapString(pString, pMaxWidth) {
+  const lLines = pString.split(/\r?\n/);
+
+  return lLines
+    .map((pLine) => {
+      const lWords = pLine.split(" ");
+      const lWrappedLines = [];
+      let lCurrentLine = "";
+      let lCurrentWidth = 0;
+
+      for (const lWord of lWords) {
+        if (lCurrentWidth + lWord.length > pMaxWidth) {
+          lWrappedLines.push(lCurrentLine.trimEnd());
+          lCurrentLine = "";
+          lCurrentWidth = 0;
+        }
+
+        if (lCurrentLine) {
+          lCurrentLine += " ";
+          lCurrentWidth += 1;
+        }
+
+        lCurrentLine += lWord;
+        lCurrentWidth += lWord.length;
+      }
+
+      lWrappedLines.push(lCurrentLine.trimEnd());
+
+      return lWrappedLines.join(EOL);
+    })
+    .join(EOL);
+}
+
 export default function wrapAndIndent(pString, pCount = DEFAULT_INDENT) {
   const lDogmaticMaxConsoleWidth = 78;
   const lMaxWidth = lDogmaticMaxConsoleWidth - pCount;
 
-  return indentString(wrapAnsi(pString, lMaxWidth), pCount);
+  return indentString(wrapString(pString, lMaxWidth), pCount);
 }

--- a/src/utl/wrap-and-indent.mjs
+++ b/src/utl/wrap-and-indent.mjs
@@ -48,9 +48,9 @@ function wrapString(pString, pMaxWidth) {
     .join("\n");
 }
 
-export default function wrapAndIndent(pString, pCount = DEFAULT_INDENT) {
-  const lDogmaticMaxConsoleWidth = 78;
-  const lMaxWidth = lDogmaticMaxConsoleWidth - pCount;
+export default function wrapAndIndent(pString, pIndent = DEFAULT_INDENT) {
+  const lMaxConsoleWidth = 78;
+  const lMaxWidth = lMaxConsoleWidth - pIndent;
 
-  return indentString(wrapString(pString, lMaxWidth), pCount);
+  return indentString(wrapString(pString, lMaxWidth), pIndent);
 }


### PR DESCRIPTION
## Description

- removes 3rd party dependency 'wrap-ansi'

## Motivation and Context

Reduces the number of 3rd party dependencies by 7, which is good for download size & performance and reduces potential vulnerabilities and maintenance burden.

We _do_ wrap with ansi-codes, but if we apply the ansi codes _after_ wrapping, we don't need the specialised `wrap-ansi` package anymore and can do with a simple hand-rolled function for wrapping, which is what this package implements (the function is _ugly_, and might not cover all edge cases but it works well enough for our use case).

From [npmgraph](https://npmgraph.js.org/?q=wrap-ansi):

<img width="952" alt="shows wrap-ansi's module dependency graph, with its 6 indirect dependencies" src="https://github.com/sverweij/dependency-cruiser/assets/4822597/1dd195cd-18c2-4022-a304-3f87416fc4a4">

<img width="406" alt="shows the number of bytes wrap-ansi adds to dependency-cruiser's install size; 96kb unpacked, with emoji-regex and get-east-asian-width as the largest contributors" src="https://github.com/sverweij/dependency-cruiser/assets/4822597/fb372f56-6c8c-4039-8f5f-8ae5fb5ee71c">


## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
