### PR TITLE
fix(types): enable IDE autocompletion for OutputType candidates

### DIFF
--- a/types/shared-types.d.mts
+++ b/types/shared-types.d.mts
@@ -29,7 +29,7 @@ export type OutputType =
   | "null"
   // for plugins: string. TODO: research whether it's possible to
   // tie this down to the `^plugin:[^:]+-reporter-plugin.[cm]?js$` regex
-  | string;
+  | (string & {}); // autocompletion hack
 
 export type SeverityType = "error" | "warn" | "info" | "ignore";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the definition of `OutputType` so that IDEs can now provide autocompletion for its literal candidates.

## Motivation and Context

Although the common candidates for ‎`OutputType` are defined as literals, autocompletion in IDEs was not available because they were unioned with ‎`string`.
However, for a better developer experience, it is preferable for these literal candidates to be available as autocomplete suggestions.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] green ci

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Although no issue has been opened for this change, I have selected “Bug fix” because it does not affect runtime behavior in any way.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
