### PR TITLE
perf(extract/typescript): adds various performance optimizations

### DIFF
--- a/src/extract/tsc/extract-typescript-deps.mjs
+++ b/src/extract/tsc/extract-typescript-deps.mjs
@@ -323,21 +323,19 @@ function isJSDocImport(pTypeNode) {
   );
 }
 
-function keyInJSDocIsIgnorable(pKey) {
-  return [
-    "parent",
-    "pos",
-    "end",
-    "flags",
-    "emitNode",
-    "modifierFlagsCache",
-    "transformFlags",
-    "id",
-    "flowNode",
-    "symbol",
-    "original",
-  ].includes(pKey);
-}
+const IGNORABLE_JSDOC_KEYS = new Set([
+  "parent",
+  "pos",
+  "end",
+  "flags",
+  "emitNode",
+  "modifierFlagsCache",
+  "transformFlags",
+  "id",
+  "flowNode",
+  "symbol",
+  "original",
+]);
 
 export function walkJSDoc(pObject, pCollection = new Set()) {
   if (isJSDocImport(pObject)) {
@@ -348,7 +346,7 @@ export function walkJSDoc(pObject, pCollection = new Set()) {
     }
   } else if (typeof pObject === "object") {
     for (const lKey in pObject) {
-      if (!keyInJSDocIsIgnorable(lKey) && pObject[lKey]) {
+      if (!IGNORABLE_JSDOC_KEYS.has(lKey) && pObject[lKey]) {
         walkJSDoc(pObject[lKey], pCollection);
       }
     }
@@ -439,6 +437,9 @@ function visitNode(
   }
 
   // const want = require; {lalala} = want('yudelyo'), window.require('elektron')
+  // strictly speaking checking whether kind is CallExpression is not necessary as
+  // the functions inside the loop will do that as well. However, it saves quite a
+  // of computation when the list of exotic require strings is not empty
   if (pASTNode.kind === typescript.SyntaxKind.CallExpression) {
     for (const lExoticRequireString of pExoticRequireStrings) {
       if (isExoticRequire(pASTNode, lExoticRequireString)) {


### PR DESCRIPTION
## Description

Adds these optimizations:

* e9041e1c: skips uninteresting node kinds in walker 
  impactful for all typescript sources - it means it'll have to look close at a lot less nodes
* 585b39e0: only check for exotic require strings for nodes that can contain them 
  impactful when you have quite a bit of exotic require strings, otherwise not at all
* f541d01/ 6436a2e4: return when dependency & type are found
  Early returns like this have impact when a lot of the things checked in there (`require`, dynamic imports, type imports etc) are in the source code. Otherwise not that much.
* 0b4566ad: replaces lookup + string comparisons with direct number comparisons
  _should_ be faster, but not super noticable even on larger code bases.


## Motivation and Context

- Skipping uninteresting node kinds (e9041e1c and 585b39e0)  in the walker ensures there's a lot less functions calls & calculations.
- Comparing numbers to numbers (and not having to do a dynamic object lookup _and_ 

Useful to do as it's likely dependency-cruiser is used most often on typescript sources.

## How Has This Been Tested?

- [x] green ci
- [x] comparing self-runs with each other:
  -  the _visit dependencies_ step took on average ~85% of the time it took previously (on my local mac 620ms vs 530 ms in low power mode, 290ms vs 250ms in normal power mode)
  - when running dependency-cruiser with c8 the coverage numbers show there's indeed significantly less calls to the typescript node classification functions.
  - the flamegraphs shows the same (less time spent in the _extractDependencies/ extractWithTsc_ function)

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
