### PR TITLE
perf(utl): improves performance of uniqBy and uniqWith functions from O(n^2) to O(n)

### DIFF
--- a/src/utl/array-util.mjs
+++ b/src/utl/array-util.mjs
@@ -7,6 +7,9 @@
  * @return {boolean} true if there's at least one element in pLeftArray also in pRightArray
  */
 export function intersects(pLeftArray, pRightArray) {
+  if (pLeftArray.length === 0 || pRightArray.length === 0) {
+    return false;
+  }
   if (pRightArray.length < pLeftArray.length) {
     return pRightArray.some((pItem) => pLeftArray.includes(pItem));
   }

--- a/test/cli/init-config/build-config.spec.mjs
+++ b/test/cli/init-config/build-config.spec.mjs
@@ -103,6 +103,36 @@ describe("[I] cli/init-config/build-config", () => {
     });
   });
 
+  it("generates a valid config - jsConfig", async () => {
+    process.chdir("test/cli/__fixtures__/init-config/no-config-files-exist");
+
+    const lResult = await createConfigNormalized({
+      useJsConfig: true,
+      jsConfig: "./jsconfig.json",
+    });
+
+    ajv.validate(configurationSchema, lResult);
+    ok(lResult.hasOwnProperty("options"));
+    deepEqual(lResult.options.tsConfig, {
+      fileName: "./jsconfig.json",
+    });
+  });
+
+  it("generates a valid config - babelConfig", async () => {
+    process.chdir("test/cli/__fixtures__/init-config/no-config-files-exist");
+
+    const lResult = await createConfigNormalized({
+      useBabelConfig: true,
+      babelConfig: "./.babelrc.json",
+    });
+
+    ajv.validate(configurationSchema, lResult);
+    ok(lResult.hasOwnProperty("options"));
+    deepEqual(lResult.options.babelConfig, {
+      fileName: "./.babelrc.json",
+    });
+  });
+
   it("generates mainFields including 'module' for package.json with a type: module field", async () => {
     const lResult = await createConfigNormalized({ isTypeModule: true });
 

--- a/test/config-utl/__mocks__/babelconfig-js/babel.syntax-error.config.js
+++ b/test/config-utl/__mocks__/babelconfig-js/babel.syntax-error.config.js
@@ -1,0 +1,6 @@
+// This file has a syntax error to test error handling
+module.exports = {
+  plugins: [
+    "this is not valid javascript syntax {{{{
+  ]
+};

--- a/test/config-utl/extract-babel-config.spec.mjs
+++ b/test/config-utl/extract-babel-config.spec.mjs
@@ -114,6 +114,24 @@ describe("[I] config-utl/extract-babel-config", () => {
     equal(lModule.plugins.length, 1);
   });
 
+  it("throws when a javascript file with a syntax error is passed", async () => {
+    let lThrown = false;
+    let lErrorMessage = "";
+    try {
+      await extractBabelConfig(
+        getFullPath("./__mocks__/babelconfig-js/babel.syntax-error.config.js"),
+      );
+    } catch (pError) {
+      lThrown = true;
+      lErrorMessage = pError.message;
+    }
+    equal(lThrown, true);
+    ok(
+      lErrorMessage.includes("Encountered an error while parsing babel config"),
+    );
+    ok(lErrorMessage.includes("babel.syntax-error.config.js"));
+  });
+
   it("returns a babel config _including_ the array of plugins when a config with presets is passed", async () => {
     const lFoundConfig = await extractBabelConfig(
       getFullPath("./__mocks__/babelconfig/babelrc.with-a-preset.json"),

--- a/test/enrich/is-same-violation.spec.mjs
+++ b/test/enrich/is-same-violation.spec.mjs
@@ -170,4 +170,166 @@ describe("[U] enrich/is-same-violation", () => {
     };
     deepEqual(isSameViolation(lLeftViolation, lRightViolation), false);
   });
+
+  it("same via (reachability) => same", () => {
+    const lViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+        {
+          name: "another-intermediate.js",
+          dependencyTypes: ["require"],
+        },
+      ],
+    };
+    deepEqual(isSameViolation(lViolation, lViolation), true);
+  });
+
+  it("different via length => not same", () => {
+    const lLeftViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+        {
+          name: "another-intermediate.js",
+          dependencyTypes: ["require"],
+        },
+      ],
+    };
+    const lRightViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+      ],
+    };
+    deepEqual(isSameViolation(lLeftViolation, lRightViolation), false);
+  });
+
+  it("different via module => not same", () => {
+    const lLeftViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+        {
+          name: "another-intermediate.js",
+          dependencyTypes: ["require"],
+        },
+      ],
+    };
+    const lRightViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+        {
+          name: "different-intermediate.js",
+          dependencyTypes: ["require"],
+        },
+      ],
+    };
+    deepEqual(isSameViolation(lLeftViolation, lRightViolation), false);
+  });
+
+  it("via with different from => not same", () => {
+    const lLeftViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+      ],
+    };
+    const lRightViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "different-somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+      ],
+    };
+    deepEqual(isSameViolation(lLeftViolation, lRightViolation), false);
+  });
+
+  it("via with different to => not same", () => {
+    const lLeftViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+      ],
+    };
+    const lRightViolation = {
+      rule: {
+        severity: "error",
+        name: "some-reachability-violation",
+      },
+      from: "somewhere.js",
+      to: "different-somewhere-else.js",
+      via: [
+        {
+          name: "intermediate.js",
+          dependencyTypes: ["local"],
+        },
+      ],
+    };
+    deepEqual(isSameViolation(lLeftViolation, lRightViolation), false);
+  });
 });

--- a/test/extract/transpile/meta.spec.mjs
+++ b/test/extract/transpile/meta.spec.mjs
@@ -1,11 +1,36 @@
 import { deepEqual } from "node:assert/strict";
 import { validRange } from "semver";
 import {
+  allExtensions,
   getAvailableTranspilers,
   scannableExtensions,
 } from "#extract/transpile/meta.mjs";
 
 describe("[U] extract/transpile/meta", () => {
+  it("returns all extensions with their availability", () => {
+    const lExtensions = allExtensions;
+    deepEqual(Array.isArray(lExtensions), true);
+    deepEqual(lExtensions.length > 0, true);
+
+    lExtensions.forEach((pExtension) => {
+      deepEqual(
+        typeof pExtension.extension,
+        "string",
+        `extension is not a string: ${pExtension.extension}`,
+      );
+      deepEqual(
+        typeof pExtension.available,
+        "boolean",
+        `available is not a boolean: ${pExtension.available}`,
+      );
+      deepEqual(
+        pExtension.extension.startsWith("."),
+        true,
+        `extension should start with a dot: ${pExtension.extension}`,
+      );
+    });
+  });
+
   it("tells which extensions can be scanned", () => {
     deepEqual(scannableExtensions, [
       ".js",


### PR DESCRIPTION
## Description

- changes the uniqBy and uniqWith functions to a less naive implementation which should result in faster execution.
- because of this coverage on some functions that were covered in integration tests/ covered indirectly only got called less often, also in test code; as a consequence some paths weren't part of test coverage, so this PR also adds test coverage for those.

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
