### PR TITLE
feat(cli): adds --baseline option (with same functionality as depcruise-baseline command)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -1,22 +1,6 @@
 [
   {
     "type": "dependency",
-    "from": "bin/depcruise-baseline.mjs",
-    "to": "src/config-utl/extract-known-violations.mjs",
-    "unresolvedTo": "#config-utl/extract-known-violations.mjs",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-subpath-import",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "bin-to-cli-only"
-    }
-  },
-  {
-    "type": "dependency",
     "from": "src/cli/init-config/get-user-input.mjs",
     "to": "src/extract/tsc/parse.mjs",
     "unresolvedTo": "#extract/tsc/parse.mjs",

--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-import { parseArgs, styleText } from "node:util";
+import { parseArgs } from "node:util";
 import assertNodeEnvironmentSuitable from "#cli/assert-node-environment-suitable.mjs";
 import cli from "#cli/index.mjs";
 import meta from "#meta.cjs";
-import extractKnownViolations from "#config-utl/extract-known-violations.mjs";
 
 function showHelp() {
   process.stdout
@@ -62,29 +61,9 @@ try {
       options.config = true;
     }
 
-    let lCurrentBaseline = [];
-    try {
-      lCurrentBaseline = await extractKnownViolations(options["output-to"]);
-    } catch (pKnownViolationsExtractionError) {
-      if (pKnownViolationsExtractionError.code === "ENOENT") {
-        process.stderr.write(
-          styleText(
-            "yellow",
-            `‼ Known violations file '${options["output-to"]}' does not exist yet. Will assume an empty current violations set and create a new one instead.\n`,
-          ),
-        );
-      } else {
-        throw pKnownViolationsExtractionError;
-      }
-    }
-
     process.exitCode = await cli(positionals, {
       config: options.config,
-      outputTo: options["output-to"],
-      cache: false,
-      outputType: "baseline",
-      ignoreKnown: false,
-      knownViolations: lCurrentBaseline,
+      baseline: options["output-to"],
       progress: options["progress"],
     });
   }

--- a/bin/dependency-cruiser.mjs
+++ b/bin/dependency-cruiser.mjs
@@ -97,8 +97,12 @@ try {
       ).hideHelp(true),
     )
     .option(
+      "--baseline [file]",
+      'create or update a known violations baseline. Implies --no-ignore-known --no-cache (default: ".dependency-cruiser-known-violations.json")',
+    )
+    .option(
       "--ignore-known [file]",
-      "ignore known violations as saved in [file] (default: .dependency-cruiser-known-violations.json)",
+      `ignore known violations as saved in [file] (default: ".dependency-cruiser-known-violations.json")${EOL}`,
     )
     .addOption(new Option("--no-ignore-known").hideHelp(true))
     .addOption(

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -817,7 +817,7 @@ it has to them. To see how dependency-cruiser perceives its environment use
 
 ### `--baseline`: create or update a known violations baseline
 
-This options creates or updates the known violations. For example:
+This option creates or updates the known violations. For example:
 
 ```sh
 dependency-cruiser src --baseline
@@ -836,9 +836,9 @@ To ensure this difference (and future features that build on it) is accurate
 `--baseline` implies `--no-ignore-known` and `--no-cache`.
 
 
-> Previously the recommended way to run depcruise-baseline - a separate script
-> distributed with dependency-cruiser. As of 18.3.0 `--baseline` is the recommended
-> way. 
+> Previously the recommended way for creating a baseline was to run 
+> depcruise-baseline - a separate script distributed with dependency-cruiser. 
+> As of 18.3.0 `--baseline` is the recommended way. 
 
 ### `--ignore-known`: ignore known violations
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -23,6 +23,7 @@ available in dependency-cruiser configurations.
 1. [`--metrics`: calculate stability metrics](#--metrics)
 1. [`--no-metrics`: do not calculate stability metrics](#--no-metrics)
 1. [`--info`: show what alt-js are supported](#--info-show-what-alt-js-are-supported)
+1. [`--baseline`: create or update a known violations baseline](#--baseline-create-or-update-a-known-violations-baseline)
 1. [`--ignore-known`: ignore known violations](#--ignore-known-ignore-known-violations)
 1. [`--no-ignore-known`: don't ignore known violations](#--no-ignore-known)
 1. [`--help`/ no parameters: get help](#--help--no-parameters)
@@ -813,35 +814,45 @@ it has to them. To see how dependency-cruiser perceives its environment use
 
 </details>
 
-### `--ignore-known`: ignore known violations
 
-> This feature was recently (september 2021) introduced. It is useful, well
-> tested, stable and it will stay. However, the file format and the ergonomics of
-> the command(s) to deal with known violations might still shift a bit _without_
-> dependency-cruiser getting a major version bump.
->
-> The `err`, `err-long` and `err-html` reporters have been adapted to reflect
-> the results of this feature well. Other reporters to which it is relevant (e.g.
-> all of the `dot` family, `html`, `teamcity`) will follow in releases after
-> dependency-cruiser v10.3.0.
+### `--baseline`: create or update a known violations baseline
+
+This options creates or updates the known violations. For example:
+
+```sh
+dependency-cruiser src --baseline
+```
+
+By default known violations go into `.dependency-cruiser-known-violations.json` 
+in the root of your project, but you can pass a different filename as well.
+When no known violations file exists yet, it'll create one. If one does exist
+it'll update it, and emit a short summary of the difference:
+
+```
+1 new, 18 same, 8 removed
+```
+
+To ensure this difference (and future features that build on it) is accurate
+`--baseline` implies `--no-ignore-known` and `--no-cache`.
+
+
+> Previously the recommended way to run depcruise-baseline - a separate script
+> distributed with dependency-cruiser. As of 18.3.0 `--baseline` is the recommended
+> way. 
+
+### `--ignore-known`: ignore known violations
 
 With this option engaged dependency-cruiser will ignore known violations as saved
 in the file you pass it as a parameter. If you don't pass a filename dependency-cruiser
 will assume the known violations to live in a file called `.dependency-cruiser-known-violations.json`.
 
-You can generate a known violations file with the `baseline` reporter e.g. like so:
+You can generate (and update) a known violations file with the 
+[`--baseline`](#--baseline-create-or-update-a-known-violations-baseline) command line 
+option.
 
-```sh
-dependency-cruiser src --config --output-type baseline --output-to .dependency-cruiser-known-violations.json
-```
-
-... or with the [`depcruise-baseline`](#depcruise-baseline) command which simplifies this a bit:
-
-```sh
-# will assume a .dependency-cruiser.{js,cjs,json} to exist and will write
-# the baseline output to .dependency-cruiser-known-violations.json
-depcruise-baseline src
-```
+> The `--baseline` option is (as of dependency-cruiser 18.3.0) the recommended way 
+> to create a baseline, over [`depcruise-baseline`](#depcruise-baseline) or the
+> baseline reporter (`--output-type baseline`)
 
 #### How dependency-cruiser ignores known violations
 

--- a/doc/options-reference.md
+++ b/doc/options-reference.md
@@ -839,7 +839,7 @@ options: {
 
 > :shell: there is no command line equivalent for this
 
-This options is _deprecated_ as per version 9.21.3; it's not necessary anymore
+This option is _deprecated_ as per version 9.21.3; it's not necessary anymore
 as detection now happens automatically (_enhanced_resolve_ supports it out of
 the box.)
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "check:full": "npm-run-all --node-run check test:glob",
     "depcruise": "node ./bin/dependency-cruiser.mjs src bin test configs types tools --ignore-known",
     "depcruise:all": "node ./bin/dependency-cruiser.mjs src bin test configs types tools",
-    "depcruise:baseline": "node ./bin/depcruise-baseline.mjs src bin test configs types tools",
+    "depcruise:baseline": "node ./bin/dependency-cruiser.mjs src bin test configs types tools --baseline --progress",
     "depcruise:explain": "node ./bin/dependency-cruiser.mjs src bin test configs types tools --output-type err-long --progress none",
     "depcruise:graph:doc": "npm-run-all --node-run depcruise:graph:doc:json --parallel depcruise:graph:doc:fmt-* depcruise:graph:doc:samples",
     "depcruise:graph:doc:json": "node ./bin/dependency-cruiser.mjs bin src test --output-type json --output-to node_modules/.cache/tmp_graph_deps.json --progress",

--- a/src/cli/index.mjs
+++ b/src/cli/index.mjs
@@ -99,7 +99,7 @@ function setUpListener(pCruiseOptions) {
 
 async function runCruise(pFileDirectoryArray, pCruiseOptions, pErrorStream) {
   const lCruiseOptions = await addKnownViolations(
-    await normalizeCliOptions(pCruiseOptions),
+    await normalizeCliOptions(pCruiseOptions, pErrorStream),
   );
 
   pFileDirectoryArray

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -261,6 +261,7 @@ export default async function normalizeOptions(
       pErrorStream,
     );
     lOptions.cache = false;
+    Reflect.deleteProperty(lOptions, "cacheStrategy");
   }
 
   lOptions = { ...lOptions, ...(await normalizeValidationOption(lOptions)) };

--- a/src/cli/normalize-cli-options.mjs
+++ b/src/cli/normalize-cli-options.mjs
@@ -1,5 +1,6 @@
 import { accessSync, constants } from "node:fs";
 import { isAbsolute } from "node:path";
+import { styleText } from "node:util";
 import {
   RULES_FILE_NAME_SEARCH_ARRAY,
   DEFAULT_BASELINE_FILE_NAME,
@@ -12,9 +13,29 @@ import {
 } from "./defaults.mjs";
 import { set } from "#utl/object-util.mjs";
 import loadConfig from "#config-utl/extract-depcruise-config/index.mjs";
+import extractKnownViolations from "#config-utl/extract-known-violations.mjs";
 
 function getOptionValue(pDefault) {
   return (pValue) => (typeof pValue === "string" ? pValue : pDefault);
+}
+
+async function getCurrentBaseline(pBaselineFileName, pErrorStream) {
+  let lCurrentBaseline = [];
+  try {
+    lCurrentBaseline = await extractKnownViolations(pBaselineFileName);
+  } catch (pKnownViolationsExtractionError) {
+    if (pKnownViolationsExtractionError.code === "ENOENT") {
+      pErrorStream.write(
+        styleText(
+          "yellow",
+          `‼ Known violations file '${pBaselineFileName}' does not exist yet. Will assume an empty current violations set and create a new one instead.\n`,
+        ),
+      );
+    } else {
+      throw pKnownViolationsExtractionError;
+    }
+  }
+  return lCurrentBaseline;
 }
 
 // eslint-disable-next-line complexity
@@ -202,11 +223,15 @@ function normalizeCache(pCliOptions) {
  * returns the pOptionsAsPassedFromCommander, so that the returned value contains a
  * valid value for each possible option
  *
- * @param  {object} pOptionsAsPassedFromCommander [description]
+ * @param {object} pOptionsAsPassedFromCommander [description]
  * @param {any} pKnownCliOptions [description]
+ * @param {typeof process.stderr} pErrorStream
  * @returns {import("../../types/options.mjs").ICruiseOptions}          [description]
  */
-export default async function normalizeOptions(pOptionsAsPassedFromCommander) {
+export default async function normalizeOptions(
+  pOptionsAsPassedFromCommander,
+  pErrorStream,
+) {
   let lOptions = {
     outputTo: OUTPUT_TO,
     outputType: OUTPUT_TYPE,
@@ -221,6 +246,21 @@ export default async function normalizeOptions(pOptionsAsPassedFromCommander) {
 
   if (Object.hasOwn(lOptions, "config")) {
     lOptions.validate = lOptions.config;
+  }
+
+  if (Object.hasOwn(lOptions, "baseline")) {
+    const lBaselineFileName =
+      typeof pOptionsAsPassedFromCommander.baseline === "string"
+        ? pOptionsAsPassedFromCommander.baseline
+        : ".dependency-cruiser-known-violations.json";
+    lOptions.ignoreKnown = false;
+    lOptions.outputTo = lBaselineFileName;
+    lOptions.outputType = "baseline";
+    lOptions.knownViolations = await getCurrentBaseline(
+      lBaselineFileName,
+      pErrorStream,
+    );
+    lOptions.cache = false;
   }
 
   lOptions = { ...lOptions, ...(await normalizeValidationOption(lOptions)) };

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -4,6 +4,7 @@ import { getSHA } from "watskeburt";
 import normalizeCliOptions, {
   determineRulesFileName,
 } from "#cli/normalize-cli-options.mjs";
+import { WritableTestStream } from "./writable-test-stream.utl.mjs";
 
 // eslint-disable-next-line max-statements
 describe("[I] cli/normalizeCliOptions - regular normalizations", () => {
@@ -419,6 +420,74 @@ describe("[I] cli/normalizeCliOptions - known violations", () => {
       ),
       true,
     );
+  });
+});
+
+describe("[I] cli/normalizeCliOptions - baseline", () => {
+  const WORKING_DIR = process.cwd();
+
+  afterEach(() => {
+    process.chdir(WORKING_DIR);
+  });
+
+  it("--baseline with a file name loads known violations and sets baseline output", async () => {
+    process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
+    deepEqual(
+      await normalizeCliOptions({ baseline: "custom-known-violations.json" }),
+      {
+        baseline: "custom-known-violations.json",
+        outputTo: "custom-known-violations.json",
+        outputType: "baseline",
+        knownViolations: [],
+        ignoreKnown: false,
+        cache: false,
+        validate: false,
+      },
+    );
+  });
+
+  it("--baseline without a file name uses the default known-violations json", async () => {
+    process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
+    deepEqual(await normalizeCliOptions({ baseline: true }), {
+      baseline: true,
+      outputTo: ".dependency-cruiser-known-violations.json",
+      outputType: "baseline",
+      knownViolations: [],
+      ignoreKnown: false,
+      cache: false,
+      validate: false,
+    });
+  });
+
+  it("--baseline with a non-existing file assumes no current known violations and tells it's going to create one", async () => {
+    deepEqual(
+      await normalizeCliOptions(
+        { baseline: "new-baseline.json" },
+        new WritableTestStream(
+          /‼ Known violations file '.+' does not exist yet[.]/,
+        ),
+      ),
+      {
+        baseline: "new-baseline.json",
+        outputTo: "new-baseline.json",
+        outputType: "baseline",
+        knownViolations: [],
+        ignoreKnown: false,
+        cache: false,
+        validate: false,
+      },
+    );
+  });
+
+  it("--baseline rethrows errors other than a missing file", async () => {
+    let lError = "none";
+
+    try {
+      await normalizeCliOptions({ baseline: "." });
+    } catch (pError) {
+      lError = pError.toString();
+    }
+    equal(lError.includes("EISDIR"), true);
   });
 });
 

--- a/test/cli/normalize-cli-options.spec.mjs
+++ b/test/cli/normalize-cli-options.spec.mjs
@@ -459,6 +459,22 @@ describe("[I] cli/normalizeCliOptions - baseline", () => {
     });
   });
 
+  it("--baseline with a cache strategy strips the cache strategy", async () => {
+    process.chdir("test/cli/__fixtures__/normalize-config/known-violations");
+    deepEqual(
+      await normalizeCliOptions({ baseline: true, cacheStrategy: "metadata" }),
+      {
+        baseline: true,
+        outputTo: ".dependency-cruiser-known-violations.json",
+        outputType: "baseline",
+        knownViolations: [],
+        ignoreKnown: false,
+        cache: false,
+        validate: false,
+      },
+    );
+  });
+
   it("--baseline with a non-existing file assumes no current known violations and tells it's going to create one", async () => {
     deepEqual(
       await normalizeCliOptions(


### PR DESCRIPTION
## Description

- adds --baseline option (with same functionality as depcruise-baseline command)
- simplifies the depcruise-baseline command code to call dependency-cruiser --baseline
- updates documentation accordingly

## Motivation and Context

Making it an option of the main command seems to prudent way to do it.

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
