### PR TITLE
fix(resolve-options): passes the correct resolve options to the tsconfig paths plugin

### DIFF
--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -116,7 +116,9 @@ async function compileResolveOptions(
         // so we do it ourselves - either with the extensions passed
         // or with the supported ones.
         extensions:
-          pResolveOptions.extensions || DEFAULT_RESOLVE_OPTIONS.extensions,
+          pResolveOptionsFromDCConfig.extensions ||
+          pResolveOptions.extensions ||
+          DEFAULT_RESOLVE_OPTIONS.extensions,
       }),
     );
   }


### PR DESCRIPTION
## Description

- passes the correct resolve options to the tsconfig paths plugin

## Motivation and Context

- addresses the issue described in #1006 (specifically https://github.com/sverweij/dependency-cruiser/issues/1006#issuecomment-3145012024)

## How Has This Been Tested?

- [x] green ci
- [ ] additional e2e and/ or integration test

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
