### PR TITLE
refactor: uses explicit exports over default where possible

### DIFF
--- a/src/enrich/add-validations.mjs
+++ b/src/enrich/add-validations.mjs
@@ -1,10 +1,10 @@
-import validate from "#validate/index.mjs";
+import { validateDependency, validateModule } from "#validate/index.mjs";
 
 function addDependencyViolations(pModule, pDependency, pRuleSet, pValidate) {
   return {
     ...pDependency,
     ...(pValidate
-      ? validate.dependency(pRuleSet, pModule, pDependency)
+      ? validateDependency(pRuleSet, pModule, pDependency)
       : { valid: true }),
   };
 }
@@ -24,7 +24,7 @@ function addDependencyViolations(pModule, pDependency, pRuleSet, pValidate) {
 export default function addValidations(pModules, pRuleSet, pValidate) {
   return pModules.map((pModule) => ({
     ...pModule,
-    ...(pValidate ? validate.module(pRuleSet, pModule) : { valid: true }),
+    ...(pValidate ? validateModule(pRuleSet, pModule) : { valid: true }),
     dependencies: pModule.dependencies.map((pDependency) =>
       addDependencyViolations(pModule, pDependency, pRuleSet, pValidate),
     ),

--- a/src/enrich/derive/folders/index.mjs
+++ b/src/enrich/derive/folders/index.mjs
@@ -1,5 +1,5 @@
 import aggregateToFolders from "./aggregate-to-folders.mjs";
-import validate from "#validate/index.mjs";
+import { validateFolder } from "#validate/index.mjs";
 
 /**
  * @param {import("../../../../types/dependency-cruiser.js").IFolder} pFolder
@@ -9,7 +9,7 @@ import validate from "#validate/index.mjs";
 function validateFolderDependency(pFolder, pOptions) {
   return (pDependency) => ({
     ...pDependency,
-    ...validate.folder(pOptions.ruleSet || {}, pFolder, pDependency),
+    ...validateFolder(pOptions.ruleSet || {}, pFolder, pDependency),
   });
 }
 

--- a/src/enrich/derive/reachable.mjs
+++ b/src/enrich/derive/reachable.mjs
@@ -1,5 +1,8 @@
 /* eslint-disable security/detect-object-injection, no-inline-comments */
-import matchers from "#validate/matchers.mjs";
+import {
+  matchToModulePath,
+  matchToModulePathNot,
+} from "#validate/matchers.mjs";
 import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
 
@@ -25,8 +28,8 @@ function isModuleInRuleTo(pRule, pModuleTo, pModuleFrom) {
     : [];
 
   return (
-    matchers.toModulePath(pRule, pModuleTo, lGroups) &&
-    matchers.toModulePathNot(pRule, pModuleTo, lGroups)
+    matchToModulePath(pRule, pModuleTo, lGroups) &&
+    matchToModulePathNot(pRule, pModuleTo, lGroups)
   );
 }
 

--- a/src/graph-utl/compare.mjs
+++ b/src/graph-utl/compare.mjs
@@ -38,7 +38,3 @@ export function compareRules(pLeftRule, pRightRule) {
 export function compareModules(pLeftModule, pRightModule) {
   return pLeftModule.source > pRightModule.source ? 1 : -1;
 }
-
-export default {
-  violations: compareViolations,
-};

--- a/src/main/options/assert-validity.mjs
+++ b/src/main/options/assert-validity.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
 import safeRegex from "safe-regex";
-import report from "#report/index.mjs";
+import { getAvailableReporters } from "#report/index.mjs";
 
 const MODULE_SYSTEM_LIST_RE = /^(?:(?:cjs|amd|es6|tsd)(?:,|$)){1,4}/gi;
 const VALID_DEPTH_RE = /^\d{1,2}$/g;
@@ -53,7 +53,7 @@ function assertRegExpSafety(pPattern) {
 function assertOutputTypeValid(pOutputType) {
   if (
     Boolean(pOutputType) &&
-    !report.getAvailableReporters().includes(pOutputType) &&
+    !getAvailableReporters().includes(pOutputType) &&
     !pOutputType.startsWith("plugin:")
   ) {
     throw new Error(`'${pOutputType}' is not a valid output type.\n`);

--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -1,4 +1,4 @@
-import report from "#report/index.mjs";
+import { getReporter } from "#report/index.mjs";
 import summarize from "#enrich/summarize/index.mjs";
 import { applyFilters } from "#graph-utl/filter-bank.mjs";
 import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
@@ -49,7 +49,7 @@ function getReporterSection(pOutputType) {
  * @returns {import("../../types/dependency-cruiser.js").IReporterOutput}
  */
 export default async function reportWrap(pResult, pFormatOptions) {
-  const lReportFunction = await report.getReporter(pFormatOptions.outputType);
+  const lReportFunction = await getReporter(pFormatOptions.outputType);
   const lReportOptions =
     pResult.summary.optionsUsed?.reporterOptions?.[
       getReporterSection(pFormatOptions.outputType)

--- a/src/report/dot/index.mjs
+++ b/src/report/dot/index.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-template */
-import theming from "./theming.mjs";
-import moduleUtl from "./module-utl.mjs";
+import { normalizeTheme } from "./theming.mjs";
+import { attributizeObject } from "./module-utl.mjs";
 import prepareFolderLevel from "./prepare-folder-level.mjs";
 import prepareCustomLevel from "./prepare-custom-level.mjs";
 import prepareFlatLevel from "./prepare-flat-level.mjs";
@@ -25,21 +25,15 @@ const GRANULARITY2REPORTER_OPTIONS = new Map([
 ]);
 
 function buildGraphAttributes(pGraph) {
-  return Boolean(pGraph)
-    ? `    ${moduleUtl.attributizeObject(pGraph || {})}`
-    : "";
+  return Boolean(pGraph) ? `    ${attributizeObject(pGraph || {})}` : "";
 }
 
 function buildNodeAttributes(pNode) {
-  return Boolean(pNode)
-    ? `    node [${moduleUtl.attributizeObject(pNode || {})}]`
-    : "";
+  return Boolean(pNode) ? `    node [${attributizeObject(pNode || {})}]` : "";
 }
 
 function buildEdgeAttributes(pEdge) {
-  return Boolean(pEdge)
-    ? `    edge [${moduleUtl.attributizeObject(pEdge || {})}]`
-    : "";
+  return Boolean(pEdge) ? `    edge [${attributizeObject(pEdge || {})}]` : "";
 }
 
 function buildGeneralAttributes(pTheme) {
@@ -120,7 +114,7 @@ function report(
   pGranularity,
   { theme, collapsePattern, filters, showMetrics },
 ) {
-  const lTheme = theming.normalizeTheme(theme);
+  const lTheme = normalizeTheme(theme);
   const lResults = filters
     ? {
         ...pResults,

--- a/src/report/dot/module-utl.mjs
+++ b/src/report/dot/module-utl.mjs
@@ -1,8 +1,7 @@
 import { basename, sep, dirname } from "node:path/posix";
 import { formatPercentage, getURLForModule } from "../utl/index.mjs";
-import theming from "./theming.mjs";
 
-function attributizeObject(pObject) {
+export function attributizeObject(pObject) {
   return (
     Object.keys(pObject)
       // eslint-disable-next-line security/detect-object-injection
@@ -11,7 +10,7 @@ function attributizeObject(pObject) {
   );
 }
 
-function extractFirstTransgression(pModule) {
+export function extractFirstTransgression(pModule) {
   return {
     ...(pModule?.rules?.[0]
       ? { ...pModule, tooltip: pModule.rules[0].name }
@@ -25,26 +24,6 @@ function extractFirstTransgression(pModule) {
         : pDependency,
     ),
   };
-}
-
-function applyTheme(pTheme) {
-  return (pModule) => ({
-    ...pModule,
-    dependencies: pModule.dependencies
-      .map((pDependency) => ({
-        ...pDependency,
-        themeAttrs: attributizeObject(
-          theming.determineAttributes(pDependency, pTheme.dependencies),
-        ),
-      }))
-      .map((pDependency) => ({
-        ...pDependency,
-        hasExtraAttributes: Boolean(pDependency.rule || pDependency.themeAttrs),
-      })),
-    themeAttrs: attributizeObject(
-      theming.determineAttributes(pModule, pTheme.modules),
-    ),
-  });
 }
 
 function toFullPath(pAll, pCurrent) {
@@ -75,7 +54,7 @@ function makeInstabilityString(pModule, pShowMetrics = false) {
   return lInstabilityString;
 }
 
-function folderify(pShowMetrics) {
+export function folderify(pShowMetrics) {
   /** @param {import("../../../types/cruise-result").IModule} pModule*/
   return (pModule) => {
     let lAdditions = {};
@@ -103,7 +82,7 @@ function folderify(pShowMetrics) {
  * @param {string} pPrefix
  * @returns {URL?: string}
  */
-function addURL(pPrefix) {
+export function addURL(pPrefix) {
   return (pModule) => {
     if (pModule.couldNotResolve) {
       return pModule;
@@ -122,19 +101,10 @@ function makeLabel(pModule, pShowMetrics) {
   )}</B>${makeInstabilityString(pModule, pShowMetrics)}>`;
 }
 
-function flatLabel(pShowMetrics) {
+export function flatLabel(pShowMetrics) {
   return (pModule) => ({
     ...pModule,
     label: makeLabel(pModule, pShowMetrics),
     tooltip: basename(pModule.source),
   });
 }
-
-export default {
-  folderify,
-  applyTheme,
-  extractFirstTransgression,
-  attributizeObject,
-  addURL,
-  flatLabel,
-};

--- a/src/report/dot/prepare-custom-level.mjs
+++ b/src/report/dot/prepare-custom-level.mjs
@@ -1,4 +1,5 @@
-import moduleUtl from "./module-utl.mjs";
+import { folderify, addURL, extractFirstTransgression } from "./module-utl.mjs";
+import { applyTheme } from "./theming.mjs";
 import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
 import { compareModules } from "#graph-utl/compare.mjs";
 import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
@@ -15,9 +16,9 @@ export default function prepareCustomLevel(
       : pResults.modules
   )
     .sort(compareModules)
-    .map(moduleUtl.folderify(pShowMetrics))
-    .map(moduleUtl.extractFirstTransgression)
+    .map(folderify(pShowMetrics))
+    .map(extractFirstTransgression)
     .map(stripSelfTransitions)
-    .map(moduleUtl.applyTheme(pTheme))
-    .map(moduleUtl.addURL(pResults.summary.optionsUsed?.prefix ?? ""));
+    .map(applyTheme(pTheme))
+    .map(addURL(pResults.summary.optionsUsed?.prefix ?? ""));
 }

--- a/src/report/dot/prepare-flat-level.mjs
+++ b/src/report/dot/prepare-flat-level.mjs
@@ -1,11 +1,12 @@
-import moduleUtl from "./module-utl.mjs";
+import { flatLabel, extractFirstTransgression, addURL } from "./module-utl.mjs";
+import { applyTheme } from "./theming.mjs";
 import { compareModules } from "#graph-utl/compare.mjs";
 
 export default function prepareFlatLevel(pResults, pTheme, _, pShowMetrics) {
   return pResults.modules
     .sort(compareModules)
-    .map(moduleUtl.flatLabel(pShowMetrics))
-    .map(moduleUtl.extractFirstTransgression)
-    .map(moduleUtl.applyTheme(pTheme))
-    .map(moduleUtl.addURL(pResults.summary.optionsUsed?.prefix ?? ""));
+    .map(flatLabel(pShowMetrics))
+    .map(extractFirstTransgression)
+    .map(applyTheme(pTheme))
+    .map(addURL(pResults.summary.optionsUsed?.prefix ?? ""));
 }

--- a/src/report/dot/prepare-folder-level.mjs
+++ b/src/report/dot/prepare-folder-level.mjs
@@ -1,14 +1,16 @@
-import moduleUtl from "./module-utl.mjs";
+import { folderify, extractFirstTransgression, addURL } from "./module-utl.mjs";
+import { applyTheme } from "./theming.mjs";
 import consolidateToFolder from "#graph-utl/consolidate-to-folder.mjs";
 import { compareModules } from "#graph-utl/compare.mjs";
 import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
+// fuk eslint
 
 export default function prepareFolderLevel(pResults, pTheme, _, pShowMetrics) {
   return consolidateToFolder(pResults.modules)
     .sort(compareModules)
-    .map(moduleUtl.extractFirstTransgression)
-    .map(moduleUtl.folderify(pShowMetrics))
+    .map(extractFirstTransgression)
+    .map(folderify(pShowMetrics))
     .map(stripSelfTransitions)
-    .map(moduleUtl.applyTheme(pTheme))
-    .map(moduleUtl.addURL(pResults.summary.optionsUsed?.prefix ?? ""));
+    .map(applyTheme(pTheme))
+    .map(addURL(pResults.summary.optionsUsed?.prefix ?? ""));
 }

--- a/src/report/index.mjs
+++ b/src/report/index.mjs
@@ -35,7 +35,7 @@ const TYPE2MODULE = new Map([
  *                       an options object (specific to that function)
  *                       and returns an IReporterOutput
  */
-async function getReporter(pOutputType) {
+export async function getReporter(pOutputType) {
   let lReturnValue = {};
   if (pOutputType?.startsWith("plugin:")) {
     lReturnValue = await getExternalPluginReporter(pOutputType);
@@ -52,11 +52,6 @@ async function getReporter(pOutputType) {
  *
  * @returns {import("../../types/shared-types.js").OutputType[]} -
  */
-function getAvailableReporters() {
+export function getAvailableReporters() {
   return Array.from(TYPE2MODULE.keys());
 }
-
-export default {
-  getAvailableReporters,
-  getReporter,
-};

--- a/src/utl/regex-util.mjs
+++ b/src/utl/regex-util.mjs
@@ -23,7 +23,7 @@ export function extractGroups(pFromRestriction, pActualPath) {
 
     if (lMatchResult && lMatchResult.length > 1) {
       lReturnValue = lMatchResult.filter(
-        (pResult) => typeof pResult === "string"
+        (pResult) => typeof pResult === "string",
       );
     }
   }
@@ -51,11 +51,6 @@ export function replaceGroupPlaceholders(pString, pExtractedGroups) {
     (pAll, pThis, pIndex) =>
       // eslint-disable-next-line security/detect-non-literal-regexp
       pAll.replace(new RegExp(`\\$${pIndex}`, "g"), pThis),
-    pString
+    pString,
   );
 }
-
-export default {
-  extractGroups,
-  replaceGroupPlaceholders,
-};

--- a/src/validate/index.mjs
+++ b/src/validate/index.mjs
@@ -89,22 +89,19 @@ function validateAgainstRules(pRuleSet, pFrom, pTo, pMatchModule) {
   }
   return lReturnValue;
 }
+export function validateModule(pRuleSet, pModule) {
+  return validateAgainstRules(pRuleSet, pModule, {}, matchModuleRule);
+}
 
-export default {
-  module: function module(pRuleSet, pModule) {
-    return validateAgainstRules(pRuleSet, pModule, {}, matchModuleRule);
-  },
+export function validateDependency(pRuleSet, pFrom, pTo) {
+  return validateAgainstRules(pRuleSet, pFrom, pTo, matchDependencyRule);
+}
 
-  dependency: function dependency(pRuleSet, pFrom, pTo) {
-    return validateAgainstRules(pRuleSet, pFrom, pTo, matchDependencyRule);
-  },
-
-  folder: function folder(pRuleSet, pFromFolder, pToFolder) {
-    return validateAgainstRules(
-      pRuleSet,
-      pFromFolder,
-      pToFolder,
-      matchFolderRule,
-    );
-  },
-};
+export function validateFolder(pRuleSet, pFromFolder, pToFolder) {
+  return validateAgainstRules(
+    pRuleSet,
+    pFromFolder,
+    pToFolder,
+    matchFolderRule,
+  );
+}

--- a/src/validate/match-dependency-rule.mjs
+++ b/src/validate/match-dependency-rule.mjs
@@ -1,6 +1,20 @@
 // @ts-check
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
-import matchers from "./matchers.mjs";
+import {
+  propertyEquals,
+  propertyMatches,
+  propertyMatchesNot,
+  matchesFromPath,
+  matchesFromPathNot,
+  matchesToPath,
+  matchesToPathNot,
+  matchesToDependencyTypes,
+  matchesToDependencyTypesNot,
+  matchesToVia,
+  matchesToViaOnly,
+  matchesToIsMoreUnstable,
+  matchesMoreThanOneDependencyType,
+} from "./matchers.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
 
 /**
@@ -15,34 +29,29 @@ function match(pFrom, pTo) {
     const lGroups = extractGroups(pRule.from, pFrom.source);
 
     return (
-      matchers.fromPath(pRule, pFrom) &&
-      matchers.fromPathNot(pRule, pFrom) &&
-      matchers.toPath(pRule, pTo, lGroups) &&
-      matchers.toPathNot(pRule, pTo, lGroups) &&
-      matchers.toDependencyTypes(pRule, pTo) &&
-      matchers.toDependencyTypesNot(pRule, pTo) &&
-      matchers.matchesMoreThanOneDependencyType(pRule, pTo) &&
+      matchesFromPath(pRule, pFrom) &&
+      matchesFromPathNot(pRule, pFrom) &&
+      matchesToPath(pRule, pTo, lGroups) &&
+      matchesToPathNot(pRule, pTo, lGroups) &&
+      matchesToDependencyTypes(pRule, pTo) &&
+      matchesToDependencyTypesNot(pRule, pTo) &&
+      matchesMoreThanOneDependencyType(pRule, pTo) &&
       // preCompilationOnly is not a mandatory attribute, but if the attribute
       // is in the rule but not in the dependency there won't be a match
       // anyway, so we can use the default propertyEquals method regardless
-      matchers.propertyEquals(pRule, pTo, "preCompilationOnly") &&
+      propertyEquals(pRule, pTo, "preCompilationOnly") &&
       // couldNotResolve, circular, dynamic and exoticallyRequired _are_ mandatory
-      matchers.propertyEquals(pRule, pTo, "couldNotResolve") &&
-      matchers.propertyEquals(pRule, pTo, "circular") &&
-      matchers.propertyEquals(pRule, pTo, "dynamic") &&
-      matchers.propertyEquals(pRule, pTo, "exoticallyRequired") &&
-      matchers.propertyMatches(pRule, pTo, "license", "license") &&
-      matchers.propertyMatchesNot(pRule, pTo, "licenseNot", "license") &&
-      matchers.propertyMatches(pRule, pTo, "exoticRequire", "exoticRequire") &&
-      matchers.propertyMatchesNot(
-        pRule,
-        pTo,
-        "exoticRequireNot",
-        "exoticRequire",
-      ) &&
-      matchers.toVia(pRule, pTo, lGroups) &&
-      matchers.toViaOnly(pRule, pTo, lGroups) &&
-      matchers.toIsMoreUnstable(pRule, pFrom, pTo)
+      propertyEquals(pRule, pTo, "couldNotResolve") &&
+      propertyEquals(pRule, pTo, "circular") &&
+      propertyEquals(pRule, pTo, "dynamic") &&
+      propertyEquals(pRule, pTo, "exoticallyRequired") &&
+      propertyMatches(pRule, pTo, "license", "license") &&
+      propertyMatchesNot(pRule, pTo, "licenseNot", "license") &&
+      propertyMatches(pRule, pTo, "exoticRequire", "exoticRequire") &&
+      propertyMatchesNot(pRule, pTo, "exoticRequireNot", "exoticRequire") &&
+      matchesToVia(pRule, pTo, lGroups) &&
+      matchesToViaOnly(pRule, pTo, lGroups) &&
+      matchesToIsMoreUnstable(pRule, pFrom, pTo)
     );
   };
 }

--- a/src/validate/match-folder-dependency-rule.mjs
+++ b/src/validate/match-folder-dependency-rule.mjs
@@ -1,5 +1,5 @@
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
-import matchers from "./matchers.mjs";
+import { propertyEquals, matchesToIsMoreUnstable } from "./matchers.mjs";
 import { extractGroups, replaceGroupPlaceholders } from "#utl/regex-util.mjs";
 
 function fromFolderPath(pRule, pFromFolder) {
@@ -44,8 +44,8 @@ function match(pFromFolder, pToFolder) {
       fromFolderPathNot(pRule, pFromFolder) &&
       toFolderPath(pRule, pToFolder, lGroups) &&
       toFolderPathNot(pRule, pToFolder, lGroups) &&
-      matchers.toIsMoreUnstable(pRule, pFromFolder, pToFolder) &&
-      matchers.propertyEquals(pRule, pToFolder, "circular")
+      matchesToIsMoreUnstable(pRule, pFromFolder, pToFolder) &&
+      propertyEquals(pRule, pToFolder, "circular")
     );
   };
 }

--- a/src/validate/match-module-rule-helpers.mjs
+++ b/src/validate/match-module-rule-helpers.mjs
@@ -1,0 +1,132 @@
+import {
+  matchToModulePath,
+  matchToModulePathNot,
+  matchesFromPath,
+  matchesFromPathNot,
+  matchesModulePath,
+  matchesModulePathNot,
+} from "./matchers.mjs";
+import { extractGroups } from "#utl/regex-util.mjs";
+/**
+ * Returns true if pRule is an orphan rule and pModule is an orphan.
+ * Returns false in all other cases
+ *
+ * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
+ * @param {import("../../types/cruise-result.mjs").IModule} pModule
+ * @returns {boolean}
+ */
+export function matchesOrphanRule(pRule, pModule) {
+  return (
+    Object.hasOwn(pRule?.from ?? {}, "orphan") &&
+    // @ts-expect-error the 'hasOwn' above guarantees there's a 'from.orphan' attribute
+    pModule.orphan === pRule.from.orphan &&
+    matchesFromPath(pRule, pModule) &&
+    matchesFromPathNot(pRule, pModule)
+  );
+}
+
+/**
+ * Returns true if pRule is a 'reachable' rule and pModule matches the reachability
+ * criteria.
+ * Returns false in all other cases
+ *
+ * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
+ * @param {import("../../types/cruise-result.mjs").IModule} pModule
+ * @returns {boolean}
+ */
+export function matchesReachableRule(pRule, pModule) {
+  if (
+    Object.hasOwn(pRule?.to ?? {}, "reachable") &&
+    Object.hasOwn(pModule, "reachable")
+  ) {
+    // @ts-expect-error the 'hasOwn' above ensures the 'reachable' exists
+    const lReachableRecord = pModule.reachable.find(
+      (pReachable) =>
+        pReachable.asDefinedInRule === pRule.name &&
+        // @ts-expect-error the 'hasOwn' above ensures the 'to.reachable' exists
+        pReachable.value === pRule.to.reachable,
+    );
+    if (lReachableRecord) {
+      const lGroups = extractGroups(pRule.from, lReachableRecord.matchedFrom);
+
+      return (
+        matchToModulePath(pRule, pModule, lGroups) &&
+        matchToModulePathNot(pRule, pModule, lGroups)
+      );
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if pRule is a 'reaches' rule and pModule matches the reachability
+ * criteria.
+ * Returns false in all other cases
+ *
+ * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
+ * @param {import("../../types/cruise-result.mjs").IModule} pModule
+ * @returns {boolean}
+ */
+export function matchesReachesRule(pRule, pModule) {
+  return (
+    Object.hasOwn(pRule?.to ?? {}, "reachable") &&
+    Object.hasOwn(pModule, "reaches") &&
+    // @ts-expect-error the 'hasOwn' above guarantees the .reaches exists
+    pModule.reaches.some(
+      (pReaches) =>
+        pReaches.asDefinedInRule === pRule.name &&
+        pReaches.modules.some(
+          (pReachesModule) =>
+            matchToModulePath(pRule, pReachesModule) &&
+            matchToModulePathNot(pRule, pReachesModule),
+        ),
+    )
+  );
+}
+/**
+ *
+ * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
+ * @param {string[]} pDependents
+ * @returns {boolean}
+ */
+function dependentsCountsMatch(pRule, pDependents) {
+  const lMatchingDependentsCount = pDependents.filter(
+    (pDependent) =>
+      Boolean(!pRule.from.path || pDependent.match(pRule.from.path)) &&
+      Boolean(!pRule.from.pathNot || !pDependent.match(pRule.from.pathNot)),
+  ).length;
+  return (
+    (!pRule.module.numberOfDependentsLessThan ||
+      lMatchingDependentsCount < pRule.module.numberOfDependentsLessThan) &&
+    (!pRule.module.numberOfDependentsMoreThan ||
+      lMatchingDependentsCount > pRule.module.numberOfDependentsMoreThan)
+  );
+}
+
+/**
+ *
+ * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
+ * @param {import("../../types/cruise-result.mjs").IModule} pModule
+ * @returns {boolean}
+ */
+// eslint-disable-next-line complexity
+export function matchesDependentsRule(pRule, pModule) {
+  if (
+    (Object.hasOwn(pModule, "dependents") &&
+      Object.hasOwn(pRule?.module ?? {}, "numberOfDependentsLessThan")) ||
+    Object.hasOwn(pRule?.module ?? {}, "numberOfDependentsMoreThan")
+  ) {
+    return (
+      // group matching seems like a nice idea, however, the 'from' part of the
+      // rule is going to match not one module (as with regular dependency rules)
+      // but a whole bunch of them, being the 'dependents'. So that match is going
+      // to produce not one result, but one per matching dependent. To get meaningful
+      // results we'd probably have to loop over these and or the
+      // matchToModulePath together.
+      matchesModulePath(pRule, pModule) &&
+      matchesModulePathNot(pRule, pModule) &&
+      dependentsCountsMatch(pRule, pModule.dependents)
+    );
+  }
+  return false;
+}

--- a/src/validate/match-module-rule.mjs
+++ b/src/validate/match-module-rule.mjs
@@ -1,130 +1,10 @@
 import { isModuleOnlyRule, isFolderScope } from "./rule-classifiers.mjs";
-import matchers from "./matchers.mjs";
-import { extractGroups } from "#utl/regex-util.mjs";
-
-/**
- * Returns true if pRule is an orphan rule and pModule is an orphan.
- * Returns false in all other cases
- *
- * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
- * @param {import("../../types/cruise-result.mjs").IModule} pModule
- * @returns {boolean}
- */
-function matchesOrphanRule(pRule, pModule) {
-  return (
-    Object.hasOwn(pRule?.from ?? {}, "orphan") &&
-    // @ts-expect-error the 'hasOwn' above guarantees there's a 'from.orphan' attribute
-    pModule.orphan === pRule.from.orphan &&
-    matchers.fromPath(pRule, pModule) &&
-    matchers.fromPathNot(pRule, pModule)
-  );
-}
-
-/**
- * Returns true if pRule is a 'reachable' rule and pModule matches the reachability
- * criteria.
- * Returns false in all other cases
- *
- * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
- * @param {import("../../types/cruise-result.mjs").IModule} pModule
- * @returns {boolean}
- */
-function matchesReachableRule(pRule, pModule) {
-  if (
-    Object.hasOwn(pRule?.to ?? {}, "reachable") &&
-    Object.hasOwn(pModule, "reachable")
-  ) {
-    // @ts-expect-error the 'hasOwn' above ensures the 'reachable' exists
-    const lReachableRecord = pModule.reachable.find(
-      (pReachable) =>
-        pReachable.asDefinedInRule === pRule.name &&
-        // @ts-expect-error the 'hasOwn' above ensures the 'to.reachable' exists
-        pReachable.value === pRule.to.reachable,
-    );
-    if (lReachableRecord) {
-      const lGroups = extractGroups(pRule.from, lReachableRecord.matchedFrom);
-
-      return (
-        matchers.toModulePath(pRule, pModule, lGroups) &&
-        matchers.toModulePathNot(pRule, pModule, lGroups)
-      );
-    }
-  }
-  return false;
-}
-
-/**
- * Returns true if pRule is a 'reaches' rule and pModule matches the reachability
- * criteria.
- * Returns false in all other cases
- *
- * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
- * @param {import("../../types/cruise-result.mjs").IModule} pModule
- * @returns {boolean}
- */
-function matchesReachesRule(pRule, pModule) {
-  return (
-    Object.hasOwn(pRule?.to ?? {}, "reachable") &&
-    Object.hasOwn(pModule, "reaches") &&
-    // @ts-expect-error the 'hasOwn' above guarantees the .reaches exists
-    pModule.reaches.some(
-      (pReaches) =>
-        pReaches.asDefinedInRule === pRule.name &&
-        pReaches.modules.some(
-          (pReachesModule) =>
-            matchers.toModulePath(pRule, pReachesModule) &&
-            matchers.toModulePathNot(pRule, pReachesModule),
-        ),
-    )
-  );
-}
-/**
- *
- * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
- * @param {string[]} pDependents
- * @returns {boolean}
- */
-function dependentsCountsMatch(pRule, pDependents) {
-  const lMatchingDependentsCount = pDependents.filter(
-    (pDependent) =>
-      Boolean(!pRule.from.path || pDependent.match(pRule.from.path)) &&
-      Boolean(!pRule.from.pathNot || !pDependent.match(pRule.from.pathNot)),
-  ).length;
-  return (
-    (!pRule.module.numberOfDependentsLessThan ||
-      lMatchingDependentsCount < pRule.module.numberOfDependentsLessThan) &&
-    (!pRule.module.numberOfDependentsMoreThan ||
-      lMatchingDependentsCount > pRule.module.numberOfDependentsMoreThan)
-  );
-}
-
-/**
- *
- * @param {import("../../types/rule-set.mjs").IAnyRuleType} pRule
- * @param {import("../../types/cruise-result.mjs").IModule} pModule
- * @returns {boolean}
- */
-// eslint-disable-next-line complexity
-function matchesDependentsRule(pRule, pModule) {
-  if (
-    (Object.hasOwn(pModule, "dependents") &&
-      Object.hasOwn(pRule?.module ?? {}, "numberOfDependentsLessThan")) ||
-    Object.hasOwn(pRule?.module ?? {}, "numberOfDependentsMoreThan")
-  ) {
-    return (
-      // group matching seems like a nice idea, however, the 'from' part of the
-      // rule is going to match not one module (as with regular dependency rules)
-      // but a whole bunch of them, being the 'dependents'. So that match is going
-      // to produce not one result, but one per matching dependent. To get meaningful
-      // results we'd probably have to loop over these and or the
-      // matchers.toModulePath together.
-      matchers.modulePath(pRule, pModule) &&
-      matchers.modulePathNot(pRule, pModule) &&
-      dependentsCountsMatch(pRule, pModule.dependents)
-    );
-  }
-  return false;
-}
+import {
+  matchesOrphanRule,
+  matchesReachableRule,
+  matchesReachesRule,
+  matchesDependentsRule,
+} from "./match-module-rule-helpers.mjs";
 
 /**
  *
@@ -148,10 +28,6 @@ const isInteresting = (pRule) =>
   isModuleOnlyRule(pRule) && !isFolderScope(pRule);
 
 export default {
-  matchesOrphanRule,
-  matchesReachableRule,
-  matchesReachesRule,
-  matchesDependentsRule,
   match,
   isInteresting,
 };

--- a/src/validate/matchers.mjs
+++ b/src/validate/matchers.mjs
@@ -19,7 +19,7 @@ const DEPENDENCY_TYPE_DUPLICATES_THAT_MATTER = new Set([
   "npm-unknown",
 ]);
 
-function propertyEquals(pRule, pDependency, pProperty) {
+export function propertyEquals(pRule, pDependency, pProperty) {
   // The properties can be booleans, so we can't use !pRule.to[pProperty]
   if (Object.hasOwn(pRule.to, pProperty)) {
     return pDependency[pProperty] === pRule.to[pProperty];
@@ -27,7 +27,7 @@ function propertyEquals(pRule, pDependency, pProperty) {
   return true;
 }
 
-function propertyMatches(pRule, pDependency, pRuleProperty, pProperty) {
+export function propertyMatches(pRule, pDependency, pRuleProperty, pProperty) {
   return Boolean(
     !pRule.to[pRuleProperty] ||
       (pDependency[pProperty] &&
@@ -35,7 +35,12 @@ function propertyMatches(pRule, pDependency, pRuleProperty, pProperty) {
   );
 }
 
-function propertyMatchesNot(pRule, pDependency, pRuleProperty, pProperty) {
+export function propertyMatchesNot(
+  pRule,
+  pDependency,
+  pRuleProperty,
+  pProperty,
+) {
   return Boolean(
     !pRule.to[pRuleProperty] ||
       (pDependency[pProperty] &&
@@ -43,21 +48,21 @@ function propertyMatchesNot(pRule, pDependency, pRuleProperty, pProperty) {
   );
 }
 
-function fromPath(pRule, pModule) {
+export function matchesFromPath(pRule, pModule) {
   return Boolean(!pRule.from.path || pModule.source.match(pRule.from.path));
 }
 
-function fromPathNot(pRule, pModule) {
+export function matchesFromPathNot(pRule, pModule) {
   return Boolean(
     !pRule.from.pathNot || !pModule.source.match(pRule.from.pathNot),
   );
 }
 
-function modulePath(pRule, pModule) {
+export function matchesModulePath(pRule, pModule) {
   return Boolean(!pRule.module.path || pModule.source.match(pRule.module.path));
 }
 
-function modulePathNot(pRule, pModule) {
+export function matchesModulePathNot(pRule, pModule) {
   return Boolean(
     !pRule.module.pathNot || !pModule.source.match(pRule.module.pathNot),
   );
@@ -70,11 +75,11 @@ function _toPath(pRule, pString, pGroups = []) {
   );
 }
 
-function toPath(pRule, pDependency, pGroups) {
+export function matchesToPath(pRule, pDependency, pGroups) {
   return _toPath(pRule, pDependency.resolved, pGroups);
 }
 
-function toModulePath(pRule, pModule, pGroups) {
+export function matchToModulePath(pRule, pModule, pGroups) {
   return _toPath(pRule, pModule.source, pGroups);
 }
 
@@ -85,22 +90,22 @@ function _toPathNot(pRule, pString, pGroups = []) {
   );
 }
 
-function toPathNot(pRule, pDependency, pGroups) {
+export function matchesToPathNot(pRule, pDependency, pGroups) {
   return _toPathNot(pRule, pDependency.resolved, pGroups);
 }
 
-function toModulePathNot(pRule, pModule, pGroups) {
+export function matchToModulePathNot(pRule, pModule, pGroups) {
   return _toPathNot(pRule, pModule.source, pGroups);
 }
 
-function toDependencyTypes(pRule, pDependency) {
+export function matchesToDependencyTypes(pRule, pDependency) {
   return Boolean(
     !pRule.to.dependencyTypes ||
       intersects(pDependency.dependencyTypes, pRule.to.dependencyTypes),
   );
 }
 
-function toDependencyTypesNot(pRule, pDependency) {
+export function matchesToDependencyTypesNot(pRule, pDependency) {
   return Boolean(
     !pRule.to.dependencyTypesNot ||
       !intersects(pDependency.dependencyTypes, pRule.to.dependencyTypesNot),
@@ -108,7 +113,7 @@ function toDependencyTypesNot(pRule, pDependency) {
 }
 
 // eslint-disable-next-line complexity
-function toVia(pRule, pDependency, pGroups) {
+export function matchesToVia(pRule, pDependency, pGroups) {
   let lReturnValue = true;
   if (pRule.to.via && pDependency.cycle) {
     if (pRule.to.via.path) {
@@ -140,7 +145,7 @@ function toVia(pRule, pDependency, pGroups) {
 }
 
 // eslint-disable-next-line complexity
-function toViaOnly(pRule, pDependency, pGroups) {
+export function matchesToViaOnly(pRule, pDependency, pGroups) {
   let lReturnValue = true;
   if (pRule.to.viaOnly && pDependency.cycle) {
     if (pRule.to.viaOnly.path) {
@@ -171,7 +176,7 @@ function toViaOnly(pRule, pDependency, pGroups) {
   return lReturnValue;
 }
 
-function toIsMoreUnstable(pRule, pModule, pDependency) {
+export function matchesToIsMoreUnstable(pRule, pModule, pDependency) {
   if (Object.hasOwn(pRule.to, "moreUnstable")) {
     return (
       (pRule.to.moreUnstable &&
@@ -182,7 +187,7 @@ function toIsMoreUnstable(pRule, pModule, pDependency) {
   return true;
 }
 
-function matchesMoreThanOneDependencyType(pRule, pDependency) {
+export function matchesMoreThanOneDependencyType(pRule, pDependency) {
   /**
    * this rule exists to weed out i.e. dependencies declared in both
    * dependencies and devDependencies. We, however, also use the dependencyTypes
@@ -208,24 +213,3 @@ function matchesMoreThanOneDependencyType(pRule, pDependency) {
   }
   return true;
 }
-
-export default {
-  replaceGroupPlaceholders,
-  propertyEquals,
-  propertyMatches,
-  propertyMatchesNot,
-  fromPath,
-  fromPathNot,
-  toPath,
-  toModulePath,
-  modulePath,
-  modulePathNot,
-  toPathNot,
-  toModulePathNot,
-  toDependencyTypes,
-  toDependencyTypesNot,
-  toVia,
-  toViaOnly,
-  toIsMoreUnstable,
-  matchesMoreThanOneDependencyType,
-};

--- a/src/validate/rule-classifiers.mjs
+++ b/src/validate/rule-classifiers.mjs
@@ -20,5 +20,3 @@ export function isFolderScope(pRule) {
   // normalized away before getting here.
   return (pRule?.scope ?? "module") === "folder";
 }
-
-export default { isModuleOnlyRule, isFolderScope };

--- a/src/validate/violates-required-rule.mjs
+++ b/src/validate/violates-required-rule.mjs
@@ -1,4 +1,8 @@
-import matchers from "./matchers.mjs";
+import {
+  matchesToPath,
+  matchesModulePath,
+  matchesModulePathNot,
+} from "./matchers.mjs";
 import { extractGroups } from "#utl/regex-util.mjs";
 
 /**
@@ -13,13 +17,13 @@ export default function violatesRequiredRule(pRule, pModule) {
   let lReturnValue = false;
 
   if (
-    matchers.modulePath(pRule, pModule) &&
-    matchers.modulePathNot(pRule, pModule)
+    matchesModulePath(pRule, pModule) &&
+    matchesModulePathNot(pRule, pModule)
   ) {
     const lGroups = extractGroups(pRule.module, pModule.source);
 
     lReturnValue = !pModule.dependencies.some((pDependency) =>
-      matchers.toPath(pRule, pDependency, lGroups),
+      matchesToPath(pRule, pDependency, lGroups),
     );
   }
   return lReturnValue;

--- a/test/configs/no-orphans.spec.mjs
+++ b/test/configs/no-orphans.spec.mjs
@@ -1,11 +1,11 @@
 import { equal } from "node:assert/strict";
 import noOrphansRule from "../../configs/rules/no-orphans.cjs";
-import matchModuleRule from "#validate/match-module-rule.mjs";
+import { matchesOrphanRule } from "#validate/match-module-rule-helpers.mjs";
 
 describe("[I] configs/rules/no-orphans", () => {
   it("flags non-excepted orphans as orphan rule transgression", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "Rémi.js",
         orphan: true,
       }),
@@ -15,7 +15,7 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("flags files ending on a dotfile as orphan rule transgression", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "looks-like-a-dot-sorta.Rémi.js",
         orphan: true,
       }),
@@ -25,7 +25,7 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("does not flag dot files as orphan rule transgressions", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: ".Rémi.js",
         orphan: true,
       }),
@@ -35,7 +35,7 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("does not flag dot files in the tree as orphan rule transgressions", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/.Rémi.js",
         orphan: true,
       }),
@@ -45,7 +45,7 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("does not flag dot files in the tree as orphan rule transgressions, regardless extension", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/.Rémi.ts",
         orphan: true,
       }),
@@ -55,14 +55,14 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("does not flag any .d.ts not as orphan rule transgressions", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/types/lalalal.d.ts",
         orphan: true,
       }),
       false,
     );
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "lalalal.d.ts",
         orphan: true,
       }),
@@ -72,7 +72,7 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("does not flag babel config files in the tree not as orphan rule transgressions", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "packages/thing/babel.config.mjs",
         orphan: true,
       }),
@@ -82,7 +82,7 @@ describe("[I] configs/rules/no-orphans", () => {
 
   it("does not flag babel config files as orphan rule transgressions", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(noOrphansRule, {
+      matchesOrphanRule(noOrphansRule, {
         source: "babel.config.mjs",
         orphan: true,
       }),

--- a/test/report/dot/module-utl.spec.mjs
+++ b/test/report/dot/module-utl.spec.mjs
@@ -1,16 +1,19 @@
 import { deepEqual } from "node:assert/strict";
-import moduleUtl from "#report/dot/module-utl.mjs";
+import {
+  extractFirstTransgression,
+  flatLabel,
+} from "#report/dot/module-utl.mjs";
 
 describe("[U] report/dot/module-utl", () => {
   it("extractFirstTransgression - keeps as is when there's no transgressions", () => {
-    deepEqual(moduleUtl.extractFirstTransgression({ dependencies: [] }), {
+    deepEqual(extractFirstTransgression({ dependencies: [] }), {
       dependencies: [],
     });
   });
 
   it("extractFirstTransgression - adds the first module rule if there's at least one", () => {
     deepEqual(
-      moduleUtl.extractFirstTransgression({
+      extractFirstTransgression({
         dependencies: [],
         rules: [
           { name: "error-thing", severity: "error" },
@@ -30,7 +33,7 @@ describe("[U] report/dot/module-utl", () => {
 
   it("extractFirstTransgression - adds the first dependency rule if there's at least one", () => {
     deepEqual(
-      moduleUtl.extractFirstTransgression({
+      extractFirstTransgression({
         dependencies: [
           {
             rules: [
@@ -55,19 +58,16 @@ describe("[U] report/dot/module-utl", () => {
   });
 
   it("flatLabel - returns the value of source as label", () => {
-    deepEqual(
-      moduleUtl.flatLabel(true)({ source: "aap/noot/mies/wim/zus.jet" }),
-      {
-        source: "aap/noot/mies/wim/zus.jet",
-        label: "<aap/noot/mies/wim/<BR/><B>zus.jet</B>>",
-        tooltip: "zus.jet",
-      },
-    );
+    deepEqual(flatLabel(true)({ source: "aap/noot/mies/wim/zus.jet" }), {
+      source: "aap/noot/mies/wim/zus.jet",
+      label: "<aap/noot/mies/wim/<BR/><B>zus.jet</B>>",
+      tooltip: "zus.jet",
+    });
   });
 
   it("flatLabel - returns the value of source & instability metric as label when instability is known", () => {
     deepEqual(
-      moduleUtl.flatLabel(true)({
+      flatLabel(true)({
         source: "aap/noot/mies/wim/zus.jet",
         instability: "0.481",
       }),
@@ -82,7 +82,7 @@ describe("[U] report/dot/module-utl", () => {
 
   it("flatLabel - returns the value of source when instability is known, but showMetrics is false", () => {
     deepEqual(
-      moduleUtl.flatLabel(false)({
+      flatLabel(false)({
         source: "aap/noot/mies/wim/zus.jet",
         instability: "0.481",
       }),

--- a/test/report/dot/theming.spec.mjs
+++ b/test/report/dot/theming.spec.mjs
@@ -1,56 +1,47 @@
 import { deepEqual } from "node:assert/strict";
-import theming from "#report/dot/theming.mjs";
+import { getThemeAttributes, normalizeTheme } from "#report/dot/theming.mjs";
 
 describe("[U] report/dot/theming - determineModuleColors - default theme", () => {
   it("empty module => no colors", () => {
-    deepEqual(
-      theming.determineAttributes({}, theming.normalizeTheme({}).module),
-      {},
-    );
+    deepEqual(getThemeAttributes({}, normalizeTheme({}).module), {});
   });
 
   it("core module => grey", () => {
     deepEqual(
-      theming.determineAttributes(
-        { coreModule: true },
-        theming.normalizeTheme({}).modules,
-      ),
+      getThemeAttributes({ coreModule: true }, normalizeTheme({}).modules),
       { color: "grey", fontcolor: "grey" },
     );
   });
 
   it("couldNotResolve => red", () => {
     deepEqual(
-      theming.determineAttributes(
-        { couldNotResolve: true },
-        theming.normalizeTheme({}).modules,
-      ),
+      getThemeAttributes({ couldNotResolve: true }, normalizeTheme({}).modules),
       {},
     );
   });
 
   it("json => darker yellowish fillcolor", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         { source: "package.json" },
-        theming.normalizeTheme({}).modules,
+        normalizeTheme({}).modules,
       ),
       { fillcolor: "#ffee44" },
     );
   });
 
   it("normalizeTheme doesn't mutate the default theme", () => {
-    const lOriginalDefaultTheme = structuredClone(theming.normalizeTheme());
+    const lOriginalDefaultTheme = structuredClone(normalizeTheme());
 
-    theming.normalizeTheme({ graph: { someAttribute: 1234 } });
-    deepEqual(theming.normalizeTheme(), lOriginalDefaultTheme);
+    normalizeTheme({ graph: { someAttribute: 1234 } });
+    deepEqual(normalizeTheme(), lOriginalDefaultTheme);
   });
 
   it("determines attributes when the property is a string and one of the criteria is an array", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         { source: "package.json" },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: { source: ["package.json", "package-lock.json"] },
@@ -65,7 +56,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
 
   it("determines attributes when the property is an array and one of the criteria is an array", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         {
           source: "src/heide/does.js",
           dependencyTypes: [
@@ -75,7 +66,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
             "aliased-tsconfig-base-url",
           ],
         },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: { dependencyTypes: ["aliased-tsconfig"] },
@@ -90,7 +81,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
 
   it("determines attributes when the property is an array and one of the criteria is an array - on multiple it takes the logical OR", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         {
           source: "src/heide/does.js",
           dependencyTypes: [
@@ -100,7 +91,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
             "aliased-tsconfig-base-url",
           ],
         },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: {
@@ -121,7 +112,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
 
   it("determines attributes when the property is an array and one of the criteria is a regexy array", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         {
           source: "src/heide/does.js",
           dependencyTypes: [
@@ -131,7 +122,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
             "aliased-tsconfig-base-url",
           ],
         },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: { dependencyTypes: ["aliased-t.+"] },
@@ -146,7 +137,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
 
   it("determines attributes when the property is an array and one of the criteria is a regexy array but there's no match", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         {
           source: "src/heide/does.js",
           dependencyTypes: [
@@ -156,7 +147,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
             "aliased-tsconfig-base-url",
           ],
         },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: { dependencyTypes: ["npm"] },
@@ -171,7 +162,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
 
   it("determines attributes when the property is an array and one of the criteria is a string", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         {
           source: "src/heide/does.js",
           dependencyTypes: [
@@ -181,7 +172,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
             "aliased-tsconfig-base-url",
           ],
         },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: { dependencyTypes: "aliased-tsconfig" },
@@ -196,7 +187,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
 
   it("determines attributes when the property is an array and one of the criteria is a regexy string", () => {
     deepEqual(
-      theming.determineAttributes(
+      getThemeAttributes(
         {
           source: "src/heide/does.js",
           dependencyTypes: [
@@ -206,7 +197,7 @@ describe("[U] report/dot/theming - determineModuleColors - default theme", () =>
             "aliased-tsconfig-base-url",
           ],
         },
-        theming.normalizeTheme({
+        normalizeTheme({
           modules: [
             {
               criteria: { dependencyTypes: "aliased-tsconfig" },

--- a/test/report/eol.spec.mjs
+++ b/test/report/eol.spec.mjs
@@ -1,5 +1,5 @@
 import { match, equal } from "node:assert/strict";
-import report from "#report/index.mjs";
+import { getAvailableReporters, getReporter } from "#report/index.mjs";
 
 const MINIMAL_CRUISE_RESULT = {
   modules: [],
@@ -14,7 +14,7 @@ const MINIMAL_CRUISE_RESULT = {
   },
 };
 
-const lAvailableReporters = report.getAvailableReporters();
+const lAvailableReporters = getAvailableReporters();
 const lReporters = await Promise.all(
   lAvailableReporters
     .filter(
@@ -22,7 +22,7 @@ const lReporters = await Promise.all(
         pReporterName !== "null" && pReporterName !== "x-dot-webpage",
     )
     .map(async (pReporter) => {
-      const lReporter = await report.getReporter(pReporter);
+      const lReporter = await getReporter(pReporter);
       const lResult = lReporter(MINIMAL_CRUISE_RESULT);
       return { reporter: pReporter, output: lResult.output };
     }),
@@ -50,7 +50,7 @@ describe("[I] most reporters' output ends on an EOL", () => {
   });
 
   it("the x-dot-webpage reporter output ends on an EOL", async () => {
-    const lXDotWebpageReporter = await report.getReporter("x-dot-webpage");
+    const lXDotWebpageReporter = await getReporter("x-dot-webpage");
 
     const lResult = lXDotWebpageReporter(MINIMAL_CRUISE_RESULT, {
       spawnFunction,
@@ -59,7 +59,7 @@ describe("[I] most reporters' output ends on an EOL", () => {
   });
 
   it("the null reporter output DOES NOT end on an EOL", async () => {
-    const lNullReporter = await report.getReporter("null");
+    const lNullReporter = await getReporter("null");
     const lResult = lNullReporter(MINIMAL_CRUISE_RESULT);
     equal(lResult.output, "");
   });

--- a/test/validate/index.core.spec.mjs
+++ b/test/validate/index.core.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - core", () => {
   const lNotToCoreRuleSet = parseRuleSet({
@@ -55,7 +55,7 @@ describe("[I] validate/index - core", () => {
 
   it("not to core - ok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToCoreRuleSet,
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["npm"] },
@@ -66,7 +66,7 @@ describe("[I] validate/index - core", () => {
 
   it("not to core - violation", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToCoreRuleSet,
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["core"] },
@@ -80,7 +80,7 @@ describe("[I] validate/index - core", () => {
 
   it("not to core fs os - ok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToCoreSpecificsRuleSet,
         { source: "koos koets" },
         { resolved: "path", dependencyTypes: ["core"] },
@@ -91,7 +91,7 @@ describe("[I] validate/index - core", () => {
 
   it("not to core fs os - violation", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToCoreSpecificsRuleSet,
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] },
@@ -116,7 +116,7 @@ describe("[I] validate/index - core", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] },
@@ -140,7 +140,7 @@ describe("[I] validate/index - core", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
 
         { source: "koos koets" },
@@ -165,7 +165,7 @@ describe("[I] validate/index - core", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "koos koets" },
         { resolved: "robbie kerkhof", dependencyTypes: ["local"] },
@@ -195,7 +195,7 @@ describe("[I] validate/index - core", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "koos koets" },
         { resolved: "ger hekking", dependencyTypes: ["npm"] },
@@ -209,7 +209,7 @@ describe("[I] validate/index - core", () => {
 
   it("only to core - via 'forbidden' - ok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lOnlyToCoreViaForbiddenRuleSet,
         { source: "koos koets" },
         { resolved: "os", dependencyTypes: ["core"] },
@@ -220,7 +220,7 @@ describe("[I] validate/index - core", () => {
 
   it("only to core - via 'forbidden' - violation", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lOnlyToCoreViaForbiddenRuleSet,
         { source: "koos koets" },
         { resolved: "ger hekking", dependencyTypes: ["local"] },

--- a/test/validate/index.could-not-resolve.spec.mjs
+++ b/test/validate/index.could-not-resolve.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - couldNotResolve", () => {
   const lNotToUnresolvableRuleSet = parseRuleSet({
@@ -18,7 +18,7 @@ describe("[I] validate/index - couldNotResolve", () => {
 
   it("not to unresolvable - ok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToUnresolvableRuleSet,
         { source: "koos koets" },
         { resolved: "diana charitee", couldNotResolve: false },
@@ -29,7 +29,7 @@ describe("[I] validate/index - couldNotResolve", () => {
 
   it("not to unresolvable - violation", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToUnresolvableRuleSet,
         { source: "koos koets" },
         { resolved: "diana charitee", couldNotResolve: true },

--- a/test/validate/index.cycle-via-only.spec.mjs
+++ b/test/validate/index.cycle-via-only.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 function stringToCycleEntry(pString) {
   return {
@@ -24,7 +24,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
 
   it("a => ba => bb => bc => a doesn't get flagged when the cycle doesn't go via the viaOnly", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -43,7 +43,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
 
   it("a => aa => ab => ac => does not get flagged when only some of them are not in the viaOnly", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -62,7 +62,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
 
   it("a => ab a gets flagged because all of the via's in the cycle are in the viaOnly", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -90,7 +90,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -124,7 +124,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
 
   it("a => aa => ab => ac => a doesn't get flagged when one of the dependencyTypes is in a pathNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaNotTypeOnlyRuleSet,
         { source: "tmp/a.js" },
         {
@@ -146,7 +146,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
 
   it("a => aa => ab => ac => a does get flagged when none of the dependencyTypes is in a pathNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaNotTypeOnlyRuleSet,
         { source: "tmp/a.js" },
         {
@@ -187,7 +187,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
   });
   it("a => aa => ab => ac => a does get flagged when none of the dependencyTypes is in a via", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaTypeOnlyRuleSet,
         { source: "tmp/a.js" },
         {
@@ -215,7 +215,7 @@ describe("[I] validate/index dependency - cycle viaOnly", () => {
 
   it("a => aa => ab => ac => a doesn't get flagged when none of the dependencyTypes is in a via", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaTypeOnlyRuleSet,
         { source: "tmp/a.js" },
         {
@@ -253,7 +253,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
 
   it("a => ba => bb => bc => a doesn't get flagged when the cycle doesn't go via the viaOnly", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -272,7 +272,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
 
   it("a => aa => ab => ac => does not get flagged when only some of them are not in the viaOnly", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -291,7 +291,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
 
   it("a => ab a gets flagged becaue all of the via's in the cycle are in the viaOnly", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -319,7 +319,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -349,7 +349,7 @@ describe("[I] validate/index dependency - cycle viaOnly - with group matching", 
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -383,7 +383,7 @@ describe("[I] validate/index dependency - cycle viaNot (which normalizes to viaO
 
   it("a => ba => bb => bc => a get flagged when none of them is in a viaNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaNotRuleSet,
         { source: "tmp/a.js" },
         {
@@ -403,7 +403,7 @@ describe("[I] validate/index dependency - cycle viaNot (which normalizes to viaO
 
   it("a => aa => ab => ac => a doesn't get flagged when one of them is in a viaNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaNotRuleSet,
         { source: "tmp/a.js" },
         {

--- a/test/validate/index.cycle-via.spec.mjs
+++ b/test/validate/index.cycle-via.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 function stringToCycleEntry(pString) {
   return {
@@ -24,7 +24,7 @@ describe("[I] validate/index dependency - cycle via", () => {
 
   it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -43,7 +43,7 @@ describe("[I] validate/index dependency - cycle via", () => {
 
   it("a => aa => ab => ac => a get flagged when one of them is in a via", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -74,7 +74,7 @@ describe("[I] validate/index dependency - cycle via", () => {
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -138,7 +138,7 @@ describe("[I] validate/index dependency - cycle via", () => {
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -208,7 +208,7 @@ describe("[I] validate/index dependency - cycle via", () => {
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -251,7 +251,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
 
   it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -270,7 +270,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
 
   it("a => ba => bb => bc => a doesn't get flagged when none of them is in a via (group match)", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -289,7 +289,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
 
   it("a => aa => ab => ac => a get flagged when one of them is in a via", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lCycleViaRuleSet,
         { source: "tmp/a.js" },
         {
@@ -320,7 +320,7 @@ describe("[I] validate/index dependency - cycle via - with group matching", () =
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "tmp/a.js" },
         {
@@ -352,7 +352,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot (normalizes to via.pa
 
   it("flags when all of the cycle (except the root) is outside the group-matched viaSomeNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
         {
@@ -380,7 +380,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot (normalizes to via.pa
 
   it("flags when only one of the cycle is outside the group-matched viaNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
         {
@@ -408,7 +408,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot (normalizes to via.pa
 
   it("does not flag when all of the cycle is inside the group-matched viaNot", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lCycleButNotViaGroupMatchRuleSet),
         { source: "src/module-a/a.js" },
         {
@@ -442,7 +442,7 @@ describe("[I] validate/index dependency - cycle viaSomeNot (normalizes to via.pa
       ],
     };
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lRuleSet),
         { source: "src/module-a/a.js" },
         {

--- a/test/validate/index.exotic-require.spec.mjs
+++ b/test/validate/index.exotic-require.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - exoticallyRequired", () => {
   const lExoticallyRequiredRuleSet = parseRuleSet({
@@ -14,7 +14,7 @@ describe("[I] validate/index - exoticallyRequired", () => {
   });
   it("does not flag dependencies that are required with a regular require or import", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticallyRequiredRuleSet,
         { source: "something" },
         {
@@ -28,7 +28,7 @@ describe("[I] validate/index - exoticallyRequired", () => {
 
   it("does flag dependencies that are required with any exotic require", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticallyRequiredRuleSet,
         { source: "something" },
         {
@@ -57,7 +57,7 @@ describe("[I] validate/index - exoticRequire", () => {
   });
   it("does not flag dependencies that are required with a regular require or import", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticRequireRuleSet,
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -68,7 +68,7 @@ describe("[I] validate/index - exoticRequire", () => {
 
   it("does not flag dependencies that are required with an exotic require not in the forbdidden RE", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticRequireRuleSet,
         { source: "something" },
         {
@@ -82,7 +82,7 @@ describe("[I] validate/index - exoticRequire", () => {
 
   it("flags dependencies that are required with a forbidden exotic require", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticRequireRuleSet,
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts", exoticRequire: "use" },
@@ -107,7 +107,7 @@ describe("[I] validate/index - exoticRequireNot", () => {
   });
   it("does not flag dependencies that are required with a regular require or import", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticRequireNotRuleSet,
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -118,7 +118,7 @@ describe("[I] validate/index - exoticRequireNot", () => {
 
   it("does not flag dependencies that are required with a sanctioned exotic require", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticRequireNotRuleSet,
         { source: "something" },
         {
@@ -132,7 +132,7 @@ describe("[I] validate/index - exoticRequireNot", () => {
 
   it("flags dependencies are required with an unsanctioned exotic require", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lExoticRequireNotRuleSet,
         { source: "something" },
         {

--- a/test/validate/index.groupmatching.spec.mjs
+++ b/test/validate/index.groupmatching.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index group matching - path group matched in a pathnot", () => {
   const lGroupToPathNotRuleSet = {
@@ -22,7 +22,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
 
   it("group-to-pathnot - Disallows dependencies between peer folders", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/noot/pinda.ts" },
@@ -41,7 +41,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
 
   it("group-to-pathnot - Allows dependencies within to peer folder 'shared'", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/shared/bananas.ts" },
@@ -52,7 +52,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
 
   it("group-to-pathnot - Allows dependencies within own folder", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/oerangoetang.ts" },
@@ -63,7 +63,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
 
   it("group-to-pathnot - Allows dependencies to sub folders of own folder", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -74,7 +74,7 @@ describe("[I] validate/index group matching - path group matched in a pathnot", 
 
   it("group-to-pathnot - Allows peer dependencies between sub folders of own folder", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupToPathNotRuleSet),
         { source: "src/aap/rekwisieten/touw.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -104,7 +104,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
 
   it("group-two-to-pathnot - Disallows dependencies between peer folders", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/noot/pinda.ts" },
@@ -123,7 +123,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
 
   it("group-two-to-pathnot - Allows dependencies within to peer folder 'shared'", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/shared/bananas.ts" },
@@ -134,7 +134,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
 
   it("group-two-to-pathnot - Allows dependencies within own folder", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/oerangoetang.ts" },
@@ -145,7 +145,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
 
   it("group-two-to-pathnot - Allows dependencies to sub folders of own folder", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/chimpansee.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -156,7 +156,7 @@ describe("[I] validate/index group matching - second path group matched in a pat
 
   it("group-two-to-pathnot - Allows peer dependencies between sub folders of own folder", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         parseRuleSet(lGroupTwoToPathNotRuleSet),
         { source: "src/aap/rekwisieten/touw.ts" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },

--- a/test/validate/index.license.spec.mjs
+++ b/test/validate/index.license.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - license", () => {
   const lLicenseRuleSet = parseRuleSet({
@@ -15,7 +15,7 @@ describe("[I] validate/index - license", () => {
 
   it("Skips dependencies that have no license attached", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lLicenseRuleSet,
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -26,7 +26,7 @@ describe("[I] validate/index - license", () => {
 
   it("does not flag dependencies that do not match the license expression", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lLicenseRuleSet,
         { source: "something" },
         {
@@ -40,7 +40,7 @@ describe("[I] validate/index - license", () => {
 
   it("flags dependencies that match the license expression", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lLicenseRuleSet,
         { source: "something" },
         {
@@ -69,7 +69,7 @@ describe("[I] validate/index - licenseNot", () => {
 
   it("Skips dependencies that have no license attached", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lLicenseNotRuleSet,
         { source: "something" },
         { resolved: "src/aap/speeltuigen/autoband.ts" },
@@ -80,7 +80,7 @@ describe("[I] validate/index - licenseNot", () => {
 
   it("does not flag dependencies that do match the license expression", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lLicenseNotRuleSet,
         { source: "something" },
         {
@@ -94,7 +94,7 @@ describe("[I] validate/index - licenseNot", () => {
 
   it("flags dependencies that do not match the license expression", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lLicenseNotRuleSet,
         { source: "something" },
         {

--- a/test/validate/index.more-than-one-dependency-type.spec.mjs
+++ b/test/validate/index.more-than-one-dependency-type.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] index/validate - moreThanOneDependencyType", () => {
   it(`no relations with modules of > 1 dep type (e.g. specified 2x in package.json)`, () => {
@@ -16,7 +16,7 @@ describe("[I] index/validate - moreThanOneDependencyType", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "src/aap/zus/jet.js" },
         {
@@ -50,7 +50,7 @@ describe("[I] index/validate - moreThanOneDependencyType", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "src/aap/zus/jet.js" },
         {
@@ -83,7 +83,7 @@ describe("[I] index/validate - moreThanOneDependencyType", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "src/aap/zus/jet.js" },
         {
@@ -110,7 +110,7 @@ describe("[I] index/validate - moreThanOneDependencyType", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "src/aap/zus/jet.js" },
         {

--- a/test/validate/index.more-unstable.spec.mjs
+++ b/test/validate/index.more-unstable.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - stability checks", () => {
   const lForbiddenRuleSet = parseRuleSet({
@@ -29,7 +29,7 @@ describe("[I] validate/index - stability checks", () => {
 
   it("moreUnstable: flags when depending on a module that is more unstable (moreUnstable=true, forbidden)", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lForbiddenRuleSet,
         { source: "something", instability: 0 },
         {
@@ -46,7 +46,7 @@ describe("[I] validate/index - stability checks", () => {
 
   it("moreUnstable: does not flag when depending on a module that is more stable (moreUnstable=true, forbidden)", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lForbiddenRuleSet,
         { source: "something", instability: 1 },
         {
@@ -62,7 +62,7 @@ describe("[I] validate/index - stability checks", () => {
 
   it("moreUnstable: flags when depending on a module that is more unstable (moreUnstable=false, allowed)", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lAllowedRuleSet,
         { source: "something", instability: 0 },
         {
@@ -79,7 +79,7 @@ describe("[I] validate/index - stability checks", () => {
 
   it("moreUnstable: does not flag when depending on a module that is more stable (moreUnstable=false, allowed)", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lAllowedRuleSet,
         { source: "something", instability: 1 },
         {

--- a/test/validate/index.orphans.spec.mjs
+++ b/test/validate/index.orphans.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency, validateModule } from "#validate/index.mjs";
 
 describe("[I] validate/index - orphans", () => {
   const lOrphanRuleSet = parseRuleSet({
@@ -14,14 +14,14 @@ describe("[I] validate/index - orphans", () => {
   });
 
   it("Skips modules that have no orphan attribute", () => {
-    deepEqual(validate.module(lOrphanRuleSet, { source: "something" }), {
+    deepEqual(validateModule(lOrphanRuleSet, { source: "something" }), {
       valid: true,
     });
   });
 
   it("Flags modules that are orphans", () => {
     deepEqual(
-      validate.module(lOrphanRuleSet, {
+      validateModule(lOrphanRuleSet, {
         source: "something",
         orphan: true,
       }),
@@ -49,7 +49,7 @@ describe("[I] validate/index - orphans in 'allowed' rules", () => {
 
   it("Flags modules that are orphans if they're in the 'allowed' section", () => {
     deepEqual(
-      validate.module(lOrphansAllowedRuleSet, {
+      validateModule(lOrphansAllowedRuleSet, {
         source: "something",
         orphan: true,
       }),
@@ -67,7 +67,7 @@ describe("[I] validate/index - orphans in 'allowed' rules", () => {
 
   it("Leaves modules alone that aren't orphans if there's a rule in the 'allowed' section forbidding them", () => {
     deepEqual(
-      validate.module(lOrphansAllowedRuleSet, {
+      validateModule(lOrphansAllowedRuleSet, {
         source: "something",
         orphan: false,
       }),
@@ -98,7 +98,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
   });
   it("Leaves modules that are orphans, but that don't match the rule path", () => {
     deepEqual(
-      validate.module(lOrphanPathRuleSet, {
+      validateModule(lOrphanPathRuleSet, {
         source: "something",
         orphan: true,
       }),
@@ -108,7 +108,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
 
   it("Flags modules that are orphans and that match the rule's path", () => {
     deepEqual(
-      validate.module(lOrphanPathRuleSet, {
+      validateModule(lOrphanPathRuleSet, {
         source: "noorphansallowedhere/blah/something.ts",
         orphan: true,
       }),
@@ -126,7 +126,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
 
   it("Leaves modules that are orphans, but that do match the rule's pathNot", () => {
     deepEqual(
-      validate.module(lOrphanPathNotRuleSet, {
+      validateModule(lOrphanPathNotRuleSet, {
         source: "orphansallowedhere/something",
         orphan: true,
       }),
@@ -136,7 +136,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
 
   it("Flags modules that are orphans, but that do not match the rule's pathNot", () => {
     deepEqual(
-      validate.module(lOrphanPathNotRuleSet, {
+      validateModule(lOrphanPathNotRuleSet, {
         source: "blah/something.ts",
         orphan: true,
       }),
@@ -154,7 +154,7 @@ describe("[I] validate/index - orphans combined with path/ pathNot", () => {
 
   it("The 'dependency' validation leaves the module only orphan rule alone", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lOrphanPathRuleSet,
         {
           source: "noorphansallowedhere/something.ts",

--- a/test/validate/index.pre-compilation-only.spec.mjs
+++ b/test/validate/index.pre-compilation-only.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - preCompilationOnly", () => {
   const lPreCompilationOnlyRuleSet = parseRuleSet({
@@ -16,7 +16,7 @@ describe("[I] validate/index - preCompilationOnly", () => {
   });
   it("Stuff that still exists after compilation - okeleedokelee", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lPreCompilationOnlyRuleSet,
         { source: "something" },
         { resolved: "real-stuff-only.ts", preCompilationOnly: false },
@@ -27,7 +27,7 @@ describe("[I] validate/index - preCompilationOnly", () => {
 
   it("Stuff that only exists before compilation - flaggeleedaggelee", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lPreCompilationOnlyRuleSet,
         { source: "something" },
         { resolved: "types.d.ts", preCompilationOnly: true },
@@ -41,7 +41,7 @@ describe("[I] validate/index - preCompilationOnly", () => {
 
   it("Unknown whether stuff that only exists before compilation - okeleedokelee", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lPreCompilationOnlyRuleSet,
         { source: "something" },
         { resolved: "types.d.ts" },

--- a/test/validate/index.reachable.spec.mjs
+++ b/test/validate/index.reachable.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateModule } from "#validate/index.mjs";
 
 describe("[I] validate/index - reachable (in forbidden set)", () => {
   const lReachableFalseRuleSet = parseRuleSet({
@@ -22,21 +22,20 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
     ],
   });
   it("Skips modules that have no reachable attribute (reachable false)", () => {
-    deepEqual(
-      validate.module(lReachableFalseRuleSet, { source: "something" }),
-      { valid: true },
-    );
+    deepEqual(validateModule(lReachableFalseRuleSet, { source: "something" }), {
+      valid: true,
+    });
   });
 
   it("Skips modules that have no reachable attribute (reachable true)", () => {
-    deepEqual(validate.module(lReachableTrueRuleSet, { source: "something" }), {
+    deepEqual(validateModule(lReachableTrueRuleSet, { source: "something" }), {
       valid: true,
     });
   });
 
   it("Triggers on modules that have a reachable attribute (non-matching, reachable false)", () => {
     deepEqual(
-      validate.module(lReachableFalseRuleSet, {
+      validateModule(lReachableFalseRuleSet, {
         source: "something",
         reachable: [
           {
@@ -52,7 +51,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
 
   it("Triggers on modules that have a reachable attribute (non-matching, reachable true)", () => {
     deepEqual(
-      validate.module(lReachableTrueRuleSet, {
+      validateModule(lReachableTrueRuleSet, {
         source: "something",
         reachable: [
           {
@@ -68,7 +67,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
 
   it("Triggers on modules that have a reachable attribute (reachable false)", () => {
     deepEqual(
-      validate.module(lReachableFalseRuleSet, {
+      validateModule(lReachableFalseRuleSet, {
         source: "something",
         reachable: [
           {
@@ -92,7 +91,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
 
   it("Triggers on modules that have a reachable attribute (reachable true)", () => {
     deepEqual(
-      validate.module(lReachableTrueRuleSet, {
+      validateModule(lReachableTrueRuleSet, {
         source: "something",
         reachable: [
           {
@@ -116,7 +115,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
 
   it("Triggers on modules that have a reachable attribute (with a path, reachable false)", () => {
     deepEqual(
-      validate.module(lReachableFalseRuleSet, {
+      validateModule(lReachableFalseRuleSet, {
         source: "something",
         reachable: [
           {
@@ -140,7 +139,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
 
   it("Triggers on modules that have a reachable attribute (with a path, reachable true)", () => {
     deepEqual(
-      validate.module(lReachableTrueRuleSet, {
+      validateModule(lReachableTrueRuleSet, {
         source: "something",
         reachable: [
           {
@@ -174,7 +173,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
     });
 
     deepEqual(
-      validate.module(lReachableFalsePathNotRuleSet, {
+      validateModule(lReachableFalsePathNotRuleSet, {
         source: "something",
         reachable: [
           {
@@ -199,7 +198,7 @@ describe("[I] validate/index - reachable (in forbidden set)", () => {
       ],
     });
     deepEqual(
-      validate.module(lReachableTruePathNotRuleSet, {
+      validateModule(lReachableTruePathNotRuleSet, {
         source: "something",
         reachable: [
           {
@@ -224,7 +223,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
   });
   it("Triggers on modules that have no reachable attribute ('allowed' rule set)", () => {
     deepEqual(
-      validate.module(lReachableAllowedRuleSet, {
+      validateModule(lReachableAllowedRuleSet, {
         source: "something",
       }),
       {
@@ -241,7 +240,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
 
   it("Skips on modules that have a reachable attribute (match - 'allowed' rule set)", () => {
     deepEqual(
-      validate.module(lReachableAllowedRuleSet, {
+      validateModule(lReachableAllowedRuleSet, {
         source: "something",
         reachable: [
           {
@@ -259,7 +258,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
 
   it("Triggers on modules that have a reachable attribute (no match - 'allowed' rule set)", () => {
     deepEqual(
-      validate.module(lReachableAllowedRuleSet, {
+      validateModule(lReachableAllowedRuleSet, {
         source: "something",
         reachable: [
           {
@@ -303,7 +302,7 @@ describe("[I] validate/index - reachable (in allowed set)", () => {
         },
       ],
     };
-    const lValidationResult = validate.module(
+    const lValidationResult = validateModule(
       lReachableCapturingGroupsRuleSet,
       lModule,
     );

--- a/test/validate/index.required-rules.spec.mjs
+++ b/test/validate/index.required-rules.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency, validateModule } from "#validate/index.mjs";
 
 describe("[I] validate/index - required rules", () => {
   const lRequiredRuleSet = parseRuleSet({
@@ -20,7 +20,7 @@ describe("[I] validate/index - required rules", () => {
 
   it("modules not matching the module criteria from the required rule are okeliedokelie", () => {
     deepEqual(
-      validate.module(lRequiredRuleSet, {
+      validateModule(lRequiredRuleSet, {
         source: "something",
       }),
       { valid: true },
@@ -29,7 +29,7 @@ describe("[I] validate/index - required rules", () => {
 
   it("modules matching the module criteria with no dependencies bork", () => {
     deepEqual(
-      validate.module(lRequiredRuleSet, {
+      validateModule(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [],
       }),
@@ -42,7 +42,7 @@ describe("[I] validate/index - required rules", () => {
 
   it("modules matching the module criteria with no matching dependencies bork", () => {
     deepEqual(
-      validate.module(lRequiredRuleSet, {
+      validateModule(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [
           {
@@ -62,7 +62,7 @@ describe("[I] validate/index - required rules", () => {
 
   it("'required' violations don't get flagged as dependency transgressions", () => {
     deepEqual(
-      validate.dependency(lRequiredRuleSet, {
+      validateDependency(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [
           {
@@ -81,7 +81,7 @@ describe("[I] validate/index - required rules", () => {
 
   it("modules matching the module criteria with matching dependencies are okeliedokelie", () => {
     deepEqual(
-      validate.module(lRequiredRuleSet, {
+      validateModule(lRequiredRuleSet, {
         source: "grub-controller.ts",
         dependencies: [
           {

--- a/test/validate/index.spec.mjs
+++ b/test/validate/index.spec.mjs
@@ -1,12 +1,12 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency, validateModule } from "#validate/index.mjs";
 
 describe("[I] validate/index dependency - generic tests", () => {
   it("is ok with the empty validation", () => {
     const lEmptyRuleSet = parseRuleSet({});
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lEmptyRuleSet,
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" },
@@ -25,7 +25,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       ],
     });
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lEverythingAllowedRuleSet,
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" },
@@ -51,7 +51,7 @@ describe("[I] validate/index dependency - generic tests", () => {
       ],
     });
 
-    deepEqual(validate.module(lRuleSet, { source: "koos koets" }), {
+    deepEqual(validateModule(lRuleSet, { source: "koos koets" }), {
       valid: true,
     });
   });
@@ -71,7 +71,7 @@ describe("[I] validate/index dependency - generic tests", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" },
@@ -99,7 +99,7 @@ describe("[I] validate/index dependency - generic tests", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" },
@@ -124,7 +124,7 @@ describe("[I] validate/index dependency - generic tests", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" },
@@ -156,7 +156,7 @@ describe("[I] validate/index dependency - generic tests", () => {
     });
 
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lRuleSet,
         { source: "something" },
         {
@@ -233,7 +233,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("node_modules inhibition - ok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNodeModulesNotAllowedRuleSet,
         { source: "koos koets" },
         { resolved: "robby van de kerkhof" },
@@ -244,7 +244,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("node_modules inhibition - violation", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNodeModulesNotAllowedRuleSet,
         { source: "koos koets" },
         { resolved: "./node_modules/evil-module" },
@@ -258,7 +258,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not to sub except sub itself - ok - sub to sub", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToSubExceptSubRuleSet,
         { source: "./keek/op/de/sub/week.js" },
         { resolved: "./keek/op/de/sub/maand.js", coreModule: false },
@@ -269,7 +269,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not to sub except sub itself - ok - not sub to not sub", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToSubExceptSubRuleSet,
         { source: "./doctor/clavan.js" },
         { resolved: "./rochebrune.js", coreModule: false },
@@ -280,7 +280,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not to sub except sub itself - ok - sub to not sub", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToSubExceptSubRuleSet,
         { source: "./doctor/sub/clavan.js" },
         { resolved: "./rochebrune.js", coreModule: false },
@@ -291,7 +291,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not to sub except sub itself  - violation - not sub to sub", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToSubExceptSubRuleSet,
         { source: "./doctor/clavan.js" },
         { resolved: "./keek/op/de/sub/week.js", coreModule: false },
@@ -305,7 +305,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not to not sub (=> everything must go to 'sub')- ok - sub to sub", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToNotSubRuleSet,
         { source: "./keek/op/de/sub/week.js" },
         { resolved: "./keek/op/de/sub/maand.js", coreModule: false },
@@ -316,7 +316,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not to not sub (=> everything must go to 'sub')- violation - not sub to not sub", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToNotSubRuleSet,
         { source: "./amber.js" },
         { resolved: "./jade.js", coreModule: false },
@@ -330,7 +330,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not-to-dev-dep disallows relations to develop dependencies", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToDevelopmentDependencyRuleSet,
         { source: "src/aap/zus/jet.js" },
         {
@@ -353,7 +353,7 @@ describe("[I] validate/index - specific tests", () => {
 
   it("not-to-dev-dep does allow relations to regular dependencies", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lNotToDevelopmentDependencyRuleSet,
         { source: "src/aap/zus/jet.js" },
         {

--- a/test/validate/index.type-only.spec.mjs
+++ b/test/validate/index.type-only.spec.mjs
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
 import parseRuleSet from "./parse-ruleset.utl.mjs";
-import validate from "#validate/index.mjs";
+import { validateDependency } from "#validate/index.mjs";
 
 describe("[I] validate/index - type-only", () => {
   const lTypeOnlyRuleSet = parseRuleSet({
@@ -18,7 +18,7 @@ describe("[I] validate/index - type-only", () => {
 
   it("only to type-only - with dependencyTypesNot in forbidden, multiple types - ok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lTypeOnlyRuleSet,
         { source: "src/koos-koets.ts" },
         {
@@ -32,7 +32,7 @@ describe("[I] validate/index - type-only", () => {
 
   it("only to type-only - with dependencyTypesNot in forbidden, multiple types - nok", () => {
     deepEqual(
-      validate.dependency(
+      validateDependency(
         lTypeOnlyRuleSet,
         { source: "src/koos-koets.ts" },
         { resolved: "src/ger-hekking.ts", dependencyTypes: ["local"] },

--- a/test/validate/match-module-rule.dependents.spec.mjs
+++ b/test/validate/match-module-rule.dependents.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "#validate/match-module-rule.mjs";
+import { matchesDependentsRule } from "#validate/match-module-rule-helpers.mjs";
 
 const EMPTY_RULE = { from: {}, module: {} };
 const ANY_DEPENDENTS = {
@@ -55,26 +55,20 @@ const USED_FROM_SNACKBAR_BETWEEN = {
 
 describe("[I] validate/match-module-rule - dependents", () => {
   it("rule without dependents restriction doesn't flag (implicit)", () => {
-    equal(matchModuleRule.matchesDependentsRule(EMPTY_RULE, {}), false);
+    equal(matchesDependentsRule(EMPTY_RULE, {}), false);
   });
   it("rule without dependents restriction doesn't flag (explicit)", () => {
-    equal(
-      matchModuleRule.matchesDependentsRule(EMPTY_RULE, { dependents: [] }),
-      false,
-    );
+    equal(matchesDependentsRule(EMPTY_RULE, { dependents: [] }), false);
   });
   it("rule with dependents doesn't match a module with no dependents attribute", () => {
-    equal(matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, {}), false);
+    equal(matchesDependentsRule(ANY_DEPENDENTS, {}), false);
   });
   it("rule that matches any dependents does match a module with a dependents attribute", () => {
-    equal(
-      matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, { dependents: [] }),
-      true,
-    );
+    equal(matchesDependentsRule(ANY_DEPENDENTS, { dependents: [] }), true);
   });
   it("rule that matches any dependents does match a module with a dependents attribute (>1 dependent)", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(ANY_DEPENDENTS, {
+      matchesDependentsRule(ANY_DEPENDENTS, {
         dependents: ["aap", "noot", "mies", "wim"],
       }),
       true,
@@ -83,46 +77,37 @@ describe("[I] validate/match-module-rule - dependents", () => {
 
   it("must-share (>=2 dependents) rule doesn't flag when there's 2 dependents", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        MUST_BE_SHARED_DONT_CARE_FROM_WHERE,
-        {
-          source: "src/utensils/simsalabim.ts",
-          dependents: ["aap", "noot"],
-        },
-      ),
+      matchesDependentsRule(MUST_BE_SHARED_DONT_CARE_FROM_WHERE, {
+        source: "src/utensils/simsalabim.ts",
+        dependents: ["aap", "noot"],
+      }),
       false,
     );
   });
 
   it("must-share (>=2 dependents) rule flags when there's 1 dependent", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        MUST_BE_SHARED_DONT_CARE_FROM_WHERE,
-        {
-          source: "src/utensils/simsalabim.ts",
-          dependents: ["aap"],
-        },
-      ),
+      matchesDependentsRule(MUST_BE_SHARED_DONT_CARE_FROM_WHERE, {
+        source: "src/utensils/simsalabim.ts",
+        dependents: ["aap"],
+      }),
       true,
     );
   });
 
   it("must-share (>=2 dependents) rule flags when there's 0 dependents", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        MUST_BE_SHARED_DONT_CARE_FROM_WHERE,
-        {
-          source: "src/utensils/simsalabim.ts",
-          dependents: [],
-        },
-      ),
+      matchesDependentsRule(MUST_BE_SHARED_DONT_CARE_FROM_WHERE, {
+        source: "src/utensils/simsalabim.ts",
+        dependents: [],
+      }),
       true,
     );
   });
 
   it("must-share (>=2 dependents) with a from doesn't flag when there's 2 dependents from that from", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
+      matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
       }),
@@ -132,7 +117,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
 
   it("must-share (>=2 dependents) with a from doesn't flag when there's 2 dependents from that from (+ some others that don't matter)", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
+      matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: [
           "src/snackbar/kapsalon.ts",
@@ -147,7 +132,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
 
   it("must-share (>=2 dependents) with a from path when there's only 1 dependents from that from path", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
+      matchesDependentsRule(MUST_BE_SHARED_FROM_SNACKBAR, {
         source: "src/utensils/frieten.ts",
         dependents: [
           "src/snackbar/kapsalon.ts",
@@ -160,67 +145,55 @@ describe("[I] validate/match-module-rule - dependents", () => {
 
   it("must-share (>=2 dependents) with a from pathNot when there's only 1 dependents from that from pathNot", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR,
-        {
-          source: "src/utensils/frieten.ts",
-          dependents: [
-            "src/snackbar/kapsalon.ts",
-            "src/fietsenwinkel/zijspan.ts",
-          ],
-        },
-      ),
+      matchesDependentsRule(MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR, {
+        source: "src/utensils/frieten.ts",
+        dependents: [
+          "src/snackbar/kapsalon.ts",
+          "src/fietsenwinkel/zijspan.ts",
+        ],
+      }),
       true,
     );
   });
 
   it("must-share (>=2 dependents) with a from pathNot when there's 0 dependents from that from pathNot", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR,
-        {
-          source: "src/utensils/frieten.ts",
-          dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
-        },
-      ),
+      matchesDependentsRule(MUST_BE_SHARED_BUT_NOT_FROM_SNACKBAR, {
+        source: "src/utensils/frieten.ts",
+        dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
+      }),
       true,
     );
   });
 
   it("must not be used more than 3 times from snackbar - happy scenario", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES,
-        {
-          source: "src/utensils/frieten.ts",
-          dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
-        },
-      ),
+      matchesDependentsRule(CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES, {
+        source: "src/utensils/frieten.ts",
+        dependents: ["src/snackbar/kapsalon.ts", "src/snackbar/zijspan.ts"],
+      }),
       false,
     );
   });
 
   it("must not be used more than 3 times from snackbar - fail scenario", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(
-        CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES,
-        {
-          source: "src/utensils/frieten.ts",
-          dependents: [
-            "src/snackbar/kapsalon.ts",
-            "src/snackbar/zijspan.ts",
-            "src/snackbar/dooierat.ts",
-            "src/snackbar/kipcorn.ts",
-          ],
-        },
-      ),
+      matchesDependentsRule(CANNOT_BE_SHARED_MORE_THAN_THREE_TIMES, {
+        source: "src/utensils/frieten.ts",
+        dependents: [
+          "src/snackbar/kapsalon.ts",
+          "src/snackbar/zijspan.ts",
+          "src/snackbar/dooierat.ts",
+          "src/snackbar/kipcorn.ts",
+        ],
+      }),
       false,
     );
   });
 
   it("combo breaker (3 < x < 5) - happy scenario", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
+      matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
         source: "src/utensils/frieten.ts",
         dependents: [
           "src/snackbar/kapsalon.ts",
@@ -235,7 +208,7 @@ describe("[I] validate/match-module-rule - dependents", () => {
 
   it("combo breaker (3 < x < 5) - fail scenario", () => {
     equal(
-      matchModuleRule.matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
+      matchesDependentsRule(USED_FROM_SNACKBAR_BETWEEN, {
         source: "src/utensils/frieten.ts",
         dependents: [
           "src/snackbar/kapsalon.ts",

--- a/test/validate/match-module-rule.orphan.spec.mjs
+++ b/test/validate/match-module-rule.orphan.spec.mjs
@@ -1,5 +1,6 @@
 import { equal } from "node:assert/strict";
 import matchModuleRule from "#validate/match-module-rule.mjs";
+import { matchesOrphanRule } from "#validate/match-module-rule-helpers.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ANY_ORPHAN = { from: { orphan: true }, to: {} };
@@ -8,32 +9,23 @@ const ORPHAN_IN_PATH_NOT = { from: { orphan: true, pathNot: "^src" }, to: {} };
 
 describe("[I] validate/match-module-rule - orphan", () => {
   it("rule without orphan attribute doesn't non-orphans (implicit)", () => {
-    equal(matchModuleRule.matchesOrphanRule(EMPTY_RULE, {}), false);
+    equal(matchesOrphanRule(EMPTY_RULE, {}), false);
   });
   it("rule without orphan attribute doesn't non-orphans (explicit)", () => {
-    equal(
-      matchModuleRule.matchesOrphanRule(EMPTY_RULE, { orphan: false }),
-      false,
-    );
+    equal(matchesOrphanRule(EMPTY_RULE, { orphan: false }), false);
   });
   it("rule without orphan attribute doesn't match orphan module", () => {
-    equal(
-      matchModuleRule.matchesOrphanRule(EMPTY_RULE, { orphan: true }),
-      false,
-    );
+    equal(matchesOrphanRule(EMPTY_RULE, { orphan: true }), false);
   });
   it("orphan match rule doesn't match non-orphans", () => {
-    equal(matchModuleRule.matchesOrphanRule(ANY_ORPHAN, {}), false);
+    equal(matchesOrphanRule(ANY_ORPHAN, {}), false);
   });
   it("orphan match rule matches orphans", () => {
-    equal(
-      matchModuleRule.matchesOrphanRule(ANY_ORPHAN, { orphan: true }),
-      true,
-    );
+    equal(matchesOrphanRule(ANY_ORPHAN, { orphan: true }), true);
   });
   it("orphan match rule with path doesn't match orphans in other paths", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH, {
+      matchesOrphanRule(ORPHAN_IN_PATH, {
         orphan: true,
         source: "test/lalal.spec.ts",
       }),
@@ -42,7 +34,7 @@ describe("[I] validate/match-module-rule - orphan", () => {
   });
   it("orphan match rule with path matches orphans in that path", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH, {
+      matchesOrphanRule(ORPHAN_IN_PATH, {
         orphan: true,
         source: "src/lalal.ts",
       }),
@@ -51,7 +43,7 @@ describe("[I] validate/match-module-rule - orphan", () => {
   });
   it("orphan match rule with path matches orphans outside that path", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH_NOT, {
+      matchesOrphanRule(ORPHAN_IN_PATH_NOT, {
         orphan: true,
         source: "test/lalal.spec.ts",
       }),
@@ -60,7 +52,7 @@ describe("[I] validate/match-module-rule - orphan", () => {
   });
   it("orphan match rule with pathNot doesn't match orphans in that path", () => {
     equal(
-      matchModuleRule.matchesOrphanRule(ORPHAN_IN_PATH_NOT, {
+      matchesOrphanRule(ORPHAN_IN_PATH_NOT, {
         orphan: true,
         source: "src/lalal.ts",
       }),

--- a/test/validate/match-module-rule.reachable.spec.mjs
+++ b/test/validate/match-module-rule.reachable.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "#validate/match-module-rule.mjs";
+import { matchesReachableRule } from "#validate/match-module-rule-helpers.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ANY_UNREACHABLE = {
@@ -25,22 +25,22 @@ const ANY_UNREACHABLE_IN_ALLOWED_SET = {
 
 describe("[I] validate/match-module-rule - reachable", () => {
   it("rule without reachable attribute doesn't match reachables (implicit)", () => {
-    equal(matchModuleRule.matchesReachableRule(EMPTY_RULE, {}), false);
+    equal(matchesReachableRule(EMPTY_RULE, {}), false);
   });
   it("rule without reachable attribute doesn't match reachables (explicit)", () => {
     equal(
-      matchModuleRule.matchesReachableRule(EMPTY_RULE, {
+      matchesReachableRule(EMPTY_RULE, {
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
       false,
     );
   });
   it("rule with reachable attribute doesn't match reachables (implicit)", () => {
-    equal(matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {}), false);
+    equal(matchesReachableRule(ANY_UNREACHABLE, {}), false);
   });
   it("rule with reachable attribute doesn't match reachables (explicit)", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {
+      matchesReachableRule(ANY_UNREACHABLE, {
         reachable: [{ value: true, asDefinedInRule: "no-unreachable" }],
       }),
       false,
@@ -48,7 +48,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute matches unreachables according to that rule name", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {
+      matchesReachableRule(ANY_UNREACHABLE, {
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
       true,
@@ -56,7 +56,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute does not match unreachables according to other rule name", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE, {
+      matchesReachableRule(ANY_UNREACHABLE, {
         reachable: [{ value: false, asDefinedInRule: "other-rule-name" }],
       }),
       false,
@@ -64,7 +64,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("nameless rule with reachable attribute does not match unreachables according to other rule name", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_IN_ALLOWED_SET, {
+      matchesReachableRule(ANY_UNREACHABLE_IN_ALLOWED_SET, {
         reachable: [{ value: false, asDefinedInRule: "other-rule-name" }],
       }),
       false,
@@ -72,7 +72,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("nameless rule with reachable attribute matchs unreachables according to not-in-allowed", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_IN_ALLOWED_SET, {
+      matchesReachableRule(ANY_UNREACHABLE_IN_ALLOWED_SET, {
         reachable: [{ value: false, asDefinedInRule: "not-in-allowed" }],
       }),
       true,
@@ -80,7 +80,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute & path matches unreachables according to that rule name in that path", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_WITH_PATH, {
+      matchesReachableRule(ANY_UNREACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
@@ -89,7 +89,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute & path does not match unreachables according to that rule name and not in that path", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_UNREACHABLE_WITH_PATH, {
+      matchesReachableRule(ANY_UNREACHABLE_WITH_PATH, {
         source: "test/lalala.ts",
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
@@ -98,7 +98,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute & path matches reachables according to that rule name in that path", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
+      matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
         reachable: [{ value: true, asDefinedInRule: "no-unreachable" }],
       }),
@@ -107,7 +107,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute & path does not match unreachables according to that rule name in that path (explicit)", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
+      matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
         reachable: [{ value: false, asDefinedInRule: "no-unreachable" }],
       }),
@@ -116,7 +116,7 @@ describe("[I] validate/match-module-rule - reachable", () => {
   });
   it("rule with reachable attribute & path does not match unreachables according to that rule name in that path (implicit)", () => {
     equal(
-      matchModuleRule.matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
+      matchesReachableRule(ANY_REACHABLE_WITH_PATH, {
         source: "src/lalala.ts",
       }),
       false,

--- a/test/validate/match-module-rule.reaches.spec.mjs
+++ b/test/validate/match-module-rule.reaches.spec.mjs
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import matchModuleRule from "#validate/match-module-rule.mjs";
+import { matchesReachesRule } from "#validate/match-module-rule-helpers.mjs";
 
 const EMPTY_RULE = { from: {}, to: {} };
 const ANY_REACHABLE = {
@@ -15,11 +15,11 @@ const ANY_REACHES_IN_ALLOWED = {
 
 describe("[I] validate/match-module-rule - reaches", () => {
   it("rule without reachable attribute doesn't match modules with a reaches (implicit)", () => {
-    equal(matchModuleRule.matchesReachesRule(EMPTY_RULE, {}), false);
+    equal(matchesReachesRule(EMPTY_RULE, {}), false);
   });
   it("rule without reachable attribute doesn't match modules with a reaches (explicit)", () => {
     equal(
-      matchModuleRule.matchesReachesRule(EMPTY_RULE, {
+      matchesReachesRule(EMPTY_RULE, {
         reaches: [
           {
             modules: [{ source: "src/hoppetee.js" }],
@@ -32,7 +32,7 @@ describe("[I] validate/match-module-rule - reaches", () => {
   });
   it("rule without reachable attribute matches modules with a reaches (explicit)", () => {
     equal(
-      matchModuleRule.matchesReachesRule(ANY_REACHABLE, {
+      matchesReachesRule(ANY_REACHABLE, {
         reaches: [
           {
             modules: [{ source: "src/hoppetee.js" }],
@@ -45,7 +45,7 @@ describe("[I] validate/match-module-rule - reaches", () => {
   });
   it("rule without reachable attribute matches modules with a reaches (explicit, nameless rule)", () => {
     equal(
-      matchModuleRule.matchesReachesRule(ANY_REACHES_IN_ALLOWED, {
+      matchesReachesRule(ANY_REACHES_IN_ALLOWED, {
         reaches: [
           {
             modules: [{ source: "src/hoppetee.js" }],


### PR DESCRIPTION
## Description

- uses explicit exports over default exports where possible

## Motivation and Context

These were leftovers from the cjs -> mjs conversion that added a level of indirection we don't need.

## How Has This Been Tested?

- [x] green ci
- [x] updated unit tests where applicable

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
