### PR TITLE
revert: "refactor(resolve)!: replaces tsconfig-paths-webpack-plugin with enhanced-resolve's own tsconfig-paths feature SLIGHTLY BREAKING (#1061)" and "refactor(main/resolve-options): removes now unused pTSConfig parameter"

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,9 +1,9 @@
 {
   "checkCoverage": true,
-  "statements": 99.97,
+  "statements": 99.96,
   "branches": 98.7,
   "functions": 100,
-  "lines": 99.97,
+  "lines": 99.96,
   "exclude": [
     "bin",
     "configs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "rechoir": "0.8.0",
         "safe-regex": "2.1.1",
         "semver": "7.8.1",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
         "watskeburt": "5.0.3"
       },
       "bin": {
@@ -2377,7 +2378,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2801,7 +2801,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3007,7 +3006,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3020,7 +3018,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -4849,7 +4846,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6014,7 +6010,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7857,7 +7852,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7893,7 +7887,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8136,6 +8129,35 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "rechoir": "0.8.0",
     "safe-regex": "2.1.1",
     "semver": "7.8.1",
+    "tsconfig-paths-webpack-plugin": "4.2.0",
     "watskeburt": "5.0.3"
   },
   "devDependencies": {

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -58,7 +58,7 @@ export default async function extractDepcruiseConfig(
   const lResolvedFileName = resolve(
     pConfigFileName,
     pBaseDirectory,
-    normalizeResolveOptions(
+    await normalizeResolveOptions(
       {
         extensions: [".js", ".json", ".cjs", ".mjs"],
       },

--- a/src/extract/resolve/resolve.mjs
+++ b/src/extract/resolve/resolve.mjs
@@ -1,6 +1,6 @@
-import { resolve as resolvePath } from "node:path";
 import enhancedResolve from "enhanced-resolve";
 import { stripQueryParameters } from "../helpers.mjs";
+import pathToPosix from "#utl/path-to-posix.mjs";
 
 /** @import {IResolveOptions} from "../../../types/resolve-options.mjs" */
 
@@ -50,10 +50,8 @@ export function resolve(
   return stripQueryParameters(
     gResolvers.get(pCachingContext).resolveSync(
       {},
-      // lookupStartPath - must be absolute so enhanced-resolve classifies
-      // it correctly on Windows (relative paths with backslashes would be
-      // treated as PathType.Normal and POSIX-normalised, breaking ".." resolution)
-      resolvePath(pFileDirectory),
+      // lookupStartPath
+      pathToPosix(pFileDirectory),
       // request
       pModuleName,
     ),

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -81,6 +81,7 @@ export default async function cruise(
   const lNormalizedResolveOptions = normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
+    pTranspileOptions?.tsConfig,
   );
 
   bus.summary("extract", c(6));

--- a/src/main/cruise.mjs
+++ b/src/main/cruise.mjs
@@ -78,7 +78,7 @@ export default async function cruise(
   );
 
   bus.summary("startup: get resolve options", c(5));
-  const lNormalizedResolveOptions = normalizeResolveOptions(
+  const lNormalizedResolveOptions = await normalizeResolveOptions(
     pResolveOptions,
     lCruiseOptions,
     pTranspileOptions?.tsConfig,

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -62,12 +62,19 @@ function getNonOverridableResolveOptions(pCacheDuration) {
   };
 }
 
-function compileResolveOptions(pResolveOptions, pResolveOptionsFromDCConfig) {
+function compileResolveOptions(
+  pResolveOptions,
+  pTSConfig,
+  pResolveOptionsFromDCConfig,
+) {
   let lResolveOptions = {};
 
   if (pResolveOptions.tsConfig) {
     lResolveOptions.tsconfig = {
       configFile: resolvePath(pResolveOptions.tsConfig),
+
+      // baseUrl: pTSConfig?.options?.baseUrl ? undefined : "./",
+      // references: pTSConfig?.options?.references ?? []
     };
   }
 
@@ -90,7 +97,11 @@ function compileResolveOptions(pResolveOptions, pResolveOptionsFromDCConfig) {
  * @returns
  */
 // eslint-disable-next-line complexity
-export default function normalizeResolveOptions(pResolveOptions, pOptions) {
+export default function normalizeResolveOptions(
+  pResolveOptions,
+  pOptions,
+  pTSConfig,
+) {
   const lRuleSet = pOptions?.ruleSet ?? {};
 
   return compileResolveOptions(
@@ -120,6 +131,7 @@ export default function normalizeResolveOptions(pResolveOptions, pOptions) {
       resolveDeprecations: ruleSetHasDeprecationRule(lRuleSet),
       ...pResolveOptions,
     },
+    pTSConfig || {},
     pOptions?.enhancedResolveOptions ?? {},
   );
 }

--- a/src/main/resolve-options/normalize.mjs
+++ b/src/main/resolve-options/normalize.mjs
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { resolve as resolvePath } from "node:path";
 import enhancedResolve from "enhanced-resolve";
 import { scannableExtensions } from "#extract/transpile/meta.mjs";
 import {
@@ -62,20 +61,64 @@ function getNonOverridableResolveOptions(pCacheDuration) {
   };
 }
 
-function compileResolveOptions(
+function pushPlugin(pPlugins, pPluginToPush) {
+  return (pPlugins || []).concat(pPluginToPush);
+}
+
+// eslint-disable-next-line max-lines-per-function
+async function compileResolveOptions(
   pResolveOptions,
   pTSConfig,
   pResolveOptionsFromDCConfig,
 ) {
   let lResolveOptions = {};
 
+  // There's a performance impact of ~1 ms per resolve even when there
+  // are 0 paths in the tsconfig, so not loading it when not necessary
+  // will be a win.
+  // Also: requiring the plugin only when it's necessary will save some
+  // startup time (especially on a cold require cache)
   if (pResolveOptions.tsConfig) {
-    lResolveOptions.tsconfig = {
-      configFile: resolvePath(pResolveOptions.tsConfig),
-
-      // baseUrl: pTSConfig?.options?.baseUrl ? undefined : "./",
-      // references: pTSConfig?.options?.references ?? []
-    };
+    const { default: TsConfigPathsPlugin } =
+      await import("tsconfig-paths-webpack-plugin");
+    lResolveOptions.plugins = pushPlugin(
+      lResolveOptions.plugins,
+      // @ts-expect-error TS2351 "TsConfPathsPlugin is not constructable" - is unjustified
+      new TsConfigPathsPlugin({
+        configFile: pResolveOptions.tsConfig,
+        // TsConfigPathsPlugin requires a baseUrl to be present in the tsconfig,
+        // otherwise it prints scary messages that it didn't and read the tsConfig
+        // (potentially making users think it's dependency-cruiser disregarding the
+        // tsconfig). Hence up till version 13.0.4 dependency-cruiser only loaded
+        // TsConfigPathsPlugin when an options.baseUrl existed. However, this
+        // isn't necessary anymore:
+        // - [tsconfig#baseUrl documentation](https://www.typescriptlang.org/tsconfig#baseUrl)
+        //   UNrecommends the use of the baseUrl for non-AMD projects
+        // - [tsconfig-paths PR #207](https://github.com/dividab/tsconfig-paths/pull/208)
+        //   'tolerates' undefined baseUrls
+        //
+        // Hence, until
+        // [tpwp issue #99](https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/99)
+        // lands:
+        // - pass a default baseUrl to TsConfigPathsPlugin if the baseUrl isn't available
+        // - pass undefined in all other cases; TsConfigPathsPlugin will read
+        //   it from the tsconfig.json in that case. Passing the processed baseUrl
+        //   (pTSConfig?.options?.baseUrl) instead would've been more obvious, but
+        //   doesn't work, as that is an absolute path and tsconfig-paths(-wpp)
+        //   seems to process that again resulting in invalid paths and unresolved
+        //   or erroneous dependencies
+        // eslint-disable-next-line no-undefined
+        baseUrl: pTSConfig?.options?.baseUrl ? undefined : "./",
+        // TsConfigPathsPlugin doesn't (can't) read enhanced-resolve's
+        // list of extensions, and the default it uses for extensions
+        // so we do it ourselves - either with the extensions passed
+        // or with the supported ones.
+        extensions:
+          pResolveOptionsFromDCConfig.extensions ||
+          pResolveOptions.extensions ||
+          DEFAULT_RESOLVE_OPTIONS.extensions,
+      }),
+    );
   }
 
   return {
@@ -97,14 +140,14 @@ function compileResolveOptions(
  * @returns
  */
 // eslint-disable-next-line complexity
-export default function normalizeResolveOptions(
+export default async function normalizeResolveOptions(
   pResolveOptions,
   pOptions,
   pTSConfig,
 ) {
   const lRuleSet = pOptions?.ruleSet ?? {};
 
-  return compileResolveOptions(
+  return await compileResolveOptions(
     {
       // EnhancedResolve's symlinks:
       // - true => symlinks are followed (vv)

--- a/test/cli/__fixtures__/workspaces-mono-repo-aliases/tsconfig.json
+++ b/test/cli/__fixtures__/workspaces-mono-repo-aliases/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "paths": {
       "@modules/*": ["./libs/*"],
-      "@sister": ["./libs/zus/"]
+      "@sister": ["./libs/zus/*"]
     },
     "noEmit": true,
     "skipLibCheck": true

--- a/test/extract/get-dependencies.amd.spec.mjs
+++ b/test/extract/get-dependencies.amd.spec.mjs
@@ -45,9 +45,9 @@ describe("[I] extract/getDependencies - AMD - ", () => {
   // amdFixtures.forEach((pFixture) => runFixture(pFixture, "tsc"));
 });
 describe("[I] extract/getDependencies - AMD - with bangs", () => {
-  it("splits extracts the module part of the plugin + module - regular requirejs", () => {
+  it("splits extracts the module part of the plugin + module - regular requirejs", async () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["amd"] });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -62,9 +62,9 @@ describe("[I] extract/getDependencies - AMD - with bangs", () => {
     );
   });
 
-  it("splits bang!./blabla into bang and ./blabla - CommonJS wrapper", () => {
+  it("splits bang!./blabla into bang and ./blabla - CommonJS wrapper", async () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["amd"] });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );

--- a/test/extract/get-dependencies.cjs.spec.mjs
+++ b/test/extract/get-dependencies.cjs.spec.mjs
@@ -30,12 +30,12 @@ function runFixture(pFixture, pParser = "acorn") {
     lOptions.preserveSymlinks = pFixture.input.preserveSymlinks;
   }
 
-  it(`${pFixture.title} (with '${pParser}' as parser)`, () => {
+  it(`${pFixture.title} (with '${pParser}' as parser)`, async () => {
     deepEqual(
       extractDependencies(
         pFixture.input.fileName,
         normalizeCruiseOptions(lOptions),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           { bustTheCache: true, resolveLicenses: true },
           normalizeCruiseOptions(lOptions),
         ),
@@ -71,9 +71,9 @@ describe("[I] extract/getDependencies - CommonJS - ", () => {
 });
 
 describe("[I] extract/getDependencies - CommonJS - with bangs", () => {
-  it("strips the inline loader prefix from the module name when resolving", () => {
+  it("strips the inline loader prefix from the module name when resolving", async () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["cjs"] });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -101,9 +101,9 @@ describe("[I] extract/getDependencies - CommonJS - with bangs", () => {
     );
   });
 
-  it("strips multiple inline loader prefixes from the module name when resolving", () => {
+  it("strips multiple inline loader prefixes from the module name when resolving", async () => {
     const lOptions = normalizeCruiseOptions({ moduleSystems: ["cjs"] });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );

--- a/test/extract/get-dependencies.odds-and-ends.spec.mjs
+++ b/test/extract/get-dependencies.odds-and-ends.spec.mjs
@@ -18,9 +18,9 @@ describe("[I] extract/getDependencies - CoffeeScript - ", () => {
 });
 
 describe("[I] extract/getDependencies - Error scenarios - ", () => {
-  it("Does not raise an exception on syntax errors (because we're on the loose parser)", () => {
+  it("Does not raise an exception on syntax errors (because we're on the loose parser)", async () => {
     const lOptions = normalizeCruiseOptions({});
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -50,9 +50,12 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
   let lOptions = {};
   let lResolveOptions = {};
 
-  before("normalize options & resolve options", () => {
+  before("normalize options & resolve options", async () => {
     lOptions = normalizeCruiseOptions({});
-    lResolveOptions = normalizeResolveOptions({ bustTheCache: true }, lOptions);
+    lResolveOptions = await normalizeResolveOptions(
+      { bustTheCache: true },
+      lOptions,
+    );
   });
 
   it("Just skips require(481)", () => {
@@ -90,11 +93,11 @@ describe("[I] extract/getDependencies - even when require gets non-string argume
 });
 
 describe("[I] extract/getDependencies - include", () => {
-  it("returns no dependencies when the includeOnly pattern is erroneous", () => {
+  it("returns no dependencies when the includeOnly pattern is erroneous", async () => {
     const lOptions = normalizeCruiseOptions({
       includeOnly: "will-not-match-dependencies-for-this-file",
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -109,9 +112,9 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it('only includes dependencies matching the passed "includeOnly" (1)', () => {
+  it('only includes dependencies matching the passed "includeOnly" (1)', async () => {
     const lOptions = normalizeCruiseOptions({ includeOnly: "/src/" });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -139,9 +142,9 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it('only includes dependencies matching the passed "includeOnly" (2)', () => {
+  it('only includes dependencies matching the passed "includeOnly" (2)', async () => {
     const lOptions = normalizeCruiseOptions({ includeOnly: "include" });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -181,9 +184,9 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("annotates the exotic require", () => {
+  it("annotates the exotic require", async () => {
     const lOptions = normalizeCruiseOptions({ exoticRequireStrings: ["need"] });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -213,13 +216,13 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("does not support nested exotic requires deeper than 3 (reallyGlobal.globalThis.process.getBuiltinModule)", () => {
+  it("does not support nested exotic requires deeper than 3 (reallyGlobal.globalThis.process.getBuiltinModule)", async () => {
     const lOptions = normalizeCruiseOptions({
       exoticRequireStrings: [
         "reallyGlobal.globalThis.process.getBuiltinModule",
       ],
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -234,11 +237,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("recognizes process.getBuiltinModule & annotates it", () => {
+  it("recognizes process.getBuiltinModule & annotates it", async () => {
     const lOptions = normalizeCruiseOptions({
       detectProcessBuiltinModuleCalls: true,
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -266,11 +269,11 @@ describe("[I] extract/getDependencies - include", () => {
       ],
     );
   });
-  it("does not recognize process.getBuiltinModule when the detectProcessBuiltinModuleCalls is off", () => {
+  it("does not recognize process.getBuiltinModule when the detectProcessBuiltinModuleCalls is off", async () => {
     const lOptions = normalizeCruiseOptions({
       detectProcessBuiltinModuleCalls: false,
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -285,11 +288,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("recognizes globalThis.process.getBuiltinModule & annotates it", () => {
+  it("recognizes globalThis.process.getBuiltinModule & annotates it", async () => {
     const lOptions = normalizeCruiseOptions({
       detectProcessBuiltinModuleCalls: true,
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -318,11 +321,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("does not parse files matching extensions in the extraExtensionsToScan array", () => {
+  it("does not parse files matching extensions in the extraExtensionsToScan array", async () => {
     const lOptions = normalizeCruiseOptions({
       extraExtensionsToScan: [".bentknee", ".yolo"],
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );
@@ -337,11 +340,11 @@ describe("[I] extract/getDependencies - include", () => {
     );
   });
 
-  it("adds a preCompilationOnly attribute when tsPreCompilationDeps === 'specify'", () => {
+  it("adds a preCompilationOnly attribute when tsPreCompilationDeps === 'specify'", async () => {
     const lOptions = normalizeCruiseOptions({
       tsPreCompilationDeps: "specify",
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       { bustTheCache: true },
       lOptions,
     );

--- a/test/extract/index.cachebusting.spec.mjs
+++ b/test/extract/index.cachebusting.spec.mjs
@@ -8,7 +8,7 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - cache busting", () => {
-  it("delivers a different output", () => {
+  it("delivers a different output", async () => {
     const lOptions = normalizeCruiseOptions({
       ruleSet: {
         forbidden: [
@@ -35,7 +35,7 @@ describe("[I] extract/index - cache busting", () => {
         ],
       },
     });
-    const lResolveOptions = normalizeResolveOptions({}, lOptions);
+    const lResolveOptions = await normalizeResolveOptions({}, lOptions);
     const lFirstResultFixture = requireJSON(
       "./__fixtures__/cache-busting-first-tree.json",
     );

--- a/test/extract/index.donotfollow.spec.mjs
+++ b/test/extract/index.donotfollow.spec.mjs
@@ -7,13 +7,13 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - do not follow", () => {
-  it("do not follow - doNotFollow.path", () => {
+  it("do not follow - doNotFollow.path", async () => {
     const lOptions = normalizeCruiseOptions({
       doNotFollow: {
         path: "donotfollowonceinthisfolder",
       },
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -28,13 +28,13 @@ describe("[I] extract/index - do not follow", () => {
     deepEqual(lResult, requireJSON("./__fixtures__/donotfollow.json"));
   });
 
-  it("do not follow - doNotFollow.dependencyTypes", () => {
+  it("do not follow - doNotFollow.dependencyTypes", async () => {
     const lOptions = normalizeCruiseOptions({
       doNotFollow: {
         dependencyTypes: ["npm-no-pkg"],
       },
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         bustTheCache: true,
       },

--- a/test/extract/index.exclude.spec.mjs
+++ b/test/extract/index.exclude.spec.mjs
@@ -7,13 +7,13 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - exclude", () => {
-  it("exclude - exclude.path", () => {
+  it("exclude - exclude.path", async () => {
     const lOptions = normalizeCruiseOptions({
       exclude: {
         path: "dynamic-to-circular",
       },
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -28,13 +28,13 @@ describe("[I] extract/index - exclude", () => {
     deepEqual(lResult, requireJSON("./__mocks__/exclude/path/es/output.json"));
   });
 
-  it("exclude - exclude.dynamic", () => {
+  it("exclude - exclude.dynamic", async () => {
     const lOptions = normalizeCruiseOptions({
       exclude: {
         dynamic: true,
       },
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         bustTheCache: true,
       },

--- a/test/extract/index.maxdepth.spec.mjs
+++ b/test/extract/index.maxdepth.spec.mjs
@@ -9,11 +9,11 @@ const requireJSON = createRequireJSON(import.meta.url);
 describe("[I] extract/index - max depth", () => {
   /* eslint no-magic-numbers:0 */
   [0, 1, 2, 4].forEach((pDepth) =>
-    it(`returns the correct graph when max-depth === ${pDepth}`, () => {
+    it(`returns the correct graph when max-depth === ${pDepth}`, async () => {
       const lOptions = normalizeCruiseOptions({
         maxDepth: pDepth,
       });
-      const lResolveOptions = normalizeResolveOptions(
+      const lResolveOptions = await normalizeResolveOptions(
         {
           bustTheCache: true,
         },

--- a/test/extract/index.with-stats.spec.mjs
+++ b/test/extract/index.with-stats.spec.mjs
@@ -7,11 +7,11 @@ import extract from "#extract/index.mjs";
 const requireJSON = createRequireJSON(import.meta.url);
 
 describe("[I] extract/index - with experimentalStats", () => {
-  it("extracts the dependencies and stats for a simple dependency", () => {
+  it("extracts the dependencies and stats for a simple dependency", async () => {
     const lOptions = normalizeCruiseOptions({
       experimentalStats: true,
     });
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         bustTheCache: true,
       },

--- a/test/extract/resolve/external-module-helpers.spec.mjs
+++ b/test/extract/resolve/external-module-helpers.spec.mjs
@@ -9,11 +9,11 @@ import {
   dependencyIsDeprecated,
 } from "#extract/resolve/external-module-helpers.mjs";
 
-const BASIC_RESOLVE_OPTIONS = normalizeResolveOptions(
+const BASIC_RESOLVE_OPTIONS = await normalizeResolveOptions(
   {},
   normalizeCruiseOptions({}),
 );
-const RESOLVE_OPTIONS_HEEDING_EXPORTS = normalizeResolveOptions(
+const RESOLVE_OPTIONS_HEEDING_EXPORTS = await normalizeResolveOptions(
   { exportsFields: ["exports"], conditionNames: ["require", "imports"] },
   normalizeCruiseOptions({}),
 );

--- a/test/extract/resolve/index.general.spec.mjs
+++ b/test/extract/resolve/index.general.spec.mjs
@@ -9,12 +9,12 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const WORKING_DIRECTORY = process.cwd();
 
-function wrappedResolve(pModuleAttributes) {
+async function wrappedResolve(pModuleAttributes) {
   return resolve(
     pModuleAttributes,
     process.cwd(),
     process.cwd(),
-    normalizeResolveOptions(
+    await normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -32,7 +32,7 @@ describe("[I] extract/resolve/index - general", () => {
     process.chdir(WORKING_DIRECTORY);
   });
 
-  it("resolves a local dependency to a file on disk", () => {
+  it("resolves a local dependency to a file on disk", async () => {
     deepEqual(
       resolve(
         {
@@ -41,7 +41,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        normalizeResolveOptions({}, {}),
+        await normalizeResolveOptions({}, {}),
       ),
       {
         coreModule: false,
@@ -141,7 +141,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves known non-followables as not followable: json", () => {
+  it("resolves known non-followables as not followable: json", async () => {
     deepEqual(
       resolve(
         {
@@ -150,7 +150,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "followability"),
-        normalizeResolveOptions({ bustTheCache: true }, {}),
+        await normalizeResolveOptions({ bustTheCache: true }, {}),
       ),
       {
         coreModule: false,
@@ -162,7 +162,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves known non-followables as not followable, even when it's a resolve registered extension: json", () => {
+  it("resolves known non-followables as not followable, even when it's a resolve registered extension: json", async () => {
     deepEqual(
       resolve(
         {
@@ -171,7 +171,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "followability"),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             extensions: [".js", ".json"],
             bustTheCache: true,
@@ -189,7 +189,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves known non-followables as not followable, even when it's a resolve registered extension: sass", () => {
+  it("resolves known non-followables as not followable, even when it's a resolve registered extension: sass", async () => {
     deepEqual(
       resolve(
         {
@@ -198,7 +198,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "followability"),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             extensions: [".js", ".json", ".scss"],
             bustTheCache: true,
@@ -216,7 +216,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("considers passed (webpack) aliases", () => {
+  it("considers passed (webpack) aliases", async () => {
     deepEqual(
       resolve(
         {
@@ -225,7 +225,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             alias: {
               hoepla: join(__dirname, "__mocks__", "i-got-aliased-to-hoepla"),
@@ -245,7 +245,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("considers a passed (webpack) modules array", () => {
+  it("considers a passed (webpack) modules array", async () => {
     deepEqual(
       resolve(
         {
@@ -254,7 +254,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             modules: [
               "node_modules",
@@ -280,7 +280,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("strips query parameters from file names", () => {
+  it("strips query parameters from file names", async () => {
     deepEqual(
       resolve(
         {
@@ -289,7 +289,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "resolve"),
-        normalizeResolveOptions({}, {}),
+        await normalizeResolveOptions({}, {}),
       ),
       {
         coreModule: false,
@@ -318,7 +318,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("looks at the 'exports' fields in package.json when enhanced-resolve is instructed to", () => {
+  it("looks at the 'exports' fields in package.json when enhanced-resolve is instructed to", async () => {
     process.chdir("test/extract/resolve/__mocks__/package-json-with-exports");
     deepEqual(
       resolve(
@@ -328,7 +328,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             bustTheCache: true,
             exportsFields: ["exports"],
@@ -382,7 +382,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("Passes mainFields correctly so it's possible to resolve type-only packages", () => {
+  it("Passes mainFields correctly so it's possible to resolve type-only packages", async () => {
     process.chdir("test/extract/resolve/__mocks__/resolve-type-only-packages");
     deepEqual(
       resolve(
@@ -392,7 +392,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        normalizeResolveOptions({
+        await normalizeResolveOptions({
           bustTheCache: true,
           mainFields: ["main", "types"],
         }),
@@ -407,7 +407,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves modules passed as builtInModules.overrides as core modules", () => {
+  it("resolves modules passed as builtInModules.overrides as core modules", async () => {
     deepEqual(
       resolve(
         {
@@ -416,7 +416,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        normalizeResolveOptions({
+        await normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             override: ["totally-not-a-core-module-irl"],
@@ -433,7 +433,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("resolves modules passed as builtInModules.add as core modules", () => {
+  it("resolves modules passed as builtInModules.add as core modules", async () => {
     deepEqual(
       resolve(
         {
@@ -442,7 +442,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        normalizeResolveOptions({
+        await normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             add: ["totally-not-a-core-module-irl"],
@@ -459,7 +459,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("does not resolve nodejs core modules when builtInModules.overrides is passed", () => {
+  it("does not resolve nodejs core modules when builtInModules.overrides is passed", async () => {
     deepEqual(
       resolve(
         {
@@ -468,7 +468,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        normalizeResolveOptions({
+        await normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             override: ["totally-not-a-core-module-irl"],
@@ -485,7 +485,7 @@ describe("[I] extract/resolve/index - general", () => {
     );
   });
 
-  it("still resolves nodejs core modules when builtInModules.add is passed", () => {
+  it("still resolves nodejs core modules when builtInModules.add is passed", async () => {
     deepEqual(
       resolve(
         {
@@ -494,7 +494,7 @@ describe("[I] extract/resolve/index - general", () => {
         },
         process.cwd(),
         process.cwd(),
-        normalizeResolveOptions({
+        await normalizeResolveOptions({
           bustTheCache: true,
           builtInModules: {
             add: ["totally-not-a-core-module-irl"],

--- a/test/extract/resolve/index.tsconfig.spec.mjs
+++ b/test/extract/resolve/index.tsconfig.spec.mjs
@@ -23,14 +23,14 @@ const TSCONFIG_RESOLUTIONS = join(
 const PARSED_TSCONFIG_RESOLUTIONS = extractTSConfig(TSCONFIG);
 
 describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
-  it("considers a typescript config - non-* alias", () => {
+  it("considers a typescript config - non-* alias", async () => {
     const lDependency = {
       module: "@shared",
       moduleSystem: "es6",
     };
     const lBaseDirectory = join(__dirname, "__mocks__");
     const lFileDirectory = join(__dirname, "__mocks__", "ts-config-with-path");
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         tsConfig: TSCONFIG,
         bustTheCache: true,
@@ -64,14 +64,14 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("considers a typescript config - combined/* alias", () => {
+  it("considers a typescript config - combined/* alias", async () => {
     const lDependency = {
       module: "gewoon/wood/tree",
       moduleSystem: "es6",
     };
     const lBaseDirectory = join(__dirname, "__mocks__");
     const lFileDirectory = join(__dirname, "__mocks__", "ts-config-with-path");
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         tsConfig: TSCONFIG,
         bustTheCache: true,
@@ -105,14 +105,14 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("considers a typescript config - * alias", () => {
+  it("considers a typescript config - * alias", async () => {
     const lDependency = {
       module: "daddayaddaya",
       moduleSystem: "es6",
     };
     const lBaseDirectory = join(__dirname, "__mocks__");
     const lFileDirectory = join(__dirname, "__mocks__", "ts-config-with-path");
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         tsConfig: TSCONFIG,
         bustTheCache: true,
@@ -146,7 +146,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("considers a typescript config - no paths, no aliases, resolves relative to baseUrl", () => {
+  it("considers a typescript config - no paths, no aliases, resolves relative to baseUrl", async () => {
     const TSCONFIG_NO_PATHS = join(
       __dirname,
       "__mocks__",
@@ -166,7 +166,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
       "src",
       "typos",
     );
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         tsConfig: TSCONFIG_NO_PATHS,
         bustTheCache: true,
@@ -199,7 +199,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("for aliases resolves in the same fashion as the typescript compiler - dts-vs-ts", () => {
+  it("for aliases resolves in the same fashion as the typescript compiler - dts-vs-ts", async () => {
     const lDependency = {
       module: "things/dts-before-ts",
       moduleSystem: "es6",
@@ -210,7 +210,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
       "__mocks__",
       "ts-config-with-path-correct-resolution-prio",
     );
-    const lResolveOptions = normalizeResolveOptions(
+    const lResolveOptions = await normalizeResolveOptions(
       {
         tsConfig: TSCONFIG_RESOLUTIONS,
         bustTheCache: true,
@@ -243,7 +243,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("for aliases resolves in the same fashion as the typescript compiler - js-vs-ts", () => {
+  it("for aliases resolves in the same fashion as the typescript compiler - js-vs-ts", async () => {
     deepEqual(
       resolve(
         {
@@ -256,7 +256,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
           "__mocks__",
           "ts-config-with-path-correct-resolution-prio",
         ),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             tsConfig: TSCONFIG_RESOLUTIONS,
             bustTheCache: true,
@@ -284,7 +284,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
     );
   });
 
-  it("gives a different result for the same input without a webpack config", () => {
+  it("gives a different result for the same input without a webpack config", async () => {
     deepEqual(
       resolve(
         {
@@ -293,7 +293,7 @@ describe("[I] extract/resolve/index - typescript tsconfig processing", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "ts-config-with-path"),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             bustTheCache: true,
           },

--- a/test/extract/resolve/index.typescript.spec.mjs
+++ b/test/extract/resolve/index.typescript.spec.mjs
@@ -8,12 +8,12 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const WORKING_DIRECTORY = process.cwd();
 
-function wrappedResolve(pModuleAttributes) {
+async function wrappedResolve(pModuleAttributes) {
   return resolve(
     pModuleAttributes,
     process.cwd(),
     process.cwd(),
-    normalizeResolveOptions(
+    await normalizeResolveOptions(
       {
         bustTheCache: true,
       },
@@ -31,7 +31,7 @@ describe("[I] extract/resolve/index - typescript", () => {
     process.chdir(WORKING_DIRECTORY);
   });
 
-  it("resolves to ts before it considers vue", () => {
+  it("resolves to ts before it considers vue", async () => {
     deepEqual(
       resolve(
         {
@@ -40,7 +40,7 @@ describe("[I] extract/resolve/index - typescript", () => {
         },
         join(__dirname, "__mocks__"),
         join(__dirname, "__mocks__", "vue-last"),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           {
             bustTheCache: true,
           },

--- a/test/extract/run-get-dependencies-fixture.utl.mjs
+++ b/test/extract/run-get-dependencies-fixture.utl.mjs
@@ -19,12 +19,12 @@ export function runFixture(pFixture, pParser = "acorn") {
     lOptions.preserveSymlinks = pFixture.input.preserveSymlinks;
   }
 
-  it(`${pFixture.title} (with '${pParser}' as parser)`, () => {
+  it(`${pFixture.title} (with '${pParser}' as parser)`, async () => {
     deepEqual(
       extractDependencies(
         pFixture.input.fileName,
         normalizeCruiseOptions(lOptions),
-        normalizeResolveOptions(
+        await normalizeResolveOptions(
           { bustTheCache: true, resolveLicenses: true },
           normalizeCruiseOptions(lOptions),
         ),

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -14,8 +14,8 @@ describe("[I] main/resolve-options/normalize", () => {
     options: { baseUrl: "", paths: { "*": ["lalala/*"] } },
   };
 
-  it("comes with a set of defaults when passed with no options at all", () => {
-    const lNormalizedOptions = normalizeResolveOptions(
+  it("comes with a set of defaults when passed with no options at all", async () => {
+    const lNormalizedOptions = await normalizeResolveOptions(
       {},
       normalizeCruiseOptions({}),
     );
@@ -29,8 +29,8 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("does not add enhanced-resolve tsconfig options if no tsConfig is specified", () => {
-    const lNormalizedOptions = normalizeResolveOptions(
+  it("does not add the typescript paths plugin to the plugins if no tsConfig is specified", async () => {
+    const lNormalizedOptions = await normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: {} },
@@ -48,8 +48,8 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("adds enhanced-resolve tsconfig options if a tsConfig is specified, even without a baseUrl", () => {
-    const lNormalizedOptions = normalizeResolveOptions(
+  it("adds the typescript paths plugin to the plugins if a tsConfig is specified, even without a baseUrl", async () => {
+    const lNormalizedOptions = await normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
@@ -66,12 +66,12 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    equal(lNormalizedOptions.tsconfig.configFile, TEST_TSCONFIG);
+    equal((lNormalizedOptions.plugins || []).length, 1);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("adds enhanced-resolve tsconfig options if a tsConfig is specified with a baseUrl and actual paths", () => {
-    const lNormalizedOptions = normalizeResolveOptions(
+  it("adds the typescript paths plugin to the plugins if a tsConfig is specified with a baseUrl and actual paths", async () => {
+    const lNormalizedOptions = await normalizeResolveOptions(
       {},
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
@@ -88,11 +88,11 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    equal(lNormalizedOptions.tsconfig.configFile, TEST_TSCONFIG);
+    equal(lNormalizedOptions.plugins.length, 1);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
-  it("should set builtInModules if override or add is defined", () => {
+  it("should set builtInModules if override or add is defined", async () => {
     const lOptions = {
       builtInModules: {
         override: ["fs", "path"],
@@ -100,15 +100,15 @@ describe("[I] main/resolve-options/normalize", () => {
       },
     };
 
-    const lNormalizedOptions = normalizeResolveOptions(lOptions);
+    const lNormalizedOptions = await normalizeResolveOptions(lOptions);
 
     deepEqual(lNormalizedOptions.builtInModules, lOptions.builtInModules);
   });
 
-  it("should not set builtInModules if neither override nor add is defined", () => {
+  it("should not set builtInModules if neither override nor add is defined", async () => {
     const lOptions = {};
 
-    const lNormalizedOptions = normalizeResolveOptions(lOptions);
+    const lNormalizedOptions = await normalizeResolveOptions(lOptions);
 
     // eslint-disable-next-line no-undefined
     equal(lNormalizedOptions.builtInModules, undefined);

--- a/test/main/resolve-options/normalize.spec.mjs
+++ b/test/main/resolve-options/normalize.spec.mjs
@@ -9,6 +9,10 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 describe("[I] main/resolve-options/normalize", () => {
   const lDefaultNoOfResolveOptions = 10;
   const TEST_TSCONFIG = join(__dirname, "__mocks__", "tsconfig.test.json");
+  const lTsconfigContents = {};
+  const lTsconfigContentsWithBaseURLAndPaths = {
+    options: { baseUrl: "", paths: { "*": ["lalala/*"] } },
+  };
 
   it("comes with a set of defaults when passed with no options at all", () => {
     const lNormalizedOptions = normalizeResolveOptions(
@@ -31,6 +35,7 @@ describe("[I] main/resolve-options/normalize", () => {
       normalizeCruiseOptions({
         ruleSet: { options: {} },
       }),
+      lTsconfigContents,
     );
 
     equal(Object.keys(lNormalizedOptions).length, lDefaultNoOfResolveOptions);
@@ -39,7 +44,7 @@ describe("[I] main/resolve-options/normalize", () => {
     equal(lNormalizedOptions.combinedDependencies, false);
     ok(lNormalizedOptions.hasOwnProperty("extensions"));
     ok(lNormalizedOptions.hasOwnProperty("fileSystem"));
-    ok(!lNormalizedOptions.hasOwnProperty("tsconfig"));
+    equal((lNormalizedOptions.plugins || []).length, 0);
     equal(lNormalizedOptions.useSyncFileSystemCalls, true);
   });
 
@@ -49,6 +54,7 @@ describe("[I] main/resolve-options/normalize", () => {
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
       }),
+      lTsconfigContents,
     );
 
     equal(
@@ -70,6 +76,7 @@ describe("[I] main/resolve-options/normalize", () => {
       normalizeCruiseOptions({
         ruleSet: { options: { tsConfig: { fileName: TEST_TSCONFIG } } },
       }),
+      lTsconfigContentsWithBaseURLAndPaths,
     );
 
     equal(


### PR DESCRIPTION


## Description

- **Reverts** replacing the tsconfig-paths-webpack-plugin with enhanced-resolve's own version of it

## Motivation and Context

- it turns out the SLIGHTLY BREAKING bit it the commit bumps into a feature that is still used in the wild. It might be a misimplementation in tsconfig-paths a.c.t. the typescript specification, however, it's used and due to its wide spread should probably be construed as a de-facto standard.
- enhanced-resolve's own tsconfig-paths resolution is _a lot_ slower on some of the larger typescript repositories. Just the commits we currently revert it added >8000ms of extra processing time to just the _extract_ step.

These issues will need to be addressed in the enhanced-resolve codebase - _if time permits_ I might open issues for it there and maybe even cook PR's. Until these land in enhanced-resolve we'll stay on the old tsconfig-paths-webpack-plugin.

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Not a breaking change as these commits weren't released yet.

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
