### PR TITLE
chore(doc): marks depcruise-baseline command as deprecated in favor of dependency-cruiser --baseline

### DIFF
--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -18,7 +18,7 @@ Options:
   -V, --version             display version number
   -h, --help                display help for command
 
-‼ Deprecated. Use dependency-cruiser --baseline in stead.
+‼ Deprecated. Use dependency-cruiser --baseline instead.
 ‼ See https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md#--baseline-create-or-update-a-known-violations-baseline
 
 `);

--- a/bin/depcruise-baseline.mjs
+++ b/bin/depcruise-baseline.mjs
@@ -10,14 +10,17 @@ function showHelp() {
     .write(`Usage: depcruise-baseline [options] <files-or-directories...>
 
 Writes all known violations of rules in a .dependency-cruiser.js to a file.
-Alias for depcruise --no-ignore-known -c -T baseline -f .dependency-cruiser-known-violations.json [files-or-directories]
-Details: https://github.com/sverweij/dependency-cruiser
+Alias for dependency-cruiser --baseline 
 
 Options:
   -c, --config [file]       read rules and options from [file] (default: true)
   -f, --output-to [file]    file to write output to; - for stdout (default: ".dependency-cruiser-known-violations.json")
   -V, --version             display version number
   -h, --help                display help for command
+
+‼ Deprecated. Use dependency-cruiser --baseline in stead.
+‼ See https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md#--baseline-create-or-update-a-known-violations-baseline
+
 `);
 }
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -843,7 +843,11 @@ When no known violations file exists yet, it'll create one. If one does exist
 it'll update it, and emit a short summary of the difference:
 
 ```
-1 new, 18 same, 8 removed
+baseline  : 19 violations
+
+  new     : 1
+  same    : 18
+  removed : 8
 ```
 
 To ensure this difference (and future features that build on it) is accurate
@@ -1506,27 +1510,24 @@ Options:
 
 ### depcruise-baseline
 
-To create a baseline of known violations. You can use the resulting file to tell
-regular dependency-cruiser you want to ignore them for now and to only focus
-on new ones.
+Deprecated, use the dependency-cruiser [`--baseline`](#--baseline-create-or-update-a-known-violations-baseline) 
+option instead. Today `depcruise-baseline` is an alias for that option.
 
-> Shortcut for `dependency-cruiser -c -T baseline -f .dependency-cruiser-known-violations.json`
-> which might be a bit of an elaborate incantation for generating a list
-> of known violations.
-
-If your sources & test live in `src`, `test` and you use the default filenames
-for the dependency-cruiser configuration and known violations (recommended)
-then...
-
-```
-depcruise-baseline src test
-```
-
-... will generate the baseline of known violations to .dependency-cruiser-known-violations.json.
-
-The two command line options exist in case you want these files to live in
-different spots; `--config` to specify where the config file lives, `--output-to`
-to write to an alternative output location.
+> Usage used to be:
+> If your sources & test live in `src`, `test` and you use the default filenames
+> for the dependency-cruiser configuration and known violations (recommended)
+> then...
+> 
+> ```diff
+> - depcruise-baseline src test
+> + dependency-cruiser src test --baseline
+> ```
+>
+> ... would generate the baseline of known violations to .dependency-cruiser-known-violations.json.
+>
+> Two additional command line options exist in case you want these files to live in
+> different spots; `--config` to specify where the config file lives, `--output-to`
+> to write to an alternative output location.
 
 ## depcruise-wrap-stream-in-html
 

--- a/doc/real-world-samples.md
+++ b/doc/real-world-samples.md
@@ -76,7 +76,7 @@ wget https://raw.githubusercontent.com/sverweij/dependency-cruiser/main/doc/real
 
   ```
     "dc": "dependency-cruiser --version && dependency-cruiser --ignore-known --config react-dependency-cruiser-config.js -T err packages/*/{*.js,src}",
-    "depcruise:baseline": "dependency-cruiser --version && depcruise-baseline packages/*/{*.js,src} --config react-dependency-cruiser-config.js",
+    "depcruise:baseline": "dependency-cruiser --version && dependency-cruiser packages/*/{*.js,src} --config react-dependency-cruiser-config.js --baseline",
     "depcruise:archi": "dependency-cruiser --ignore-known --config react-dependency-cruiser-config.js -T archi packages/*/{*.js,src} | dot -T svg | tee react-high-level-dependencies.svg | depcruise-wrap-stream-in-html > react-high-level-dependencies.html
   ```
 

--- a/src/extract/transpile/try-import-available.mjs
+++ b/src/extract/transpile/try-import-available.mjs
@@ -14,7 +14,7 @@ function extractRootModuleName(pModuleName) {
 
 function getVersion(pModuleName) {
   // of course we'd love to use something like an import with an import assertion
-  // As that's _experimental_ we have to use _require_ in stead.
+  // As that's _experimental_ we have to use _require_ instead.
   // eslint-disable-next-line import/no-dynamic-require, security/detect-non-literal-require
   const lManifest = require(
     path.join(extractRootModuleName(pModuleName), "package.json"),

--- a/src/utl/try-import.mjs
+++ b/src/utl/try-import.mjs
@@ -14,7 +14,7 @@ function getVersion(pModuleName) {
   // The 'proper' way to do this would be with a dynamic import with an
   // import assertion. Because it's 'experimental' since node 16 and prints
   // an ugly warning on stderr since node 19 we'll be using the require
-  // hack below in stead. Code would otherwise have been:
+  // hack below instead. Code would otherwise have been:
   //
   // const lManifest = await import(
   //   // @ts-expect-error TS2345 extractRootModuleName can return either a string or


### PR DESCRIPTION
## Description

- marks depcruise-baseline command as deprecated in favor of dependency-cruiser --baseline

## Motivation and Context

Consolidating all functionality into the dependency-cruiser main script

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/main/.github/CONTRIBUTING.md).
