### PR TITLE
perf(enrich/derive/metrics): only create indexed graph once

### DIFF
--- a/src/enrich/derive/metrics/get-module-metrics.mjs
+++ b/src/enrich/derive/metrics/get-module-metrics.mjs
@@ -1,5 +1,4 @@
 import { calculateInstability, metricsAreCalculable } from "../module-utl.mjs";
-import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 
 export function addInstabilityMetric(pModule) {
   return {
@@ -15,25 +14,23 @@ export function addInstabilityMetric(pModule) {
   };
 }
 
-function addInstabilityToDependency(pAllModules) {
-  const lIndexedModules = new IndexedModuleGraph(pAllModules);
+function addInstabilityToDependency(pIndexedModules) {
   return (pDependency) => ({
     ...pDependency,
     instability:
-      (lIndexedModules.findVertexByName(pDependency.resolved) || {})
+      (pIndexedModules.findVertexByName(pDependency.resolved) || {})
         .instability || 0,
   });
 }
 
 export function deNormalizeInstabilityMetricsToDependencies(
   pModule,
-  _,
-  pAllModules,
+  pIndexedModules,
 ) {
   return {
     ...pModule,
     dependencies: pModule.dependencies.map(
-      addInstabilityToDependency(pAllModules),
+      addInstabilityToDependency(pIndexedModules),
     ),
   };
 }

--- a/src/enrich/derive/metrics/index.mjs
+++ b/src/enrich/derive/metrics/index.mjs
@@ -2,12 +2,16 @@ import {
   addInstabilityMetric,
   deNormalizeInstabilityMetricsToDependencies,
 } from "./get-module-metrics.mjs";
+import IndexedModuleGraph from "#graph-utl/indexed-module-graph.mjs";
 
 export default function deriveModulesMetrics(pModules, pOptions) {
   if (pOptions.metrics) {
-    return pModules
-      .map(addInstabilityMetric)
-      .map(deNormalizeInstabilityMetricsToDependencies);
+    const lModules = pModules.map(addInstabilityMetric);
+    const lIndexedModules = new IndexedModuleGraph(lModules);
+
+    return lModules.map((pModule) =>
+      deNormalizeInstabilityMetricsToDependencies(pModule, lIndexedModules),
+    );
   }
   return pModules;
 }


### PR DESCRIPTION
## Description

- perf(enrich/derive/metrics): only create indexed graph once

And yes, I _also_ wonder what was in my tea while I wrote this 3 years ago. Dzjeebus 🤦 .

From dc's self-scan with `--progress performance-log`, the _analyze: module metrics_ step before and after this PR:


|       | ∆ rss     | ∆ heapTotal | ∆ heapUsed | ∆ external | ⏱  system | ⏱  user | ⏱  real |
|-      | --------: | ---------:  | ---------: | --------: | ---------: | -------: | ------: |
|before| +16,688kB | -19,552kB   |  -43,798kB |    -589kB |        7ms |    358ms | **292ms**|
|after |     +16kB |       0KB   |   +2,053kB |       0kB |        0ms |      6ms |   **2ms**|

In the before the -∆ in the heap are probably because the garbage collector had enough time during the step to kick in. Impressive that, despite of that we _still_ had an ∆ rss of +16MB 

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
