### PR TITLE
feat: enables configurations in typescript

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -626,6 +626,7 @@ dependency-cruiser.
 
 Validates against a list of rules in a configuration file. This defaults to a file
 called `.dependency-cruiser.js` (/ `.dependency-cruiser.cjs`/ `.dependency-cruiser.mjs`/
+/ `.dependency-cruiser.ts`/, `.dependency-cruiser.cts`/ `.dependency-cruiser.mts`/
 `.dependency-cruiser.json`), but you can specify your own rules file, which can
 be in json format or a valid node module returning a rules object literal.
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -22,7 +22,7 @@ Dependency-cruiser doesn't come shipped with the necessary transpilers to
 handle these languages. Instead, it uses what is already available in the
 environment (see [below](#q-does-this-mean-dependency-cruiser-installs-transpilers-for-all-these-languages)).
 You can check if the transpilers are available to dependency-cruiser by
-running `depcruise --info`.
+running `dependency-cruiser --info`.
 
 When it turns out they aren't yet:
 
@@ -34,7 +34,7 @@ When it turns out they aren't yet:
   compiler(s) with the `-p` option. E.g. to get a list of all incoming and
   outgoing dependencies of a TypeScript file you could use this:
   ```
-  npx -p typescript@4.3.5 -p dependency-cruiser@latest depcruise src -T text --focus src/main/index.ts
+  npx -p typescript@4.3.5 -p dependency-cruiser@latest dependency-cruiser src -T text --focus src/main/index.ts
   ```
 
 </details>
@@ -93,7 +93,7 @@ for a solution.
 <details>
 <summary>Background</summary>
 
-The graph above is the result of a command like `depcruise src/index.ts -T dot | dot -T svg > deps.svg`.
+The graph above is the result of a command like `dependency-cruiser src/index.ts -T dot | dot -T svg > deps.svg`.
 As dependency-cruiser got _src/index.ts_ as an explicit argument, it'll scan it.
 When no TypeScript compiler is available it'll fall back to the JavaScript one.
 As TypeScript looks a lot like JavaScript, it will still find all direct dependencies.
@@ -173,7 +173,7 @@ E.g. to focus on stuff _within_ src only and not
 show any test and mock files, you'd do something like this:
 
 ```sh
-depcruise src --include-only "^src/" --exclude "mocks\\.ts$|\\.spec\\.ts$" --output-type dot | dot -T svg > dependency-graph.svg
+dependency-cruiser src --include-only "^src/" --exclude "mocks\\.ts$|\\.spec\\.ts$" --output-type dot | dot -T svg > dependency-graph.svg
 ```
 
 </details>
@@ -230,7 +230,7 @@ quite a bit.
 To achieve that either pass `-Gsplines=ortho` to dot, e.g. in a complete incantation:
 
 ```sh
-depcruise src --config .dependency-cruiser-graph.js --output-type dot | dot -Gsplines=ortho -T svg > dependency-graph-with-orthogonal-edges.svg
+dependency-cruiser src --config .dependency-cruiser-graph.js --output-type dot | dot -Gsplines=ortho -T svg > dependency-graph-with-orthogonal-edges.svg
 ```
 
 ... or put it permanently in your dependency-cruiser configuration in the dot
@@ -613,6 +613,9 @@ export default {
 
 > Newer versions of the `--init` generator automatically do this for you.
 
+As of version 18.2.0 dependency-cruiser also recognizes configuration files written
+in TypeScript - provided the node.js environment it runs in directly supports them.
+
 </details>
 
 ### Q: Does dependency-cruiser support granularity finer than modules (e.g. classes, functions, variables, ...)?
@@ -641,10 +644,10 @@ maintain both of which take time.
   (pCruiseResult: ICruiseResult): IReporterOutput;
   ```
 - pass the module as an output type, e.g. on the command line:
-  - `depcruise src --output-type plugin:my-awesome-plugin`
+  - `dependency-cruiser src --output-type plugin:my-awesome-plugin`
   - dependency-cruiser should be able to find `my-awesome-plugin`. For
     local modules this typically means you have to provide it the full path
-    path e.g. `depcruise src --output-type plugin:$(pwd)/path/to/my-awesome-plugin`
+    path e.g. `dependency-cruiser src --output-type plugin:$(pwd)/path/to/my-awesome-plugin`
 - before executing the plugin dependency-cruiser checks whether the function
   has the correct signature and whether it can handle minimal input.
 

--- a/doc/rules-reference.md
+++ b/doc/rules-reference.md
@@ -11,9 +11,9 @@
 - Some examples:
   - dependency-cruiser's [own configuration](../.dependency-cruiser.json)
   - the configuration [State Machine cat](https://state-machine-cat.js.org) uses
-    [for validation](https://github.com/sverweij/state-machine-cat/blob/develop/config/dependency-cruiser.js)
-    and the one it uses [for generating a visual graph](https://github.com/sverweij/state-machine-cat/blob/develop/config/dependency-cruiser-graph.js).
-  - [mscgen.js](https://mscgen.js.org)'s [.dependency-cruiser.js](https://github.com/mscgenjs/mscgenjs-core/blob/develop/.dependency-cruiser.js)
+    [for validation](https://github.com/sverweij/state-machine-cat/blob/main/config/dependency-cruiser/base.mjs)
+    and the one it uses [for generating a visual graph](https://github.com/sverweij/state-machine-cat/blob/main/config/dependency-cruiser/graph.mjs).
+  - [mscgen.js](https://mscgen.js.org)'s [.dependency-cruiser.js](https://github.com/mscgenjs/mscgenjs-core/blob/master/.dependency-cruiser.js)
 - Tip: run `depcruise --init` to create a .dependency-cruiser.js with
   some rules that make sense in most projects.
 

--- a/src/cli/defaults.mjs
+++ b/src/cli/defaults.mjs
@@ -4,6 +4,9 @@ export const RULES_FILE_NAME_SEARCH_ARRAY = [
   ".dependency-cruiser.js",
   ".dependency-cruiser.cjs",
   ".dependency-cruiser.mjs",
+  ".dependency-cruiser.ts",
+  ".dependency-cruiser.cts",
+  ".dependency-cruiser.mts",
 ];
 export const DEFAULT_BASELINE_FILE_NAME =
   ".dependency-cruiser-known-violations.json";

--- a/src/config-utl/extract-depcruise-config/index.mjs
+++ b/src/config-utl/extract-depcruise-config/index.mjs
@@ -60,7 +60,7 @@ export default async function extractDepcruiseConfig(
     pBaseDirectory,
     await normalizeResolveOptions(
       {
-        extensions: [".js", ".json", ".cjs", ".mjs"],
+        extensions: [".js", ".json", ".cjs", ".mjs", ".ts", ".cts", ".mts"],
       },
       {},
     ),

--- a/src/config-utl/extract-depcruise-config/read-config.mjs
+++ b/src/config-utl/extract-depcruise-config/read-config.mjs
@@ -8,7 +8,9 @@ import { extname } from "node:path";
  */
 export default async function readConfig(pAbsolutePathToConfigFile) {
   if (
-    [".js", ".cjs", ".mjs", ""].includes(extname(pAbsolutePathToConfigFile))
+    [".js", ".cjs", ".mjs", ".mts", ".cts", ".ts", ""].includes(
+      extname(pAbsolutePathToConfigFile),
+    )
   ) {
     const { default: config } = await import(
       `file://${pAbsolutePathToConfigFile}`


### PR DESCRIPTION
## Description

- enables configurations in typescript

todo

- [x] documented the caveats/ [constraints](https://nodejs.org/learn/typescript/run-natively#constraints) with or without flashing warning lights.

## Motivation and Context

by popular demand

## How Has This Been Tested?

- [x] green ci
- [x] actually using a .dependency-cruiser.mts config locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
