### PR TITLE
feat(extract): improves detection of protocol-only builtins (node & bun)

### DIFF
--- a/src/extract/helpers.mjs
+++ b/src/extract/helpers.mjs
@@ -46,11 +46,13 @@ export function extractModuleAttributes(pString) {
   let lReturnValue = { module: pString };
   const lModuleAttributes = pString.match(
     // eslint-disable-next-line security/detect-unsafe-regex
-    /^(?<protocol>node:|file:|data:)(?:(?<mimeType>[^,]+),)?(?<module>.+)$/,
+    /^(?<protocol>node:|file:|data:|bun:)(?:(?<mimeType>[^,]+),)?(?<module>.+)$/,
   );
 
   if (lModuleAttributes?.groups) {
-    lReturnValue.module = lModuleAttributes?.groups.module;
+    lReturnValue.module =
+      String(lModuleAttributes?.groups?.protocol ?? "") +
+      lModuleAttributes?.groups.module;
     if (lModuleAttributes?.groups?.protocol) {
       lReturnValue.protocol = lModuleAttributes.groups.protocol;
     }

--- a/src/extract/helpers.mjs
+++ b/src/extract/helpers.mjs
@@ -42,6 +42,7 @@ export function detectPreCompilationNess(pTSDependencies, pJSDependencies) {
  * @param {string} pString
  * @returns {{module:string; protocol?:string; mimeType?:string}}
  */
+// eslint-disable-next-line complexity
 export function extractModuleAttributes(pString) {
   let lReturnValue = { module: pString };
   const lModuleAttributes = pString.match(

--- a/src/extract/helpers.mjs
+++ b/src/extract/helpers.mjs
@@ -50,10 +50,10 @@ const PROTOCOL_ONLY_BUILTINS = new Set([
  */
 function getCanonicalModuleName(pModuleName, pProtocol) {
   const lModuleWithProtocol = pProtocol + pModuleName;
-  const lIsJsIshModule = pProtocol === "node:" || pProtocol === "bun:";
+  const lIsJsIshProtocol = pProtocol === "node:" || pProtocol === "bun:";
   const lIsProtocolOnlyModule = PROTOCOL_ONLY_BUILTINS.has(lModuleWithProtocol);
 
-  if (!lIsJsIshModule || lIsProtocolOnlyModule) {
+  if (!lIsJsIshProtocol || lIsProtocolOnlyModule) {
     return lModuleWithProtocol;
   }
   return pModuleName;

--- a/src/extract/resolve/is-built-in.mjs
+++ b/src/extract/resolve/is-built-in.mjs
@@ -1,28 +1,30 @@
-import { builtinModules } from "node:module";
-
-function getBuiltIns(pResolveOptions) {
-  // builtinModules does not expose all builtin modules for #reasons -
-  // see https://github.com/nodejs/node/issues/42785. In stead we could use
-  // isBuiltin, but that is not available in node 16.14, the lowest version
-  // of node dependency-cruiser currently supports. So we add the missing
-  // modules here.
-  let lReturnValue = builtinModules.concat(["test", "node:test"]);
-
-  if (pResolveOptions?.builtInModules?.override) {
-    lReturnValue = pResolveOptions?.builtInModules?.override;
-  }
-  if (pResolveOptions?.builtInModules?.add) {
-    lReturnValue = lReturnValue.concat(pResolveOptions.builtInModules.add);
-  }
-  return lReturnValue;
-}
+import { isBuiltin as moduleIsBuiltin } from "node:module";
 
 /**
- *
  * @param {string} pModuleName - the unresolved module name
  * @param {*} pResolveOptions
  * @returns {boolean} - true if the module is a built-in module
  */
 export function isBuiltin(pModuleName, pResolveOptions) {
-  return getBuiltIns(pResolveOptions).includes(pModuleName);
+  if (pResolveOptions?.builtInModules?.override) {
+    return pResolveOptions.builtInModules.override.includes(pModuleName);
+  }
+
+  // bun, as it turns out, has some additional builtin modules. Even when running
+  // dependency-cruiser with bunx, bunx will use node by default. To cover that scenario
+  // there's three options
+  // - tell everyone to run bunx with the --bun option, so bun uses bun instead of node
+  //   and hope everyone actually does that and it doesn't lead to a bunch of questions
+  //   in the issues section. I don't expect that to happen anytime soon => other options
+  // - add the bun builtins here.
+  //   this sounds attractive, but some of the modules ('undici', 'ws') are
+  //   also npm packages. In nodejs context that will lead to a.o. false
+  //   classifications.
+  // - add the bun builtins in dependency-cruiser.js
+  //   Current approach. The --init command will try to detect whether it's
+  //   in a bun repo and add the bun builtins to the config.
+  return (
+    moduleIsBuiltin(pModuleName) ||
+    (pResolveOptions?.builtInModules?.add ?? []).includes(pModuleName)
+  );
 }

--- a/test/extract/helpers-extract-module-attributes.spec.mjs
+++ b/test/extract/helpers-extract-module-attributes.spec.mjs
@@ -10,8 +10,15 @@ describe("[U] extract/helpers - extractModuleAttributes", () => {
 
   it("extracts the protocol if there is one", () => {
     deepEqual(extractModuleAttributes("node:fs"), {
-      module: "fs",
+      module: "node:fs",
       protocol: "node:",
+    });
+  });
+
+  it("extracts the protocol if there is one (bun)", () => {
+    deepEqual(extractModuleAttributes("bun:ffi"), {
+      module: "bun:ffi",
+      protocol: "bun:",
     });
   });
 
@@ -29,7 +36,7 @@ describe("[U] extract/helpers - extractModuleAttributes", () => {
 
   it("extracts both protocol and mimeType when they're in the URI", () => {
     deepEqual(extractModuleAttributes("data:application/json,gegevens.json"), {
-      module: "gegevens.json",
+      module: "data:gegevens.json",
       protocol: "data:",
       mimeType: "application/json",
     });
@@ -37,7 +44,7 @@ describe("[U] extract/helpers - extractModuleAttributes", () => {
 
   it("handles emtpy mimeTypes gracefulley", () => {
     deepEqual(extractModuleAttributes("data:,gegevens.json"), {
-      module: ",gegevens.json",
+      module: "data:,gegevens.json",
       protocol: "data:",
     });
   });
@@ -50,7 +57,7 @@ describe("[U] extract/helpers - extractModuleAttributes", () => {
 
   it("when protocol separator is mistyped, returns it as part of the module name", () => {
     deepEqual(extractModuleAttributes("data:application/json;gegevens.json"), {
-      module: "application/json;gegevens.json",
+      module: "data:application/json;gegevens.json",
       protocol: "data:",
     });
   });

--- a/test/extract/helpers-extract-module-attributes.spec.mjs
+++ b/test/extract/helpers-extract-module-attributes.spec.mjs
@@ -10,19 +10,33 @@ describe("[U] extract/helpers - extractModuleAttributes", () => {
 
   it("extracts the protocol if there is one", () => {
     deepEqual(extractModuleAttributes("node:fs"), {
-      module: "node:fs",
+      module: "fs",
       protocol: "node:",
     });
   });
 
   it("extracts the protocol if there is one (bun)", () => {
+    deepEqual(extractModuleAttributes("bun:fs"), {
+      module: "fs",
+      protocol: "bun:",
+    });
+  });
+
+  it("extracts the protocol if there is one and leaves protocol in the name if no protocol-less variant exists (node)", () => {
+    deepEqual(extractModuleAttributes("node:sea"), {
+      module: "node:sea",
+      protocol: "node:",
+    });
+  });
+
+  it("extracts the protocol if there is one and leaves protocol in the name if no protocol-less variant exists (bun)", () => {
     deepEqual(extractModuleAttributes("bun:ffi"), {
       module: "bun:ffi",
       protocol: "bun:",
     });
   });
 
-  it("leaves things alone the protocol is unknown", () => {
+  it("leaves things alone when the protocol is unknown", () => {
     deepEqual(extractModuleAttributes("nod:fs"), {
       module: "nod:fs",
     });

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -74,11 +74,13 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves the 'test'  core module as core module", () => {
+  it("resolves the 'node:test'  core module as core module", () => {
+    // 'test' is not a core module. node:test is and it's not an alias or something for 'test'
+    // issue is the same in bun with bun:test
     deepEqual(
       resolve(
         {
-          module: "test",
+          module: "node:test",
           moduleSystem: "es6",
         },
         join(__dirname, "__mocks__"),
@@ -90,7 +92,7 @@ describe("[I] extract/resolve/index - general", () => {
         couldNotResolve: false,
         dependencyTypes: ["core"],
         followable: false,
-        resolved: "test",
+        resolved: "node:test",
       },
     );
   });

--- a/test/extract/resolve/is-built-in.spec.mjs
+++ b/test/extract/resolve/is-built-in.spec.mjs
@@ -33,6 +33,21 @@ describe("[U] extract/resolve/is-built-in - isBuiltIn", () => {
     equal(lResult, true);
   });
 
+  it("should override default built-ins with custom built-ins", () => {
+    const lModuleName = "overridden";
+    const lResolveOptions = {
+      builtInModules: {
+        override: [lModuleName],
+      },
+    };
+
+    const lResultOverridden = isBuiltin(lModuleName, lResolveOptions);
+    const lResultForFs = isBuiltin("fs", lResolveOptions);
+
+    equal(lResultOverridden, true);
+    equal(lResultForFs, false);
+  });
+
   it("should override default built-ins with custom built-ins if both are provided", () => {
     const lModuleName = "overridden";
     const lResolveOptions = {


### PR DESCRIPTION
## Description

- uses `modules.isBuiltin` instead of the `modules.builtinModules` array, so throwing in builtin modules wih protocol prefixes doesn't need any pre- or post processing anymore. We can do this since now all versions of node we support have the `modules.isBuiltin` method available.
- adds `bun:` to the list of protocols we recognize.
- leaves the protocol with the module name for builtins that are only available with the protocol in the name (e.g. node:test, node:sqlite, node:sea or bun:ffi).

- [x] To decide - previously if you had both `fs` and `node:fs` in your source code, both would map to `fs`, nicely de-duplicating them. 
	- [x] Should we bring that back somehow? Yes
	- [x] If we don't are we going to run into backwards compatibility issues (and how serious might these be)? We will, not sure how much
	- [x] Can we mitigate? Yes - implemented in this PR

## Motivation and Context

- Makes it easier to support new builtin modules that follow the new trend of being protocol-prefixed only.
- Now out of the box supports recognizing node:sqlite, node:sea, node:test/reporters as core modules.
- Adds support for recognizing modules prototype-prefixed with `bun:` (which is relevant if you use dependency-cruiser with bun).

## How Has This Been Tested?

- [x] green ci
- [x] updated and additional automated non-regression tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
