### PR TITLE
perf(utl): memoizes regexes that can be compiled in advance

### DIFF
--- a/src/extract/clear-caches.mjs
+++ b/src/extract/clear-caches.mjs
@@ -5,8 +5,10 @@ import { clearCache as externalModuleHelpers_clearCache } from "./resolve/extern
 import { clearCache as getManifest_clearCache } from "./resolve/get-manifest.mjs";
 import { clearCache as resolveAMD_clearCache } from "./resolve/resolve-amd.mjs";
 import { clearCache as resolve_clearCache } from "./resolve/resolve.mjs";
+import { clearCache as regex_clearCache } from "#utl/regex-cache.mjs";
 
 export default function clearCaches() {
+  regex_clearCache();
   tscClearCache();
   acornClearCache();
   swcClearCache();

--- a/src/extract/extract-dependencies.mjs
+++ b/src/extract/extract-dependencies.mjs
@@ -14,6 +14,7 @@ import {
   extractModuleAttributes,
 } from "./helpers.mjs";
 import { uniqBy, intersects } from "#utl/array-util.mjs";
+import { testCachedRegex } from "#utl/regex-cache.mjs";
 
 /**
  * @import { IDependency } from "../../types/cruise-result.mjs";
@@ -79,7 +80,7 @@ function extractDependencies(pCruiseOptions, pFileName, pTranspileOptions) {
 
 function matchesDoNotFollow({ resolved, dependencyTypes }, pDoNotFollow) {
   const lMatchesPath = pDoNotFollow.path
-    ? RegExp(pDoNotFollow.path, "g").test(resolved)
+    ? testCachedRegex(resolved, pDoNotFollow.path)
     : false;
   const lMatchesDependencyTypes = pDoNotFollow.dependencyTypes
     ? intersects(dependencyTypes, pDoNotFollow.dependencyTypes)
@@ -111,10 +112,6 @@ function addResolutionAttributes(
       matchesDoNotFollow: lMatchesDoNotFollow,
     };
   };
-}
-
-function matchesPattern(pFullPathToFile, pPattern) {
-  return RegExp(pPattern, "g").test(pFullPathToFile);
 }
 
 /**
@@ -178,9 +175,9 @@ export default function getDependencies(
       .filter(
         ({ resolved }) =>
           (!pCruiseOptions?.exclude?.path ||
-            !matchesPattern(resolved, pCruiseOptions.exclude.path)) &&
+            !testCachedRegex(resolved, pCruiseOptions.exclude.path)) &&
           (!pCruiseOptions?.includeOnly?.path ||
-            matchesPattern(resolved, pCruiseOptions.includeOnly.path)),
+            testCachedRegex(resolved, pCruiseOptions.includeOnly.path)),
       );
   } catch (pError) {
     throw new Error(

--- a/src/graph-utl/match-facade.mjs
+++ b/src/graph-utl/match-facade.mjs
@@ -1,5 +1,7 @@
+import { testCachedRegex } from "#utl/regex-cache.mjs";
+
 export function filenameMatchesPattern(pFullPathToFile, pPattern) {
-  return RegExp(pPattern, "g").test(pFullPathToFile);
+  return testCachedRegex(pFullPathToFile, pPattern);
 }
 
 export function moduleMatchesFilter(pModule, pFilter) {

--- a/src/utl/regex-cache.mjs
+++ b/src/utl/regex-cache.mjs
@@ -1,0 +1,48 @@
+/**
+ * Memoized regex compilation. Reduces redundant regex creation
+ * in hot paths where the same patterns are tested repeatedly.
+ *
+ * @module utl/regex-cache
+ */
+
+import memoize, { memoizeClear } from "memoize";
+
+/**
+ * Compiles a RegExp from pattern and flags.
+ * This function is memoized to avoid recompiling the same regex.
+ *
+ * @param {string} pPattern - The regex pattern
+ * @param {string} pFlags - The regex flags
+ * @returns {RegExp} - Compiled regular expression
+ */
+function compileRegex(pPattern, pFlags) {
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  return new RegExp(pPattern, pFlags);
+}
+
+/**
+ * Memoized version of compileRegex with LRU cache of 500 entries.
+ * Cache key combines pattern and flags to ensure uniqueness.
+ */
+const getCachedRegex = memoize(compileRegex, {
+  cache: new Map(),
+  cacheKey: (pArguments) => `${pArguments[0]}|${pArguments[1] || ""}`,
+});
+
+/**
+ * Tests a string against a cached regex pattern.
+ *
+ * @param {string} pString - The string to test
+ * @param {string} pPattern - The regex pattern
+ * @param {string} [pFlags=""] - The regex flags (default: no flags)
+ * @returns {boolean} - Whether the pattern matches
+ */
+export function testCachedRegex(pString, pPattern, pFlags = "") {
+  return getCachedRegex(pPattern, pFlags).test(pString);
+}
+
+export { getCachedRegex };
+
+export function clearCache() {
+  memoizeClear(getCachedRegex);
+}

--- a/test/utl/regex-cache.spec.mjs
+++ b/test/utl/regex-cache.spec.mjs
@@ -1,0 +1,77 @@
+import { deepEqual, ok } from "node:assert/strict";
+import { getCachedRegex, testCachedRegex } from "#utl/regex-cache.mjs";
+
+describe("[U] utl/regex-cache", () => {
+  describe("[U] getCachedRegex", () => {
+    it("returns a RegExp object", () => {
+      const lRegex = getCachedRegex("test");
+      ok(lRegex instanceof RegExp);
+    });
+
+    it("returns the same RegExp instance for identical pattern and flags", () => {
+      const lRegex1 = getCachedRegex("test", "i");
+      const lRegex2 = getCachedRegex("test", "i");
+      deepEqual(lRegex1, lRegex2);
+    });
+
+    it("returns different RegExp instances for different patterns", () => {
+      const lRegex1 = getCachedRegex("test1");
+      const lRegex2 = getCachedRegex("test2");
+      ok(lRegex1 !== lRegex2);
+    });
+
+    it("returns different RegExp instances for same pattern but different flags", () => {
+      const lRegex1 = getCachedRegex("test", "i");
+      const lRegex2 = getCachedRegex("test", "g");
+      ok(lRegex1 !== lRegex2);
+    });
+
+    it("uses empty string as default flags", () => {
+      const lRegex = getCachedRegex("test");
+      deepEqual(lRegex.flags, "");
+    });
+
+    it("respects custom flags", () => {
+      const lRegex = getCachedRegex("test", "gi");
+      deepEqual(lRegex.flags, "gi");
+    });
+  });
+
+  describe("[U] testCachedRegex", () => {
+    it("returns true when pattern matches", () => {
+      const lResult = testCachedRegex("hello world", "world");
+      deepEqual(lResult, true);
+    });
+
+    it("returns false when pattern doesn't match", () => {
+      const lResult = testCachedRegex("hello world", "foo");
+      deepEqual(lResult, false);
+    });
+
+    it("works with case-insensitive flag", () => {
+      const lResult = testCachedRegex("Hello World", "hello", "i");
+      deepEqual(lResult, true);
+    });
+
+    it("caches regex between calls", () => {
+      // First call
+      testCachedRegex("test1", "test");
+      // Second call should use cached regex
+      const lResult = testCachedRegex("test2", "test");
+      deepEqual(lResult, true);
+    });
+
+    it("handles special regex characters", () => {
+      const lResult = testCachedRegex("file.js", "\\.js$");
+      deepEqual(lResult, true);
+    });
+
+    it("works correctly without global flag (no stateful lastIndex issues)", () => {
+      // Call test multiple times with same pattern
+      deepEqual(testCachedRegex("test", "test"), true);
+      deepEqual(testCachedRegex("test", "test"), true);
+      deepEqual(testCachedRegex("test", "test"), true);
+      // All should return true; if 'g' flag was used, alternating true/false could occur
+    });
+  });
+});


### PR DESCRIPTION
## Description

- memoizes regexes that can be compiled in advance

## Motivation and Context

This should make some steps a bit faster (TBD on a decently sized code base).


## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
