### PR TITLE
fix(graph-utl): makes the summary more deterministic

### DIFF
--- a/src/graph-utl/compare.mjs
+++ b/src/graph-utl/compare.mjs
@@ -1,3 +1,4 @@
+/** @import { IViolation } from "../../types/dependency-cruiser.mjs" */
 /* eslint-disable no-magic-numbers */
 function severity2number(pSeverity) {
   const lSeverity2Number = new Map([
@@ -42,6 +43,37 @@ function compareArraysByName(pFirstArray, pSecondArray) {
   return Math.sign(lFirst.length - lSecond.length);
 }
 
+/**
+ * Compare two arrays of strings.
+ *
+ * @param {Array<string>} pFirstArray - First array (or undefined)
+ * @param {Array<string>} pSecondArray - Second array (or undefined)
+ * @returns {number} - -1/0/1 following comparison semantics
+ */
+function compareArrays(pFirstArray, pSecondArray) {
+  const lFirst = pFirstArray || [];
+  const lSecond = pSecondArray || [];
+  const lMinLength = Math.min(lFirst.length, lSecond.length);
+
+  // eslint-disable-next-line unicorn/prevent-abbreviations, no-plusplus
+  for (let i = 0; i < lMinLength; i++) {
+    // eslint-disable-next-line security/detect-object-injection
+    const lComparison = lFirst[i].localeCompare(lSecond[i]);
+    if (lComparison !== 0) {
+      return lComparison;
+    }
+  }
+
+  return Math.sign(lFirst.length - lSecond.length);
+}
+
+/**
+ *
+ * @param {IViolation} pFirstViolation
+ * @param {IViolation} pSecondViolation
+ * @returns
+ */
+// eslint-disable-next-line complexity
 export function compareViolations(pFirstViolation, pSecondViolation) {
   return (
     compareSeverities(
@@ -51,6 +83,14 @@ export function compareViolations(pFirstViolation, pSecondViolation) {
     pFirstViolation.rule.name.localeCompare(pSecondViolation.rule.name) ||
     pFirstViolation.from.localeCompare(pSecondViolation.from) ||
     pFirstViolation.to.localeCompare(pSecondViolation.to) ||
+    (pFirstViolation.unresolvedTo ?? "").localeCompare(
+      pSecondViolation.unresolvedTo ?? "",
+    ) ||
+    (pFirstViolation.type ?? "").localeCompare(pSecondViolation.type ?? "") ||
+    compareArrays(
+      pFirstViolation.dependencyTypes,
+      pSecondViolation.dependencyTypes,
+    ) ||
     compareArraysByName(pFirstViolation.cycle, pSecondViolation.cycle) ||
     compareArraysByName(pFirstViolation.via, pSecondViolation.via)
   );

--- a/src/graph-utl/compare.mjs
+++ b/src/graph-utl/compare.mjs
@@ -16,6 +16,32 @@ export function compareSeverities(pFirstSeverity, pSecondSeverity) {
   );
 }
 
+/**
+ * Compare two arrays of mini dependencies by their 'name' field.
+ * Used to deterministically order violations that have the same severity/rule/from/to
+ * but differ in their cycle or via paths.
+ *
+ * @param {Array<{name: string}>} pFirstArray - First array (or undefined)
+ * @param {Array<{name: string}>} pSecondArray - Second array (or undefined)
+ * @returns {number} - -1/0/1 following comparison semantics
+ */
+function compareArraysByName(pFirstArray, pSecondArray) {
+  const lFirst = pFirstArray || [];
+  const lSecond = pSecondArray || [];
+  const lMinLength = Math.min(lFirst.length, lSecond.length);
+
+  // eslint-disable-next-line unicorn/prevent-abbreviations, no-plusplus
+  for (let i = 0; i < lMinLength; i++) {
+    // eslint-disable-next-line security/detect-object-injection
+    const lComparison = lFirst[i].name.localeCompare(lSecond[i].name);
+    if (lComparison !== 0) {
+      return lComparison;
+    }
+  }
+
+  return Math.sign(lFirst.length - lSecond.length);
+}
+
 export function compareViolations(pFirstViolation, pSecondViolation) {
   return (
     compareSeverities(
@@ -24,7 +50,9 @@ export function compareViolations(pFirstViolation, pSecondViolation) {
     ) ||
     pFirstViolation.rule.name.localeCompare(pSecondViolation.rule.name) ||
     pFirstViolation.from.localeCompare(pSecondViolation.from) ||
-    pFirstViolation.to.localeCompare(pSecondViolation.to)
+    pFirstViolation.to.localeCompare(pSecondViolation.to) ||
+    compareArraysByName(pFirstViolation.cycle, pSecondViolation.cycle) ||
+    compareArraysByName(pFirstViolation.via, pSecondViolation.via)
   );
 }
 

--- a/test/graph-utl/compare.violations.spec.mjs
+++ b/test/graph-utl/compare.violations.spec.mjs
@@ -174,4 +174,52 @@ describe("[U] graph-utl/compare - violations", () => {
     };
     equal(compareViolations(lNoCycle, lWithCycle), -1);
   });
+
+  it("returns -1 when unresolvedTo is alphabetically earlier", () => {
+    const lUnresA = {
+      from: "from",
+      to: "to",
+      rule: { name: "cool-rule", severity: "error" },
+      unresolvedTo: "a",
+    };
+    const lUnresB = {
+      from: "from",
+      to: "to",
+      rule: { name: "cool-rule", severity: "error" },
+      unresolvedTo: "z",
+    };
+    equal(compareViolations(lUnresA, lUnresB), -1);
+  });
+
+  it("returns -1 when type is alphabetically earlier", () => {
+    const lTypeA = {
+      from: "from",
+      to: "to",
+      rule: { name: "cool-rule", severity: "error" },
+      type: "a",
+    };
+    const lTypeB = {
+      from: "from",
+      to: "to",
+      rule: { name: "cool-rule", severity: "error" },
+      type: "z",
+    };
+    equal(compareViolations(lTypeA, lTypeB), -1);
+  });
+
+  it("returns -1 when dependencyTypes is alphabetically earlier", () => {
+    const lDepTypesA = {
+      from: "from",
+      to: "to",
+      rule: { name: "cool-rule", severity: "error" },
+      dependencyTypes: ["alpha", "beta"],
+    };
+    const lDepTypesB = {
+      from: "from",
+      to: "to",
+      rule: { name: "cool-rule", severity: "error" },
+      dependencyTypes: ["alpha", "kappa"],
+    };
+    equal(compareViolations(lDepTypesA, lDepTypesB), -1);
+  });
 });

--- a/test/graph-utl/compare.violations.spec.mjs
+++ b/test/graph-utl/compare.violations.spec.mjs
@@ -70,4 +70,108 @@ describe("[U] graph-utl/compare - violations", () => {
   it("returns -1 when rule 'to' < the one compared against", () => {
     equal(compareViolations(lViolation, lLaterToViolation), -1);
   });
+
+  it("returns -1 when cycle is alphabetically earlier", () => {
+    const lCycleA = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [
+        { name: "a", dependencyTypes: ["local"] },
+        { name: "b", dependencyTypes: ["local"] },
+      ],
+    };
+    const lCycleB = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [
+        { name: "c", dependencyTypes: ["local"] },
+        { name: "b", dependencyTypes: ["local"] },
+      ],
+    };
+    equal(compareViolations(lCycleA, lCycleB), -1);
+  });
+
+  it("returns 1 when cycle is alphabetically later", () => {
+    const lCycleA = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [
+        { name: "c", dependencyTypes: ["local"] },
+        { name: "b", dependencyTypes: ["local"] },
+      ],
+    };
+    const lCycleB = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [
+        { name: "a", dependencyTypes: ["local"] },
+        { name: "b", dependencyTypes: ["local"] },
+      ],
+    };
+    equal(compareViolations(lCycleA, lCycleB), 1);
+  });
+
+  it("returns -1 when first cycle is shorter", () => {
+    const lCycleA = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [{ name: "a", dependencyTypes: ["local"] }],
+    };
+    const lCycleB = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [
+        { name: "a", dependencyTypes: ["local"] },
+        { name: "b", dependencyTypes: ["local"] },
+      ],
+    };
+    equal(compareViolations(lCycleA, lCycleB), -1);
+  });
+
+  it("returns -1 when via is alphabetically earlier", () => {
+    const lViaA = {
+      from: "a",
+      to: "d",
+      rule: { name: "reachability", severity: "error" },
+      via: [
+        { name: "b", dependencyTypes: ["local"] },
+        { name: "c", dependencyTypes: ["local"] },
+      ],
+    };
+    const lViaB = {
+      from: "a",
+      to: "d",
+      rule: { name: "reachability", severity: "error" },
+      via: [
+        { name: "x", dependencyTypes: ["local"] },
+        { name: "c", dependencyTypes: ["local"] },
+      ],
+    };
+    equal(compareViolations(lViaA, lViaB), -1);
+  });
+
+  it("returns 0 when both violations lack cycle or via fields", () => {
+    equal(compareViolations(lViolation, lViolation), 0);
+  });
+
+  it("returns -1 when first violation has no cycle and second does", () => {
+    const lNoCycle = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+    };
+    const lWithCycle = {
+      from: "a",
+      to: "b",
+      rule: { name: "no-cycles", severity: "error" },
+      cycle: [{ name: "a", dependencyTypes: ["local"] }],
+    };
+    equal(compareViolations(lNoCycle, lWithCycle), -1);
+  });
 });


### PR DESCRIPTION
## Description

- makes the summary (and with that e.g. the _baseline_ reporter's output) more deterministic by also comparing the cycles and vias in the summary


## Motivation and Context

Addresses #1065 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] AI was involved in the creation of this PR (for planning, implementation or test generation).

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
