### PR TITLE
feat(cli): enables nodejs compile cache if it is available

### DIFF
--- a/bin/dependency-cruise.mjs
+++ b/bin/dependency-cruise.mjs
@@ -1,9 +1,18 @@
 #!/usr/bin/env node
+import { enableCompileCache } from "node:module";
 import { EOL } from "node:os";
 import { program, Option } from "commander";
 import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
 import cli from "#cli/index.mjs";
 import meta from "#meta.cjs";
+
+if (enableCompileCache) {
+  try {
+    enableCompileCache();
+  } catch {
+    // deliberately ignored
+  }
+}
 
 try {
   assertNodeEnvironmentSuitable();


### PR DESCRIPTION
## Description

Inspired by the recent update of webpack-cli that enables this, tried to switch on the [compile cache](https://nodejs.org/api/module.html#module-compile-cache) (if it is available). 

However, _**it makes NO difference**_ whatsoever. So if I (or someone else) later gets the same idea to bestow this on dependency-cruiser we can refer to this PR's data.

## How Has This Been Tested?

By running the same command 30x _with_ and _without_ the compile cache enabled, and measuring differences in startup time (in the performance-log the step "startup: nodejs loading") under the same circumstances (MBP M4, on low power energy mode so any difference would be magnified) 

```
node ./bin/dependency-cruise.mjs src bin test configs types \
  tools --ignore-known  -Tnull --no-cache --progress ndjson 2>&1|\
  grep "startup: nodejs loading" |\
  jq .elapsedTime
```

with compile cache enabled: 522ms
without compile cache enabled: 526ms

In other words: there is no difference (4ms or 0.7% "faster" is close to a rounding error the variance between runs is bigger than that). Even when it _would_ be consistently 4ms slower - on half a second startup time there's bigger fish to fry.

<details>
<summary>with</summary>

```csv
time in microseconds
532246
517416
518506
521232
518101
517937
514691
517496
521971
516623
521289
526109
523384
521104
521698
520242
520412
520237
517063
526092
525136
536579
525296
525083
527059
519683
518515
520934
517249
529471
537436
```

</details>

<details>
<summary>without</summary>

```csv
time in microseconds
541862
520798
518934
526108
525304
524139
523634
526459
524633
524531
541924
519750
527131
514198
527710
526590
530991
536344
518366
519657
538451
532340
524486
527723
526465
524138
521713
527658
532252
524008
```

</details>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
