### PR TITLE
refactor(resolve)!: replaces tsconfig-paths-webpack-plugin with enhanced-resolve's own tsconfig-paths feature SLIGHTLY BREAKING

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,9 +1,9 @@
 {
   "checkCoverage": true,
-  "statements": 99.96,
+  "statements": 99.97,
   "branches": 98.7,
   "functions": 100,
-  "lines": 99.96,
+  "lines": 99.97,
   "exclude": [
     "bin",
     "configs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "rechoir": "0.8.0",
         "safe-regex": "2.1.1",
         "semver": "7.8.1",
-        "tsconfig-paths-webpack-plugin": "4.2.0",
         "watskeburt": "5.0.3"
       },
       "bin": {
@@ -2378,6 +2377,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2801,6 +2801,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3006,6 +3007,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3018,6 +3020,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -4846,6 +4849,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6010,6 +6014,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7852,6 +7857,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7887,6 +7893,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8129,35 +8136,6 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths-webpack-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
-      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.7.0",
-        "tapable": "^2.2.1",
-        "tsconfig-paths": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {

--- a/package.json
+++ b/package.json
@@ -227,7 +227,6 @@
     "rechoir": "0.8.0",
     "safe-regex": "2.1.1",
     "semver": "7.8.1",
-    "tsconfig-paths-webpack-plugin": "4.2.0",
     "watskeburt": "5.0.3"
   },
   "devDependencies": {

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -58,7 +58,7 @@ export default async function extractDepcruiseConfig(
   const lResolvedFileName = resolve(
     pConfigFileName,
     pBaseDirectory,
-    await normalizeResolveOptions(
+    normalizeResolveOptions(
       {
         extensions: [".js", ".json", ".cjs", ".mjs"],
       },

--- a/src/extract/resolve/resolve.mjs
+++ b/src/extract/resolve/resolve.mjs
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from "node:path";
 import enhancedResolve from "enhanced-resolve";
 import { stripQueryParameters } from "../helpers.mjs";
 
@@ -49,8 +50,10 @@ export function resolve(
   return stripQueryParameters(
     gResolvers.get(pCachingContext).resolveSync(
       {},
-      // lookupStartPath
-      pFileDirectory,
+      // lookupStartPath - must be absolute so enhanced-resolve classifies
+      // it correctly on Windows (relative paths with backslashes would be
+      // treated as PathType.Normal and POSIX-normalised, breaking ".." resolution)
+      resolvePath(pFileDirectory),
       // request
       pModuleName,
     ),

--- a/src/extract/resolve/resolve.mjs
+++ b/src/extract/resolve/resolve.mjs
@@ -1,6 +1,5 @@
 import enhancedResolve from "enhanced-resolve";
 import { stripQueryParameters } from "../helpers.mjs";
-import pathToPosix from "#utl/path-to-posix.mjs";
 
 /** @import {IResolveOptions} from "../../../types/resolve-options.mjs" */
 
@@ -51,7 +50,7 @@ export function resolve(
     gResolvers.get(pCachingContext).resolveSync(
       {},
       // lookupStartPath
-      pathToPosix(pFileDirectory),
+      pFileDirectory,
       // request
       pModuleName,
     ),

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -78,7 +78,7 @@ export default async function cruise(
   );
 
   bus.summary("startup: get resolve options", c(5));
-  const lNormalizedResolveOptions = await normalizeResolveOptions(
+  const lNormalizedResolveOptions = normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
     pTranspileOptions?.tsConfig,

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -61,10 +61,6 @@ function getNonOverridableResolveOptions(pCacheDuration) {
   };
 }
 
-function pushPlugin(pPlugins, pPluginToPush) {
-  return (pPlugins || []).concat(pPluginToPush);
-}
-
 function compileResolveOptions(
   pResolveOptions,
   pTSConfig,

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -68,11 +68,6 @@ function compileResolveOptions(
 ) {
   let lResolveOptions = {};
 
-  // There's a performance impact of ~1 ms per resolve even when there
-  // are 0 paths in the tsconfig, so not loading it when not necessary
-  // will be a win.
-  // Also: requiring the plugin only when it's necessary will save some
-  // startup time (especially on a cold require cache)
   if (pResolveOptions.tsConfig) {
     lResolveOptions.tsconfig = {
       configFile: pResolveOptions.tsConfig.fileName,

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import enhancedResolve from "enhanced-resolve";
 import { scannableExtensions } from "#extract/transpile/meta.mjs";
 import {
@@ -70,7 +71,7 @@ function compileResolveOptions(
 
   if (pResolveOptions.tsConfig) {
     lResolveOptions.tsconfig = {
-      configFile: pResolveOptions.tsConfig.fileName,
+      configFile: resolvePath(pResolveOptions.tsConfig),
 
       // baseUrl: pTSConfig?.options?.baseUrl ? undefined : "./",
       // references: pTSConfig?.options?.references ?? []

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -65,8 +65,7 @@ function pushPlugin(pPlugins, pPluginToPush) {
   return (pPlugins || []).concat(pPluginToPush);
 }
 
-// eslint-disable-next-line max-lines-per-function
-async function compileResolveOptions(
+function compileResolveOptions(
   pResolveOptions,
   pTSConfig,
   pResolveOptionsFromDCConfig,
@@ -79,46 +78,12 @@ async function compileResolveOptions(
   // Also: requiring the plugin only when it's necessary will save some
   // startup time (especially on a cold require cache)
   if (pResolveOptions.tsConfig) {
-    const { default: TsConfigPathsPlugin } =
-      await import("tsconfig-paths-webpack-plugin");
-    lResolveOptions.plugins = pushPlugin(
-      lResolveOptions.plugins,
-      // @ts-expect-error TS2351 "TsConfPathsPlugin is not constructable" - is unjustified
-      new TsConfigPathsPlugin({
-        configFile: pResolveOptions.tsConfig,
-        // TsConfigPathsPlugin requires a baseUrl to be present in the tsconfig,
-        // otherwise it prints scary messages that it didn't and read the tsConfig
-        // (potentially making users think it's dependency-cruiser disregarding the
-        // tsconfig). Hence up till version 13.0.4 dependency-cruiser only loaded
-        // TsConfigPathsPlugin when an options.baseUrl existed. However, this
-        // isn't necessary anymore:
-        // - [tsconfig#baseUrl documentation](https://www.typescriptlang.org/tsconfig#baseUrl)
-        //   UNrecommends the use of the baseUrl for non-AMD projects
-        // - [tsconfig-paths PR #207](https://github.com/dividab/tsconfig-paths/pull/208)
-        //   'tolerates' undefined baseUrls
-        //
-        // Hence, until
-        // [tpwp issue #99](https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/99)
-        // lands:
-        // - pass a default baseUrl to TsConfigPathsPlugin if the baseUrl isn't available
-        // - pass undefined in all other cases; TsConfigPathsPlugin will read
-        //   it from the tsconfig.json in that case. Passing the processed baseUrl
-        //   (pTSConfig?.options?.baseUrl) instead would've been more obvious, but
-        //   doesn't work, as that is an absolute path and tsconfig-paths(-wpp)
-        //   seems to process that again resulting in invalid paths and unresolved
-        //   or erroneous dependencies
-        // eslint-disable-next-line no-undefined
-        baseUrl: pTSConfig?.options?.baseUrl ? undefined : "./",
-        // TsConfigPathsPlugin doesn't (can't) read enhanced-resolve's
-        // list of extensions, and the default it uses for extensions
-        // so we do it ourselves - either with the extensions passed
-        // or with the supported ones.
-        extensions:
-          pResolveOptionsFromDCConfig.extensions ||
-          pResolveOptions.extensions ||
-          DEFAULT_RESOLVE_OPTIONS.extensions,
-      }),
-    );
+    lResolveOptions.tsconfig = {
+      configFile: pResolveOptions.tsConfig.fileName,
+
+      // baseUrl: pTSConfig?.options?.baseUrl ? undefined : "./",
+      // references: pTSConfig?.options?.references ?? []
+    };
   }
 
   return {
@@ -140,14 +105,14 @@ async function compileResolveOptions(
  * @returns
  */
 // eslint-disable-next-line complexity
-export default async function normalizeResolveOptions(
+export default function normalizeResolveOptions(
   pResolveOptions,
   pOptions,
   pTSConfig,
 ) {
   const lRuleSet = pOptions?.ruleSet ?? {};
 
-  return await compileResolveOptions(
+  return compileResolveOptions(
     {
       // EnhancedResolve's symlinks:
       // - true => symlinks are followed (vv)

--- a/test/cli/__fixtures__/workspaces-mono-repo-aliases/tsconfig.json
+++ b/test/cli/__fixtures__/workspaces-mono-repo-aliases/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "paths": {
       "@modules/*": ["./libs/*"],
-      "@sister": ["./libs/zus/*"]
+      "@sister": ["./libs/zus/"]
     },
     "noEmit": true,
     "skipLibCheck": true

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -45,9 +45,9 @@ describe("[I] extract/getDependencies - AMD - ", () => {
   // amdFixtures.forEach((pFixture) => runFixture(pFixture, "tsc"));
 });
 describe("[I] extract/getDependencies - AMD - with bangs", () => {
-  it("splits extracts the module part of the plugin + module - regular requirejs", async () => {
+  it("splits extracts the module part of the plugin + module - regular requirejs", () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["amd"] });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -62,9 +62,9 @@ describe("[I] extract/getDependencies - AMD - with bangs", () => {
     );
   });
 
-  it("splits bang!./blabla into bang and ./blabla - CommonJS wrapper", async () => {
+  it("splits bang!./blabla into bang and ./blabla - CommonJS wrapper", () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["amd"] });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -30,12 +30,12 @@ function runFixture(pFixture, pParser = "acorn") {
     lOptions.preserveSymlinks = pFixture.input.preserveSymlinks;
   }
 
-  it(`${pFixture.title} (with '${pParser}' as parser)`, async () => {
+  it(`${pFixture.title} (with '${pParser}' as parser)`, () => {
     deepEqual(
       extractDependencies(
         pFixture.input.fileName,
         normalizeCruiseOptions(lOptions),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           { bustTheCache: true, resolveLicenses: true },
           normalizeCruiseOptions(lOptions),
         ),
@@ -71,9 +71,9 @@ describe("[I] extract/getDependencies - CommonJS - ", () => {
 });
 
 describe("[I] extract/getDependencies - CommonJS - with bangs", () => {
-  it("strips the inline loader prefix from the module name when resolving", async () => {
+  it("strips the inline loader prefix from the module name when resolving", () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["cjs"] });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -101,9 +101,9 @@ describe("[I] extract/getDependencies - CommonJS - with bangs", () => {
     );
   });
 
-  it("strips multiple inline loader prefixes from the module name when resolving", async () => {
+  it("strips multiple inline loader prefixes from the module name when resolving", () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["cjs"] });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );

--- a/test/extract/get-dependencies.odds-and-ends.spec.mjs
+++ b/test/extract/get-dependencies.odds-and-ends.spec.mjs
@@ -18,9 +18,9 @@ describe("[I] extract/getDependencies - CoffeeScript - ", () => {
 });
 
 describe("[I] extract/getDependencies - Error scenarios - ", () => {
-  it("Does not raise an exception on syntax errors (because we're on the loose parser)", async () => {
+  it("Does not raise an exception on syntax errors (because we're on the loose parser)", () => {
     const lOptions = normalizeCruiseOptions({});
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -50,12 +50,9 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
   let lOptions = {};
   let lResolveOptions = {};
 
-  before("normalize options & resolve options", async () => {
+  before("normalize options & resolve options", () => {
     lOptions = normalizeCruiseOptions({});
-    lResolveOptions = await normalizeResolveOptions(
-      { bustTheCache: true },
-      lOptions,
-    );
+    lResolveOptions = normalizeResolveOptions({ bustTheCache: true }, lOptions);
   });
 
   it("Just skips require(481)", () => {
@@ -93,11 +90,11 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
 });
 
 describe("[I] extract/getDependencies - include", () => {
-  it("returns no dependencies when the includeOnly pattern is erroneous", async () => {
+  it("returns no dependencies when the includeOnly pattern is erroneous", () => {
     const lOptions = normalizeCruiseOptions({
       includeOnly: "will-not-match-dependencies-for-this-file",
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -112,9 +109,9 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it('only includes dependencies matching the passed "includeOnly" (1)', async () => {
+  it('only includes dependencies matching the passed "includeOnly" (1)', () => {
     const lOptions = normalizeCruiseOptions({ includeOnly: "/src/" });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -142,9 +139,9 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it('only includes dependencies matching the passed "includeOnly" (2)', async () => {
+  it('only includes dependencies matching the passed "includeOnly" (2)', () => {
     const lOptions = normalizeCruiseOptions({ includeOnly: "include" });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -184,9 +181,9 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("annotates the exotic require", async () => {
+  it("annotates the exotic require", () => {
     const lOptions = normalizeCruiseOptions({ exoticRequireStrings: ["need"] });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -216,13 +213,13 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("does not support nested exotic requires deeper than 3 (reallyGlobal.globalThis.process.getBuiltinModule)", async () => {
+  it("does not support nested exotic requires deeper than 3 (reallyGlobal.globalThis.process.getBuiltinModule)", () => {
     const lOptions = normalizeCruiseOptions({
       exoticRequireStrings: [
         "reallyGlobal.globalThis.process.getBuiltinModule",
       ],
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -237,11 +234,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("recognizes process.getBuiltinModule & annotates it", async () => {
+  it("recognizes process.getBuiltinModule & annotates it", () => {
     const lOptions = normalizeCruiseOptions({
       detectProcessBuiltinModuleCalls: true,
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -269,11 +266,11 @@ describe("[I] extract/getDependencies - include", () => {
       ],
     );
   });
-  it("does not recognize process.getBuiltinModule when the detectProcessBuiltinModuleCalls is off", async () => {
+  it("does not recognize process.getBuiltinModule when the detectProcessBuiltinModuleCalls is off", () => {
     const lOptions = normalizeCruiseOptions({
       detectProcessBuiltinModuleCalls: false,
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -288,11 +285,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("recognizes globalThis.process.getBuiltinModule & annotates it", async () => {
+  it("recognizes globalThis.process.getBuiltinModule & annotates it", () => {
     const lOptions = normalizeCruiseOptions({
       detectProcessBuiltinModuleCalls: true,
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -321,11 +318,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("does not parse files matching extensions in the extraExtensionsToScan array", async () => {
+  it("does not parse files matching extensions in the extraExtensionsToScan array", () => {
     const lOptions = normalizeCruiseOptions({
       extraExtensionsToScan: [".bentknee", ".yolo"],
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -340,11 +337,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("adds a preCompilationOnly attribute when tsPreCompilationDeps === 'specify'", async () => {
+  it("adds a preCompilationOnly attribute when tsPreCompilationDeps === 'specify'", () => {
     const lOptions = normalizeCruiseOptions({
       tsPreCompilationDeps: "specify",
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -8,7 +8,7 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - cache busting", () => {
-  it("delivers a different output", async () => {
+  it("delivers a different output", () => {
     const lOptions = normalizeCruiseOptions({
       ruleSet: {
         forbidden: [
@@ -35,7 +35,7 @@ describe("[I] extract/index - cache busting", () => {
         ],
       },
     });
-    const lResolveOptions = await normalizeResolveOptions({}, lOptions);
+    const lResolveOptions = normalizeResolveOptions({}, lOptions);
     const lFirstResultFixture = requireJSON(
       "./__fixtures__/cache-busting-first-tree.json",
     );

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -7,13 +7,13 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - do not follow", () => {
-  it("do not follow - doNotFollow.path", async () => {
+  it("do not follow - doNotFollow.path", () => {
     const lOptions = normalizeCruiseOptions({
       doNotFollow: {
         path: "donotfollowonceinthisfolder",
       },
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -28,13 +28,13 @@ describe("[I] extract/index - do not follow", () => {
     deepEqual(lResult, requireJSON("./__fixtures__/donotfollow.json"));
   });
 
-  it("do not follow - doNotFollow.dependencyTypes", async () => {
+  it("do not follow - doNotFollow.dependencyTypes", () => {
     const lOptions = normalizeCruiseOptions({
       doNotFollow: {
         dependencyTypes: ["npm-no-pkg"],
       },
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         bustTheCache: true,
       },

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -7,13 +7,13 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - exclude", () => {
-  it("exclude - exclude.path", async () => {
+  it("exclude - exclude.path", () => {
     const lOptions = normalizeCruiseOptions({
       exclude: {
         path: "dynamic-to-circular",
       },
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -28,13 +28,13 @@ describe("[I] extract/index - exclude", () => {
     deepEqual(lResult, requireJSON("./__mocks__/exclude/path/es/output.json"));
   });
 
-  it("exclude - exclude.dynamic", async () => {
+  it("exclude - exclude.dynamic", () => {
     const lOptions = normalizeCruiseOptions({
       exclude: {
         dynamic: true,
       },
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         bustTheCache: true,
       },

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -9,11 +9,11 @@ const requireJSON = createRequireJSON(import.meta.url);
 describe("[I] extract/index - max depth", () => {
   /* eslint no-magic-numbers:0 */
   [0, 1, 2, 4].forEach((pDepth) =>
-    it(`returns the correct graph when max-depth === ${pDepth}`, async () => {
+    it(`returns the correct graph when max-depth === ${pDepth}`, () => {
       const lOptions = normalizeCruiseOptions({
         maxDepth: pDepth,
       });
-      const lResolveOptions = await normalizeResolveOptions(
+      const lResolveOptions = normalizeResolveOptions(
         {
           bustTheCache: true,
         },

--- a/test/extract/index.with-stats.spec.mjs
+++ b/test/extract/index.with-stats.spec.mjs
@@ -7,11 +7,11 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - with experimentalStats", () => {
-  it("extracts the dependencies and stats for a simple dependency", async () => {
+  it("extracts the dependencies and stats for a simple dependency", () => {
     const lOptions = normalizeCruiseOptions({
       experimentalStats: true,
     });
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         bustTheCache: true,
       },

--- a/test/extract/resolve/external-module-helpers.spec.mjs
+++ b/test/extract/resolve/external-module-helpers.spec.mjs
@@ -9,11 +9,11 @@ import {
   dependencyIsDeprecated,
 } from "#extract/resolve/external-module-helpers.mjs";
 
-const BASIC_RESOLVE_OPTIONS = await normalizeResolveOptions(
+const BASIC_RESOLVE_OPTIONS = normalizeResolveOptions(
   {},
   normalizeCruiseOptions({}),
 );
-const RESOLVE_OPTIONS_HEEDING_EXPORTS = await normalizeResolveOptions(
+const RESOLVE_OPTIONS_HEEDING_EXPORTS = normalizeResolveOptions(
   { exportsFields: ["exports"], conditionNames: ["require", "imports"] },
   normalizeCruiseOptions({}),
 );

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -9,12 +9,12 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const WORKING_DIRECTORY = process.cwd();
 
-async function wrappedResolve(pModuleAttributes) {
+function wrappedResolve(pModuleAttributes) {
   return resolve(
     pModuleAttributes,
     process.cwd(),
     process.cwd(),
-    await normalizeResolveOptions(
+    normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -32,7 +32,7 @@ describe("[I] extract/resolve/index - general", () => {
     process.chdir(WORKING_DIRECTORY);
   });
 
-  it("resolves a local dependency to a file on disk", async () => {
+  it("resolves a local dependency to a file on disk", () => {
     deepEqual(
       resolve(
         {
@@ -41,7 +41,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        await normalizeResolveOptions({}, {}),
+        normalizeResolveOptions({}, {}),
       ),
       {
         coreModule: false,
@@ -141,7 +141,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves known non-followables as not followable: json", async () => {
+  it("resolves known non-followables as not followable: json", () => {
     deepEqual(
       resolve(
         {
@@ -150,7 +150,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "followability"),
-        await normalizeResolveOptions({ bustTheCache: true }, {}),
+        normalizeResolveOptions({ bustTheCache: true }, {}),
       ),
       {
         coreModule: false,
@@ -162,7 +162,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves known non-followables as not followable, even when it's a resolve registered extension: json", async () => {
+  it("resolves known non-followables as not followable, even when it's a resolve registered extension: json", () => {
     deepEqual(
       resolve(
         {
@@ -171,7 +171,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "followability"),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             extensions: [".js", ".json"],
             bustTheCache: true,
@@ -189,7 +189,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves known non-followables as not followable, even when it's a resolve registered extension: sass", async () => {
+  it("resolves known non-followables as not followable, even when it's a resolve registered extension: sass", () => {
     deepEqual(
       resolve(
         {
@@ -198,7 +198,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "followability"),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             extensions: [".js", ".json", ".scss"],
             bustTheCache: true,
@@ -216,7 +216,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("considers passed (webpack) aliases", async () => {
+  it("considers passed (webpack) aliases", () => {
     deepEqual(
       resolve(
         {
@@ -225,7 +225,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             alias: {
               hoepla: join(__dirname, "__mocks__", "i-got-aliased-to-hoepla"),
@@ -245,7 +245,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("considers a passed (webpack) modules array", async () => {
+  it("considers a passed (webpack) modules array", () => {
     deepEqual(
       resolve(
         {
@@ -254,7 +254,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             modules: [
               "node_modules",
@@ -280,7 +280,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("strips query parameters from file names", async () => {
+  it("strips query parameters from file names", () => {
     deepEqual(
       resolve(
         {
@@ -289,7 +289,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        await normalizeResolveOptions({}, {}),
+        normalizeResolveOptions({}, {}),
       ),
       {
         coreModule: false,
@@ -318,7 +318,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("looks at the 'exports' fields in package.json when enhanced-resolve is instructed to", async () => {
+  it("looks at the 'exports' fields in package.json when enhanced-resolve is instructed to", () => {
     process.chdir("test/extract/resolve/__mocks__/package-json-with-exports");
     deepEqual(
       resolve(
@@ -328,7 +328,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             bustTheCache: true,
             exportsFields: ["exports"],
@@ -382,7 +382,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("Passes mainFields correctly so it's possible to resolve type-only packages", async () => {
+  it("Passes mainFields correctly so it's possible to resolve type-only packages", () => {
     process.chdir("test/extract/resolve/__mocks__/resolve-type-only-packages");
     deepEqual(
       resolve(
@@ -392,7 +392,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        await normalizeResolveOptions({
+        normalizeResolveOptions({
           bustTheCache: true,
           mainFields: ["main", "types"],
         }),
@@ -407,7 +407,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves modules passed as builtInModules.overrides as core modules", async () => {
+  it("resolves modules passed as builtInModules.overrides as core modules", () => {
     deepEqual(
       resolve(
         {
@@ -416,7 +416,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        await normalizeResolveOptions({
+        normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             override: ["totally-not-a-core-module-irl"],
@@ -433,7 +433,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves modules passed as builtInModules.add as core modules", async () => {
+  it("resolves modules passed as builtInModules.add as core modules", () => {
     deepEqual(
       resolve(
         {
@@ -442,7 +442,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        await normalizeResolveOptions({
+        normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             add: ["totally-not-a-core-module-irl"],
@@ -459,7 +459,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("does not resolve nodejs core modules when builtInModules.overrides is passed", async () => {
+  it("does not resolve nodejs core modules when builtInModules.overrides is passed", () => {
     deepEqual(
       resolve(
         {
@@ -468,7 +468,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        await normalizeResolveOptions({
+        normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             override: ["totally-not-a-core-module-irl"],
@@ -485,7 +485,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("still resolves nodejs core modules when builtInModules.add is passed", async () => {
+  it("still resolves nodejs core modules when builtInModules.add is passed", () => {
     deepEqual(
       resolve(
         {
@@ -494,7 +494,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        await normalizeResolveOptions({
+        normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             add: ["totally-not-a-core-module-irl"],

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -23,14 +23,14 @@ const TSCONFIG_RESOLUTIONS = join(
 const PARSED_TSCONFIG_RESOLUTIONS = extractTSConfig(TSCONFIG);
 
 describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
-  it("considers a typescript config - non-* alias", async () => {
+  it("considers a typescript config - non-* alias", () => {
     const lDependency = {
       module: "@shared",
       moduleSystem: "es6",
     };
     const lBaseDirectory = join(__dirname, "__mocks__");
     const lFileDirectory = join(__dirname, "__mocks__", "ts-config-with-path");
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         tsConfig: TSCONFIG,
         bustTheCache: true,
@@ -64,14 +64,14 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("considers a typescript config - combined/* alias", async () => {
+  it("considers a typescript config - combined/* alias", () => {
     const lDependency = {
       module: "gewoon/wood/tree",
       moduleSystem: "es6",
     };
     const lBaseDirectory = join(__dirname, "__mocks__");
     const lFileDirectory = join(__dirname, "__mocks__", "ts-config-with-path");
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         tsConfig: TSCONFIG,
         bustTheCache: true,
@@ -105,14 +105,14 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("considers a typescript config - * alias", async () => {
+  it("considers a typescript config - * alias", () => {
     const lDependency = {
       module: "daddayaddaya",
       moduleSystem: "es6",
     };
     const lBaseDirectory = join(__dirname, "__mocks__");
     const lFileDirectory = join(__dirname, "__mocks__", "ts-config-with-path");
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         tsConfig: TSCONFIG,
         bustTheCache: true,
@@ -146,7 +146,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("considers a typescript config - no paths, no aliases, resolves relative to baseUrl", async () => {
+  it("considers a typescript config - no paths, no aliases, resolves relative to baseUrl", () => {
     const TSCONFIG_NO_PATHS = join(
       __dirname,
       "__mocks__",
@@ -166,7 +166,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
       "src",
       "typos",
     );
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         tsConfig: TSCONFIG_NO_PATHS,
         bustTheCache: true,
@@ -199,7 +199,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("for aliases resolves in the same fashion as the typescript compiler - dts-vs-ts", async () => {
+  it("for aliases resolves in the same fashion as the typescript compiler - dts-vs-ts", () => {
     const lDependency = {
       module: "things/dts-before-ts",
       moduleSystem: "es6",
@@ -210,7 +210,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
       "__mocks__",
       "ts-config-with-path-correct-resolution-prio",
     );
-    const lResolveOptions = await normalizeResolveOptions(
+    const lResolveOptions = normalizeResolveOptions(
       {
         tsConfig: TSCONFIG_RESOLUTIONS,
         bustTheCache: true,
@@ -243,7 +243,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("for aliases resolves in the same fashion as the typescript compiler - js-vs-ts", async () => {
+  it("for aliases resolves in the same fashion as the typescript compiler - js-vs-ts", () => {
     deepEqual(
       resolve(
         {
@@ -256,7 +256,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
           "__mocks__",
           "ts-config-with-path-correct-resolution-prio",
         ),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             tsConfig: TSCONFIG_RESOLUTIONS,
             bustTheCache: true,
@@ -284,7 +284,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("gives a different result for the same input without a webpack config", async () => {
+  it("gives a different result for the same input without a webpack config", () => {
     deepEqual(
       resolve(
         {
@@ -293,7 +293,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "ts-config-with-path"),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             bustTheCache: true,
           },

--- a/test/extract/resolve/index.typescript.spec.mjs
+++ b/test/extract/resolve/index.typescript.spec.mjs
@@ -8,12 +8,12 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const WORKING_DIRECTORY = process.cwd();
 
-async function wrappedResolve(pModuleAttributes) {
+function wrappedResolve(pModuleAttributes) {
   return resolve(
     pModuleAttributes,
     process.cwd(),
     process.cwd(),
-    await normalizeResolveOptions(
+    normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -31,7 +31,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(WORKING_DIRECTORY);
   });
 
-  it("resolves to ts before it considers vue", async () => {
+  it("resolves to ts before it considers vue", () => {
     deepEqual(
       resolve(
         {
@@ -40,7 +40,7 @@ describe("[I] extract/resolve/index - typescript", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "vue-last"),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           {
             bustTheCache: true,
           },

--- a/test/extract/run-get-dependencies-fixture.utl.mjs
+++ b/test/extract/run-get-dependencies-fixture.utl.mjs
@@ -19,12 +19,12 @@ export function runFixture(pFixture, pParser = "acorn") {
     lOptions.preserveSymlinks = pFixture.input.preserveSymlinks;
   }
 
-  it(`${pFixture.title} (with '${pParser}' as parser)`, async () => {
+  it(`${pFixture.title} (with '${pParser}' as parser)`, () => {
     deepEqual(
       extractDependencies(
         pFixture.input.fileName,
         normalizeCruiseOptions(lOptions),
-        await normalizeResolveOptions(
+        normalizeResolveOptions(
           { bustTheCache: true, resolveLicenses: true },
           normalizeCruiseOptions(lOptions),
         ),

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -14,8 +14,8 @@ describe("[I] main/resolve-options/normalize", () => {
     options: { baseUrl: "", paths: { "*": ["lalala/*"] } },
   };
 
-  it("comes with a set of defaults when passed with no options at all", async () => {
-    const lNormalizedOptions = await normalizeResolveOptions(
+  it("comes with a set of defaults when passed with no options at all", () => {
+    const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({}),
     );
@@ -29,8 +29,8 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", async () => {
-    const lNormalizedOptions = await normalizeResolveOptions(
+  it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", () => {
+    const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: {} },
@@ -48,8 +48,8 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", async () => {
-    const lNormalizedOptions = await normalizeResolveOptions(
+  it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", () => {
+    const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
@@ -66,12 +66,12 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    equal((lNormalizedOptions.plugins || []).length, 1);
+    // equal((lNormalizedOptions.plugins || []).length, 1);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", async () => {
-    const lNormalizedOptions = await normalizeResolveOptions(
+  it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", () => {
+    const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
@@ -88,11 +88,11 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    equal(lNormalizedOptions.plugins.length, 1);
+    // equal(lNormalizedOptions.plugins.length, 1);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("should set builtInModules if override or add is defined", async () => {
+  it("should set builtInModules if override or add is defined", () => {
     const lOptions = {
       builtInModules: {
         override: ["fs", "path"],
@@ -100,15 +100,15 @@ describe("[I] main/resolve-options/normalize", () => {
       },
     };
 
-    const lNormalizedOptions = await normalizeResolveOptions(lOptions);
+    const lNormalizedOptions = normalizeResolveOptions(lOptions);
 
     deepEqual(lNormalizedOptions.builtInModules, lOptions.builtInModules);
   });
 
-  it("should not set builtInModules if neither override nor add is defined", async () => {
+  it("should not set builtInModules if neither override nor add is defined", () => {
     const lOptions = {};
 
-    const lNormalizedOptions = await normalizeResolveOptions(lOptions);
+    const lNormalizedOptions = normalizeResolveOptions(lOptions);
 
     // eslint-disable-next-line no-undefined
     equal(lNormalizedOptions.builtInModules, undefined);

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -29,7 +29,7 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", () => {
+  it("does not add enhanced-resolve tsconfig options if no tsConfig is specified", () => {
     const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
@@ -48,7 +48,7 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", () => {
+  it("adds enhanced-resolve tsconfig options if a tsConfig is specified, even without a baseUrl", () => {
     const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
@@ -70,7 +70,7 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", () => {
+  it("adds enhanced-resolve tsconfig options if a tsConfig is specified with a baseUrl and actual paths", () => {
     const lNormalizedOptions = normalizeResolveOptions(
       {},
       normalizeCruiseOptions({

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -66,7 +66,7 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    // equal((lNormalizedOptions.plugins || []).length, 1);
+    equal(lNormalizedOptions.tsconfig.configFile, TEST_TSCONFIG);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
@@ -88,7 +88,7 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    // equal(lNormalizedOptions.plugins.length, 1);
+    equal(lNormalizedOptions.tsconfig.configFile, TEST_TSCONFIG);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 


### PR DESCRIPTION
## Description

- replaces tsconfig-paths-webpack-plugin with enhanced-resolve's own tsconfig-paths feature


> It seems that in one edge-case enhanced-resolve reacts differently. References to config-paths defined as below (with no `*` on the LHS, but _with_ a `*` on the RHS don't resolve, where they _did_ in tsconfig-paths-webpack-plugin.
> TBD:
>  - is this pattern 'allowed'/ supported by the official typescript implementation?
>    -> as it turns out it is not rejected, but it doesn't do anything either. It
>       is / was something specific in the tsconfig-paths package.
>  - if so, maybe make a PR at enhanced-resolve. If not, maybe plonk in a workaround locally - or put it in the list of 'breaking changes' (we're major-bumping anyway).
>     -> breaking change it is.
> 
> ```js
> // ...
>     "paths": {
>       "@sister": ["./libs/zus/*"]
>     },
> // ...
> ```

## Motivation and Context

- With enhanced-resolve's 'native' support for tsconfig-paths it's not necessary anymore to use a separate plugin for it.
- tsconfig-paths-webpack-plugin currently seems to be nominally maintained anymore
- as a bonus we loose 1 direct and 9 indirect dependencies we don't have to worry about anymore.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
