### PR TITLE
feat(extract): adds recognition of jsdoc 'bracket' imports

### DIFF
--- a/.dependency-cruiser.mjs
+++ b/.dependency-cruiser.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 const defaultStrictRules = fileURLToPath(
   new URL("configs/recommended-strict.cjs", import.meta.url),
 );
-/** @type {import('./').IConfiguration} */
+/** @type {import('./types/configuration.mjs').IConfiguration} */
 export default {
   extends: defaultStrictRules,
   forbidden: [

--- a/configs/.dependency-cruiser-show-metrics-config.mjs
+++ b/configs/.dependency-cruiser-show-metrics-config.mjs
@@ -1,5 +1,5 @@
 import baseConfig from "../.dependency-cruiser.mjs";
-/** @type {import('../').IConfiguration} */
+/** @type {import('../types/configuration.mjs').IConfiguration} */
 export default {
   ...baseConfig,
   forbidden: [

--- a/configs/.dependency-cruiser-unlimited.mjs
+++ b/configs/.dependency-cruiser-unlimited.mjs
@@ -1,5 +1,5 @@
 import baseConfig from "../.dependency-cruiser.mjs";
-/** @type {import('../').IConfiguration} */
+/** @type {import('../types/configuration.mjs').IConfiguration} */
 export default {
   ...baseConfig,
   options: {

--- a/test/cache/cache.spec.mjs
+++ b/test/cache/cache.spec.mjs
@@ -82,7 +82,7 @@ describe("[I] cache/cache - writeCache", () => {
   });
 
   it("writes the passed cruise options to the cache folder (which is created when it doesn't exist yet) - content based cached strategy", async () => {
-    /** @type {import("../..").ICruiseResult} */
+    /** @type {import("../../types/cruise-result.mjs").ICruiseResult} */
     const lDummyCacheContents = {
       modules: [],
       summary: { optionsUsed: { baseDir: "test/cache/__mocks__/cache" } },
@@ -102,7 +102,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
     OUTPUTS_FOLDER,
     "serve-from-cache-compatible",
   );
-  /** @type import("../..").ICruiseResult */
+  /** @type import("../../types/cruise-result.mjs").ICruiseResult */
   const lMinimalCruiseResult = {
     modules: [],
     summary: {
@@ -117,7 +117,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
     revisionData: { cacheFormatVersion: 16.2, SHA1: "dummy-sha", changes: [] },
   };
 
-  /** @type import("../..").ICruiseResult */
+  /** @type import("../../types/cruise-result.mjs").ICruiseResult */
   const lNoVersionCruiseResult = {
     modules: [],
     summary: {
@@ -132,7 +132,7 @@ describe("[I] cache/cache - canServeFromCache", () => {
     revisionData: { SHA1: "dummy-sha", changes: [] },
   };
 
-  /** @type import("../..").ICruiseResult */
+  /** @type import("../../types/cruise-result.mjs").ICruiseResult */
   const lOldVersionCruiseResult = {
     modules: [],
     summary: {

--- a/test/cache/content-strategy.spec.mjs
+++ b/test/cache/content-strategy.spec.mjs
@@ -254,7 +254,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
         violations: [],
       },
     };
-    /** @type {import("../..").IRevisionData} */
+    /** @type {import("../../types/cruise-result.mjs").IRevisionData} */
     const lEmptyRevisionData = {
       SHA1: "shwoop",
       changes: [],
@@ -284,7 +284,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
   });
 
   it("adds checksums to modules in the cruise result", () => {
-    /** @type {import("../..").ICruiseResult} */
+    /** @type {import("../../types/cruise-result.mjs").ICruiseResult} */
     const lEmptyCruiseResult = {
       modules: [
         { source: "foo.js" },
@@ -305,7 +305,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
         violations: [],
       },
     };
-    /** @type {import("../..").IRevisionData} */
+    /** @type {import("../../types/cruise-result.mjs").IRevisionData} */
     const lEmptyRevisionData = {
       SHA1: "shwoop",
       changes: [],
@@ -343,7 +343,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
   });
 
   it("removes changes from the revision data that aren't different anymore from the cruise result", () => {
-    /** @type {import("../..").ICruiseResult} */
+    /** @type {import("../../types/cruise-result.mjs").ICruiseResult} */
     const lCruiseResult = {
       modules: [
         { source: "foo.js" },
@@ -364,7 +364,7 @@ describe("[U] cache/content-strategy - prepareRevisionDataForSaving", () => {
         violations: [],
       },
     };
-    /** @type {import("../..").IRevisionData} */
+    /** @type {import("../../types/cruise-result.mjs").IRevisionData} */
     const lRevisionData = {
       SHA1: "shwoop",
       changes: [

--- a/test/extract/tsc/jsdoc-bracket-imports.spec.mjs
+++ b/test/extract/tsc/jsdoc-bracket-imports.spec.mjs
@@ -1,0 +1,201 @@
+import { deepEqual } from "node:assert/strict";
+import extractTypescript from "./extract-typescript.utl.mjs";
+
+describe("[U] ast-extractors/extract-typescript - jsdoc 'bracket' imports", () => {
+  it("extracts @type whole module", () => {
+    deepEqual(
+      extractTypescript(
+        "/** @type {import('./hello.mjs')} */ export default {};",
+        [],
+        true,
+      ),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+
+  it("extracts @type one type from a module", () => {
+    deepEqual(
+      extractTypescript("/** @type {import('./hello.mjs').thing} */", [], true),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+
+  it("extracts @typedef whole module", () => {
+    deepEqual(
+      extractTypescript(
+        "/** @typedef {import('./hello.mjs')} Hello */ ",
+        [],
+        true,
+      ),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+  //         * @returns {import('./goodby.mjs).wave} A goodbye
+  it("extracts @param & @returns for a function definitions", () => {
+    deepEqual(
+      extractTypescript(
+        `/**
+        * This function says hello and goodbye
+        * 
+        * @param {import('./hello.mjs')} pHello a hello
+        * @returns {import('./goodbye.mjs').waveyWavey} A goodbye
+        */
+       function findGoodbyeForGreeting(pHello) {
+        return Goodbyes[pHello];
+      }`,
+        [],
+        true,
+      ),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+        {
+          module: "./goodbye.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+
+  /* eslint mocha/no-skipped-tests: "off" */
+  xit("extracts @type whole module even when wrapped in type shenanigans (Partial)", () => {
+    deepEqual(
+      extractTypescript(
+        "/** @type {Partial<import('./hello.mjs')>} */",
+        [],
+        true,
+      ),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+  xit("extracts @type whole module even when wrapped in type shenanigans (Map)", () => {
+    deepEqual(
+      extractTypescript(
+        "/** @type {Map<string,import('./hello.mjs')>} */",
+        [],
+        true,
+      ),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+  xit("extracts @type whole module even when wrapped in type shenanigans (Map & Parital)", () => {
+    deepEqual(
+      extractTypescript(
+        "/** @type {string, Partial<import('./hello.mjs')>} */",
+        [],
+        true,
+      ),
+      [
+        {
+          module: "./hello.mjs",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: [
+            "type-only",
+            "import",
+            "jsdoc",
+            "jsdoc-bracket-import",
+          ],
+        },
+      ],
+    );
+  });
+
+  it("leaves @type things alone that are not imports (but that look a bit like them)", () => {
+    deepEqual(
+      extractTypescript(
+        "/** @type {notAnImport('./hello.mjs').thing} */",
+        [],
+        true,
+      ),
+      [],
+    );
+  });
+  it("leaves @type things alone that is empty", () => {
+    deepEqual(extractTypescript("/** @type } */", [], true), []);
+  });
+});

--- a/test/extract/tsc/jsdoc-import-tags.spec.mjs
+++ b/test/extract/tsc/jsdoc-import-tags.spec.mjs
@@ -93,11 +93,4 @@ describe("[U] ast-extractors/extract-typescript - jsdoc @imports", () => {
       [],
     );
   });
-
-  it("does not extract imports with dynamic looking imports (@type {import('./ting.mjs')})", () => {
-    deepEqual(
-      extractTypescript("/** @type {import('./thing.mjs').thing} */", [], true),
-      [],
-    );
-  });
 });

--- a/tools/schema/.dependency-cruiser.mjs
+++ b/tools/schema/.dependency-cruiser.mjs
@@ -1,6 +1,6 @@
 import baseConfig from "../../.dependency-cruiser.mjs";
 
-/** @type {import('../../').IConfiguration} */
+/** @type {import('../../types/configuration.mjs').IConfiguration} */
 export default {
   ...baseConfig,
   options: {

--- a/types/.dependency-cruiser.mjs
+++ b/types/.dependency-cruiser.mjs
@@ -1,6 +1,6 @@
 import baseConfig from "../.dependency-cruiser.mjs";
 
-/** @type {import('../').IConfiguration} */
+/** @type {import('./configuration.mjs').IConfiguration} */
 export default {
   ...baseConfig,
   options: {


### PR DESCRIPTION
## Description

- adds recognition for the 'older' bracket style imports in jsdoc


## Motivation and Context

- necessary to be more complete than just `@import` tags 

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
