### PR TITLE
chore!: drops support for nodejs 20 and 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 26.x]
+        node-version: [22.x, 26.x]
         platform: [ubuntu-latest]
     runs-on: ${{matrix.platform}}
     steps:
@@ -56,13 +56,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install graphviz
-          
-          # engine-strict disable:
-          # some devDependency (listr2 via lint-staged) dropped node 20 support. we didn't yet.
-          # it's not relevant on the ci, but still blocks installs. Hence ...
-          rm -f .npmrc
-          # ... and for good measure
-          npm set engine-strict=false
           
           # legacy-peer-deps because otherwise typescript-eslint hard-complains
           # as it can't find a suitable typescript compiler (we're on 6 now, 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -764,9 +764,9 @@ it has to them. To see how dependency-cruiser perceives its environment use
 <summary>Typical output</summary>
 
 ```
-    dependency-cruiser@17.0.0
+    dependency-cruiser@18.0.0
 
-    node version supported : ^20.12||^22||>=24
+    node version supported : ^22||^24||>=26
     node version found     : v24.4.0
     os version found       : arm64 darwin@24.5.0
 

--- a/package.json
+++ b/package.json
@@ -314,11 +314,6 @@
         "because": "incomaptibilities that take ages to resolve"
       },
       {
-        "package": "commander",
-        "policy": "wanted",
-        "because": "commander@^15 dropped node 20 support "
-      },
-      {
         "package": "eslint",
         "policy": "wanted",
         "because": "incomaptibilities that take ages to resolve"
@@ -366,7 +361,7 @@
     ]
   },
   "engines": {
-    "node": "^20.12||^22||>=24"
+    "node": "^22||^24||>=26"
   },
   "supportedTranspilers": {
     "babel": ">=7.0.0 <8.0.0",

--- a/src/meta.cjs
+++ b/src/meta.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   version: "17.4.3",
   engines: {
-    node: "^20.12||^22||>=24",
+    node: "^22||^24||>=26",
   },
   supportedTranspilers: {
     babel: ">=7.0.0 <8.0.0",


### PR DESCRIPTION
## Description

- drops support for node.js 20 and 25

## Motivation and Context

Follows the [Node.js release schedule](https://nodejs.org/en/about/previous-releases). Node.js 20 is EOL and 25 will be that very soon.


## How Has This Been Tested?

- [x] green ci

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
