### PR TITLE
refactor(cli): replaces commander with node:util/parseArgs - depcruise-fmt

### DIFF
--- a/bin/depcruise-fmt.mjs
+++ b/bin/depcruise-fmt.mjs
@@ -1,82 +1,126 @@
 #!/usr/bin/env node
-
-import { program } from "commander";
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+import { parseArgs } from "node:util";
 import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
 import format from "#cli/format.mjs";
 import meta from "#meta.cjs";
 
-function formatError(pError) {
-  process.stderr.write(pError.message);
-  process.exitCode = 1;
+function showHelp() {
+  process.stdout.write(`Usage: depcruise-fmt [options] <dependency-cruiser-json>
+
+Format dependency-cruiser output json.
+Details: https://github.com/sverweij/dependency-cruiser
+
+Options:
+  -f, --output-to <file>      file to write output to; - for stdout (default: "-")
+  -T, --output-type <type>    output type; e.g. err, err-html, dot, ddot, archi, flat, 
+                              d2, mermaid or json (default: "err")
+  -I, --include-only <regex>  only include modules matching the regex
+  -F, --focus <regex>         only include modules matching the regex + their direct neighbours
+      --focus-depth <number>  the depth to focus on - only applied when --focus is passed too.
+                              1= direct neighbors, 2=neighbours of neighbours etc. (default: 1)
+  -R, --reaches <regex>       only include modules matching the regex + all modules that can reach it
+  -H, --highlight <regex>     mark modules matching the regex as 'highlighted'
+  -x, --exclude <regex>       exclude all modules matching the regex
+  -S, --collapse <regex>      collapse to a folder depth by passing a single digit (e.g. 2). Or 
+                              pass a regex to collapse to a pattern E.g. ^packages/[^/]+/ would 
+                              collapse to modules/ folders directly under your packages folder.
+  -P, --prefix <prefix>       prefix to use for links in the dot and err-html reporters
+  -e, --exit-code             exit with a non-zero exit code when the input json contains error 
+                              level dependency violations. Works for err, err-long and teamcity 
+                              output types
+  -V, --version               display version number
+  -h, --help                  display help for command
+`);
 }
 
 try {
   assertNodeEnvironmentSuitable();
 
-  program
-    .description(
-      "Format dependency-cruiser output json.\nDetails: https://github.com/sverweij/dependency-cruiser",
-    )
-    .option(
-      "-f, --output-to <file>",
-      "file to write output to; - for stdout",
-      "-",
-    )
-    .option(
-      "-T, --output-type <type>",
-      "output type; e.g. err, err-html, dot, ddot, archi, flat, d2, mermaid or json",
-      "err",
-    )
-    .option(
-      "-I, --include-only <regex>",
-      "only include modules matching the regex",
-    )
-    .option(
-      "-F, --focus <regex>",
-      "only include modules matching the regex + their direct neighbours",
-    )
-    .option(
-      "--focus-depth <number>",
-      "the depth to focus on - only applied when --focus is passed too. " +
-        "1= direct neighbors, 2=neighbours of neighbours etc.",
-      1,
-    )
-    .option(
-      "-R, --reaches <regex>",
-      "only include modules matching the regex + all modules that can reach it",
-    )
-    .option(
-      "-H, --highlight <regex>",
-      "mark modules matching the regex as 'highlighted'",
-    )
-    .option("-x, --exclude <regex>", "exclude all modules matching the regex")
-    .option(
-      "-S, --collapse <regex>",
-      "collapse to a folder depth by passing a single digit (e.g. 2). Or pass a " +
-        "regex to collapse to a pattern E.g. ^packages/[^/]+/ would collapse to " +
-        "modules/ folders directly under your packages folder. ",
-    )
-    .option(
-      "-P, --prefix <prefix>",
-      "prefix to use for links in the dot and err-html reporters",
-    )
-    .option(
-      "-e, --exit-code",
-      "exit with a non-zero exit code when the input json contains error level " +
-        "dependency violations. Works for err, err-long and teamcity output types",
-    )
-    .version(meta.version)
-    .argument("<dependency-cruiser-json>")
-    .parse(process.argv);
+  const { values: options, positionals } = parseArgs({
+    options: {
+      "output-to": {
+        type: "string",
+        short: "f",
+        default: "-",
+      },
+      "output-type": {
+        type: "string",
+        short: "T",
+        default: "err",
+      },
+      "include-only": {
+        type: "string",
+        short: "I",
+      },
+      focus: {
+        type: "string",
+        short: "F",
+      },
+      "focus-depth": {
+        type: "string",
+        default: "1",
+      },
+      reaches: {
+        type: "string",
+        short: "R",
+      },
+      highlight: {
+        type: "string",
+        short: "H",
+      },
+      exclude: {
+        type: "string",
+        short: "x",
+      },
+      collapse: {
+        type: "string",
+        short: "S",
+      },
+      prefix: {
+        type: "string",
+        short: "P",
+      },
+      "exit-code": {
+        type: "boolean",
+        short: "e",
+      },
+      version: {
+        type: "boolean",
+        short: "V",
+      },
+      help: {
+        type: "boolean",
+        short: "h",
+      },
+    },
+    allowPositionals: true,
+  });
 
-  if (program.args[0]) {
-    const lExitCode = await format(program.args[0], program.opts());
-    if (program.opts().exitCode) {
+  if (options.version) {
+    process.stdout.write(`${meta.version}\n`);
+  } else if (options.help || positionals.length === 0) {
+    showHelp();
+  } else {
+    const lFormatOptions = {
+      ...options,
+      outputTo: options["output-to"],
+      outputType: options["output-type"],
+      includeOnly: options["include-only"],
+      focusDepth: options["focus-depth"],
+      exitCode: options["exit-code"],
+    };
+    delete lFormatOptions["output-to"];
+    delete lFormatOptions["output-type"];
+    delete lFormatOptions["include-only"];
+    delete lFormatOptions["focus-depth"];
+    delete lFormatOptions["exit-code"];
+    const lExitCode = await format(positionals[0], lFormatOptions);
+    if (lFormatOptions.exitCode) {
       process.exitCode = lExitCode;
     }
-  } else {
-    program.help();
   }
 } catch (pError) {
-  formatError(pError);
+  process.stderr.write(pError.message);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
## Description

- replaces commander with node:util/parseArgs  for depcruise-fmt

## Motivation and Context

Less dependencies = less worries

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
