### PR TITLE
chore(progress): cleans up steps & performance log

### DIFF
--- a/.dependency-cruiser.mjs
+++ b/.dependency-cruiser.mjs
@@ -686,7 +686,7 @@ export default {
 
     progress: { 
       type: "performance-log", 
-      maximumLevel: 60 
+      maximumLevel: 50 
     },
     cache: {
       strategy: "metadata",

--- a/src/cache/cache.mjs
+++ b/src/cache/cache.mjs
@@ -87,7 +87,7 @@ export default class Cache {
         },
       ));
     this.#revisionData.cacheFormatVersion = CACHE_FORMAT_VERSION;
-    bus.debug("cache: - compare");
+    bus.debug("cache: compare");
     return (
       this.cacheFormatVersionCompatible(pCachedCruiseResult) &&
       this.#cacheStrategy.revisionDataEqual(

--- a/src/cache/find-content-changes.mjs
+++ b/src/cache/find-content-changes.mjs
@@ -83,7 +83,7 @@ export default function findContentChanges(
   pCachedCruiseResult,
   pOptions,
 ) {
-  bus.debug("cache: - get revision data");
+  bus.debug("cache: content: get revision data");
   const lFileSet = new Set(
     findAllFiles(pDirectory, {
       baseDir: pOptions.baseDir,
@@ -92,12 +92,12 @@ export default function findContentChanges(
     }).filter(hasInterestingExtension(pOptions.extensions)),
   );
 
-  bus.debug("cache: - get (cached - new)");
+  bus.debug("cache: content: get (cached - new)");
   const lDiffCachedVsNew = pCachedCruiseResult.modules.map(
     diffCachedModuleAgainstFileSet(lFileSet, pOptions.baseDir),
   );
 
-  bus.debug("cache: - get (new - cached)");
+  bus.debug("cache: content: get (new - cached)");
   // eslint-disable-next-line budapestian/local-variable-pattern
   for (const { name } of lDiffCachedVsNew) {
     lFileSet.delete(name);
@@ -112,6 +112,6 @@ export default function findContentChanges(
     });
   }
 
-  bus.debug("cache: - return revision data");
+  bus.debug("cache: content: return revision data");
   return lDiffCachedVsNew.concat(lDiffNewVsCached);
 }

--- a/src/cache/metadata-strategy.mjs
+++ b/src/cache/metadata-strategy.mjs
@@ -43,9 +43,9 @@ export default class MetaDataStrategy {
       ...pOptions,
     };
     try {
-      bus.debug("cache: - get sha");
+      bus.debug("cache: metadata: get sha");
       const lSHA = await lOptions.shaRetrievalFn();
-      bus.debug("cache: - get diff");
+      bus.debug("cache: metadata: get diff");
       const lDiff = /** @type {IChange[]} */ (
         await lOptions.diffListFn({ oldRevision: lSHA })
       );
@@ -56,7 +56,7 @@ export default class MetaDataStrategy {
         )
         .filter(changeHasInterestingExtension(lOptions.extensions))
         .filter(isInterestingChangeType(lOptions.interestingChangeTypes));
-      bus.debug("cache: - sha-sum diff");
+      bus.debug("cache: metadata: sha-sum diff");
       return {
         SHA1: lSHA,
         changes: lChanges.map(lOptions.checksumFn),

--- a/src/cli/listeners/ndjson.mjs
+++ b/src/cli/listeners/ndjson.mjs
@@ -76,7 +76,7 @@ export default function setUpNDJSONListener(
 ) {
   let lState = {
     runStartTime: new Date(Date.now()).toISOString(),
-    previousMessage: "nodejs starting",
+    previousMessage: "startup: nodejs loading",
     previousTime: 0,
     previousUserUsage: 0,
     previousSystemUsage: 0,

--- a/src/cli/listeners/performance-log/format-helpers.mjs
+++ b/src/cli/listeners/performance-log/format-helpers.mjs
@@ -1,5 +1,5 @@
 import { styleText } from "node:util";
-import { INFO } from "#utl/bus.mjs";
+import { INFO, SUMMARY } from "#utl/bus.mjs";
 
 const MS_PER_SECOND = 1000;
 const MS_PER_MICRO_SECOND = 0.001;
@@ -64,7 +64,7 @@ function formatMessage(pMessage, pLevel) {
 export function formatTime(
   pNumber,
   pConversionMultiplier = MS_PER_SECOND,
-  pLevel = INFO,
+  pLevel = SUMMARY,
 ) {
   return formatMessage(
     gTimeFormat(pConversionMultiplier * pNumber)

--- a/src/cli/listeners/performance-log/handlers.mjs
+++ b/src/cli/listeners/performance-log/handlers.mjs
@@ -50,7 +50,7 @@ export function getEndText(pState, pLevel, pMaxLevel) {
     const lTime = process.uptime();
     const { user, system } = process.cpuUsage();
     const { heapUsed, heapTotal, external, rss } = process.memoryUsage();
-    pState.previousMessage = "really done";
+    pState.previousMessage = "end: really done";
 
     return (
       getProgressLine("", pState, pLevel, pMaxLevel) +

--- a/src/cli/listeners/performance-log/index.mjs
+++ b/src/cli/listeners/performance-log/index.mjs
@@ -35,7 +35,7 @@ export default function setUpPerformanceLogListener(
   pStream = process.stderr,
 ) {
   let lState = {
-    previousMessage: "nodejs starting",
+    previousMessage: "startup: nodejs loading",
     previousTime: 0,
     previousUserUsage: 0,
     previousSystemUsage: 0,

--- a/src/extract/index.mjs
+++ b/src/extract/index.mjs
@@ -70,13 +70,13 @@ function extractFileDirectoryArray(
 ) {
   let lVisited = new Set();
 
-  bus.info("read files: gather initial sources");
+  bus.debug("extract: gather initial sources");
   const lInitialSources = gatherInitialSources(
     pFileDirectoryArray,
     pCruiseOptions,
   );
 
-  bus.info("read files: visit dependencies");
+  bus.debug("extract: visit dependencies");
   const lResult = [];
   for (const lFilename of lInitialSources) {
     if (!lVisited.has(lFilename)) {

--- a/src/extract/resolve/resolve.mjs
+++ b/src/extract/resolve/resolve.mjs
@@ -2,9 +2,21 @@ import enhancedResolve from "enhanced-resolve";
 import { stripQueryParameters } from "../helpers.mjs";
 import pathToPosix from "#utl/path-to-posix.mjs";
 
+/** @import {IResolveOptions} from "../../../types/resolve-options.mjs" */
+
+/** @type {Map<string, enhancedResolve.Resolver>} */
 let gResolvers = new Map();
+/** @type {Map<string, boolean>} */
 let gInitialized = new Map();
 
+/**
+ * Initializes a resolver for the given caching context if not already done
+ *
+ * @param {IResolveOptions} pEHResolveOptions Options to pass to enhanced resolve
+ * @param {string} pCachingContext - caching
+ *
+ * @returns {void}
+ */
 function init(pEHResolveOptions, pCachingContext) {
   if (!gInitialized.get(pCachingContext) || pEHResolveOptions.bustTheCache) {
     // assuming the cached file system here
@@ -23,8 +35,8 @@ function init(pEHResolveOptions, pCachingContext) {
  *
  * @param {string} pModuleName The module name to resolve (e.g. 'slodash', './myModule')
  * @param {string} pFileDirectory The directory from which to resolve the module
- * @param {any} pResolveOptions Options to pass to enhanced resolve
- * @param {any} pCachingContext - caching
+ * @param {IResolveOptions} pResolveOptions Options to pass to enhanced resolve
+ * @param {string} pCachingContext - caching
  *
  * @returns {string} path to the resolved file on disk
  */

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -19,7 +19,7 @@ export default async function cruise(
   pResolveOptions,
   pTranspileOptions,
 ) {
-  bus.summary("parse options", c(1));
+  bus.summary("startup: parse options", c(1));
   const lCruiseOptionsValid = assertCruiseOptionsValid(pCruiseOptions);
   /** @type {import("../../types/strict-options.js").IStrictCruiseOptions} */
   let lCruiseOptions = normalizeCruiseOptions(
@@ -47,7 +47,7 @@ export default async function cruise(
     }
   }
 
-  bus.summary("import analytical modules", c(3));
+  bus.summary("startup: import analytical modules", c(3));
   const [
     { default: normalizeRuleSet },
     { default: assertRuleSetValid },
@@ -67,7 +67,7 @@ export default async function cruise(
   ]);
 
   if (lCruiseOptions.ruleSet) {
-    bus.summary("parse rule set", c(4));
+    bus.summary("startup: parse rule set", c(4));
     lCruiseOptions.ruleSet = normalizeRuleSet(
       assertRuleSetValid(lCruiseOptions.ruleSet),
     );
@@ -77,14 +77,14 @@ export default async function cruise(
     pFileAndDirectoryArray,
   );
 
-  bus.summary("determine how to resolve", c(5));
+  bus.summary("startup: get resolve options", c(5));
   const lNormalizedResolveOptions = await normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
     pTranspileOptions?.tsConfig,
   );
 
-  bus.summary("read files", c(6));
+  bus.summary("extract", c(6));
   const lExtractionResult = extract(
     lNormalizedFileAndDirectoryArray,
     lCruiseOptions,
@@ -107,7 +107,7 @@ export default async function cruise(
   bus.summary("report", c(9));
   const lResult = await reportWrap(lCruiseResult, lCruiseOptions);
 
-  bus.debug("clear regex cache");
+  bus.debug("end: clear regex cache");
   clearRegExpCache();
 
   return lResult;

--- a/src/main/report-wrap.mjs
+++ b/src/main/report-wrap.mjs
@@ -4,6 +4,7 @@ import { applyFilters } from "#graph-utl/filter-bank.mjs";
 import consolidateToPattern from "#graph-utl/consolidate-to-pattern.mjs";
 import { compareModules } from "#graph-utl/compare.mjs";
 import stripSelfTransitions from "#graph-utl/strip-self-transitions.mjs";
+import { bus } from "#utl/bus.mjs";
 
 /**
  * @import { ICruiseResult } from "../../types/cruise-result.mjs";
@@ -54,12 +55,14 @@ function getReporterSection(pOutputType) {
  * @returns {IReporterOutput}
  */
 export default async function reportWrap(pResult, pFormatOptions) {
+  bus.debug("report: get");
   const lReportFunction = await getReporter(pFormatOptions.outputType);
   const lReportOptions =
     pResult.summary.optionsUsed?.reporterOptions?.[
       getReporterSection(pFormatOptions.outputType)
     ] ?? {};
 
+  bus.debug("report: execute");
   return lReportFunction(
     reSummarizeResults(pResult, pFormatOptions),
     // passing format options here so reporters that read collapse patterns

--- a/src/main/rule-set/assert-validity.mjs
+++ b/src/main/rule-set/assert-validity.mjs
@@ -80,16 +80,16 @@ function assertRuleSafety(pRule) {
  * @throws {Error}          An error with the reason for the error as a message
  */
 export default function assertRuleSetValid(pConfiguration) {
-  bus.info("parse rule set: validate");
+  bus.debug("startup: parse rule set: validate");
 
-  bus.debug("parse rule set: validate: schema compliance");
+  bus.trace("startup: parse rule set: validate: schema");
   assertSchemaCompliance(pConfiguration);
 
-  bus.debug("parse rule set: validate: rule safety");
+  bus.trace("startup: parse rule set: validate: rule safety");
   (pConfiguration.allowed || []).forEach(assertRuleSafety);
   (pConfiguration.forbidden || []).forEach(assertRuleSafety);
 
-  bus.debug("parse rule set: validate: cruise options validity");
+  bus.trace("startup: parse rule set: validate: options");
   if (pConfiguration?.options) {
     assertCruiseOptionsValid(pConfiguration.options);
   }

--- a/src/main/rule-set/normalize.mjs
+++ b/src/main/rule-set/normalize.mjs
@@ -114,7 +114,7 @@ function normalizeRule(pRule) {
  * @return {IStrictRuleSet}
  */
 export default function normalizeRuleSet(pRuleSet) {
-  bus.info("parse rule set: normalize");
+  bus.debug("startup: parse rule set: normalize");
   const lRuleSet = structuredClone(pRuleSet);
 
   if (lRuleSet?.allowed) {

--- a/src/utl/bus.mjs
+++ b/src/utl/bus.mjs
@@ -24,6 +24,10 @@ class Bus extends EventEmitter {
   debug(pMessage, pOptions, ...pArguments) {
     this.progress(pMessage, { ...pOptions, level: DEBUG }, pArguments);
   }
+
+  trace(pMessage, pOptions, ...pArguments) {
+    this.progress(pMessage, { ...pOptions, level: TRACE }, pArguments);
+  }
 }
 
 export const bus = new Bus();

--- a/types/resolve-options.d.mts
+++ b/types/resolve-options.d.mts
@@ -8,7 +8,6 @@ import type { ResolveOptions, CachedInputFileSystem } from "enhanced-resolve";
  */
 interface IResolveOptions extends ResolveOptions {
   /**
-   *
    * Without bustTheCache (or with the value `false`) the resolver
    * is initialized only once per session. If the attribute
    * equals `true` the resolver is initialized on each call


### PR DESCRIPTION
## Description

- renames steps for better clarity
- introduces a new `trace` method and pushes _really_ detailed messages in there
- moves some messages from `info` to `debug` as they're only informational for debugging purposes
- lowers the log level of dependency-cruiser's self scan

## How Has This Been Tested?

- [x] green ci

## Screenshots

performance-log output on dependency-cruiser's self scan:

### Before
```
        ∆ rss   ∆ heapTotal    ∆ heapUsed    ∆ external     ⏱  system       ⏱  user       ⏱  real after step...
------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------
   +199,184kB    +101,760kB     +64,599kB     +11,242kB          97ms         770ms         622ms nodejs starting
     +1,152kB      +1,280kB        +574kB           0kB           0ms          12ms           6ms parse options
     +1,664kB      +1,440kB      +4,362kB        +469kB           4ms          18ms          21ms import analytical modules
        +16kB           0kB        -398kB           0kB           0ms           0ms           0ms parse rule set
          0kB           0kB          +5kB           0kB           0ms           0ms           0ms parse rule set: validate
       +496kB        +256kB        +615kB           0kB           0ms           6ms           5ms parse rule set: validate: schema compliance
     +9,968kB      +7,680kB      -3,181kB           0kB           3ms          69ms          30ms parse rule set: validate: rule safety
          0kB           0kB         +96kB           0kB           0ms           1ms           0ms parse rule set: validate: cruise options validity
        +64kB           0kB        +432kB           0kB           0ms           2ms           1ms parse rule set: normalize
        +16kB           0kB         +47kB           0kB           0ms           0ms           0ms determine how to resolve
          0kB           0kB         +10kB           0kB           0ms           0ms           0ms read files
        +64kB           0kB      +2,380kB           0kB           6ms           6ms          10ms read files: gather initial sources
   +139,328kB    +133,984kB    +103,124kB      -8,794kB          60ms         962ms         562ms read files: visit dependencies
          0kB           0kB        -335kB           0kB           0ms           1ms           0ms analyze
    +16,912kB     +16,384kB     -21,075kB           0kB           5ms          37ms          15ms analyze: cycles
        +48kB           0kB        +541kB           0kB           0ms          12ms           9ms analyze: dependents
          0kB           0kB        +313kB           0kB           0ms           1ms           0ms analyze: orphans
       +256kB           0kB     +19,548kB           0kB           1ms          51ms          39ms analyze: reachables
          0kB           0kB         +13kB           0kB           0ms           0ms           0ms analyze: module metrics
          0kB           0kB         +14kB           0kB           0ms           0ms           0ms analyze: focus
       +368kB        +512kB     +10,040kB           0kB           1ms          43ms          22ms analyze: validations
        +96kB           0kB      +2,147kB           0kB           0ms           6ms           2ms analyze: compare to known errors
          0kB           0kB         +13kB           0kB           0ms           0ms           0ms analyze: aggregate to folders
        +32kB           0kB        +321kB           0kB           0ms           1ms           1ms analyze: summary
        +32kB           0kB      +1,952kB          +8kB           0ms           7ms           7ms report
          0kB           0kB          +4kB           0kB           0ms           0ms           0ms clear regex cache
          0kB           0kB         +15kB           0kB           0ms           0ms           0ms really done
------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------
   +369,696kB    +263,296kB    +186,175kB      +2,925kB         178ms       2,006ms       1,354ms 
```

### After

```
        ∆ rss   ∆ heapTotal    ∆ heapUsed    ∆ external     ⏱  system       ⏱  user       ⏱  real after step...
------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------
   +198,992kB    +102,784kB     +65,919kB     +11,242kB          98ms         775ms         624ms startup: nodejs loading
       +992kB           0kB        -893kB           0kB           0ms           7ms           5ms startup: parse options
     +1,696kB      +1,440kB      +4,375kB        +469kB           4ms          19ms          22ms startup: import analytical modules
     +7,488kB      +5,632kB      -2,053kB           0kB           3ms          78ms          38ms startup: parse rule set
        +16kB           0kB         +38kB           0kB           0ms           0ms           0ms startup: get resolve options
   +142,384kB    +136,032kB    +105,218kB      -8,794kB          64ms         965ms         573ms extract
        +32kB        +256kB        -152kB           0kB           0ms           1ms           0ms analyze
    +16,688kB     +16,384kB     -20,969kB           0kB           4ms          36ms          16ms analyze: cycles
        +64kB           0kB        +561kB           0kB           0ms          13ms          10ms analyze: dependents
        +16kB           0kB        +321kB           0kB           0ms           1ms           1ms analyze: orphans
       +224kB           0kB     +19,696kB           0kB           1ms          51ms          39ms analyze: reachables
          0kB           0kB         +13kB           0kB           0ms           0ms           0ms analyze: module metrics
          0kB           0kB         +14kB           0kB           0ms           0ms           0ms analyze: focus
       +416kB        +512kB     +10,055kB           0kB           1ms          41ms          22ms analyze: validations
        +48kB           0kB      +2,073kB           0kB           0ms           7ms           2ms analyze: compare to known errors
        +32kB           0kB         +48kB           0kB           0ms           1ms           0ms analyze: aggregate to folders
        +48kB           0kB        +326kB           0kB           0ms           1ms           1ms analyze: summary
        +32kB           0kB      +1,949kB          +8kB           0ms           7ms           6ms report
          0kB           0kB          +6kB           0kB           0ms           0ms           0ms end: really done
------------- ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------
   +369,168kB    +263,040kB    +186,545kB      +2,925kB         175ms       2,003ms       1,361ms
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
