### PR TITLE
feat(extract/swc): adds support recognizing type-only imports

### DIFF
--- a/src/extract/swc/dependency-visitor.mjs
+++ b/src/extract/swc/dependency-visitor.mjs
@@ -114,6 +114,16 @@ function isInterestingCallExpression(pExoticRequireStrings, pNode) {
   );
 }
 
+function nodeIsTypeOnly(pNode) {
+  if (pNode.typeOnly) {
+    return true;
+  }
+  return (
+    pNode?.specifiers.length > 0 &&
+    pNode.specifiers.every((pSpecifier) => pSpecifier.isTypeOnly)
+  );
+}
+
 export default Visitor
   ? class SwcDependencyVisitor extends Visitor {
       #exoticRequireStrings;
@@ -134,14 +144,15 @@ export default Visitor
           });
         }
       }
-
       #pushImportSource(pNode) {
         if (pNode.source) {
           this.#result.push({
             module: pNode.source.value,
             moduleSystem: "es6",
             exoticallyRequired: false,
-            dependencyTypes: ["import"],
+            dependencyTypes: nodeIsTypeOnly(pNode)
+              ? ["import", "type-only"]
+              : ["import"],
           });
         }
       }

--- a/test/extract/swc/extract-with-swc-type-imports.spec.mjs
+++ b/test/extract/swc/extract-with-swc-type-imports.spec.mjs
@@ -92,7 +92,7 @@ describe("[U] extract/swc - type imports", () => {
     ]);
   });
 
-  it("extracts type-only imports (typescript 3.8+); not type-only, but each specifier is type-only", () => {
+  it("extracts imports whose specifiers are all type-only (typescript 4.5+)", () => {
     deepEqual(
       extractWithSwc(
         "import { type SomeType, type SomeOtherType } from './some-module'",
@@ -109,7 +109,7 @@ describe("[U] extract/swc - type imports", () => {
     );
   });
 
-  it("extracts type-only imports (typescript 3.8+); not type-only, but each specifier is type-only", () => {
+  it("extracts imports with mixed type-only and value specifiers as runtime imports (typescript 4.5+)", () => {
     deepEqual(
       extractWithSwc(
         "import { type SomeType, SomeOtherThing } from './some-module'",

--- a/test/extract/swc/extract-with-swc-type-imports.spec.mjs
+++ b/test/extract/swc/extract-with-swc-type-imports.spec.mjs
@@ -2,7 +2,7 @@ import { deepEqual } from "node:assert/strict";
 import extractWithSwc from "./extract-with-swc.utl.mjs";
 
 describe("[U] extract/swc - type imports", () => {
-  // normal fail, but Visitor.visitTsTypeAnnotation doesn't seem to get called
+  // // normal fail, but Visitor.visitTsTypeAnnotation doesn't seem to get called
   // it("extracts type imports in const declarations", () => {
   //   deepEqual(
   //     extractWithSwc("const tiepetjes: import('./types').T;"),
@@ -87,8 +87,42 @@ describe("[U] extract/swc - type imports", () => {
         moduleSystem: "es6",
         dynamic: false,
         exoticallyRequired: false,
-        dependencyTypes: ["import"],
+        dependencyTypes: ["import", "type-only"],
       },
     ]);
+  });
+
+  it("extracts type-only imports (typescript 3.8+); not type-only, but each specifier is type-only", () => {
+    deepEqual(
+      extractWithSwc(
+        "import { type SomeType, type SomeOtherType } from './some-module'",
+      ),
+      [
+        {
+          module: "./some-module",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: ["import", "type-only"],
+        },
+      ],
+    );
+  });
+
+  it("extracts type-only imports (typescript 3.8+); not type-only, but each specifier is type-only", () => {
+    deepEqual(
+      extractWithSwc(
+        "import { type SomeType, SomeOtherThing } from './some-module'",
+      ),
+      [
+        {
+          module: "./some-module",
+          moduleSystem: "es6",
+          dynamic: false,
+          exoticallyRequired: false,
+          dependencyTypes: ["import"],
+        },
+      ],
+    );
   });
 });


### PR DESCRIPTION
## Description

- makes the swc extraction code recognize type-only imports too

## Motivation and Context

#1082 

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
