### PR TITLE
refactor(cli): replaces commander with node:util/parseArgs - depcruise-baseline

### DIFF
--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -1,43 +1,69 @@
 #!/usr/bin/env node
-import { program } from "commander";
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+import { parseArgs } from "node:util";
 import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
 import cli from "#cli/index.mjs";
 import meta from "#meta.cjs";
 
-function formatError(pError) {
-  process.stderr.write(pError.message);
-  process.exitCode = 1;
+function showHelp() {
+  process.stdout
+    .write(`Usage: depcruise-baseline [options] <files-or-directories...>
+
+Writes all known violations of rules in a .dependency-cruiser.js to a file.
+Alias for depcruise -c -T baseline -f .dependency-cruiser-known-violations.json [files-or-directories]
+Details: https://github.com/sverweij/dependency-cruiser
+
+Options:
+  -c, --config [file]       read rules and options from [file] (default: true)
+  -f, --output-to [file]    file to write output to; - for stdout (default: ".dependency-cruiser-known-violations.json")
+  -V, --version             display version number
+  -h, --help                display help for command
+`);
 }
 
 try {
   assertNodeEnvironmentSuitable();
 
-  program
-    .description(
-      "Writes all known violations of rules in a .dependency-cruiser.js to a file.\n" +
-        "Alias for depcruise -c -T baseline -f .dependency-cruiser-known-violations.json [files-or-directories]\n" +
-        "Details: https://github.com/sverweij/dependency-cruiser",
-    )
-    .option("-c, --config [file]", "read rules and options from [file]", true)
-    .option(
-      "-f, --output-to [file]",
-      "file to write output to; - for stdout",
-      ".dependency-cruiser-known-violations.json",
-    )
-    .version(meta.version)
-    .argument("<files-or-directories...>")
-    .parse(process.argv);
+  const { values: options, positionals } = parseArgs({
+    options: {
+      config: {
+        type: "string",
+        short: "c",
+        default: "",
+      },
+      "output-to": {
+        type: "string",
+        short: "f",
+        default: ".dependency-cruiser-known-violations.json",
+      },
+      version: {
+        type: "boolean",
+        short: "V",
+      },
+      help: {
+        type: "boolean",
+        short: "h",
+      },
+    },
+    allowPositionals: true,
+  });
 
-  if (program.args[0]) {
-    process.exitCode = await cli(program.args, {
-      ...program.opts(),
+  if (options.version) {
+    process.stdout.write(`${meta.version}\n`);
+  } else if (options.help || positionals.length === 0) {
+    showHelp();
+  } else {
+    if (options.config === "") {
+      options.config = true;
+    }
+    process.exitCode = await cli(positionals, {
+      config: options.config,
+      outputTo: options["output-to"],
       cache: false,
       outputType: "baseline",
     });
-  } else {
-    program.help();
   }
 } catch (pError) {
-  formatError(pError);
+  process.stderr.write(pError.message);
   process.exitCode = 1;
 }


### PR DESCRIPTION
## Description

- replaces commander with node:util/parseArgs (depcruise-baseline)

## Motivation and Context

Less dependencies = better
## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
