### PR TITLE
refactor(config-utl): only imports json5 when it's used

### DIFF
--- a/src/config-utl/extract-babel-config.mjs
+++ b/src/config-utl/extract-babel-config.mjs
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 
 import { extname } from "node:path";
-import json5 from "json5";
 import makeAbsolute from "./make-absolute.mjs";
 import tryImport from "#utl/try-import.mjs";
 import meta from "#meta.cjs";
@@ -36,6 +35,7 @@ async function getJSConfig(pBabelConfigFileName) {
 
 async function getJSON5Config(pBabelConfigFileName) {
   let lReturnValue = {};
+  const { default: json5 } = await import("json5");
 
   try {
     lReturnValue = json5.parse(await readFile(pBabelConfigFileName, "utf8"));

--- a/src/config-utl/extract-depcruise-config/read-config.mjs
+++ b/src/config-utl/extract-depcruise-config/read-config.mjs
@@ -1,6 +1,5 @@
 import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
-import json5 from "json5";
 
 /**
  *
@@ -16,5 +15,6 @@ export default async function readConfig(pAbsolutePathToConfigFile) {
     );
     return config;
   }
+  const { default: json5 } = await import("json5");
   return json5.parse(await readFile(pAbsolutePathToConfigFile, "utf8"));
 }

--- a/src/config-utl/extract-known-violations.mjs
+++ b/src/config-utl/extract-known-violations.mjs
@@ -1,5 +1,4 @@
 import { readFile } from "node:fs/promises";
-import json5 from "json5";
 import makeAbsolute from "./make-absolute.mjs";
 
 /**
@@ -53,6 +52,8 @@ function makeForwardCompatible(pKnownViolation) {
 }
 
 export default async function extractKnownViolations(pKnownViolationsFileName) {
+  const { default: json5 } = await import("json5");
+
   try {
     const lFileContents = await readFile(
       makeAbsolute(pKnownViolationsFileName),


### PR DESCRIPTION
## Description

- only imports json5 when it's used

## Motivation and Context

What you don't load doesn't cost memory or speed.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
