### PR TITLE
feat(init): adds question to enable detection of jsdoc imports

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -1,6 +1,15 @@
 [
   {
     "type": "dependency",
+    "from": "src/cli/init-config/get-user-input.mjs",
+    "to": "src/extract/tsc/parse.mjs",
+    "rule": {
+      "severity": "error",
+      "name": "cli-to-main-only"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "test/utl/try-import.spec.mjs",
     "to": "test/utl/node_modules/beta/index.js",
     "rule": {

--- a/src/cli/init-config/build-config.mjs
+++ b/src/cli/init-config/build-config.mjs
@@ -63,6 +63,17 @@ function buildTsPreCompilationDepsAttribute(pInitOptions) {
 }
 
 /**
+ *
+ * @param {IInitConfig} pInitOptions
+ * @returns {string}
+ */
+function buildDetectJSDocumentImportsAttribute(pInitOptions) {
+  return pInitOptions.detectJSDocImports
+    ? "detectJSDocImports: true,"
+    : "// detectJSDocImports: true,";
+}
+
+/**
  * @param {IInitConfig} pInitOptions
  * @returns {string}
  */
@@ -168,6 +179,10 @@ export default function buildConfig(pInitOptions) {
       extensionsToString(pInitOptions.resolutionExtensions),
     )
     .replace("{{notToTestRule}}", buildNotToTestRule(pInitOptions))
+    .replace(
+      "{{detectJSDocImportsAttribute}}",
+      buildDetectJSDocumentImportsAttribute(pInitOptions),
+    )
     .replace(
       "{{tsPreCompilationDepsAttribute}}",
       buildTsPreCompilationDepsAttribute(pInitOptions),

--- a/src/cli/init-config/config-template.mjs
+++ b/src/cli/init-config/config-template.mjs
@@ -229,7 +229,7 @@ module.exports = {
     // moduleSystems: ['cjs', 'es6'],
 
     /* 
-      false: don't look at JSDoc imports
+      false: don't look at JSDoc imports (the default)
       true: dependency-cruiser will detect dependencies in JSDoc-style
       import statements. Implies "parser": "tsc", so the dependency-cruiser
       will use the typescript parser for JavaScript files.
@@ -237,7 +237,7 @@ module.exports = {
       For this to work the typescript compiler will need to be installed in the
       same spot as you're running dependency-cruiser from.
      */
-    // detectJSDocImports: true,
+    {{detectJSDocImportsAttribute}}
 
     /* prefix for links in html and svg output (e.g. 'https://github.com/you/yourrepo/blob/main/'
        to open it on your online repo or \`vscode://file/$\{process.cwd()}/\` to 

--- a/src/cli/init-config/get-user-input.mjs
+++ b/src/cli/init-config/get-user-input.mjs
@@ -112,7 +112,7 @@ const QUESTIONS = [
   {
     name: "detectJSDocImports",
     type: () => (tscIsAvailable() ? "confirm" : false),
-    message: "Do you want to detect JSDoc imports?",
+    message: "Do you want to detect JSDoc imports as well (slower)?",
     initial: false,
   },
   {

--- a/src/cli/init-config/get-user-input.mjs
+++ b/src/cli/init-config/get-user-input.mjs
@@ -18,6 +18,7 @@ import {
   getWebpackConfigCandidates,
 } from "./environment-helpers.mjs";
 import { validateLocation } from "./validators.mjs";
+import { isAvailable as tscIsAvailable } from "#extract/tsc/parse.mjs";
 
 function toPromptChoice(pString) {
   return {
@@ -107,6 +108,12 @@ const QUESTIONS = [
     type: (_, pAnswers) => (pAnswers.useTsConfig ? "select" : false),
     message: "Full path to your 'tsconfig.json",
     choices: getTSConfigCandidates().map(toPromptChoice),
+  },
+  {
+    name: "detectJSDocImports",
+    type: () => (tscIsAvailable() ? "confirm" : false),
+    message: "Do you want to detect JSDoc imports?",
+    initial: false,
   },
   {
     name: "tsPreCompilationDeps",

--- a/src/cli/init-config/index.mjs
+++ b/src/cli/init-config/index.mjs
@@ -43,6 +43,7 @@ function getOneShotConfig(pOneShotConfigId) {
     jsConfig: getJSConfigCandidates().shift(),
     useTsConfig: hasTSConfigCandidates(),
     tsConfig: getTSConfigCandidates().shift(),
+    detectJSDocImports: false,
     tsPreCompilationDeps: hasTSConfigCandidates(),
     useWebpackConfig: hasWebpackConfigCandidates(),
     webpackConfig: getWebpackConfigCandidates().shift(),

--- a/src/cli/init-config/types.d.ts
+++ b/src/cli/init-config/types.d.ts
@@ -33,6 +33,10 @@ export interface IInitConfig {
    */
   tsConfig?: string;
   /**
+   * Whether or not to detect JSDoc imports
+   */
+  detectJSDocImports?: boolean;
+  /**
    * Whether or not to take dependencies into account that only exist before
    * compilation to javascript
    */

--- a/src/cli/init-config/write-run-scripts-to-manifest.mjs
+++ b/src/cli/init-config/write-run-scripts-to-manifest.mjs
@@ -56,11 +56,6 @@ const EXPERIMENTAL_SCRIPT_DOC = [
       EOL +
       "      to stdout - in simple text",
   },
-  // {
-  //   name: "depcruise:text",
-  //   headline: "",
-  //   description: "",
-  // },
 ];
 
 /**


### PR DESCRIPTION
## Description

- adds question to enable detection of jsdoc imports to the --init  command

## Motivation and Context

Improves discoverability 

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
