### PR TITLE
feat(extract/swc): adds support for parsing tsx/jsx

### DIFF
--- a/src/extract/helpers.mjs
+++ b/src/extract/helpers.mjs
@@ -119,6 +119,7 @@ const TS_COMPATIBLE_EXTENSIONS = new Set([
   ".mts",
   ".cts",
   ".js",
+  ".jsx",
   ".mjs",
   ".cjs",
   ".vue",

--- a/src/extract/swc/parse.mjs
+++ b/src/extract/swc/parse.mjs
@@ -17,13 +17,23 @@ const SWC_PARSE_OPTIONS = {
   target: "es2022",
   // allow for decorators
   decorators: true,
-  // TODO: {tj}sx ?
+  // no tsx by default - overridden when the extension calls for it (see getOptionsFor)
+  // tsx: false
 };
 /** @type {Map<string, ModuleItem[]>} */
 const CACHE = new Map();
 
-export function getASTFromSource(pSource) {
-  return swc.parseSync(pSource, SWC_PARSE_OPTIONS);
+/**
+ * Returns the parse options necessary to have swc parse the file name
+ * pFileName correctly (mainly important for jsx/ tsx)
+ *
+ * @param {string} pFileName
+ * @returns {ParseOptions}
+ */
+export function getOptionsFor(pFileName) {
+  return /[.](?:tsx|jsx)$/.test(pFileName)
+    ? { ...SWC_PARSE_OPTIONS, tsx: true }
+    : SWC_PARSE_OPTIONS;
 }
 
 /**
@@ -39,7 +49,7 @@ export function getASTCached(pFileName) {
     return CACHE.get(pFileName);
   }
   /** @type {swcCore} */
-  const lAST = swc.parseFileSync(pFileName, SWC_PARSE_OPTIONS);
+  const lAST = swc.parseFileSync(pFileName, getOptionsFor(pFileName));
   CACHE.set(pFileName, lAST);
   return lAST;
 }

--- a/test/extract/swc/__mocks__/brol.ts
+++ b/test/extract/swc/__mocks__/brol.ts
@@ -1,0 +1,1 @@
+Dit is heel geen typeschrift!

--- a/test/extract/swc/__mocks__/jsx.jsx
+++ b/test/extract/swc/__mocks__/jsx.jsx
@@ -1,0 +1,3 @@
+export function Component() {
+  return <div className="x" aria-label="y" />;
+}

--- a/test/extract/swc/__mocks__/tsx.tsx
+++ b/test/extract/swc/__mocks__/tsx.tsx
@@ -1,0 +1,3 @@
+export function Component() {
+  return <div className="x" aria-label="y" />;
+}

--- a/test/extract/swc/__mocks__/typescript.ts
+++ b/test/extract/swc/__mocks__/typescript.ts
@@ -1,0 +1,1 @@
+export function doMagic() { return 42 }

--- a/test/extract/swc/extract-with-swc-commonjs.spec.mjs
+++ b/test/extract/swc/extract-with-swc-commonjs.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
-describe("[U] ast-extractors/extract-swc - regular commonjs require", () => {
+describe("[U] extract/swc - regular commonjs require", () => {
   it("extracts require of a module that uses an export-equals'", () => {
     deepEqual(
       extractWithSwc(

--- a/test/extract/swc/extract-with-swc-dynamic-imports.spec.mjs
+++ b/test/extract/swc/extract-with-swc-dynamic-imports.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
-describe("[U] ast-extractors/extract-swc - dynamic imports", () => {
+describe("[U] extract/swc - dynamic imports", () => {
   it("correctly detects a dynamic import statement", () => {
     deepEqual(
       extractWithSwc(

--- a/test/extract/swc/extract-with-swc-exotics.spec.mjs
+++ b/test/extract/swc/extract-with-swc-exotics.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
-describe("[U] ast-extractors/extract-swc - exotics", () => {
+describe("[U] extract/swc - exotics", () => {
   it("doesn't detects 'exotic' dependencies when no exoticRequireStrings were passed", () => {
     deepEqual(
       extractWithSwc(

--- a/test/extract/swc/extract-with-swc-exports.spec.mjs
+++ b/test/extract/swc/extract-with-swc-exports.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
-describe("[U] ast-extractors/extract-swc - re-exports", () => {
+describe("[U] extract/swc - re-exports", () => {
   it("extracts 're-export everything'", () => {
     deepEqual(extractWithSwc("export * from './ts-thing';"), [
       {

--- a/test/extract/swc/extract-with-swc-imports.spec.mjs
+++ b/test/extract/swc/extract-with-swc-imports.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
-describe("[U] ast-extractors/extract-swc - regular imports", () => {
+describe("[U] extract/swc - regular imports", () => {
   it("extracts 'import for side effects only'", () => {
     deepEqual(extractWithSwc("import './import-for-side-effects';"), [
       {

--- a/test/extract/swc/extract-with-swc-type-imports.spec.mjs
+++ b/test/extract/swc/extract-with-swc-type-imports.spec.mjs
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
-describe("[U] ast-extractors/extract-swc - type imports", () => {
+describe("[U] extract/swc - type imports", () => {
   // normal fail, but Visitor.visitTsTypeAnnotation doesn't seem to get called
   // it("extracts type imports in const declarations", () => {
   //   deepEqual(

--- a/test/extract/swc/extract-with-swc.utl.mjs
+++ b/test/extract/swc/extract-with-swc.utl.mjs
@@ -1,5 +1,25 @@
 import extractSwcDependencies from "#extract/swc/extract-swc-deps.mjs";
-import { getASTFromSource } from "#extract/swc/parse.mjs";
+import tryImport from "#utl/try-import.mjs";
+import meta from "#meta.cjs";
+
+const swc = await tryImport("@swc/core", meta.supportedTranspilers.swc);
+
+/** @type {ParseOptions} */
+const SWC_PARSE_OPTIONS = {
+  dynamicImport: true,
+  // typescript is a superset of ecmascript, so we use typescript always
+  syntax: "typescript",
+  // target doesn't have effect on parsing it seems
+  target: "es2022",
+  // allow for decorators
+  decorators: true,
+  // no tsx by default - overridden when the extension calls for it
+  // tsx: false
+};
+
+export function getASTFromSource(pSource) {
+  return swc.parseSync(pSource, SWC_PARSE_OPTIONS);
+}
 
 export default (pTypesScriptSource, pExoticRequireStrings = []) =>
   extractSwcDependencies(

--- a/test/extract/swc/parse-swc.spec.mjs
+++ b/test/extract/swc/parse-swc.spec.mjs
@@ -1,0 +1,43 @@
+import { clearCache, getASTCached } from "#extract/swc/parse.mjs";
+import { equal, throws } from "node:assert/strict";
+import { join } from "node:path";
+
+describe("[U] extract/swc - parse ", () => {
+  beforeEach(() => {
+    clearCache();
+  });
+  afterEach(() => {
+    clearCache();
+  });
+  it("parses regular javascript", () => {
+    const lAST = getASTCached(
+      join(import.meta.dirname, "__mocks__", "javascript.js"),
+    );
+    equal(lAST.type, "Module");
+  });
+  it("parses regular typescript", () => {
+    const lAST = getASTCached(
+      join(import.meta.dirname, "__mocks__", "typescript.ts"),
+    );
+    equal(lAST.type, "Module");
+  });
+  it("parses jsx", () => {
+    const lAST = getASTCached(
+      join(import.meta.dirname, "__mocks__", "jsx.jsx"),
+    );
+    equal(lAST.type, "Module");
+  });
+  it("parses tsx", () => {
+    const lAST = getASTCached(
+      join(import.meta.dirname, "__mocks__", "tsx.tsx"),
+    );
+    equal(lAST.type, "Module");
+  });
+  it("throws on syntactically erroneous file contents", () => {
+    throws(() => {
+      const _lAST = getASTCached(
+        join(import.meta.dirname, "__mocks__", "brol.ts"),
+      );
+    });
+  });
+});

--- a/test/extract/swc/parse-swc.spec.mjs
+++ b/test/extract/swc/parse-swc.spec.mjs
@@ -1,6 +1,6 @@
-import { clearCache, getASTCached } from "#extract/swc/parse.mjs";
 import { equal, throws } from "node:assert/strict";
 import { join } from "node:path";
+import { clearCache, getASTCached } from "#extract/swc/parse.mjs";
 
 describe("[U] extract/swc - parse ", () => {
   beforeEach(() => {


### PR DESCRIPTION
On merging ensure to credit @JPBuildsRoot as a co-author as he had the code ready to go in the linked issue.

## Description

- adds support for parsing tsx/jsx with swc as compiler
- 🏕️ side-catch: removes unused "getASTFromSource" function from the swc parse module (was only used in test to provide AST's to the _extract_ functionality so moved over there)
- 🏕️ side-catch: also classify .jsx as something typescript compilers can stomach

## Motivation and Context

See #1081 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
