### PR TITLE
fix: adds support for node v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_LATEST: 23.x
+  NODE_LATEST: 24.x
   PLATFORM: ubuntu-latest
   CI: true
   # the LANG (used by the Intl API, which we use for some of the number
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 23.x]
+        node-version: [18.x, 24.x]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 23.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
       - run: npm clean-install
       - run: npm publish --provenance --access public --tag beta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 23.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
       - run: npm clean-install
       - run: npm publish --provenance --access public

--- a/src/cli/init-config/environment-helpers.mjs
+++ b/src/cli/init-config/environment-helpers.mjs
@@ -1,4 +1,10 @@
-import { readFileSync, readdirSync, accessSync, statSync, R_OK } from "node:fs";
+import {
+  readFileSync,
+  readdirSync,
+  accessSync,
+  statSync,
+  constants,
+} from "node:fs";
 import { join } from "node:path";
 import { DEFAULT_CONFIG_FILE_NAME } from "../defaults.mjs";
 
@@ -31,7 +37,7 @@ export function readManifest(pManifestFileName = "./package.json") {
  */
 export function fileExists(pFile) {
   try {
-    accessSync(pFile, R_OK);
+    accessSync(pFile, constants.R_OK);
   } catch (pError) {
     return false;
   }

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -1,4 +1,4 @@
-import { accessSync, R_OK } from "node:fs";
+import { accessSync, constants } from "node:fs";
 import { isAbsolute } from "node:path";
 import {
   RULES_FILE_NAME_SEARCH_ARRAY,
@@ -43,7 +43,7 @@ function normalizeConfigFileName(pCliOptions, pConfigWrapperName, pDefault) {
 
 function fileExists(pFileName) {
   try {
-    accessSync(pFileName, R_OK);
+    accessSync(pFileName, constants.R_OK);
     return true;
   } catch (pError) {
     return false;

--- a/src/cli/utl/assert-file-existence.mjs
+++ b/src/cli/utl/assert-file-existence.mjs
@@ -1,8 +1,8 @@
-import { accessSync, R_OK } from "node:fs";
+import { accessSync, constants } from "node:fs";
 
 export default function assertFileExistence(pDirectoryOrFile) {
   try {
-    accessSync(pDirectoryOrFile, R_OK);
+    accessSync(pDirectoryOrFile, constants.R_OK);
   } catch (pError) {
     throw new Error(
       `Can't open '${pDirectoryOrFile}' for reading. Does it exist?\n`,

--- a/src/extract/resolve/resolve-amd.mjs
+++ b/src/extract/resolve/resolve-amd.mjs
@@ -1,4 +1,4 @@
-import { accessSync, R_OK } from "node:fs";
+import { accessSync, constants } from "node:fs";
 import { relative, join } from "node:path";
 import memoize, { memoizeClear } from "memoize";
 import { isBuiltin } from "./is-built-in.mjs";
@@ -6,7 +6,7 @@ import pathToPosix from "#utl/path-to-posix.mjs";
 
 const fileExists = memoize((pFile) => {
   try {
-    accessSync(pFile, R_OK);
+    accessSync(pFile, constants.R_OK);
   } catch (pError) {
     return false;
   }


### PR DESCRIPTION
## Description

It does 2 things:
* imports R_OK via constants instead of direct import
* replaces 23 node with 24 in CI

## Motivation and Context

R_OK was removed from fs in nodejs 24 https://github.com/nodejs/node/pull/49686

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] green ci

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
