### PR TITLE
chore!: drops support for node 18, 21 and 23 BREAKING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 24.x]
+        node-version: [20.x, 24.x]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}
     steps:

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -759,11 +759,11 @@ it has to them. To see how dependency-cruiser perceives its environment use
 <summary>Typical output</summary>
 
 ```
-    dependency-cruiser@16.4.2
+    dependency-cruiser@17.0.0
 
-    node version supported : ^18.17||>=20
-    node version found     : v22.8.0
-    os version found       : x64 darwin@21.6.0
+    node version supported : ^20.12||^22||>=24
+    node version found     : v24.4.0
+    os version found       : arm64 darwin@24.5.0
 
     If you need a supported, but not enabled transpiler ('x' below), just install
     it in the same folder dependency-cruiser is installed. E.g. 'npm i livescript'
@@ -771,14 +771,14 @@ it has to them. To see how dependency-cruiser perceives its environment use
 
     ✔ transpiler             versions supported  version found
     - ---------------------- ------------------- ------------------------
-    ✔ javascript             *                   acorn@8.12.1
-    ✔ babel                  >=7.0.0 <8.0.0      @babel/core@7.25.2
+    ✔ javascript             *                   acorn@8.15.0
+    ✔ babel                  >=7.0.0 <8.0.0      @babel/core@7.28.0
     ✔ coffee-script          >=1.0.0 <2.0.0      coffeescript@2.7.0
     ✔ coffeescript           >=1.0.0 <3.0.0      coffeescript@2.7.0
     x livescript             >=1.0.0 <2.0.0      -
-    ✔ svelte                 >=3.0.0 <5.0.0      svelte/compiler@4.2.19
-    ✔ swc                    >=1.0.0 <2.0.0      @swc/core@1.7.26
-    ✔ typescript             >=2.0.0 <6.0.0      typescript@5.6.2
+    ✔ svelte                 >=3.0.0 <6.0.0      svelte/compiler@5.36.13
+    ✔ swc                    >=1.0.0 <2.0.0      @swc/core@1.13.1
+    ✔ typescript             >=2.0.0 <6.0.0      typescript@5.8.3
     ✔ vue-template-compiler  >=2.0.0 <3.0.0      vue-template-compiler
     ✔ @vue/compiler-sfc      >=3.0.0 <4.0.0      vue-template-compiler
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "yarn": "1.22.22"
       },
       "engines": {
-        "node": "^18.17||>=20"
+        "node": "^20.12||>=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     ]
   },
   "engines": {
-    "node": "^18.17||>=20"
+    "node": "^20.12||^22||>=24"
   },
   "supportedTranspilers": {
     "babel": ">=7.0.0 <8.0.0",

--- a/src/meta.cjs
+++ b/src/meta.cjs
@@ -3,7 +3,7 @@
 module.exports = {
   version: "16.10.4",
   engines: {
-    node: "^18.17||>=20",
+    node: "^20.12||^22||>=24",
   },
   supportedTranspilers: {
     babel: ">=7.0.0 <8.0.0",

--- a/test/cli/validate-node-environment.spec.mjs
+++ b/test/cli/validate-node-environment.spec.mjs
@@ -40,7 +40,7 @@ describe("[U] cli/validateNodeEnv", () => {
 
   it("doesn't throw when a supported node version is passed", () => {
     doesNotThrow(() => {
-      assertNodeEnvironmentSuitable("20.0.0");
+      assertNodeEnvironmentSuitable("22.0.0");
     });
   });
 });


### PR DESCRIPTION
## Description

- drops support for node 18, 21 and 23; sets the minimum required node version to 20.12, 
- updates the ci to reflect this

## Motivation and Context

We follow the node.js release cycle (as slow as possible) -- node 18 and 21 are end of life since 2025-03-27 and 2024-04-10 (!) respectively and shouldn't be run in production anymore. Same goes for node 23. Moreover node 20 has been in production since 2023-03-18, node 22 since 2024-03-24, so most serious consumers will have migrated to one of these versions already - if they aren't on node 24, that is.

We've tried to keep this off as long as possible but some of our dependencies (like commander.js) dropped support for node 18 and we want to keep those up to date to keep dependency-cruiser secure. Moreover node.js 20+ has useful features that makes it possible to do away with some 3rd party libraries, reducing dependency-cruiser's maintenance surface.

Reference: https://nodejs.org/en/about/previous-releases


## How Has This Been Tested?

- [x] green ci

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
