### PR TITLE
fix: Using the API  but tsconfig does not work

### DIFF
--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -157,7 +157,10 @@ export default async function normalizeResolveOptions(
       // - true => symlinks are NOT followed (vv)
       // => symlinks = !preserveSymlinks
       symlinks: !pOptions?.preserveSymlinks,
-      tsConfig: pOptions?.tsConfig?.fileName ?? pOptions?.ruleSet?.options?.tsConfig?.fileName ?? null,
+      tsConfig:
+        pOptions?.tsConfig?.fileName ??
+        pOptions?.ruleSet?.options?.tsConfig?.fileName ??
+        null,
 
       /* squirrel the externalModuleResolutionStrategy and combinedDependencies
          thing into the resolve options


### PR DESCRIPTION
Compatible parameters

<!--- Provide a general summary of your changes in the Title above -->

> Plan to do something drastic?  
> Leave an [issue](https://github.com/sverweij/dependency-cruiser/issues/new/choose) with a
> summary of the changes you propose + some context on why you'd want to
> do that, so we can have a conversation before you start. This will save you time!

## Description
ts config does not work in api
```
await cruise(['src'], 
    {
    validate: true,
    includeOnly: [
      `^src`
    ],
    tsConfig: {
      fileName: 'tsconfig.json',
    },
    ruleSet: {
      forbidden: allForbiddenRules,
    },
    
  });
```
or
```
await cruise(['src'], 
    {
    validate: true,
    includeOnly: [
      `^src`
    ],
    ruleSet: {
      forbidden: allForbiddenRules,
    },
  }, undefined, {
    tsConfig: {
      fileName: 'tsconfig.json',
    },
  });
```
<!--- Describe your changes in detail -->

## Motivation and Context
I want to analyze the project through the API, but the TS configuration cannot be recognized！！
<!--- Why is this change required? What problem does it solve? -->
only use code like this, it works
```
await cruise(['src'], 
    {
    validate: true,
    includeOnly: [
      `^src`
    ],
    ruleSet: {
      options: {
        tsConfig: {
          fileName: path.resolve(projectRoot, 'tsconfig.json'),
        },
      },
    },
  });
```
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] green ci

## Screenshots

<!-- Only if appropriate - feel free to delete this section if it's not applicable -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
