### PR TITLE
refactor!: replaces picocolors with node:util/styleText

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-      - name: remove .npmrc on node 18 so that the npm install works
-        if: matrix.node-version == '18.x'
-        run: |
-          rm -f .npmrc
-          npm config set package-lock=true
-          npm config set save-exact=true
       - name: install & build
         run: |
           sudo apt-get update

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "is-installed-globally": "^1.0.0",
         "json5": "^2.2.3",
         "memoize": "^10.1.0",
-        "picocolors": "^1.1.1",
         "picomatch": "^4.0.3",
         "prompts": "^2.4.2",
         "rechoir": "^0.8.0",
@@ -6176,6 +6175,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     "is-installed-globally": "^1.0.0",
     "json5": "^2.2.3",
     "memoize": "^10.1.0",
-    "picocolors": "^1.1.1",
     "picomatch": "^4.0.3",
     "prompts": "^2.4.2",
     "rechoir": "^0.8.0",

--- a/src/cli/format-meta-info.mjs
+++ b/src/cli/format-meta-info.mjs
@@ -44,7 +44,7 @@ export default function formatMetaInfo() {
     os version found       : ${arch()} ${platform()}@${release()}
 
     If you need a supported, but not enabled transpiler ('${styleText(
-      ["red"],
+      "red",
       "x",
     )}' below), just install
     it in the same folder dependency-cruiser is installed. E.g. 'npm i livescript'

--- a/src/cli/format-meta-info.mjs
+++ b/src/cli/format-meta-info.mjs
@@ -5,7 +5,7 @@ import { getAvailableTranspilers, allExtensions } from "#main/index.mjs";
 import meta from "#meta.cjs";
 
 function bool2Symbol(pBool) {
-  return pBool ? styleText(["green"], "✔") : styleText(["red"], "x");
+  return pBool ? styleText("green", "✔") : styleText("red", "x");
 }
 
 const MAX_VERSION_RANGE_STRING_LENGTH = 19;
