### PR TITLE
fix(extract): ensures we work again when typescript isn't installed

### DIFF
--- a/src/extract/tsc/extract-typescript-deps.mjs
+++ b/src/extract/tsc/extract-typescript-deps.mjs
@@ -15,13 +15,16 @@ const typescript = await tryImport(
   meta.supportedTranspilers.typescript,
 );
 
-const INTERESTING_NODE_KINDS = new Set([
-  typescript.SyntaxKind.CallExpression,
-  typescript.SyntaxKind.ExportDeclaration,
-  typescript.SyntaxKind.ImportDeclaration,
-  typescript.SyntaxKind.ImportEqualsDeclaration,
-  typescript.SyntaxKind.LastTypeNode,
-]);
+const INTERESTING_NODE_KINDS = typescript
+  ? new Set([
+      typescript.SyntaxKind.CallExpression,
+      typescript.SyntaxKind.ExportDeclaration,
+      typescript.SyntaxKind.ImportDeclaration,
+      typescript.SyntaxKind.ImportEqualsDeclaration,
+      typescript.SyntaxKind.LastTypeNode,
+    ])
+  : /* c8 ignore next 1 */
+    new Set();
 
 function isTypeOnlyImport(pStatement) {
   return (


### PR DESCRIPTION
## Description

- ensures we work again when typescript isn't installed

## Motivation and Context

dependency-cruiser currently breaks when run on non-typescript code bases - this fixes that.

## How Has This Been Tested?

- [x] green ci
- [x] manually against a javascript-only codebase. Automated non-regression will follow separately as this issue occurs on the current _latest_ on npmjs and we'd like that fixed a.s.a.p.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
