### PR TITLE
refactor(report): replaces teamcity-service-messages with local functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "rechoir": "^0.8.0",
         "safe-regex": "^2.1.1",
         "semver": "^7.7.2",
-        "teamcity-service-messages": "^0.1.14",
         "tsconfig-paths-webpack-plugin": "^4.2.0",
         "watskeburt": "^4.2.3"
       },
@@ -7468,12 +7467,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/teamcity-service-messages": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/teamcity-service-messages/-/teamcity-service-messages-0.1.14.tgz",
-      "integrity": "sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w==",
-      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,6 @@
     "rechoir": "^0.8.0",
     "safe-regex": "^2.1.1",
     "semver": "^7.7.2",
-    "teamcity-service-messages": "^0.1.14",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "watskeburt": "^4.2.3"
   },

--- a/src/report/teamcity.mjs
+++ b/src/report/teamcity.mjs
@@ -39,6 +39,7 @@ function escape(pMessageString) {
  */
 function getRandomFlowIdBare() {
   const lFlowIdLength = 10;
+  // eslint-disable-next-line no-magic-numbers
   const lFlowIdMax = 10 ** lFlowIdLength;
 
   return randomInt(1, lFlowIdMax).toString().padStart(lFlowIdLength, "0");

--- a/src/report/teamcity.mjs
+++ b/src/report/teamcity.mjs
@@ -38,8 +38,8 @@ function escape(pMessageString) {
  * @return {string} a random flowId consisting of 10 numeric digits
  */
 function getRandomFlowIdBare() {
-  const lFlowIdMax = 1e10;
   const lFlowIdLength = 10;
+  const lFlowIdMax = 10 ** lFlowIdLength;
 
   return randomInt(1, lFlowIdMax).toString().padStart(lFlowIdLength, "0");
 }
@@ -51,7 +51,7 @@ function getTimeStamp() {
 }
 
 function inspectionType(pData) {
-  let lAttributes = [];
+  const lAttributes = [];
   lAttributes.push(
     `id='${pData.id}'`,
     `name='${pData.name}'`,
@@ -64,7 +64,7 @@ function inspectionType(pData) {
 }
 
 function inspection(pData) {
-  let lAttributes = [];
+  const lAttributes = [];
   lAttributes.push(
     `typeId='${pData.typeId}'`,
     `message='${escape(pData.message)}'`,

--- a/src/report/teamcity.mjs
+++ b/src/report/teamcity.mjs
@@ -35,6 +35,11 @@ function escape(pMessageString) {
 }
 
 /**
+ * Returns a random flowId consisting of 10 numeric digits. TeamCity doesn't
+ * currently seem to have demands on the format (it's just a string as far
+ * as I can tell), but this is what teamcity-service-messages used, so as
+ * per the rule of least surprise, this is what we use.
+ *
  * @return {string} a random flowId consisting of 10 numeric digits
  */
 function getRandomFlowIdBare() {
@@ -47,6 +52,14 @@ function getRandomFlowIdBare() {
 
 const getRandomFlowId = memoize(getRandomFlowIdBare);
 
+/**
+ * Returns a timestamp in ISO format without the trailing 'Z'. It used to be
+ * an issue with TeamCity that it didn't use the trailing 'Z' (this is
+ * documented in the teamcity-service-messages source code) - not sure whether
+ * this is still the case, but this is what we do to be on the safe side.
+ *
+ * @returns {string} a timestamp in ISO format without the trailing 'Z'
+ */
 function getTimeStamp() {
   return new Date().toISOString().slice(0, -1);
 }
@@ -219,8 +232,10 @@ function reportViolations(pViolations, pIgnoredCount) {
 
 /**
  * Returns a bunch of TeamCity service messages:
- * - for each violated rule in the passed results: an `inspectionType` with the name and comment of that rule
- * - for each violation in the passed results: an `inspection` with the violated rule name and the tos and froms
+ * - for each violated rule in the passed results: an `inspectionType` with the
+ *   name and comment of that rule
+ * - for each violation in the passed results: an `inspection` with the
+ *   violated rule name and the tos and froms
  *
  * @param {import("../../types/dependency-cruiser.js").ICruiseResult} pResults
  * @returns {import("../../types/dependency-cruiser.js").IReporterOutput}

--- a/test/report/teamcity/teamcity.spec.mjs
+++ b/test/report/teamcity/teamcity.spec.mjs
@@ -115,6 +115,26 @@ describe("[I] report/teamcity", () => {
     equal(lResult.exitCode, 5);
   });
 
+  it("writes flowIds, and writes them as 10 digit numbers", () => {
+    const lResult = render(moduleErrs);
+    const lFlowIdRegex = / flowId='\d{10}'/;
+    const lFlowIdMatch = lResult.output.match(lFlowIdRegex);
+    equal(lFlowIdMatch.length, 1);
+    // eslint-disable-next-line no-magic-numbers
+    equal(lFlowIdMatch[0].length, 20);
+  });
+
+  it("writes timestamps in the team city specific format omitting the 'Z' at the end", () => {
+    const lResult = render(moduleErrs);
+    // 2025-08-02T19:43:28.893
+    const lTimestampRegex =
+      / timestamp='\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.]\d{3}'/;
+    const lTimestampMatch = lResult.output.match(lTimestampRegex);
+    equal(lTimestampMatch.length, 1);
+    // eslint-disable-next-line no-magic-numbers
+    equal(lTimestampMatch[0].length, 36);
+  });
+
   it("renders known errors in a single warning", () => {
     const lFixture = readFixture(
       "__mocks__/known-violations-teamcity-format.txt",


### PR DESCRIPTION
## Description

- replaces teamcity-service-messages with local functions

## Motivation and Context

The teamcity-service-messages has been working great, without a hitch since the moment we started using it. It's not maintained anymore, however, that's not an issue either: _there's no need for maintenance and it's dependency-less. 

However, it _does_ remain a dependency, while the functionality we use of it is relatively straightforward. With dependencies there's always the risk some overactive go-getter finds a bogus CVE, or, potentially worse, the package owner gets hacked and all of a sudden there _is_ a risk because just installing it will run an llm-crypto-miner-scam-of-the-day on install.

It also makes dependency-cruiser's installed footprint slightly smaller.

AKA less dependencies === more happiness.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