@@ -14,7 +14,7 @@ const MAX_VERSION_STRING_LENGTH = 24;
 
 function formatTranspilers() {
   let lTranspilerTableHeader = styleText(
-    ["bold"],
+    "bold",
     `    ✔ ${"transpiler".padEnd(MAX_TRANSPILER_NAME_LENGTH)} ${"versions supported".padEnd(MAX_VERSION_RANGE_STRING_LENGTH)} version found`,
   );
   let lTranspilerTableDivider = `    - ${"-".repeat(MAX_TRANSPILER_NAME_LENGTH)} ${"-".repeat(MAX_VERSION_RANGE_STRING_LENGTH)} ${"-".repeat(MAX_VERSION_STRING_LENGTH)}`;
@@ -37,7 +37,7 @@ function formatExtensions(pExtensions) {
 
 export default function formatMetaInfo() {
   return `
-    ${styleText(["bold"], "dependency-cruiser")}@${meta.version}
+    ${styleText("bold", "dependency-cruiser")}@${meta.version}
 
     node version supported : ${meta.engines.node}
     node version found     : ${process.version}
@@ -51,7 +51,7 @@ export default function formatMetaInfo() {
     will enable livescript support if it's installed in your project folder.
 
 ${formatTranspilers()}
-    ${styleText(["bold"], "✔ extension")}
+    ${styleText("bold", "✔ extension")}
     - ---------
 ${formatExtensions(allExtensions)}
 `;

--- a/src/cli/format-meta-info.mjs
+++ b/src/cli/format-meta-info.mjs
@@ -1,11 +1,11 @@
 import { release, platform, arch } from "node:os";
-import pc from "picocolors";
+import { styleText } from "node:util";
 
 import { getAvailableTranspilers, allExtensions } from "#main/index.mjs";
 import meta from "#meta.cjs";
 
 function bool2Symbol(pBool) {
-  return pBool ? pc.green("✔") : pc.red("x");
+  return pBool ? styleText(["green"], "✔") : styleText(["red"], "x");
 }
 
 const MAX_VERSION_RANGE_STRING_LENGTH = 19;
@@ -13,7 +13,8 @@ const MAX_TRANSPILER_NAME_LENGTH = 22;
 const MAX_VERSION_STRING_LENGTH = 24;
 
 function formatTranspilers() {
-  let lTranspilerTableHeader = pc.bold(
+  let lTranspilerTableHeader = styleText(
+    ["bold"],
     `    ✔ ${"transpiler".padEnd(MAX_TRANSPILER_NAME_LENGTH)} ${"versions supported".padEnd(MAX_VERSION_RANGE_STRING_LENGTH)} version found`,
   );
   let lTranspilerTableDivider = `    - ${"-".repeat(MAX_TRANSPILER_NAME_LENGTH)} ${"-".repeat(MAX_VERSION_RANGE_STRING_LENGTH)} ${"-".repeat(MAX_VERSION_STRING_LENGTH)}`;
@@ -36,20 +37,21 @@ function formatExtensions(pExtensions) {
 
 export default function formatMetaInfo() {
   return `
-    ${pc.bold("dependency-cruiser")}@${meta.version}
+    ${styleText(["bold"], "dependency-cruiser")}@${meta.version}
 
     node version supported : ${meta.engines.node}
     node version found     : ${process.version}
     os version found       : ${arch()} ${platform()}@${release()}
 
-    If you need a supported, but not enabled transpiler ('${pc.red(
+    If you need a supported, but not enabled transpiler ('${styleText(
+      ["red"],
       "x",
     )}' below), just install
     it in the same folder dependency-cruiser is installed. E.g. 'npm i livescript'
     will enable livescript support if it's installed in your project folder.
 
 ${formatTranspilers()}
-    ${pc.bold("✔ extension")}
+    ${styleText(["bold"], "✔ extension")}
     - ---------
 ${formatExtensions(allExtensions)}
 `;

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -189,7 +189,7 @@ export default async function executeCli(
     }
   } catch (pError) {
     lStreams.stderr.write(
-      `\n  ${styleText("yellow", "ERROR")}: ${pError.message}\n`,
+      `\n  ${styleText("red", "ERROR")}: ${pError.message}\n`,
     );
     bus.emit("end");
     lExitCode = 1;

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -163,7 +163,7 @@ export default async function executeCli(
     if (isInstalledGlobally) {
       lStreams.stderr.write(
         `\n  ${styleText(
-          ["yellow"],
+          "yellow",
           "WARNING",
         )}: You're running a globally installed dependency-cruiser.\n\n` +
           `           We recommend to ${styleText(

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -167,7 +167,7 @@ export default async function executeCli(
           "WARNING",
         )}: You're running a globally installed dependency-cruiser.\n\n` +
           `           We recommend to ${styleText(
-            ["bold", "italic", "underline"],
+            "underline",
             "install and run it as a local devDependency",
           )} in\n` +
           `           your project instead. There it has your project's environment and\n` +

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -1,7 +1,7 @@
 import { join } from "node:path";
+import { styleText } from "node:util";
 import picomatch from "picomatch";
 import isInstalledGlobally from "is-installed-globally";
-import pc from "picocolors";
 
 import assertFileExistence from "./utl/assert-file-existence.mjs";
 import normalizeCliOptions from "./normalize-cli-options.mjs";
@@ -161,13 +161,13 @@ export default async function executeCli(
     /* c8 ignore start */
     if (isInstalledGlobally) {
       lStreams.stderr.write(
-        `\n  ${pc.yellow(
+        `\n  ${styleText(
+          ["yellow"],
           "WARNING",
         )}: You're running a globally installed dependency-cruiser.\n\n` +
-          `           We recommend to ${pc.bold(
-            pc.italic(
-              pc.underline("install and run it as a local devDependency"),
-            ),
+          `           We recommend to ${styleText(
+            ["bold", "italic", "underline"],
+            "install and run it as a local devDependency",
           )} in\n` +
           `           your project instead. There it has your project's environment and\n` +
           `           transpilers at its disposal. That will ensure it can find e.g.\n` +
@@ -187,7 +187,9 @@ export default async function executeCli(
       lExitCode = await runCruise(pFileDirectoryArray, lCruiseOptions);
     }
   } catch (pError) {
-    lStreams.stderr.write(`\n  ${pc.red("ERROR")}: ${pError.message}\n`);
+    lStreams.stderr.write(
+      `\n  ${styleText(["yellow"], "ERROR")}: ${pError.message}\n`,
+    );
     bus.emit("end");
     lExitCode = 1;
   }

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -144,6 +144,7 @@ async function runCruise(pFileDirectoryArray, pCruiseOptions) {
  * @returns {number}
  */
 
+// eslint-disable-next-line max-lines-per-function
 export default async function executeCli(
   pFileDirectoryArray,
   pCruiseOptions,
@@ -188,7 +189,7 @@ export default async function executeCli(
     }
   } catch (pError) {
     lStreams.stderr.write(
-      `\n  ${styleText(["yellow"], "ERROR")}: ${pError.message}\n`,
+      `\n  ${styleText("yellow", "ERROR")}: ${pError.message}\n`,
     );
     bus.emit("end");
     lExitCode = 1;

--- a/src/cli/init-config/write-config.mjs
+++ b/src/cli/init-config/write-config.mjs
@@ -29,7 +29,7 @@ export default function writeConfig(
     try {
       writeFileSync(pFileName, pConfig);
       pOutStream.write(
-        `\n  ${styleText(["green"], "✔")} Successfully created '${pFileName}'\n\n`,
+        `\n  ${styleText("green", "✔")} Successfully created '${pFileName}'\n\n`,
       );
       /* c8 ignore start */
     } catch (pError) {

--- a/src/cli/init-config/write-config.mjs
+++ b/src/cli/init-config/write-config.mjs
@@ -1,5 +1,5 @@
 import { writeFileSync } from "node:fs";
-import pc from "picocolors";
+import { styleText } from "node:util";
 import {
   fileExists,
   getDefaultConfigFileName,
@@ -29,7 +29,7 @@ export default function writeConfig(
     try {
       writeFileSync(pFileName, pConfig);
       pOutStream.write(
-        `\n  ${pc.green("✔")} Successfully created '${pFileName}'\n\n`,
+        `\n  ${styleText(["green"], "✔")} Successfully created '${pFileName}'\n\n`,
       );
       /* c8 ignore start */
     } catch (pError) {

--- a/src/cli/init-config/write-run-scripts-to-manifest.mjs
+++ b/src/cli/init-config/write-run-scripts-to-manifest.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable prefer-template */
 /* eslint-disable security/detect-object-injection */
 import { writeFileSync } from "node:fs";
+import { styleText } from "node:util";
 import { EOL } from "node:os";
-import pc from "picocolors";
 import { PACKAGE_MANIFEST as _PACKAGE_MANIFEST } from "../defaults.mjs";
 import { readManifest } from "./environment-helpers.mjs";
 import { folderNameArrayToRE } from "./utl.mjs";
@@ -124,11 +124,11 @@ function getSuccessMessage(pDestinationManifestFileName) {
   return EXPERIMENTAL_SCRIPT_DOC.reduce(
     (pAll, pScript) => {
       return `${pAll}${
-        `\n    ${pc.green("►")} ${pScript.headline}` +
+        `\n    ${styleText(["green"], "►")} ${pScript.headline}` +
         `\n${pScript.description}\n\n`
       }`;
     },
-    `  ${pc.green("✔")} Run scripts added to '${pDestinationManifestFileName}':\n`,
+    `  ${styleText(["green"], "✔")} Run scripts added to '${pDestinationManifestFileName}':\n`,
   );
 }
 

--- a/src/cli/init-config/write-run-scripts-to-manifest.mjs
+++ b/src/cli/init-config/write-run-scripts-to-manifest.mjs
@@ -124,11 +124,11 @@ function getSuccessMessage(pDestinationManifestFileName) {
   return EXPERIMENTAL_SCRIPT_DOC.reduce(
     (pAll, pScript) => {
       return `${pAll}${
-        `\n    ${styleText(["green"], "►")} ${pScript.headline}` +
+        `\n    ${styleText("green", "►")} ${pScript.headline}` +
         `\n${pScript.description}\n\n`
       }`;
     },
-    `  ${styleText(["green"], "✔")} Run scripts added to '${pDestinationManifestFileName}':\n`,
+    `  ${styleText("green", "✔")} Run scripts added to '${pDestinationManifestFileName}':\n`,
   );
 }
 

--- a/src/cli/listeners/cli-feedback.mjs
+++ b/src/cli/listeners/cli-feedback.mjs
@@ -17,8 +17,8 @@ function getPercentageBar(pPercentage, pParameters) {
   const lBlocks = Math.floor(lParameters.barSize * lPercentage);
   const lBlanks = lParameters.barSize - lBlocks;
 
-  return `${styleText(["green"], lParameters.block.repeat(lBlocks))}${styleText(
-    ["green"],
+  return `${styleText("green", lParameters.block.repeat(lBlocks))}${styleText(
+    "green",
     lParameters.blank.repeat(lBlanks),
   )} ${Math.round(FULL_ON * lPercentage)}%`;
 }

--- a/src/cli/listeners/cli-feedback.mjs
+++ b/src/cli/listeners/cli-feedback.mjs
@@ -1,4 +1,4 @@
-import pc from "picocolors";
+import { styleText } from "node:util";
 import { SUMMARY } from "#utl/bus.mjs";
 
 const FULL_ON = 100;
@@ -17,9 +17,13 @@ function getPercentageBar(pPercentage, pParameters) {
   const lBlocks = Math.floor(lParameters.barSize * lPercentage);
   const lBlanks = lParameters.barSize - lBlocks;
 
-  return `${pc.green(lParameters.block.repeat(lBlocks))}${pc.green(
+  return `${styleText(["green"], lParameters.block.repeat(lBlocks))}${styleText(
+    ["green"],
     lParameters.blank.repeat(lBlanks),
   )} ${Math.round(FULL_ON * lPercentage)}%`;
+  // return `${pc.green(lParameters.block.repeat(lBlocks))}${pc.green(
+  //   lParameters.blank.repeat(lBlanks),
+  // )} ${Math.round(FULL_ON * lPercentage)}%`;
 }
 
 function getProgressMessageWriter(pStream, pState, pMaxLogLevel) {

--- a/src/cli/listeners/cli-feedback.mjs
+++ b/src/cli/listeners/cli-feedback.mjs
@@ -21,9 +21,6 @@ function getPercentageBar(pPercentage, pParameters) {
     ["green"],
     lParameters.blank.repeat(lBlanks),
   )} ${Math.round(FULL_ON * lPercentage)}%`;
-  // return `${pc.green(lParameters.block.repeat(lBlocks))}${pc.green(
-  //   lParameters.blank.repeat(lBlanks),
-  // )} ${Math.round(FULL_ON * lPercentage)}%`;
 }
 
 function getProgressMessageWriter(pStream, pState, pMaxLogLevel) {

--- a/src/cli/listeners/performance-log/format-helpers.mjs
+++ b/src/cli/listeners/performance-log/format-helpers.mjs
@@ -1,4 +1,4 @@
-import pc from "picocolors";
+import { styleText } from "node:util";
 import { INFO } from "#utl/bus.mjs";
 
 const MS_PER_SECOND = 1000;
@@ -43,23 +43,22 @@ export function formatDividerLine() {
 }
 
 export function formatHeader() {
-  return pc
-    .bold(
-      `${
-        pad("∆ rss") +
-        pad("∆ heapTotal") +
-        pad("∆ heapUsed") +
-        pad("∆ external") +
-        pad("⏱  system") +
-        pad("⏱  user") +
-        pad("⏱  real")
-      }after step...\n`,
-    )
-    .concat(formatDividerLine());
+  return styleText(
+    ["bold"],
+    `${
+      pad("∆ rss") +
+      pad("∆ heapTotal") +
+      pad("∆ heapUsed") +
+      pad("∆ external") +
+      pad("⏱  system") +
+      pad("⏱  user") +
+      pad("⏱  real")
+    }after step...\n`,
+  ).concat(formatDividerLine());
 }
 
 function formatMessage(pMessage, pLevel) {
-  return pLevel >= INFO ? pc.dim(pMessage) : pMessage;
+  return pLevel >= INFO ? styleText(["dim"], pMessage) : pMessage;
 }
 
 export function formatTime(
@@ -81,7 +80,7 @@ export function formatMemory(pBytes, pLevel) {
   );
 
   return formatMessage(
-    (pBytes < 0 ? pc.blue(lReturnValue) : lReturnValue).concat(" "),
+    (pBytes < 0 ? styleText(["blue"], lReturnValue) : lReturnValue).concat(" "),
     pLevel,
   );
 }

--- a/src/cli/listeners/performance-log/format-helpers.mjs
+++ b/src/cli/listeners/performance-log/format-helpers.mjs
@@ -58,7 +58,7 @@ export function formatHeader() {
 }
 
 function formatMessage(pMessage, pLevel) {
-  return pLevel >= INFO ? styleText(["dim"], pMessage) : pMessage;
+  return pLevel >= INFO ? styleText("dim", pMessage) : pMessage;
 }
 
 export function formatTime(
@@ -80,7 +80,7 @@ export function formatMemory(pBytes, pLevel) {
   );
 
   return formatMessage(
-    (pBytes < 0 ? styleText(["blue"], lReturnValue) : lReturnValue).concat(" "),
+    (pBytes < 0 ? styleText("blue", lReturnValue) : lReturnValue).concat(" "),
     pLevel,
   );
 }

--- a/src/cli/listeners/performance-log/format-helpers.mjs
+++ b/src/cli/listeners/performance-log/format-helpers.mjs
@@ -44,7 +44,7 @@ export function formatDividerLine() {
 
 export function formatHeader() {
   return styleText(
-    ["bold"],
+    "bold",
     `${
       pad("∆ rss") +
       pad("∆ heapTotal") +

--- a/src/report/error.mjs
+++ b/src/report/error.mjs
@@ -1,5 +1,5 @@
 import { EOL } from "node:os";
-import pc from "picocolors";
+import { styleText } from "node:util";
 import {
   formatPercentage,
   formatViolation as _formatViolation,
@@ -7,11 +7,11 @@ import {
 import { findRuleByName } from "#graph-utl/rule-set.mjs";
 import wrapAndIndent from "#utl/wrap-and-indent.mjs";
 
-const SEVERITY2COLOR_FN = new Map([
-  ["error", pc.red],
-  ["warn", pc.yellow],
-  ["info", pc.cyan],
-  ["ignore", pc.gray],
+const SEVERITY2COLOR = new Map([
+  ["error", "red"],
+  ["warn", "yellow"],
+  ["info", "cyan"],
+  ["ignore", "gray"],
 ]);
 
 const EXTRA_PATH_INFORMATION_INDENT = 6;
@@ -26,25 +26,24 @@ function formatMiniDependency(pMiniDependency) {
 }
 
 function formatModuleViolation(pViolation) {
-  return pc.bold(pViolation.from);
+  return styleText(["bold"], pViolation.from);
 }
 
 function formatDependencyViolation(pViolation) {
-  return `${pc.bold(pViolation.from)} → ${pc.bold(pViolation.to)}`;
+  return `${styleText(["bold"], pViolation.from)} → ${styleText(["bold"], pViolation.to)}`;
 }
 
 function formatCycleViolation(pViolation) {
-  return `${pc.bold(pViolation.from)} → ${formatMiniDependency(pViolation.cycle)}`;
+  return `${styleText(["bold"], pViolation.from)} → ${formatMiniDependency(pViolation.cycle)}`;
 }
 
 function formatReachabilityViolation(pViolation) {
-  return `${pc.bold(pViolation.from)} → ${pc.bold(
-    pViolation.to,
-  )}${formatMiniDependency(pViolation.via)}`;
+  return `${styleText(["bold"], pViolation.from)} → ${styleText(["bold"], pViolation.to)}${formatMiniDependency(pViolation.via)}`;
 }
 
 function formatInstabilityViolation(pViolation) {
-  return `${formatDependencyViolation(pViolation)}${EOL}${pc.dim(
+  return `${formatDependencyViolation(pViolation)}${EOL}${styleText(
+    ["dim"],
     wrapAndIndent(
       `instability: ${formatPercentage(pViolation.metrics.from.instability)} → ${formatPercentage(pViolation.metrics.to.instability)}`,
       EXTRA_PATH_INFORMATION_INDENT,
@@ -67,12 +66,13 @@ function formatViolation(pViolation) {
   );
 
   return (
-    `${SEVERITY2COLOR_FN.get(pViolation.rule.severity)(
+    `${styleText(
+      [SEVERITY2COLOR.get(pViolation.rule.severity)],
       pViolation.rule.severity,
     )} ${pViolation.rule.name}: ${lFormattedViolators}` +
     `${
       pViolation.comment
-        ? `${EOL}${pc.dim(wrapAndIndent(pViolation.comment))}${EOL}`
+        ? `${EOL}${styleText(["dim"], wrapAndIndent(pViolation.comment))}${EOL}`
         : ""
     }`
   );
@@ -93,7 +93,7 @@ function formatSummary(pSummary) {
     pSummary.totalCruised
   } modules, ${pSummary.totalDependenciesCruised} dependencies cruised.${EOL}`;
 
-  return pSummary.error > 0 ? pc.red(lMessage) : lMessage;
+  return pSummary.error > 0 ? styleText(["red"], lMessage) : lMessage;
 }
 
 function addExplanation(pRuleSet, pLong) {
@@ -107,7 +107,8 @@ function addExplanation(pRuleSet, pLong) {
 
 function formatIgnoreWarning(pNumberOfIgnoredViolations) {
   if (pNumberOfIgnoredViolations > 0) {
-    return pc.yellow(
+    return styleText(
+      ["yellow"],
       `‼ ${pNumberOfIgnoredViolations} known violations ignored. Run with --no-ignore-known to see them.${EOL}`,
     );
   }
@@ -120,7 +121,7 @@ function report(pResults, pLong) {
   );
 
   if (lNonIgnorableViolations.length === 0) {
-    return `${EOL}${pc.green("✔")} no dependency violations found (${
+    return `${EOL}${styleText(["green"], "✔")} no dependency violations found (${
       pResults.summary.totalCruised
     } modules, ${
       pResults.summary.totalDependenciesCruised

--- a/src/report/error.mjs
+++ b/src/report/error.mjs
@@ -26,24 +26,24 @@ function formatMiniDependency(pMiniDependency) {
 }
 
 function formatModuleViolation(pViolation) {
-  return styleText(["bold"], pViolation.from);
+  return styleText("bold", pViolation.from);
 }
 
 function formatDependencyViolation(pViolation) {
-  return `${styleText(["bold"], pViolation.from)} → ${styleText(["bold"], pViolation.to)}`;
+  return `${styleText("bold", pViolation.from)} → ${styleText("bold", pViolation.to)}`;
 }
 
 function formatCycleViolation(pViolation) {
-  return `${styleText(["bold"], pViolation.from)} → ${formatMiniDependency(pViolation.cycle)}`;
+  return `${styleText("bold", pViolation.from)} → ${formatMiniDependency(pViolation.cycle)}`;
 }
 
 function formatReachabilityViolation(pViolation) {
-  return `${styleText(["bold"], pViolation.from)} → ${styleText(["bold"], pViolation.to)}${formatMiniDependency(pViolation.via)}`;
+  return `${styleText("bold", pViolation.from)} → ${styleText("bold", pViolation.to)}${formatMiniDependency(pViolation.via)}`;
 }
 
 function formatInstabilityViolation(pViolation) {
   return `${formatDependencyViolation(pViolation)}${EOL}${styleText(
-    ["dim"],
+    "dim",
     wrapAndIndent(
       `instability: ${formatPercentage(pViolation.metrics.from.instability)} → ${formatPercentage(pViolation.metrics.to.instability)}`,
       EXTRA_PATH_INFORMATION_INDENT,
@@ -67,12 +67,12 @@ function formatViolation(pViolation) {
 
   return (
     `${styleText(
-      [SEVERITY2COLOR.get(pViolation.rule.severity)],
+      SEVERITY2COLOR.get(pViolation.rule.severity),
       pViolation.rule.severity,
     )} ${pViolation.rule.name}: ${lFormattedViolators}` +
     `${
       pViolation.comment
-        ? `${EOL}${styleText(["dim"], wrapAndIndent(pViolation.comment))}${EOL}`
+        ? `${EOL}${styleText("dim", wrapAndIndent(pViolation.comment))}${EOL}`
         : ""
     }`
   );
@@ -93,7 +93,7 @@ function formatSummary(pSummary) {
     pSummary.totalCruised
   } modules, ${pSummary.totalDependenciesCruised} dependencies cruised.${EOL}`;
 
-  return pSummary.error > 0 ? styleText(["red"], lMessage) : lMessage;
+  return pSummary.error > 0 ? styleText("red", lMessage) : lMessage;
 }
 
 function addExplanation(pRuleSet, pLong) {
@@ -108,7 +108,7 @@ function addExplanation(pRuleSet, pLong) {
 function formatIgnoreWarning(pNumberOfIgnoredViolations) {
   if (pNumberOfIgnoredViolations > 0) {
     return styleText(
-      ["yellow"],
+      "yellow",
       `‼ ${pNumberOfIgnoredViolations} known violations ignored. Run with --no-ignore-known to see them.${EOL}`,
     );
   }
@@ -121,7 +121,7 @@ function report(pResults, pLong) {
   );
 
   if (lNonIgnorableViolations.length === 0) {
-    return `${EOL}${styleText(["green"], "✔")} no dependency violations found (${
+    return `${EOL}${styleText("green", "✔")} no dependency violations found (${
       pResults.summary.totalCruised
     } modules, ${
       pResults.summary.totalDependenciesCruised

--- a/src/report/metrics.mjs
+++ b/src/report/metrics.mjs
@@ -224,7 +224,7 @@ function formatToTextData(pData, pMetaData) {
  * @returns {string}
  */
 function formatToTextTable(pData, pMetaData) {
-  return [styleText(["bold"], formatToTextHeader(pMetaData))]
+  return [styleText("bold", formatToTextHeader(pMetaData))]
     .concat(formatToTextDemarcationLine(pMetaData))
     .concat(formatToTextData(pData, pMetaData))
     .join(EOL)

--- a/src/report/metrics.mjs
+++ b/src/report/metrics.mjs
@@ -1,5 +1,5 @@
 import { EOL } from "node:os";
-import pc from "picocolors";
+import { styleText } from "node:util";
 import { formatNumber, formatPercentage } from "./utl/index.mjs";
 
 /**
@@ -224,7 +224,7 @@ function formatToTextData(pData, pMetaData) {
  * @returns {string}
  */
 function formatToTextTable(pData, pMetaData) {
-  return [pc.bold(formatToTextHeader(pMetaData))]
+  return [styleText(["bold"], formatToTextHeader(pMetaData))]
     .concat(formatToTextDemarcationLine(pMetaData))
     .concat(formatToTextData(pData, pMetaData))
     .join(EOL)

--- a/src/report/text.mjs
+++ b/src/report/text.mjs
@@ -1,4 +1,4 @@
-import pc from "picocolors";
+import { styleText } from "node:util";
 
 const DEFAULT_OPTIONS = {
   highlightFocused: false,
@@ -36,7 +36,9 @@ function toFlatDependencies(pModules, pModulesInFocus, pHighlightFocused) {
 }
 
 function stringifyModule(pModule) {
-  return pModule.highlight ? pc.underline(pModule.name) : pModule.name;
+  return pModule.highlight
+    ? styleText(["underline"], pModule.name)
+    : pModule.name;
 }
 
 function stringify(pFlatDependency) {

--- a/src/report/text.mjs
+++ b/src/report/text.mjs
@@ -37,7 +37,7 @@ function toFlatDependencies(pModules, pModulesInFocus, pHighlightFocused) {
 
 function stringifyModule(pModule) {
   return pModule.highlight
-    ? styleText(["underline"], pModule.name)
+    ? styleText("underline", pModule.name)
     : pModule.name;
 }
 


### PR DESCRIPTION
## Description

- replaces picocolors with node:util/styleText
- as the first parameter of styleText use a _string_ in stead of an array as only with strings does NO_COLORS work in node 20 (it works fine in node 22 and 24) as well - see https://github.com/nodejs/node/issues/56717 for details
- ⛺ side-catch: removes Node.js 18 specific workarounds from the ci workflow.

## Motivation and Context

Less dependencies === less worries

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).